### PR TITLE
Page skeleton for Patch and Task pages

### DIFF
--- a/src/components/Loading/PageSkeleton.tsx
+++ b/src/components/Loading/PageSkeleton.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { BigTitle } from "components/styles/Typography";
+import { PageWrapper } from "components/styles/PageWrapper";
+import { SiderCard } from "components/styles/SiderCard";
+import { PageHeader } from "components/styles/PageHeader";
+import { PageContent, PageLayout, PageSider } from "components/styles/Layout";
+import { Skeleton } from "antd";
+
+export const PageSkeleton: React.FC = () => {
+  return (
+    <PageWrapper>
+      <PageHeader>
+        <BigTitle>
+          <Skeleton title={{ width: 300 }} paragraph={false} active={true} />
+        </BigTitle>
+      </PageHeader>
+      <PageLayout>
+        <PageSider>
+          <SiderCard>
+            <Skeleton active={true} />
+          </SiderCard>
+          <SiderCard>
+            <Skeleton active={true} />
+          </SiderCard>
+        </PageSider>
+        <PageLayout>
+          <PageContent>
+            <Skeleton active={true} paragraph={{ rows: 10 }} />
+          </PageContent>
+        </PageLayout>
+      </PageLayout>
+    </PageWrapper>
+  );
+};


### PR DESCRIPTION
When the data for the patch and task page are loading, this is what will be shown. 

![skeleton-gif](https://user-images.githubusercontent.com/15262143/74364957-24269780-4d9b-11ea-955a-276ead4b1e78.gif)
