### PR TITLE
Change param to enum

### DIFF
--- a/src/context/toast.tsx
+++ b/src/context/toast.tsx
@@ -22,7 +22,7 @@ enum Toast {
   info = "info"
 }
 
-const showToastMessage = (t: keyof typeof Toast) => (toastMessage: string) =>
+const showToastMessage = (t: Toast) => (toastMessage: string) =>
   message[t](toastMessage);
 
 const toast: ToastDispatchValue = {


### PR DESCRIPTION
change param type from `keyof typeof Toast` to `Toast` because it _does_ actually work