### PR TITLE
get login domain based on env

### DIFF
--- a/config/.cmdrc_sample.json
+++ b/config/.cmdrc_sample.json
@@ -1,7 +1,9 @@
 {
   "devServer": {
     "REACT_APP_GQL_URL": "http://localhost:9090/graphql/query",
-    "REACT_APP_API_URL": "http://localhost:3000/api"
+    "REACT_APP_API_URL": "http://localhost:3000/api",
+    "REACT_APP_UI_URL": "http://localhost:9090",
+    "REACT_APP_SPRUCE_URL": "http://localhost:3000"
   },
   "mockIntrospectSchema": {
     "REACT_APP_GQL_URL": "http://localhost:9090/graphql/query",

--- a/src/context/auth.tsx
+++ b/src/context/auth.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useReducer, useCallback } from "react";
 import axios from "axios";
-import { getUiUrl } from "utils/getEnvironmentVariables";
+import { getLoginDomain } from "utils/getEnvironmentVariables";
 
 interface State {
   isAuthenticated: boolean;
@@ -45,7 +45,7 @@ const reducer = (state: State, action: Action): State => {
 
 const logout = async (dispatch: Dispatch) => {
   try {
-    await axios.get(`${getUiUrl()}/logout`);
+    await axios.get(`${getLoginDomain()}/logout`);
     dispatch({ type: "deauthenticate" });
   } catch (error) {
     // TODO: log errors
@@ -61,7 +61,10 @@ const login = async (
   { username, password }: LoginParams
 ) => {
   try {
-    await axios.post(`${getUiUrl()}/login`, { username, password });
+    await axios.post(`${getLoginDomain()}/login`, {
+      username,
+      password
+    });
     dispatch({ type: "authenticate" });
   } catch (error) {
     // TODO: log errors

--- a/src/utils/getEnvironmentVariables.ts
+++ b/src/utils/getEnvironmentVariables.ts
@@ -15,3 +15,11 @@ export const getGQLUrl = () => process.env.REACT_APP_GQL_URL || "";
 
 export const shouldEnableGQLMockServer = () =>
   process.env.REACT_APP_ENABLE_GQL_MOCK_SERVER === "true" ? true : false;
+
+// in development, the dev server on port 3000 proxies the local evergreen server on port 9090
+// therefore in dev we want the login domain to be localhost:3000
+// however in prod and staging and we want the login domain to be evergreen.com
+export const getLoginDomain = () =>
+  isDevelopment() || isTest()
+    ? process.env.REACT_APP_SPRUCE_URL
+    : process.env.REACT_APP_UI_URL;


### PR DESCRIPTION
the login domain was originally being set using `getUiUrl` which was returning `localhost:3000`. However the ui url refers to the evergreen ui, which means `getUiUrl` should return `loclahost:9090` in dev/test and `evergreen.mongodb.com` in prod.

I broke the auth tests when i updated the return value of `getUiUrl` to be `localhost:9090` and realized that some additional logic was necessary to determine the domain used to make HTTP requests to `/login`.

This PR adds `getLoginDomain` to the env var utility functions. 

- add `REACT_APP_SPRUCE_URL` env var to dev in `.cmd-rc` file equal to `localhost:3000`
- if in de/test - return `REACT_APP_SPRUCE_URL`
- if in prod/staging - return `REACT_APP_UI_URL`

The dev server currently proxies all requests to `localhost:9090` from `localhost:3000`. **An alternative to doing this would be to add CORS to the login/logout endpoints.** 