### PR TITLE
EVG-6411: Patch expand panels collapse when a new page of patches is loaded

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5821,9 +5821,9 @@
       }
     },
     "evergreen.js": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/evergreen.js/-/evergreen.js-1.0.16.tgz",
-      "integrity": "sha512-0AkJ7eG5NpQbTTZ5UIkHGPuvEUuH1QTqpsvx3TMysF2ikJ4Kx9A5grg/o9hliEOrO+BlKdlpt274ctgrF3RvbQ==",
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/evergreen.js/-/evergreen.js-1.0.17.tgz",
+      "integrity": "sha512-T1qdZ7SU7at+hdOmGkcGi0WpQaK7FZpZkzcqaHzqm8aq1UlYkzBG7qfC3ZrHqhhZP/a97FiZRR63UQwwImoaZw==",
       "requires": {
         "@types/js-yaml": "^3.12.1",
         "@types/request": "^2.48.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "eslint-plugin-import": "2.14.0",
     "eslint-plugin-jsx-a11y": "6.1.1",
     "eslint-plugin-react": "7.11.1",
-    "evergreen.js": "^1.0.16",
+    "evergreen.js": "^1.0.17",
     "file-loader": "2.0.0",
     "fork-ts-checker-webpack-plugin": "0.4.9",
     "fs-extra": "7.0.0",

--- a/src/components/app/App.tsx
+++ b/src/components/app/App.tsx
@@ -31,7 +31,7 @@ export class Evergreen extends React.Component<Props, State> {
 
   public render() {
     const admin = () => <Admin APIClient={this.state.APIClient} />
-    const patches = () => <PatchContainer client={this.state.APIClient} />
+    const patches = () => <PatchContainer client={this.state.APIClient} onFinishStateUpdate={null}/>
     const config = () => <ConfigDrop updateClientConfig={this.updateConfig} onLoadFinished={null}/>
     const menuOpen = Boolean(this.state.MenuAnchor);
 

--- a/src/components/patch/Patch.tsx
+++ b/src/components/patch/Patch.tsx
@@ -38,7 +38,6 @@ export class Patch extends React.Component<Props, State> {
   }
 
   public render() {
-    // console.log( this.props.Patch.Version.id + " is expanded: " + this.props.expanded)
 
     const Variants = () => (
       <Grid container={true} spacing={24}>

--- a/src/components/patch/Patch.tsx
+++ b/src/components/patch/Patch.tsx
@@ -16,6 +16,8 @@ interface State {
 
 class Props {
   public Patch: UIVersion;
+  public expanded: boolean;
+  public updateOpenPatches: (patchObj: UIVersion) => void;
 }
 
 export class Patch extends React.Component<Props, State> {
@@ -54,8 +56,8 @@ export class Patch extends React.Component<Props, State> {
 
     return (
       <Grid>
-        <ExpansionPanel className="patch">
-          <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />} aria-controls="panel1a-content" id="panel1a-header">
+        <ExpansionPanel className="patch" expanded={this.props.expanded} onChange={this.onExpandChange}>
+          <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
             <Typography className="patch-header" variant="h6">{this.state.description}</Typography>
           </ExpansionPanelSummary>
           <ExpansionPanelDetails>
@@ -63,7 +65,11 @@ export class Patch extends React.Component<Props, State> {
           </ExpansionPanelDetails>
         </ExpansionPanel>
       </Grid>
-    );
+    );  
+  }
+
+  private onExpandChange = () => {
+    this.props.updateOpenPatches(this.props.Patch);
   }
 }
 

--- a/src/components/patch/Patch.tsx
+++ b/src/components/patch/Patch.tsx
@@ -38,6 +38,7 @@ export class Patch extends React.Component<Props, State> {
   }
 
   public render() {
+    // console.log( this.props.Patch.Version.id + " is expanded: " + this.props.expanded)
 
     const Variants = () => (
       <Grid container={true} spacing={24}>

--- a/src/components/patch/PatchContainer.test.tsx
+++ b/src/components/patch/PatchContainer.test.tsx
@@ -1,8 +1,9 @@
-import { InputBase } from '@material-ui/core';
+import { ExpansionPanel, InputBase } from '@material-ui/core';
 import * as enzyme from "enzyme";
 import { UIVersion } from 'evergreen.js/lib/models';
 import * as moment from 'moment';
 import * as React from "react";
+import * as InfiniteScroll from 'react-infinite-scroller';
 import * as rest from "../../rest/interface";
 import { Variant } from '../variant/Variant';
 import { Patch } from './Patch';
@@ -45,6 +46,24 @@ describe("PatchContainer", () => {
     expect(variant.state("name")).toBe("Ubuntu 16.04");
     expect(variant.state("statusCount")).toEqual({ success: 2, failed: 1 });
     expect(variant.state("sortedStatus")).toEqual([{"count": 1, "status": "failed"}, {"count": 2, "status": "success"}]);
+  })
+
+  it("check that expanded state persists on re-render", () => {
+    expect(wrapper.state("expandedPatches")).toEqual({});
+    const patch = wrapper.findWhere(node => node.key() === "5d1385720305b932b1d50d01");
+    expect(patch).toHaveLength(1);
+    // expect(patch.instance().props.children["props"]["expanded"]).toBe(false);
+    const expansionPanel = patch.find(ExpansionPanel);
+    expect(expansionPanel).toHaveLength(1);
+    expect(expansionPanel.prop("expanded")).toBe(false);
+    expect(expansionPanel.prop("onChange")).toBeDefined();
+    // expansionPanel.simulate("change");
+    // console.log(wrapper.state("visiblePatches"));
+    expansionPanel.prop("onChange")({} as React.ChangeEvent, true);
+    expect(wrapper.state("expandedPatches")).toEqual({"5d1385720305b932b1d50d01": 1});
+    // tslint:disable-next-line: no-string-literal
+    expect(patch.props().children["props"]["expanded"]).toBe(true);
+    // expect(expansionPanel.prop("expanded")).toBe(true);
   })
 
   it("check that search returns correct results", () => {

--- a/src/components/patch/PatchContainer.test.tsx
+++ b/src/components/patch/PatchContainer.test.tsx
@@ -10,18 +10,7 @@ import { PatchContainer } from "./PatchContainer";
 
 describe("PatchContainer", () => {
 
-  const checkState = jest.fn(() => {
-    wrapper.update();
-    expect(wrapper.state("expandedPatches")).toEqual({ "5d1385720305b932b1d50d01": 1 });
-    const patch = wrapper.findWhere(node => node.key() === "5d1385720305b932b1d50d01").find(Patch);
-    expect(patch).toHaveLength(1);
-    expect(patch.prop("expanded")).toBe(true);
-    const expansionPanel = patch.find(ExpansionPanel);
-    expect(expansionPanel).toHaveLength(1);
-    expect(expansionPanel.prop("expanded")).toBe(true);
-  });
-
-  const wrapper = enzyme.mount(<PatchContainer client={rest.EvergreenClient("", "", "", "", true)} onFinishStateUpdate={checkState} />);
+  const wrapper = enzyme.mount(<PatchContainer client={rest.EvergreenClient("", "", "", "", true)} onFinishStateUpdate={null} />);
 
   it("check that patches loaded from mock data correctly", () => {
     expect(wrapper.find(Patch)).toHaveLength(4);
@@ -58,7 +47,19 @@ describe("PatchContainer", () => {
     expect(variant.state("sortedStatus")).toEqual([{ "count": 1, "status": "failed" }, { "count": 2, "status": "success" }]);
   })
 
+  const checkState = jest.fn(() => {
+    wrapper.update();
+    expect(wrapper.state("expandedPatches")).toEqual({ "5d1385720305b932b1d50d01": 1 });
+    const patch = wrapper.findWhere(node => node.key() === "5d1385720305b932b1d50d01").find(Patch);
+    expect(patch).toHaveLength(1);
+    expect(patch.prop("expanded")).toBe(true);
+    const expansionPanel = patch.find(ExpansionPanel);
+    expect(expansionPanel).toHaveLength(1);
+    expect(expansionPanel.prop("expanded")).toBe(true);
+  });
+
   it("check that expanded state persists on re-render", () => {
+    wrapper.setProps({ onFinishStateUpdate: checkState });
     expect(wrapper.state("expandedPatches")).toEqual({});
     const patch = wrapper.findWhere(node => node.key() === "5d1385720305b932b1d50d01").find(Patch);
     expect(patch).toHaveLength(1);

--- a/src/components/patch/PatchContainer.test.tsx
+++ b/src/components/patch/PatchContainer.test.tsx
@@ -13,10 +13,9 @@ describe("PatchContainer", () => {
   const checkState = jest.fn(() => {
     wrapper.update();
     expect(wrapper.state("expandedPatches")).toEqual({ "5d1385720305b932b1d50d01": 1 });
-    const patch = wrapper.findWhere(node => node.key() === "5d1385720305b932b1d50d01");
+    const patch = wrapper.findWhere(node => node.key() === "5d1385720305b932b1d50d01").find(Patch);
     expect(patch).toHaveLength(1);
-    // tslint:disable-next-line: no-string-literal
-    expect(patch.props().children["props"]["expanded"]).toBe(true);
+    expect(patch.prop("expanded")).toBe(true);
     const expansionPanel = patch.find(ExpansionPanel);
     expect(expansionPanel).toHaveLength(1);
     expect(expansionPanel.prop("expanded")).toBe(true);
@@ -61,10 +60,9 @@ describe("PatchContainer", () => {
 
   it("check that expanded state persists on re-render", () => {
     expect(wrapper.state("expandedPatches")).toEqual({});
-    const patch = wrapper.findWhere(node => node.key() === "5d1385720305b932b1d50d01");
+    const patch = wrapper.findWhere(node => node.key() === "5d1385720305b932b1d50d01").find(Patch);
     expect(patch).toHaveLength(1);
-    // tslint:disable-next-line: no-string-literal
-    expect(patch.instance().props.children["props"]["expanded"]).toBe(false);
+    expect(patch.prop("expanded")).toBe(false);
     const expansionPanel = patch.find(ExpansionPanel);
     expect(expansionPanel).toHaveLength(1);
     expect(expansionPanel.prop("expanded")).toBe(false);

--- a/src/components/patch/PatchContainer.tsx
+++ b/src/components/patch/PatchContainer.tsx
@@ -17,6 +17,7 @@ interface State {
 
 class Props {
   public client: rest.Evergreen;
+  public onFinishStateUpdate: () => void;
 }
 
 export class PatchContainer extends React.Component<Props, State> {
@@ -118,7 +119,7 @@ export class PatchContainer extends React.Component<Props, State> {
     }
     this.setState({
       expandedPatches: newExpanded
-    });
+    }, this.props.onFinishStateUpdate);
   }
 
   private isExpanded = (patchObj: UIVersion) => {

--- a/src/components/patch/PatchContainer.tsx
+++ b/src/components/patch/PatchContainer.tsx
@@ -11,7 +11,8 @@ interface State {
   pageNum: number
   hasMore: boolean
   allPatches: UIVersion[]
-  visiblePatches: UIVersion[]
+  visiblePatches: UIVersion[], 
+  expandedPatches: number[]
 }
 
 class Props {
@@ -25,7 +26,8 @@ export class PatchContainer extends React.Component<Props, State> {
       hasMore: true,
       pageNum: 0,
       allPatches: [],
-      visiblePatches: []
+      visiblePatches: [],
+      expandedPatches: []
     };
   }
 
@@ -39,7 +41,7 @@ export class PatchContainer extends React.Component<Props, State> {
       <Grid className="patch-container" container={true} spacing={24}>
         {this.state.visiblePatches.map(patchObj => (
           <Grid item={true} xs={12} key={patchObj.Version.id}>
-            <Patch Patch={patchObj} />
+            <Patch Patch={patchObj} updateOpenPatches={this.updateOpenPatches} expanded={this.isExpanded(patchObj)} />
           </Grid>
         ))}
       </Grid>
@@ -105,6 +107,24 @@ export class PatchContainer extends React.Component<Props, State> {
       }
     });
     return filtered;
+  }
+
+  private updateOpenPatches = (patchObj: UIVersion) => {
+    let newExpanded = this.state.expandedPatches;
+    if (this.state.expandedPatches.indexOf(this.state.allPatches.indexOf(patchObj)) === -1) {
+      newExpanded.push(this.state.allPatches.indexOf(patchObj));
+    } else {
+        newExpanded = this.state.expandedPatches.filter((value, index, array) => {
+        return value !== this.state.allPatches.indexOf(patchObj);
+      });
+    }
+    this.setState({
+      expandedPatches: newExpanded
+    });
+  }
+
+  private isExpanded = (patchObj: UIVersion) => {
+    return this.state.expandedPatches.indexOf(this.state.allPatches.indexOf(patchObj)) === -1 ? false : true
   }
 }
 

--- a/src/components/patch/PatchContainer.tsx
+++ b/src/components/patch/PatchContainer.tsx
@@ -11,8 +11,8 @@ interface State {
   pageNum: number
   hasMore: boolean
   allPatches: UIVersion[]
-  visiblePatches: UIVersion[], 
-  expandedPatches: number[]
+  visiblePatches: UIVersion[],
+  expandedPatches: object
 }
 
 class Props {
@@ -27,7 +27,7 @@ export class PatchContainer extends React.Component<Props, State> {
       pageNum: 0,
       allPatches: [],
       visiblePatches: [],
-      expandedPatches: []
+      expandedPatches: {}
     };
   }
 
@@ -70,8 +70,8 @@ export class PatchContainer extends React.Component<Props, State> {
       this.props.client.getPatches((err, resp, body) => {
         const newPatches = Object.values(ConvertToPatches(resp.body).VersionsMap);
         if (newPatches.length === 0) {
-          this.setState({ 
-            hasMore: false 
+          this.setState({
+            hasMore: false
           });
           return;
         }
@@ -81,7 +81,7 @@ export class PatchContainer extends React.Component<Props, State> {
           pageNum: prevState.pageNum + 1,
           allPatches: [... this.state.allPatches, ...newPatches],
           visiblePatches: [... this.state.allPatches, ...newPatches],
-      })); 
+        }));
       }, this.props.client.username, this.state.pageNum);
     }
   }
@@ -110,13 +110,11 @@ export class PatchContainer extends React.Component<Props, State> {
   }
 
   private updateOpenPatches = (patchObj: UIVersion) => {
-    let newExpanded = this.state.expandedPatches;
-    if (this.state.expandedPatches.indexOf(this.state.allPatches.indexOf(patchObj)) === -1) {
-      newExpanded.push(this.state.allPatches.indexOf(patchObj));
+    const newExpanded = this.state.expandedPatches;
+    if (patchObj.Version.id in this.state.expandedPatches) {
+      delete newExpanded[patchObj.Version.id];
     } else {
-        newExpanded = this.state.expandedPatches.filter((value, index, array) => {
-        return value !== this.state.allPatches.indexOf(patchObj);
-      });
+      newExpanded[patchObj.Version.id] = 1;
     }
     this.setState({
       expandedPatches: newExpanded
@@ -124,7 +122,7 @@ export class PatchContainer extends React.Component<Props, State> {
   }
 
   private isExpanded = (patchObj: UIVersion) => {
-    return this.state.expandedPatches.indexOf(this.state.allPatches.indexOf(patchObj)) === -1 ? false : true
+    return patchObj.Version.id in this.state.expandedPatches;
   }
 }
 


### PR DESCRIPTION
This set of changes includes adding logic to determine whether a patch should be expanded on rendering after changes occur somewhere on the page. 