### PR TITLE
Fix getReferrer func

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 # testing
 /coverage
 cypress/videos/
+cypress/screenshots/
 
 # production
 /build

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -5,7 +5,10 @@ import { Redirect, RouteComponentProps } from "react-router-dom";
 import { Location } from "history";
 
 const getReferrer = (location: Location<{ referrer?: string }>) => {
-  return location.state.referrer ?? "/";
+  if (location && location.state && "referrer" in location.state) {
+    return location.state.referrer;
+  }
+  return "/";
 };
 
 export const Login: React.FC<RouteComponentProps> = ({ location }) => {


### PR DESCRIPTION
`location.state.referrer ?? "/"` was throwing a TypeError because `location.state` is undefined at some point in the render lifecycle 