### PR TITLE
EVG-6830: fix patches filter functionality

### DIFF
--- a/src/components/patch/Patch.tsx
+++ b/src/components/patch/Patch.tsx
@@ -15,7 +15,7 @@ interface State {
   reconfigureLink: string;
 }
 
-class Props {
+export class PatchProps {
   public client: rest.Evergreen
   public patch: PatchInfo
   public builds: BuildInfo[]
@@ -23,8 +23,8 @@ class Props {
   public updateOpenPatches: (patchObj: PatchInfo) => void
 }
 
-export class Patch extends React.Component<Props, State> {
-  constructor(props: Props) {
+export class Patch extends React.Component<PatchProps, State> {
+  constructor(props: PatchProps) {
     super(props);
     const datetime = moment(String(this.props.patch.create_time));
     if (this.props.patch.description === "") {
@@ -40,7 +40,7 @@ export class Patch extends React.Component<Props, State> {
     };
   }
 
-  public shouldComponentUpdate(nextProps: Readonly<Props>, nextState: Readonly<State>): boolean {
+  public shouldComponentUpdate(nextProps: Readonly<PatchProps>, nextState: Readonly<State>): boolean {
     return nextProps.expanded !== this.props.expanded;
   }
 

--- a/src/components/patch/PatchContainer.test.tsx
+++ b/src/components/patch/PatchContainer.test.tsx
@@ -1,22 +1,28 @@
-import { ExpansionPanel, InputBase, Select } from '@material-ui/core';
+import { ExpansionPanel, InputBase, Select } from "@material-ui/core";
 import * as enzyme from "enzyme";
-import * as moment from 'moment';
+import * as moment from "moment";
 import * as React from "react";
-import * as InfiniteScroll from 'react-infinite-scroller';
+import * as InfiniteScroll from "react-infinite-scroller";
 import * as rest from "../../rest/interface";
-import { Variant } from '../variant/Variant';
-import { Patch, PatchProps } from './Patch';
+import { Variant } from "../variant/Variant";
+import { Patch, PatchProps } from "./Patch";
 import { PatchContainer } from "./PatchContainer";
 
 describe("PatchContainer", () => {
-  const wrapper = enzyme.mount(<PatchContainer client={rest.EvergreenClient("", "", "", "", true)} username={"admin"} onFinishStateUpdate={null} />);
+  const wrapper = enzyme.mount(
+    <PatchContainer
+      client={rest.EvergreenClient("", "", "", "", true)}
+      username={"admin"}
+      onFinishStateUpdate={null}
+    />
+  );
 
   const infiniteScroll = wrapper.find(InfiniteScroll);
   infiniteScroll.prop("loadMore")(0);
 
   const checkExpandedState = jest.fn(() => {
     wrapper.update();
-    expect(wrapper.state("expandedPatches")).toEqual( {
+    expect(wrapper.state("expandedPatches")).toEqual({
       "5d66d4aa97b1d3794298a82f": 1,
       "5d66f0fd9dbe32552f1c9166": 1,
       "5d66f2e89dbe32552f1c91f5": 1,
@@ -25,19 +31,21 @@ describe("PatchContainer", () => {
       "5d6ffa6897b1d37d85dae0bd": 1,
       "5d700d89b237361b480b8488": 1,
       "5d700fcb97b1d30d193967d0": 1,
-      "5d7018929dbe325975f6a049": 1,
+      "5d7018929dbe325975f6a049": 1
     });
-    const patch = wrapper.findWhere(node => node.key() === "5d7148f497b1d36cde6c995e").find(Patch);
+    const patch = wrapper
+      .findWhere(node => node.key() === "5d7148f497b1d36cde6c995e")
+      .find(Patch);
     expect(patch).toHaveLength(1);
     expect(patch.prop("expanded")).toBe(false);
     const expansionPanel = patch.find(ExpansionPanel);
     expect(expansionPanel).toHaveLength(1);
     expect(expansionPanel.prop("expanded")).toBe(false);
-  })
+  });
 
   it("check that expanded state persists on re-render", () => {
     wrapper.setProps({ onFinishStateUpdate: checkExpandedState });
-    expect(wrapper.state("expandedPatches")).toEqual( {
+    expect(wrapper.state("expandedPatches")).toEqual({
       "5d66d4aa97b1d3794298a82f": 1,
       "5d66f0fd9dbe32552f1c9166": 1,
       "5d66f2e89dbe32552f1c91f5": 1,
@@ -47,9 +55,11 @@ describe("PatchContainer", () => {
       "5d700d89b237361b480b8488": 1,
       "5d700fcb97b1d30d193967d0": 1,
       "5d7018929dbe325975f6a049": 1,
-      "5d7148f497b1d36cde6c995e": 1,
+      "5d7148f497b1d36cde6c995e": 1
     });
-    const patch = wrapper.findWhere(node => node.key() === "5d7148f497b1d36cde6c995e").find(Patch);
+    const patch = wrapper
+      .findWhere(node => node.key() === "5d7148f497b1d36cde6c995e")
+      .find(Patch);
     expect(patch).toHaveLength(1);
     expect(patch.prop("expanded")).toBe(true);
     const expansionPanel = patch.find(ExpansionPanel);
@@ -59,16 +69,20 @@ describe("PatchContainer", () => {
     expansionPanel.prop("onChange")({} as React.ChangeEvent, true);
 
     wrapper.setProps({ onFinishStateUpdate: null });
-  })
+  });
 
   it("check that patches loaded from mock data correctly", () => {
     expect(wrapper.state("allPatches")).toHaveLength(10);
     expect(wrapper.find(Patch)).toHaveLength(10);
-  })
+  });
 
   it("check that patch state and number of variants are correct", () => {
-    const patch = wrapper.findWhere(node => node.key() === "5d7018929dbe325975f6a049").find(Patch);
-    const variants = wrapper.findWhere(node => node.key() === "5d7018929dbe325975f6a049").find(Variant);
+    const patch = wrapper
+      .findWhere(node => node.key() === "5d7018929dbe325975f6a049")
+      .find(Patch);
+    const variants = wrapper
+      .findWhere(node => node.key() === "5d7018929dbe325975f6a049")
+      .find(Variant);
     expect(patch).toHaveLength(1);
     expect(variants).toHaveLength(2);
     expect(patch.state("description")).toBe("busyb");
@@ -76,62 +90,89 @@ describe("PatchContainer", () => {
     expect(patch.state("project")).toBe("evergreen");
     expect(patch.prop("builds")).toHaveLength(2);
     expect(patch.state("datetime")).toEqual(moment("2019-09-04T20:03:31.122Z"));
-  })
+  });
 
   it("check that patch with no description has the correct default description", () => {
-    const patch = wrapper.findWhere(node => node.key() === "5d7148f497b1d36cde6c995e").find(Patch);
+    const patch = wrapper
+      .findWhere(node => node.key() === "5d7148f497b1d36cde6c995e")
+      .find(Patch);
     expect(patch).toHaveLength(1);
     expect(patch.state("description")).toBeDefined();
-    expect(patch.state("description")).toContain("Patch from baxter.hacker at ");
-  })
+    expect(patch.state("description")).toContain(
+      "Patch from baxter.hacker at "
+    );
+  });
 
   it("check that variant state is correct", () => {
-    const variant = wrapper.findWhere(node => node.key() === "5d66f0fd9dbe32552f1c9166").find(Variant);
+    const variant = wrapper
+      .findWhere(node => node.key() === "5d66f0fd9dbe32552f1c9166")
+      .find(Variant);
     const failedBox = variant.findWhere(node => node.key() === "failed");
     const successBox = variant.findWhere(node => node.key() === "success");
     expect(variant).toHaveLength(1);
     expect(successBox).toHaveLength(1);
     expect(failedBox).toHaveLength(1);
     expect(variant.state("name")).toBe("Ubuntu 16.04");
-    expect(variant.state("sortedStatus")).toEqual([{ "count": 1, "status": "failed", "tasks": ["test-rest-client"] }, { "count": 5, "status": "success", "tasks": ["test-agent", "test-command", "test-rest-model", "test-rest-route", "test-auth"] }]);
-  })
+    expect(variant.state("sortedStatus")).toEqual([
+      { count: 1, status: "failed", tasks: ["test-rest-client"] },
+      {
+        count: 5,
+        status: "success",
+        tasks: [
+          "test-agent",
+          "test-command",
+          "test-rest-model",
+          "test-rest-route",
+          "test-auth"
+        ]
+      }
+    ]);
+  });
 
-  describe('Filtering pathces', () => {
-    let otherWrapper: enzyme.ReactWrapper
+  describe("Filtering pathces", () => {
+    let otherWrapper: enzyme.ReactWrapper;
 
     beforeEach(() => {
-      otherWrapper = enzyme.mount(<PatchContainer client={rest.EvergreenClient("", "", "", "", true)} username={"admin"} onFinishStateUpdate={null} />);
-    })
+      otherWrapper = enzyme.mount(
+        <PatchContainer
+          client={rest.EvergreenClient("", "", "", "", true)}
+          username={"admin"}
+          onFinishStateUpdate={null}
+        />
+      );
+    });
     afterEach(() => {
-      otherWrapper.unmount()
-    })
+      otherWrapper.unmount();
+    });
 
     it("filters patches by search input", () => {
       // arrange
       const input = otherWrapper.find(".search-container").find(InputBase);
       // act
-      input.simulate('change', { target: { value: 'change' }})
-      const patches = otherWrapper.find('Patch')
+      input.simulate("change", { target: { value: "change" } });
+      const patches = otherWrapper.find("Patch");
       // assert
       const displayedPatchesMatchSearchTerm = patches.everyWhere(patch => {
-        const props = patch.props() as PatchProps
-        return props.patch.description.includes('change')
-      })
+        const props = patch.props() as PatchProps;
+        return props.patch.description.includes("change");
+      });
       expect(displayedPatchesMatchSearchTerm).toBe(true);
-    })
-  
+    });
+
     it("filters patches based on selected filters", () => {
       // arrange
-      const projectsFilters = otherWrapper.findWhere(node => node.key() === "project").find(Select);
+      const projectsFilters = otherWrapper
+        .findWhere(node => node.key() === "project")
+        .find(Select);
       // act
-      projectsFilters.simulate('change', { target: { value: ['evergreen'] }})
-      const patches = otherWrapper.find('Patch')
+      projectsFilters.simulate("change", { target: { value: ["evergreen"] } });
+      const patches = otherWrapper.find("Patch");
       //assert
       const allPatchesAreEvergreen = patches.everyWhere(patch => {
-        const props = patch.props() as PatchProps
-        return props.patch.project === 'evergreen'
-      })
-      expect(allPatchesAreEvergreen).toBe(true)
-    })
-  })
-})
+        const props = patch.props() as PatchProps;
+        return props.patch.project === "evergreen";
+      });
+      expect(allPatchesAreEvergreen).toBe(true);
+    });
+  });
+});

--- a/src/components/patch/PatchContainer.test.tsx
+++ b/src/components/patch/PatchContainer.test.tsx
@@ -12,9 +12,9 @@ describe("PatchContainer", () => {
   const wrapper = enzyme.mount(<PatchContainer client={rest.EvergreenClient("", "", "", "", true)} username={"admin"} onFinishStateUpdate={null} />);
 
   const infiniteScroll = wrapper.find(InfiniteScroll);
-    infiniteScroll.prop("loadMore")(0);
+  infiniteScroll.prop("loadMore")(0);
 
-    const checkExpandedState = jest.fn(() => {
+  const checkExpandedState = jest.fn(() => {
     wrapper.update();
     expect(wrapper.state("expandedPatches")).toEqual( {
       "5d66d4aa97b1d3794298a82f": 1,


### PR DESCRIPTION
**JIRA ticket:** https://jira.mongodb.org/browse/EVG-6830

## Summary
Filtering on patches page was broken; the displayed patches were not being filtered based on the selected filters. This was due to multiple versions of the patches data being stored in state to represent all patches, filtered patches, and expanded patches. Having three different sources of truth for the state of the patches caused the state used to display the patches components to become out-of-sync. The changes in this PR remove the `visiblePatches` field from state. Filtering is now accomplished by filtering the patches on every re-render from `setState` based on the selected filters. Using this approach assures the the patches displayed in the UI are always in sync with the patches in state by having one source of truth for the patches state, which is the `allPatches` field in state. 

## Tests
**Things that could break as a result of this code:**
- the filtering functionality for patches
- the Spruce app

**I assured that these things did not break by:**
- manually testing the filter functionality, including selecting filters as well as search
- adding 2 integration tests that test filtering and search as the software is intended to be used by a real user 
- ran patch on committed changes