### PR TITLE
EVG-7139: Retry requests in case of network error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2498,6 +2498,16 @@
         "tslib": "^1.9.3"
       }
     },
+    "apollo-link-retry": {
+      "version": "2.2.15",
+      "resolved": "https://registry.npmjs.org/apollo-link-retry/-/apollo-link-retry-2.2.15.tgz",
+      "integrity": "sha512-ltwXGxm+2NXzskrk+GTofj66LQtcc9OGCjIxAPbjlvtHanpKJn8CviWq8dIsMiYGS9T9rGG/kPPx/VdJfcFb6w==",
+      "requires": {
+        "@types/zen-observable": "0.8.0",
+        "apollo-link": "^1.2.13",
+        "tslib": "^1.9.3"
+      }
+    },
     "apollo-link-schema": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/apollo-link-schema/-/apollo-link-schema-1.2.4.tgz",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "apollo-link": "^1.2.13",
     "apollo-link-error": "^1.1.12",
     "apollo-link-http": "^1.5.16",
+    "apollo-link-retry": "^2.2.15",
     "apollo-link-schema": "^1.2.4",
     "axios": "^0.19.2",
     "env-cmd": "^10.0.1",

--- a/src/gql/GQLWrapper.tsx
+++ b/src/gql/GQLWrapper.tsx
@@ -94,7 +94,7 @@ const retryLink = new RetryLink({
   },
   attempts: {
     max: 5,
-    retryIf: (error): boolean => error && error.response.status !== 401
+    retryIf: (error): boolean => error && error.response.status >= 500
   }
 });
 

--- a/src/gql/GQLWrapper.tsx
+++ b/src/gql/GQLWrapper.tsx
@@ -94,9 +94,7 @@ const retryLink = new RetryLink({
   },
   attempts: {
     max: 5,
-    retryIf: (error, _operation): boolean => {
-      return error && error.response.status !== 401;
-    }
+    retryIf: (error): boolean => error && error.response.status !== 401
   }
 });
 

--- a/src/gql/GQLWrapper.tsx
+++ b/src/gql/GQLWrapper.tsx
@@ -89,7 +89,7 @@ const authenticateIfSuccessfulLink = (dispatch: Dispatch) =>
 const retryLink = new RetryLink({
   delay: {
     initial: 300,
-    max: Infinity,
+    max: 3000,
     jitter: true
   },
   attempts: {


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-7139

Don't retry if the error is 401 (Unauthorized). Otherwise retry up to a maximum of 5 times where the initial delay is 300ms and subsequent delay times are randomized. The Retry link currently uses default params except for the `retryIf` field.