### PR TITLE
Include basic config file

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -136,7 +136,6 @@ functions:
     params:
       working_dir: spruce
       script: |
-        sleep 10
         npx cypress run --record --key ${cypress_record_key} --reporter junit
 
   copy-cmdrc:

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -136,6 +136,7 @@ functions:
     params:
       working_dir: spruce
       script: |
+        sleep 10
         npx cypress run --record --key ${cypress_record_key} --reporter junit
 
   copy-cmdrc:

--- a/config/.cmdrc.json
+++ b/config/.cmdrc.json
@@ -1,0 +1,6 @@
+{
+  "devServer": {
+    "REACT_APP_GQL_URL": "http://localhost:9090/graphql/query",
+    "REACT_APP_API_URL": "http://localhost:3000/api"
+  }
+}

--- a/config/.cmdrc_sample.json
+++ b/config/.cmdrc_sample.json
@@ -1,5 +1,0 @@
-{
-  "devServer": {
-    "REACT_APP_GQL_URL": "http://localhost:9090/graphql/query"
-  }
-}


### PR DESCRIPTION
Replacing `.cmdrc-sample.json` with `.cmdrc.json` so that cloning the app has a sufficient config file to begin deving locally. The config file is still ignored.