### PR TITLE
EVG-7210: Render Logs column in task page tests table

### DIFF
--- a/cypress/integration/test_table.js
+++ b/cypress/integration/test_table.js
@@ -4,7 +4,7 @@ import { waitForGQL } from "../utils/networking";
 const TABLE_SORT_SELECTOR = ".ant-table-column-title";
 const waitForTestsQuery = () => waitForGQL("@gqlQuery", "taskTests");
 const TESTS_ROUTE =
-  "/task/mci_windows_test_agent_8a4f834ba24ddf91f93d0a96b90452e9653f4138_17_10_23_21_58_33/tests";
+  "/task/logkeeper_ubuntu_test_edd78c1d581bf757a880777b00685321685a8e67_16_10_20_21_58_58/tests";
 describe("tests table", function() {
   beforeEach(() => {
     cy.server();
@@ -12,13 +12,13 @@ describe("tests table", function() {
     cy.route("POST", "/graphql/query").as("gqlQuery");
   });
 
-  it.skip("Should display No Data when given an invalid TaskID in the url", () => {
+  it("Should display No Data when given an invalid TaskID in the url", () => {
     cy.visit("/task/NO-SUCH-THANG/tests");
     waitForGQL("@gqlQuery", "GetTask");
     cy.get(".ant-table").should("not.exist");
   });
 
-  it.skip("Should have sort buttons disabled when fetching data", () => {
+  it("Should have sort buttons disabled when fetching data", () => {
     cy.visit(TESTS_ROUTE);
     cy.contains(TABLE_SORT_SELECTOR, "Name").click();
     cy.once("fail", err => {
@@ -28,7 +28,8 @@ describe("tests table", function() {
     });
   });
 
-  it.skip("Adjusts query params when table headers are clicked", () => {
+  //this test is skipped until we can use POST body to match routes with cypress
+  it("Adjusts query params when table headers are clicked", () => {
     cy.visit(TESTS_ROUTE);
     waitForTestsQuery();
     cy.contains(TABLE_SORT_SELECTOR, "Name").click();

--- a/cypress/integration/test_table.js
+++ b/cypress/integration/test_table.js
@@ -28,7 +28,6 @@ describe("tests table", function() {
     });
   });
 
-  //this test is skipped until we can use POST body to match routes with cypress
   it("Adjusts query params when table headers are clicked", () => {
     cy.visit(TESTS_ROUTE);
     waitForTestsQuery();

--- a/cypress/integration/test_table.js
+++ b/cypress/integration/test_table.js
@@ -67,7 +67,7 @@ describe("tests table", function() {
     });
   });
 
-  it("Should not adjust URL params when clicking Logs tab", () => {
+  it.skip("Should not adjust URL params when clicking Logs tab", () => {
     const assertInitialURLState = () =>
       cy.location().should(loc => {
         expect(loc.pathname).to.equal(TESTS_ROUTE);
@@ -79,5 +79,12 @@ describe("tests table", function() {
     waitForTestsQuery();
     cy.contains(TABLE_SORT_SELECTOR, "Logs").click();
     assertInitialURLState();
+  });
+
+  it("Buttons in log column should have target=_blank attribute", () => {
+    cy.visit(TESTS_ROUTE);
+    waitForTestsQuery();
+    cy.get(".htmlBtn").should("have.attr", "target", "_blank");
+    cy.get(".rawBtn").should("have.attr", "target", "_blank");
   });
 });

--- a/cypress/integration/test_table.js
+++ b/cypress/integration/test_table.js
@@ -67,7 +67,7 @@ describe("tests table", function() {
     });
   });
 
-  it.skip("Should not adjust URL params when clicking Logs tab", () => {
+  it("Should not adjust URL params when clicking Logs tab", () => {
     const assertInitialURLState = () =>
       cy.location().should(loc => {
         expect(loc.pathname).to.equal(TESTS_ROUTE);

--- a/cypress/integration/test_table.js
+++ b/cypress/integration/test_table.js
@@ -84,7 +84,7 @@ describe("tests table", function() {
   it("Buttons in log column should have target=_blank attribute", () => {
     cy.visit(TESTS_ROUTE);
     waitForTestsQuery();
-    cy.get(".htmlBtn").should("have.attr", "target", "_blank");
-    cy.get(".rawBtn").should("have.attr", "target", "_blank");
+    cy.get("#htmlBtn0").should("have.attr", "target", "_blank");
+    cy.get("#rawBtn0").should("have.attr", "target", "_blank");
   });
 });

--- a/cypress/integration/test_table.js
+++ b/cypress/integration/test_table.js
@@ -66,4 +66,18 @@ describe("tests table", function() {
       expect(loc.search).to.include("sort=-1");
     });
   });
+
+  it("Should not adjust URL params when clicking Logs tab", () => {
+    const assertInitialURLState = () =>
+      cy.location().should(loc => {
+        expect(loc.pathname).to.equal(TESTS_ROUTE);
+        expect(loc.search).to.include("category=TEST_NAME");
+        expect(loc.search).to.include("sort=1");
+      });
+    cy.visit(TESTS_ROUTE);
+    assertInitialURLState();
+    waitForTestsQuery();
+    cy.contains(TABLE_SORT_SELECTOR, "Logs").click();
+    assertInitialURLState();
+  });
 });

--- a/cypress/integration/test_table.js
+++ b/cypress/integration/test_table.js
@@ -4,7 +4,7 @@ import { waitForGQL } from "../utils/networking";
 const TABLE_SORT_SELECTOR = ".ant-table-column-title";
 const waitForTestsQuery = () => waitForGQL("@gqlQuery", "taskTests");
 const TESTS_ROUTE =
-  "/task/logkeeper_ubuntu_test_edd78c1d581bf757a880777b00685321685a8e67_16_10_20_21_58_58/tests";
+  "/task/mci_windows_test_agent_8a4f834ba24ddf91f93d0a96b90452e9653f4138_17_10_23_21_58_33/tests";
 describe("tests table", function() {
   beforeEach(() => {
     cy.server();
@@ -12,13 +12,13 @@ describe("tests table", function() {
     cy.route("POST", "/graphql/query").as("gqlQuery");
   });
 
-  it("Should display No Data when given an invalid TaskID in the url", () => {
+  it.skip("Should display No Data when given an invalid TaskID in the url", () => {
     cy.visit("/task/NO-SUCH-THANG/tests");
     waitForGQL("@gqlQuery", "GetTask");
     cy.get(".ant-table").should("not.exist");
   });
 
-  it("Should have sort buttons disabled when fetching data", () => {
+  it.skip("Should have sort buttons disabled when fetching data", () => {
     cy.visit(TESTS_ROUTE);
     cy.contains(TABLE_SORT_SELECTOR, "Name").click();
     cy.once("fail", err => {
@@ -28,8 +28,7 @@ describe("tests table", function() {
     });
   });
 
-  //this test is skipped until we can use POST body to match routes with cypress
-  it("Adjusts query params when table headers are clicked", () => {
+  it.skip("Adjusts query params when table headers are clicked", () => {
     cy.visit(TESTS_ROUTE);
     waitForTestsQuery();
     cy.contains(TABLE_SORT_SELECTOR, "Name").click();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1524,6 +1524,16 @@
         "@leafygreen-ui/palette": "^2.0.0"
       }
     },
+    "@leafygreen-ui/button": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/button/-/button-4.1.0.tgz",
+      "integrity": "sha512-vPiM4x1yMW9aCVgjm8nAXE0krIlXOvbimiq7xL30H2uDao815B863/6Y9H2MZnNXYQ13cGaSTmQ3KtfO3t9+Xg==",
+      "requires": {
+        "@leafygreen-ui/lib": "^4.0.0",
+        "@leafygreen-ui/palette": "^2.0.0",
+        "lodash": "^4.17.15"
+      }
+    },
     "@leafygreen-ui/card": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@leafygreen-ui/card/-/card-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@emotion/core": "^10.0.27",
     "@emotion/styled": "^10.0.27",
     "@leafygreen-ui/badge": "^3.0.0",
+    "@leafygreen-ui/button": "^4.1.0",
     "@leafygreen-ui/card": "^2.0.0",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.4.0",

--- a/src/gql/queries/get-task-tests.ts
+++ b/src/gql/queries/get-task-tests.ts
@@ -19,6 +19,9 @@ export const GET_TASK_TESTS = gql`
       status
       testFile
       duration
+      logs {
+        url
+      }
     }
   }
 `;

--- a/src/gql/queries/get-task-tests.ts
+++ b/src/gql/queries/get-task-tests.ts
@@ -20,7 +20,8 @@ export const GET_TASK_TESTS = gql`
       testFile
       duration
       logs {
-        url
+        htmlDisplayURL
+        rawDisplayURL
       }
     }
   }

--- a/src/pages/task/TestsTable.test.tsx
+++ b/src/pages/task/TestsTable.test.tsx
@@ -9,76 +9,92 @@ import { MemoryRouter, Route } from "react-router";
 import wait from "waait";
 import { fireEvent } from "@testing-library/react";
 
+const testLog = {
+  htmlDisplayURL: "",
+  rawDisplayURL: "",
+  __typename: "TestLog"
+};
 const taskTestsPageZero = [
   {
     id: "59ef7a20a7798219e191d106",
     status: "skip",
     testFile: "TestMetricsSuite/TestRunForIntervalAndSendMessages",
     duration: 0,
-    __typename: "TestResult"
+    __typename: "TestResult",
+    logs: testLog
   },
   {
     id: "59ef7a20a7798219e191d0f2",
     status: "skip",
     testFile: "TestMetricsSuite/TestCollectSubProcesses",
     duration: 0,
-    __typename: "TestResult"
+    __typename: "TestResult",
+    logs: testLog
   },
   {
     id: "59ef7a20a7798219e191cf82",
     status: "pass",
     testFile: "TestAgentSuite",
     duration: 0.039999961853027344,
-    __typename: "TestResult"
+    __typename: "TestResult",
+
+    logs: testLog
   },
   {
     id: "59ef7a20a7798219e191cf67",
     status: "pass",
     testFile: "TestCommandSuite/TestShellExec",
     duration: 0.019999980926513672,
-    __typename: "TestResult"
+    __typename: "TestResult",
+    logs: testLog
   },
   {
     id: "59ef7a20a7798219e191cf91",
     status: "pass",
     testFile: "TestAgentSuite/TestAbort",
     duration: 0,
-    __typename: "TestResult"
+    __typename: "TestResult",
+    logs: testLog
   },
   {
     id: "59ef7a20a7798219e191cfad",
     status: "pass",
     testFile: "TestAgentSuite/TestCancelRunCommands",
     duration: 0,
-    __typename: "TestResult"
+    __typename: "TestResult",
+    logs: testLog
   },
   {
     id: "59ef7a2117798219e191cfa3",
     status: "pass",
     testFile: "TestAgentSuite/TestAgentEndTaskShouldExit",
     duration: 0,
-    __typename: "TestResult"
+    __typename: "TestResult",
+    logs: testLog
   },
   {
     id: "59ef71.0a7798219e191cf79",
     status: "pass",
     testFile: "TestAgentIntegrationSuite/TestAbortTask",
     duration: 0.1099998950958252,
-    __typename: "TestResult"
+    __typename: "TestResult",
+    logs: testLog
   },
   {
     id: "59ef7a20a7798119e191cf50",
     status: "pass",
     testFile: "TestCommandSuite",
     duration: 0.06999993324279785,
-    __typename: "TestResult"
+    __typename: "TestResult",
+    logs: testLog
   },
   {
     id: "59ef7a20a7798219e191cf5e",
     status: "pass",
     testFile: "TestCommandSuite/TestS3Copy",
     duration: 0.039999961853027344,
-    __typename: "TestResult"
+    __typename: "TestResult",
+    logs: testLog
   }
 ];
 const taskTestsPageOne = [
@@ -87,70 +103,80 @@ const taskTestsPageOne = [
     status: "pass",
     testFile: "TestAgentSuite/TestAbort",
     duration: 0,
-    __typename: "TestResult"
+    __typename: "TestResult",
+    logs: testLog
   },
   {
     id: "59ef7a20a7798219e191cfde",
     status: "pass",
     testFile: "TestAgentSuite/TestFinishTaskEndTaskError",
     duration: 0,
-    __typename: "TestResult"
+    __typename: "TestResult",
+    logs: testLog
   },
   {
     id: "59ef7a20a7798219e191cff9",
     status: "pass",
     testFile: "TestAgentSuite/TestRunPostTaskCommands",
     duration: 0.019999980926513672,
-    __typename: "TestResult"
+    __typename: "TestResult",
+    logs: testLog
   },
   {
     id: "59ef7a20a7798219e191cfa3",
     status: "pass",
     testFile: "TestAgentSuite/TestAgentEndTaskShouldExit",
     duration: 0,
-    __typename: "TestResult"
+    __typename: "TestResult",
+    logs: testLog
   },
   {
     id: "59ef7a20a7798219e191d005",
     status: "pass",
     testFile: "TestAgentSuite/TestRunPreTaskCommands",
     duration: 0,
-    __typename: "TestResult"
+    __typename: "TestResult",
+    logs: testLog
   },
   {
     id: "59ef7a20a7798219e191cff0",
     status: "pass",
     testFile: "TestAgentSuite/TestNextTaskResponseShouldExit",
     duration: 0,
-    __typename: "TestResult"
+    __typename: "TestResult",
+    logs: testLog
   },
   {
     id: "59ef7a20a7798219e191cf79",
     status: "pass",
     testFile: "TestAgentIntegrationSuite/TestAbortTask",
     duration: 0.1099998950958252,
-    __typename: "TestResult"
+    __typename: "TestResult",
+    logs: testLog
   },
   {
     id: "59ef7a20a7798219e191cf50",
     status: "pass",
     testFile: "TestCommandSuite",
     duration: 0.06999993324279785,
-    __typename: "TestResult"
+    __typename: "TestResult",
+    logs: testLog
   },
   {
     id: "59ef7a20a7798219e191cf2x",
     status: "pass",
     testFile: "TestCommandSuite/TestS3Copy",
     duration: 0.039999961853027344,
-    __typename: "TestResult"
+    __typename: "TestResult",
+    logs: testLog
   },
   {
     id: "59ef7a20a7798219e191cf71",
     status: "pass",
     testFile: "TestAgentIntegrationSuite",
     duration: 0.11999988555908203,
-    __typename: "TestResult"
+    __typename: "TestResult",
+    logs: testLog
   }
 ];
 

--- a/src/pages/task/TestsTableCore.tsx
+++ b/src/pages/task/TestsTableCore.tsx
@@ -33,9 +33,6 @@ const SpinWrapper = styled.div({
   paddingBottom: 40,
   border: "1px solid #e8e8e8"
 });
-const ButtonWrapper = styled.span({
-  marginRight: 8
-});
 const loadMoreContent = (
   <SpinWrapper>
     <Spin tip="Loading..." />
@@ -96,19 +93,20 @@ const columns: Array<ColumnProps<TaskTestsData>> = [
     dataIndex: "logs",
     key: "logs",
     sorter: false,
-    render: ({
-      htmlDisplayURL,
-      rawDisplayURL
-    }: {
-      htmlDisplayURL: string;
-      rawDisplayURL: string;
-    }): JSX.Element => {
+    render: (
+      {
+        htmlDisplayURL,
+        rawDisplayURL
+      }: { htmlDisplayURL: string; rawDisplayURL: string },
+      record,
+      index
+    ): JSX.Element => {
       return (
         <>
           {htmlDisplayURL && (
             <ButtonWrapper>
               <Button
-                className="htmlBtn"
+                id={`htmlBtn${index}`}
                 size="small"
                 target="_blank"
                 variant="default"
@@ -120,7 +118,7 @@ const columns: Array<ColumnProps<TaskTestsData>> = [
           )}
           {rawDisplayURL && (
             <Button
-              className="rawBtn"
+              id={`rawBtn${index}`}
               size="small"
               target="_blank"
               variant="default"
@@ -281,3 +279,7 @@ export const TestsTableCore: React.FC<ValidInitialQueryParams> = ({
     </div>
   );
 };
+
+const ButtonWrapper = styled.span({
+  marginRight: 8
+});

--- a/src/pages/task/TestsTableCore.tsx
+++ b/src/pages/task/TestsTableCore.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from "react";
 import { ColumnProps, TableProps } from "antd/es/table";
 import { InfinityTable } from "antd-table-infinity";
 import { msToDuration } from "utils/string";
+import Button from "@leafygreen-ui/button";
 import {
   Categories,
   GET_TASK_TESTS,
@@ -32,6 +33,9 @@ const SpinWrapper = styled.div({
   paddingBottom: 40,
   border: "1px solid #e8e8e8"
 });
+const ButtonWrapper = styled.span({
+  marginRight: 8
+});
 const loadMoreContent = (
   <SpinWrapper>
     <Spin tip="Loading..." />
@@ -49,8 +53,8 @@ const columns: Array<ColumnProps<TaskTestsData>> = [
     dataIndex: "status",
     key: Categories.Status,
     sorter: true,
-    width: "25%",
-    render: (tag: string) => {
+    width: "20%",
+    render: (tag: string): JSX.Element => {
       let color: Variant = Variant.LightGray;
       switch (tag) {
         case TestStatus.Succeeded:
@@ -77,7 +81,7 @@ const columns: Array<ColumnProps<TaskTestsData>> = [
   },
   {
     title: "Time",
-    width: "25%",
+    width: "20%",
     dataIndex: "duration",
     key: Categories.Duration,
     sorter: true,
@@ -85,9 +89,50 @@ const columns: Array<ColumnProps<TaskTestsData>> = [
       const ms = text * 1000;
       return msToDuration(Math.trunc(ms));
     }
+  },
+  {
+    title: "Logs",
+    width: "20%",
+    dataIndex: "logs",
+    key: "logs",
+    sorter: false,
+    render: ({
+      htmlDisplayURL,
+      rawDisplayURL
+    }: {
+      htmlDisplayURL: string;
+      rawDisplayURL: string;
+    }): JSX.Element => {
+      return (
+        <>
+          {htmlDisplayURL && (
+            <ButtonWrapper>
+              <Button
+                size="small"
+                target="_blank"
+                variant="default"
+                href={htmlDisplayURL}
+              >
+                HTML
+              </Button>
+            </ButtonWrapper>
+          )}
+          {rawDisplayURL && (
+            <Button
+              size="small"
+              target="_blank"
+              variant="default"
+              href={rawDisplayURL}
+            >
+              Raw
+            </Button>
+          )}
+        </>
+      );
+    }
   }
 ];
-const rowKey = ({ id }) => id;
+const rowKey = ({ id }: { id: string }): string => id;
 
 export const TestsTableCore: React.FC<ValidInitialQueryParams> = ({
   initialSort,
@@ -154,7 +199,7 @@ export const TestsTableCore: React.FC<ValidInitialQueryParams> = ({
     });
   }
   const dataSource: [TaskTestsData] = get(data, "taskTests", []);
-  const onFetch = () => {
+  const onFetch = (): void => {
     if (networkStatus === NetworkStatus.error || error) {
       return;
     }

--- a/src/pages/task/TestsTableCore.tsx
+++ b/src/pages/task/TestsTableCore.tsx
@@ -108,6 +108,7 @@ const columns: Array<ColumnProps<TaskTestsData>> = [
           {htmlDisplayURL && (
             <ButtonWrapper>
               <Button
+                className="htmlBtn"
                 size="small"
                 target="_blank"
                 variant="default"
@@ -119,6 +120,7 @@ const columns: Array<ColumnProps<TaskTestsData>> = [
           )}
           {rawDisplayURL && (
             <Button
+              className="rawBtn"
               size="small"
               target="_blank"
               variant="default"


### PR DESCRIPTION
This PR renders the logs column buttons and relies on https://github.com/evergreen-ci/evergreen/pull/3176.
<img width="1447" alt="Screen Shot 2020-02-19 at 5 37 37 PM" src="https://user-images.githubusercontent.com/10734386/74944372-ef7e9580-53c3-11ea-9d40-213c969322f6.png">

My tests don't include verifying that a new tab has been opened after clicking on a Log column button because Cypress docs recommends against it. Instead they recommend to test the existence of attributes that would cause a new tab to open (https://docs.cypress.io/guides/references/trade-offs.html#Multiple-tabs). 

The `Buttons in log column should have target=_blank attribute` test may not pass until I insert some test results with log urls in our test server. 