### PR TITLE
EVG-7318: Allow Cypress to wait for specific GQL operations

### DIFF
--- a/cypress/integration/test_table.js
+++ b/cypress/integration/test_table.js
@@ -3,7 +3,8 @@ import { waitForGQL } from "../utils/networking";
 
 const TABLE_SORT_SELECTOR = ".ant-table-column-title";
 const waitForTestsQuery = () => waitForGQL("@gqlQuery", "taskTests");
-
+const TESTS_ROUTE =
+  "/task/logkeeper_ubuntu_test_edd78c1d581bf757a880777b00685321685a8e67_16_10_20_21_58_58/tests";
 describe("tests table", function() {
   beforeEach(() => {
     cy.server();
@@ -17,11 +18,8 @@ describe("tests table", function() {
     cy.get(".ant-table").should("not.exist");
   });
 
-  //this test is skipped until we can use POST body to match routes with cypress
   it("Should have sort buttons disabled when fetching data", () => {
-    cy.visit(
-      "/task/mci_windows_test_agent_8a4f834ba24ddf91f93d0a96b90452e9653f4138_17_10_23_21_58_33/tests"
-    );
+    cy.visit(TESTS_ROUTE);
     cy.contains(TABLE_SORT_SELECTOR, "Name").click();
     cy.once("fail", err => {
       expect(err.message).to.include(
@@ -32,51 +30,39 @@ describe("tests table", function() {
 
   //this test is skipped until we can use POST body to match routes with cypress
   it("Adjusts query params when table headers are clicked", () => {
-    cy.visit(
-      "/task/mci_windows_test_agent_8a4f834ba24ddf91f93d0a96b90452e9653f4138_17_10_23_21_58_33/tests"
-    );
+    cy.visit(TESTS_ROUTE);
     waitForTestsQuery();
     cy.contains(TABLE_SORT_SELECTOR, "Name").click();
     cy.location().should(loc => {
-      expect(loc.pathname).to.equal(
-        "/task/mci_windows_test_agent_8a4f834ba24ddf91f93d0a96b90452e9653f4138_17_10_23_21_58_33/tests"
-      );
+      expect(loc.pathname).to.equal(TESTS_ROUTE);
       expect(loc.search).to.include("category=TEST_NAME");
       expect(loc.search).to.include("sort=-1");
     });
     waitForTestsQuery();
     cy.contains(TABLE_SORT_SELECTOR, "Status").click();
     cy.location().should(loc => {
-      expect(loc.pathname).to.equal(
-        "/task/mci_windows_test_agent_8a4f834ba24ddf91f93d0a96b90452e9653f4138_17_10_23_21_58_33/tests"
-      );
+      expect(loc.pathname).to.equal(TESTS_ROUTE);
       expect(loc.search).to.include("category=STATUS");
       expect(loc.search).to.include("sort=1");
     });
     waitForTestsQuery();
     cy.contains(TABLE_SORT_SELECTOR, "Status").click();
     cy.location().should(loc => {
-      expect(loc.pathname).to.equal(
-        "/task/mci_windows_test_agent_8a4f834ba24ddf91f93d0a96b90452e9653f4138_17_10_23_21_58_33/tests"
-      );
+      expect(loc.pathname).to.equal(TESTS_ROUTE);
       expect(loc.search).to.include("category=STATUS");
       expect(loc.search).to.include("sort=-1");
     });
     waitForTestsQuery();
     cy.contains(TABLE_SORT_SELECTOR, "Time").click();
     cy.location().should(loc => {
-      expect(loc.pathname).to.equal(
-        "/task/mci_windows_test_agent_8a4f834ba24ddf91f93d0a96b90452e9653f4138_17_10_23_21_58_33/tests"
-      );
+      expect(loc.pathname).to.equal(TESTS_ROUTE);
       expect(loc.search).to.include("category=DURATION");
       expect(loc.search).to.include("sort=1");
     });
     waitForTestsQuery();
     cy.contains(TABLE_SORT_SELECTOR, "Time").click();
     cy.location().should(loc => {
-      expect(loc.pathname).to.equal(
-        "/task/mci_windows_test_agent_8a4f834ba24ddf91f93d0a96b90452e9653f4138_17_10_23_21_58_33/tests"
-      );
+      expect(loc.pathname).to.equal(TESTS_ROUTE);
       expect(loc.search).to.include("category=DURATION");
       expect(loc.search).to.include("sort=-1");
     });

--- a/cypress/integration/test_table.js
+++ b/cypress/integration/test_table.js
@@ -1,4 +1,8 @@
 /// <reference types="Cypress" />
+import { waitForGQL } from "../utils/networking";
+
+const TABLE_SORT_SELECTOR = ".ant-table-column-title";
+const waitForTestsQuery = () => waitForGQL("@gqlQuery", "taskTests");
 
 describe("tests table", function() {
   beforeEach(() => {
@@ -9,18 +13,16 @@ describe("tests table", function() {
 
   it("Should display No Data when given an invalid TaskID in the url", () => {
     cy.visit("/task/NO-SUCH-THANG/tests");
-    cy.wait(["@gqlQuery"]);
-    cy.wait(["@gqlQuery"]);
+    waitForGQL("@gqlQuery", "GetTask");
     cy.get(".ant-table").should("not.exist");
   });
 
   //this test is skipped until we can use POST body to match routes with cypress
-  it.skip("Should have sort buttons disabled when fetching data", () => {
+  it("Should have sort buttons disabled when fetching data", () => {
     cy.visit(
       "/task/mci_windows_test_agent_8a4f834ba24ddf91f93d0a96b90452e9653f4138_17_10_23_21_58_33/tests"
     );
-    cy.contains("Name").click();
-    cy.once;
+    cy.contains(TABLE_SORT_SELECTOR, "Name").click();
     cy.once("fail", err => {
       expect(err.message).to.include(
         "'pointer-events: none' prevents user mouse interaction."
@@ -29,16 +31,12 @@ describe("tests table", function() {
   });
 
   //this test is skipped until we can use POST body to match routes with cypress
-  it.skip("Adjusts query params when table headers are clicked", () => {
+  it("Adjusts query params when table headers are clicked", () => {
     cy.visit(
       "/task/mci_windows_test_agent_8a4f834ba24ddf91f93d0a96b90452e9653f4138_17_10_23_21_58_33/tests"
     );
-    // waits on requests that we are not related to the test table
-    cy.wait(["@gqlQuery"]);
-    cy.wait(["@gqlQuery"]);
-    cy.wait(["@gqlQuery"]);
-    cy.wait(["@gqlQuery"]);
-    cy.contains("Name").click();
+    waitForTestsQuery();
+    cy.contains(TABLE_SORT_SELECTOR, "Name").click();
     cy.location().should(loc => {
       expect(loc.pathname).to.equal(
         "/task/mci_windows_test_agent_8a4f834ba24ddf91f93d0a96b90452e9653f4138_17_10_23_21_58_33/tests"
@@ -46,8 +44,8 @@ describe("tests table", function() {
       expect(loc.search).to.include("category=TEST_NAME");
       expect(loc.search).to.include("sort=-1");
     });
-    cy.wait(["@gqlQuery"]);
-    cy.contains("Status").click();
+    waitForTestsQuery();
+    cy.contains(TABLE_SORT_SELECTOR, "Status").click();
     cy.location().should(loc => {
       expect(loc.pathname).to.equal(
         "/task/mci_windows_test_agent_8a4f834ba24ddf91f93d0a96b90452e9653f4138_17_10_23_21_58_33/tests"
@@ -55,8 +53,8 @@ describe("tests table", function() {
       expect(loc.search).to.include("category=STATUS");
       expect(loc.search).to.include("sort=1");
     });
-    cy.wait(["@gqlQuery"]);
-    cy.contains("Status").click();
+    waitForTestsQuery();
+    cy.contains(TABLE_SORT_SELECTOR, "Status").click();
     cy.location().should(loc => {
       expect(loc.pathname).to.equal(
         "/task/mci_windows_test_agent_8a4f834ba24ddf91f93d0a96b90452e9653f4138_17_10_23_21_58_33/tests"
@@ -64,8 +62,8 @@ describe("tests table", function() {
       expect(loc.search).to.include("category=STATUS");
       expect(loc.search).to.include("sort=-1");
     });
-    cy.wait(["@gqlQuery"]);
-    cy.contains("Time").click();
+    waitForTestsQuery();
+    cy.contains(TABLE_SORT_SELECTOR, "Time").click();
     cy.location().should(loc => {
       expect(loc.pathname).to.equal(
         "/task/mci_windows_test_agent_8a4f834ba24ddf91f93d0a96b90452e9653f4138_17_10_23_21_58_33/tests"
@@ -73,8 +71,8 @@ describe("tests table", function() {
       expect(loc.search).to.include("category=DURATION");
       expect(loc.search).to.include("sort=1");
     });
-    cy.wait(["@gqlQuery"]);
-    cy.contains("Time").click();
+    waitForTestsQuery();
+    cy.contains(TABLE_SORT_SELECTOR, "Time").click();
     cy.location().should(loc => {
       expect(loc.pathname).to.equal(
         "/task/mci_windows_test_agent_8a4f834ba24ddf91f93d0a96b90452e9653f4138_17_10_23_21_58_33/tests"

--- a/cypress/utils/networking.js
+++ b/cypress/utils/networking.js
@@ -1,8 +1,8 @@
-// this fn will wait until a query with queryName is executed on the aliased route
+// this fn will wait until a gql query with queryName is executed on the aliased route
 export const waitForGQL = (alias, queryName) => {
   const waitOnce = () => {
     cy.wait(alias).then(xhr => {
-      if (!xhr.requestBody || !xhr.requestBody.query.includes(queryName)) {
+      if (!xhr.requestBody || xhr.requestBody.operationName !== queryName) {
         waitOnce();
       }
     });

--- a/cypress/utils/networking.js
+++ b/cypress/utils/networking.js
@@ -1,13 +1,12 @@
-export function waitForGQL(alias, queryName, onQueryFoundFn) {
-  function waitOnce() {
+// this fn will wait until a query with queryName is executed on the aliased route
+export const waitForGQL = (alias, queryName) => {
+  const waitOnce = () => {
     cy.wait(alias).then(xhr => {
-      if (xhr.requestBody && xhr.requestBody.query.includes(queryName)) {
-        if (onQueryFoundFn) onQueryFoundFn(xhr);
-      } else {
+      if (!xhr.requestBody || !xhr.requestBody.query.includes(queryName)) {
         waitOnce();
       }
     });
-  }
+  };
 
   waitOnce();
-}
+};

--- a/cypress/utils/networking.js
+++ b/cypress/utils/networking.js
@@ -1,0 +1,13 @@
+export function waitForGQL(alias, queryName, onQueryFoundFn) {
+  function waitOnce() {
+    cy.wait(alias).then(xhr => {
+      if (xhr.requestBody && xhr.requestBody.query.includes(queryName)) {
+        if (onQueryFoundFn) onQueryFoundFn(xhr);
+      } else {
+        waitOnce();
+      }
+    });
+  }
+
+  waitOnce();
+}


### PR DESCRIPTION
This PR allows us to wait on specific gql operations in cypress with the `waitForGQL` function. Previously we've only been able to wait for the GQL endpoint without any visibility into which query we are waiting on, now we can wait on specific query operations.