### PR TITLE
EVG-6552: expand first page of patches by default and create expand all option

### DIFF
--- a/src/components/patch/Patch.less
+++ b/src/components/patch/Patch.less
@@ -14,11 +14,21 @@
   padding-left: 100px;
   padding-right: 200px;
 }
+.dropdown-container {
+  display: inline-flex;
+}
 .filter-container {
   padding-bottom: 30px;
   padding-left: 100px;
   padding-right: 200px;
-  display: inline-flex;
+}
+.expand-container {
+  float: right;
+  position: relative;
+}
+.expand {
+  position: absolute;
+  bottom: 0;
 }
 .search-input {
   padding-left: 20px;

--- a/src/components/patch/Patch.less
+++ b/src/components/patch/Patch.less
@@ -24,11 +24,10 @@
 }
 .expand-container {
   float: right;
-  position: relative;
+  padding-top: 10px;
 }
-.expand {
-  position: absolute;
-  bottom: 0;
+.expand-button {
+  margin-left: 15px !important;
 }
 .search-input {
   padding-left: 20px;

--- a/src/components/patch/PatchContainer.test.tsx
+++ b/src/components/patch/PatchContainer.test.tsx
@@ -17,24 +17,35 @@ describe("PatchContainer", () => {
 
   const checkExpandedState = jest.fn(() => {
     wrapper.update();
-    expect(wrapper.state("expandedPatches")).toEqual({ "5d430370850e6177128e0b11": 1 });
-    const patch = wrapper.findWhere(node => node.key() === "5d430370850e6177128e0b11").find(Patch);
-    expect(patch).toHaveLength(1);
-    expect(patch.prop("expanded")).toBe(true);
-    const expansionPanel = patch.find(ExpansionPanel);
-    expect(expansionPanel).toHaveLength(1);
-    expect(expansionPanel.prop("expanded")).toBe(true);
-  })
-
-  it("check that expanded state persists on re-render", () => {
-    wrapper.setProps({ onFinishStateUpdate: checkExpandedState });
-    expect(wrapper.state("expandedPatches")).toEqual({});
+    expect(wrapper.state("expandedPatches")).toEqual( {
+      "5d4306f33e8e863bf3bfa63c": 1,
+      "5d4325c961837d1fdf407a4e": 1,
+      "5d432ecbe3c3317db456ac59": 1,
+      "5d432fc1e3c3317db456be9f": 1,
+    });
     const patch = wrapper.findWhere(node => node.key() === "5d430370850e6177128e0b11").find(Patch);
     expect(patch).toHaveLength(1);
     expect(patch.prop("expanded")).toBe(false);
     const expansionPanel = patch.find(ExpansionPanel);
     expect(expansionPanel).toHaveLength(1);
     expect(expansionPanel.prop("expanded")).toBe(false);
+  })
+
+  it("check that expanded state persists on re-render", () => {
+    wrapper.setProps({ onFinishStateUpdate: checkExpandedState });
+    expect(wrapper.state("expandedPatches")).toEqual( {
+      "5d430370850e6177128e0b11": 1,
+      "5d4306f33e8e863bf3bfa63c": 1,
+      "5d4325c961837d1fdf407a4e": 1,
+      "5d432ecbe3c3317db456ac59": 1,
+      "5d432fc1e3c3317db456be9f": 1,
+    });
+    const patch = wrapper.findWhere(node => node.key() === "5d430370850e6177128e0b11").find(Patch);
+    expect(patch).toHaveLength(1);
+    expect(patch.prop("expanded")).toBe(true);
+    const expansionPanel = patch.find(ExpansionPanel);
+    expect(expansionPanel).toHaveLength(1);
+    expect(expansionPanel.prop("expanded")).toBe(true);
     expect(expansionPanel.prop("onChange")).toBeDefined();
     expansionPanel.prop("onChange")({} as React.ChangeEvent, true);
   })

--- a/src/components/patch/PatchContainer.tsx
+++ b/src/components/patch/PatchContainer.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, FormControl, FormControlLabel, FormLabel, Grid, Input, InputBase, InputLabel, ListItemText, MenuItem, Paper, Select, Typography } from '@material-ui/core';
+import { Button, Checkbox, FormControl, FormLabel, Grid, Input, InputBase, InputLabel, ListItemText, MenuItem, Paper, Select, Typography } from '@material-ui/core';
 import SearchIcon from '@material-ui/icons/Search';
 import { ConvertToPatches, UIPatch, UIVersion } from 'evergreen.js/lib/models';
 import * as React from 'react';
@@ -31,7 +31,6 @@ interface State {
   selectedStatuses: string[]
   allProjects: string[]
   selectedProjects: string[]
-  expandAllChecked: boolean
 }
 
 class Props {
@@ -55,7 +54,6 @@ export class PatchContainer extends React.Component<Props, State> {
       selectedStatuses: [],
       allProjects: [],
       selectedProjects: [],
-      expandAllChecked: false
     };
   }
 
@@ -86,7 +84,7 @@ export class PatchContainer extends React.Component<Props, State> {
           </Paper>
         </div>
         <Grid container={true} className="filter-container">
-          <Grid item={true} xs={10}>
+          <Grid item={true} xs={9}>
             <div className="dropdown-container">
               <FormLabel className="filter-label">Filter Patches</FormLabel>
               <FormControl className="advanced-select" key="status">
@@ -127,17 +125,10 @@ export class PatchContainer extends React.Component<Props, State> {
               </FormControl>
             </div>
           </Grid>
-          <Grid item={true} xs={2} className="expand-container">
-            <div className="expand">
-              <FormControlLabel
-              control={
-                <Checkbox
-                  checked={this.state.expandAllChecked}
-                  onChange={this.onExpandAllChange}
-                />
-              }
-              label="Expand All"
-              />
+          <Grid item={true} xs={3}>
+            <div className="expand-container">
+              <Button className="expand-button" variant="outlined" onClick={this.onExpandAllClick}>Expand All</Button>
+              <Button className="expand-button" variant="outlined" onClick={this.onCollapseAllClick}>Collapse All</Button>
             </div>
           </Grid>
         </Grid>
@@ -184,11 +175,11 @@ export class PatchContainer extends React.Component<Props, State> {
             if (!this.state.allProjects.includes(project) && !newProjects.includes(project)) {
               newProjects.push(project);
             }
-            if((this.state.selectedProjects.length === 0 || this.state.selectedProjects.indexOf(project) > -1) &&
+            if ((this.state.selectedProjects.length === 0 || this.state.selectedProjects.indexOf(project) > -1) &&
               (this.state.selectedStatuses.length === 0 || this.state.selectedStatuses.indexOf(status) > -1)) {
-                newVisiblePatches.push(patch);
+              newVisiblePatches.push(patch);
             }
-            if(this.state.pageNum === 0) {
+            if (this.state.pageNum === 0) {
               newExpanded[patch.Patch.Id] = 1;
             }
           });
@@ -291,22 +282,20 @@ export class PatchContainer extends React.Component<Props, State> {
     }, this.props.onFinishStateUpdate);
   }
 
-  private onExpandAllChange = () => {
-    if(this.state.expandAllChecked) {
-      this.setState({
-        expandAllChecked: !this.state.expandAllChecked,
-        expandedPatches: {}
-      });
-    } else {
-      const newExpanded = {}
-      this.state.allPatches.map((patchObj) => {
-        newExpanded[patchObj.Patch.Id] = 1;
-      })
-      this.setState({
-        expandAllChecked: !this.state.expandAllChecked,
-        expandedPatches: newExpanded
-      })
-    }
+  private onExpandAllClick = () => {
+    const newExpanded = {}
+    this.state.allPatches.map((patchObj) => {
+      newExpanded[patchObj.Patch.Id] = 1;
+    })
+    this.setState({
+      expandedPatches: newExpanded
+    });
+  }
+
+  private onCollapseAllClick = () => {
+    this.setState({
+      expandedPatches: {}
+    });
   }
 
   private renderSelection = (value: string[]) => {

--- a/src/components/patch/PatchContainer.tsx
+++ b/src/components/patch/PatchContainer.tsx
@@ -85,9 +85,9 @@ export class PatchContainer extends React.Component<Props, State> {
             />
           </Paper>
         </div>
-        <Grid container={true}>
-          <Grid item={true} xs={8}>
-            <div className="filter-container">
+        <Grid container={true} className="filter-container">
+          <Grid item={true} xs={10}>
+            <div className="dropdown-container">
               <FormLabel className="filter-label">Filter Patches</FormLabel>
               <FormControl className="advanced-select" key="status">
                 <InputLabel>Status</InputLabel>
@@ -127,16 +127,18 @@ export class PatchContainer extends React.Component<Props, State> {
               </FormControl>
             </div>
           </Grid>
-          <Grid item={true} xs={4}>
-            <FormControlLabel
-            control={
-              <Checkbox
-                checked={this.state.expandAllChecked}
-                onChange={this.onExpandAllChange}
+          <Grid item={true} xs={2} className="expand-container">
+            <div className="expand">
+              <FormControlLabel
+              control={
+                <Checkbox
+                  checked={this.state.expandAllChecked}
+                  onChange={this.onExpandAllChange}
+                />
+              }
+              label="Expand All"
               />
-            }
-            label="Expand All"
-            />
+            </div>
           </Grid>
         </Grid>
         <InfiniteScroll hasMore={this.state.hasMore} loadMore={this.loadPatches} initialLoad={true}>

--- a/src/components/patch/PatchContainer.tsx
+++ b/src/components/patch/PatchContainer.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, FormControl, FormLabel, Grid, Input, InputBase, InputLabel, ListItemText, MenuItem, Paper, Select, Typography } from '@material-ui/core';
+import { Checkbox, FormControl, FormControlLabel, FormLabel, Grid, Input, InputBase, InputLabel, ListItemText, MenuItem, Paper, Select, Typography } from '@material-ui/core';
 import SearchIcon from '@material-ui/icons/Search';
 import { ConvertToPatches, UIPatch, UIVersion } from 'evergreen.js/lib/models';
 import * as React from 'react';
@@ -31,6 +31,7 @@ interface State {
   selectedStatuses: string[]
   allProjects: string[]
   selectedProjects: string[]
+  expandAllChecked: boolean
 }
 
 class Props {
@@ -53,7 +54,8 @@ export class PatchContainer extends React.Component<Props, State> {
       allStatuses: [],
       selectedStatuses: [],
       allProjects: [],
-      selectedProjects: []
+      selectedProjects: [],
+      expandAllChecked: false
     };
   }
 
@@ -83,45 +85,60 @@ export class PatchContainer extends React.Component<Props, State> {
             />
           </Paper>
         </div>
-        <div className="filter-container">
-          <FormLabel className="filter-label">Filter Patches</FormLabel>
-          <FormControl className="advanced-select" key="status">
-            <InputLabel>Status</InputLabel>
-            <Select
-              multiple={true}
-              value={this.state.selectedStatuses as string[]}
-              onChange={this.onStatusSelectChange}
-              renderValue={this.renderSelection}
-              input={<Input className="advanced-input" />}
-              MenuProps={MenuProps}
-            >
-              {this.state.allStatuses.map(status => (
-                <MenuItem key={status} value={status}>
-                  <Checkbox checked={this.state.selectedStatuses.indexOf(status) > -1} />
-                  <ListItemText primary={status} />
-                </MenuItem>
-              ))}
-            </Select>
-          </FormControl>
-          <FormControl className="advanced-select" key="project">
-            <InputLabel>Project</InputLabel>
-            <Select
-              multiple={true}
-              value={this.state.selectedProjects}
-              onChange={this.onProjectSelectChange}
-              renderValue={this.renderSelection}
-              input={<Input className="advanced-input" />}
-              MenuProps={MenuProps}
-            >
-              {this.state.allProjects.map(project => (
-                <MenuItem key={project} value={project}>
-                  <Checkbox checked={this.state.selectedProjects.indexOf(project) > -1} />
-                  <ListItemText primary={project} />
-                </MenuItem>
-              ))}
-            </Select>
-          </FormControl>
-        </div>
+        <Grid container={true}>
+          <Grid item={true} xs={8}>
+            <div className="filter-container">
+              <FormLabel className="filter-label">Filter Patches</FormLabel>
+              <FormControl className="advanced-select" key="status">
+                <InputLabel>Status</InputLabel>
+                <Select
+                  multiple={true}
+                  value={this.state.selectedStatuses as string[]}
+                  onChange={this.onStatusSelectChange}
+                  renderValue={this.renderSelection}
+                  input={<Input className="advanced-input" />}
+                  MenuProps={MenuProps}
+                >
+                  {this.state.allStatuses.map(status => (
+                    <MenuItem key={status} value={status}>
+                      <Checkbox checked={this.state.selectedStatuses.indexOf(status) > -1} />
+                      <ListItemText primary={status} />
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+              <FormControl className="advanced-select" key="project">
+                <InputLabel>Project</InputLabel>
+                <Select
+                  multiple={true}
+                  value={this.state.selectedProjects}
+                  onChange={this.onProjectSelectChange}
+                  renderValue={this.renderSelection}
+                  input={<Input className="advanced-input" />}
+                  MenuProps={MenuProps}
+                >
+                  {this.state.allProjects.map(project => (
+                    <MenuItem key={project} value={project}>
+                      <Checkbox checked={this.state.selectedProjects.indexOf(project) > -1} />
+                      <ListItemText primary={project} />
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            </div>
+          </Grid>
+          <Grid item={true} xs={4}>
+            <FormControlLabel
+            control={
+              <Checkbox
+                checked={this.state.expandAllChecked}
+                onChange={this.onExpandAllChange}
+              />
+            }
+            label="Expand All"
+            />
+          </Grid>
+        </Grid>
         <InfiniteScroll hasMore={this.state.hasMore} loadMore={this.loadPatches} initialLoad={true}>
           <Patches />
         </InfiniteScroll>
@@ -265,6 +282,24 @@ export class PatchContainer extends React.Component<Props, State> {
       visiblePatches: filtered,
       selectedProjects: selectedValues
     }, this.props.onFinishStateUpdate);
+  }
+
+  private onExpandAllChange = () => {
+    if(this.state.expandAllChecked) {
+      this.setState({
+        expandAllChecked: !this.state.expandAllChecked,
+        expandedPatches: {}
+      });
+    } else {
+      const newExpanded = {}
+      this.state.allPatches.map((patchObj) => {
+        newExpanded[patchObj.Patch.Id] = 1;
+      })
+      this.setState({
+        expandAllChecked: !this.state.expandAllChecked,
+        expandedPatches: newExpanded
+      })
+    }
   }
 
   private renderSelection = (value: string[]) => {

--- a/src/components/patch/PatchContainer.tsx
+++ b/src/components/patch/PatchContainer.tsx
@@ -168,6 +168,7 @@ export class PatchContainer extends React.Component<Props, State> {
         const newVisiblePatches: UIPatch[] = [];
         const newStatuses: string[] = [];
         const newProjects: string[] = [];
+        const newExpanded = {};
         if (newPatches.length === 0) {
           this.setState({
             hasMore: false
@@ -187,6 +188,9 @@ export class PatchContainer extends React.Component<Props, State> {
               (this.state.selectedStatuses.length === 0 || this.state.selectedStatuses.indexOf(status) > -1)) {
                 newVisiblePatches.push(patch);
             }
+            if(this.state.pageNum === 0) {
+              newExpanded[patch.Patch.Id] = 1;
+            }
           });
         }
         this.setState((prevState, props) => ({
@@ -195,7 +199,8 @@ export class PatchContainer extends React.Component<Props, State> {
           visiblePatches: [... this.state.visiblePatches, ...newVisiblePatches],
           versionsMap: { ... this.state.versionsMap, ...newVersions },
           allStatuses: [...this.state.allStatuses, ...newStatuses],
-          allProjects: [...this.state.allProjects, ...newProjects]
+          allProjects: [...this.state.allProjects, ...newProjects],
+          expandedPatches: prevState.pageNum === 0 ? newExpanded : prevState.expandedPatches
         }));
       }, username, this.state.pageNum);
     }


### PR DESCRIPTION
I'm still working on the styling for the expand all button (it's surprisingly hard to pin things to the bottom right of a div), but the functionality is all there. I also think it might be worth adding some code to one of the tests to confirm that the first page is in fact expanded on initial load, and another test to make sure that checking and unchecking the expand all button works. Let me know what you think. 