### PR TITLE
EVG-7485: patch page tabs

### DIFF
--- a/cypress/integration/breadcrumbs.js
+++ b/cypress/integration/breadcrumbs.js
@@ -1,7 +1,7 @@
 /// <reference types="Cypress" />
 
 const taskRoute =
-  "/task/logkeeper_ubuntu_test_edd78c1d581bf757a880777b00685321685a8e67_16_10_20_21_58_58";
+  "/task/evergreen_lint_generate_lint_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48";
 
 describe("TaskBreadcrumb", function() {
   before(() => {
@@ -10,7 +10,7 @@ describe("TaskBreadcrumb", function() {
 
   it("Shows tasks display name", function() {
     cy.visit(taskRoute);
-    cy.get("span[id=bc-task]").should("include.text", "test");
+    cy.get("span[id=bc-task]").should("include.text", "generate-lint");
   });
 
   it("Shows the patches name", function() {
@@ -20,10 +20,7 @@ describe("TaskBreadcrumb", function() {
 
   it("Clicking on the patch breadcrumb goes to patch for task", function() {
     cy.get("span[id=bc-patch]").click();
-    cy.url().should(
-      "include",
-      "/patch/logkeeper_edd78c1d581bf757a880777b00685321685a8e67"
-    );
+    cy.url().should("include", "/patch/5e4ff3abe3c3317e352062e4");
   });
 
   it("Clicking 'My Patches' breadcrumb goes to /my-patches route", function() {
@@ -38,9 +35,9 @@ describe("PatchBreadcrumb", function() {
   before(() => {
     cy.login();
   });
-  
+
   it("Shows the patches name", function() {
-    cy.visit("/patch/5e53f9c9a0182531515737ef");
+    cy.visit("/patch/5e4ff3abe3c3317e352062e4");
     // TODO: replace "Patch" with the actual patch's name once patch query is done
     cy.get("span[id=bc-patch]").should("include.text", "Patch");
   });

--- a/cypress/integration/patch-route.js
+++ b/cypress/integration/patch-route.js
@@ -1,13 +1,20 @@
 /// <reference types="Cypress" />
 
 const patch = {
-  id: "5e53f9c9a0182531515737ef",
-  desc: "'evergreen-ci/evergreen' pull request #3186 by bsamek: EVG-7425 Don't send ShouldExit to unprovisioned hosts (https://github.com/evergreen-ci/evergreen/pull/3186)"
+  id: "5e4ff3abe3c3317e352062e4",
+  desc:
+    "'evergreen-ci/evergreen' pull request #3186 by bsamek: EVG-7425 Don't send ShouldExit to unprovisioned hosts (https://github.com/evergreen-ci/evergreen/pull/3186)"
 };
+const path = `/patch/${patch.id}`;
+const pathTasks = `${path}/tasks`;
+const pathChanges = `${path}/changes`;
 
 const badPatch = {
   id: "i-dont-exist"
 };
+
+const locationPathEquals = path =>
+  cy.location().should(loc => expect(loc.pathname).to.eq(path));
 
 describe("Patch route", function() {
   beforeEach(() => {
@@ -21,11 +28,38 @@ describe("Patch route", function() {
 
   it("'Base commit' link in metadata links to version page of legacy UI", function() {
     cy.visit(`/patch/${patch.id}`);
-    cy.get("a[id=patch-base-commit]").should("have.attr", "href").and("eq", "http://localhost:9090/version/5e4ff3abe3c3317e352062e4")
+    cy.get("a[id=patch-base-commit]")
+      .should("have.attr", "href")
+      .and("eq", "http://localhost:9090/version/5e4ff3abe3c3317e352062e4");
   });
 
   it("Shows an error page if there was a problem loading data", () => {
     cy.visit(`/patch/${badPatch.id}`);
     cy.get("div[id=patch-error]").should("exist");
+  });
+
+  describe("Tabs", () => {
+    it("selects tasks tasb by default", () => {
+      cy.visit(path);
+      cy.get("button[id=task-tab]")
+        .should("have.attr", "aria-selected")
+        .and("eq", "true");
+    });
+
+    it("includes selected tab name in url path", () => {
+      cy.visit(path);
+      locationPathEquals(pathTasks);
+    });
+
+    it("updates the url path when another tab is selected", () => {
+      cy.visit(path);
+      cy.get("button[id=changes-tab]").click();
+      locationPathEquals(pathChanges);
+    });
+
+    it("replaces invalid tab names in url path with default", () => {
+      cy.visit(`${path}/chicken`);
+      locationPathEquals(pathTasks);
+    });
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1568,6 +1568,16 @@
       "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-2.0.0.tgz",
       "integrity": "sha512-QA7MKgg46RH+SRJIlSa1ebbrCr1Iijeo7FL3wAG+2vEKoPolpOd165p+q/awGaTe0COj2r1FMu93JvVZ3LJPsQ=="
     },
+    "@leafygreen-ui/tabs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tabs/-/tabs-2.0.0.tgz",
+      "integrity": "sha512-HY7gHvfCCRxJgs1MTYxvffOkOGLWIgmWVL/r2RDxJQzAj88DdEYKXaqUZ8eK8RYcElKreb16ykm29TSoy8dZOA==",
+      "requires": {
+        "@leafygreen-ui/lib": "^4.0.0",
+        "@leafygreen-ui/palette": "^2.0.0",
+        "lodash": "^4.17.11"
+      }
+    },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@leafygreen-ui/button": "^4.1.0",
     "@leafygreen-ui/card": "^2.0.0",
     "@leafygreen-ui/palette": "^2.0.0",
+    "@leafygreen-ui/tabs": "^2.0.0",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.4.0",
     "@testing-library/user-event": "^7.2.1",

--- a/src/contants/routes.ts
+++ b/src/contants/routes.ts
@@ -9,5 +9,5 @@ export const routes = {
   login: paths.login,
   myPatches: paths.myPatches,
   task: `${paths.task}/:taskID/:tab?`,
-  patch: `${paths.patch}/:patchID`
+  patch: `${paths.patch}/:patchID/:tab?`
 };

--- a/src/contants/routes.ts
+++ b/src/contants/routes.ts
@@ -8,6 +8,6 @@ export const paths = {
 export const routes = {
   login: paths.login,
   myPatches: paths.myPatches,
-  task: `${paths.task}/:taskID/:tab?`,
-  patch: `${paths.patch}/:patchID/:tab?`
+  task: `${paths.task}/:id/:tab?`,
+  patch: `${paths.patch}/:id/:tab?`
 };

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,4 +1,6 @@
 import { useEffect, useRef } from "react";
+import { useTabs } from "hooks/useTabs";
+import { useDefaultPath } from "hooks/useDefaultPath";
 
 export const usePrevious = <T>(state: T): T | undefined => {
   const ref = useRef<T>();
@@ -7,3 +9,5 @@ export const usePrevious = <T>(state: T): T | undefined => {
   }, [state]);
   return ref.current;
 };
+
+export { useTabs, useDefaultPath };

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -1,0 +1,1 @@
+export type TabToIndexMap = { [key: string]: number };

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -1,1 +1,3 @@
-export type TabToIndexMap = { [key: string]: number };
+export interface TabToIndexMap {
+  [key: string]: number;
+}

--- a/src/hooks/useDefaultPath.ts
+++ b/src/hooks/useDefaultPath.ts
@@ -22,5 +22,5 @@ export const useDefaultPath = (
     if (!tab || !(tab in tabToIndexMap)) {
       history.replace(`${path}/${id}/${defaultTab}`);
     }
-  }, [tab, history, tabToIndexMap]);
+  }, [tab, history, tabToIndexMap, defaultTab, id, path]);
 };

--- a/src/hooks/useDefaultPath.ts
+++ b/src/hooks/useDefaultPath.ts
@@ -1,0 +1,26 @@
+import { useEffect } from "react";
+import { TabToIndexMap } from "hooks/types";
+import { useParams, useHistory } from "react-router-dom";
+
+/**
+ * This hook is used to automatically put the default selected tab at the end of the url path
+ *
+ * @param  {TabToIndexMap} tabToIndexMap a JS object that maps a tab to an index
+ * the leafygreen Tab component works by using indexes which is why this is required
+ * @param  {string} path the route path, e.g. on patch page the route is "/patch"
+ * @param  {string} defaultTab the tab that is selected by default
+ */
+export const useDefaultPath = (
+  tabToIndexMap: TabToIndexMap,
+  path: string,
+  defaultTab: string
+) => {
+  const history = useHistory();
+  const { tab, id } = useParams<{ tab?: string; id: string }>();
+
+  useEffect(() => {
+    if (!tab || !(tab in tabToIndexMap)) {
+      history.replace(`${path}/${id}/${defaultTab}`);
+    }
+  }, [tab, history, tabToIndexMap]);
+};

--- a/src/hooks/useTabs.ts
+++ b/src/hooks/useTabs.ts
@@ -1,0 +1,44 @@
+import { useState } from "react";
+import { TabToIndexMap } from "hooks/types";
+import { useParams, useHistory } from "react-router-dom";
+
+type TabSelectHandler = (index: number) => void;
+
+/**
+ * This hook is used to get the state and handler function associated with using the leafygreen <Tab/> component
+ *
+ * @param  {TabToIndexMap} tabToIndexMap a JS object that maps a tab to an index
+ * the leafygreen Tab component works by using indexes which is why this is required
+ * @param  {string} path the route path, e.g. on patch page the route is "/patch"
+ * @param  {string} defaultTab the tab that is selected by default
+ * @returns {[number, (index: number) => void]}
+ * first item in returned array represents the selected tab index
+ * second item in returned array is a handler function for selecting a tab. Pass it to the <Tab/> component
+ */
+export const useTabs = (
+  tabToIndexMap: TabToIndexMap,
+  path: string,
+  defaultTab: string
+): [number, TabSelectHandler] => {
+  const { tab, id } = useParams<{ tab?: string; id: string }>();
+  const history = useHistory();
+
+  const getIndexFromTab = (tab: string) => {
+    if (tab && tab in tabToIndexMap) {
+      return tabToIndexMap[tab];
+    }
+    return tabToIndexMap[defaultTab];
+  };
+
+  const getTabFromIndex = (index: number) =>
+    Object.keys(tabToIndexMap).find(key => tabToIndexMap[key] === index);
+
+  const [selectedTab, setSelectedTab] = useState<number>(getIndexFromTab(tab));
+
+  const selectTabHandler = (tabIndex: number) => {
+    setSelectedTab(tabIndex);
+    history.replace(`${path}/${id}/${getTabFromIndex(tabIndex)}`);
+  };
+
+  return [selectedTab, selectTabHandler];
+};

--- a/src/hooks/useTabs.ts
+++ b/src/hooks/useTabs.ts
@@ -23,9 +23,9 @@ export const useTabs = (
   const { tab, id } = useParams<{ tab?: string; id: string }>();
   const history = useHistory();
 
-  const getIndexFromTab = (tab: string) => {
-    if (tab && tab in tabToIndexMap) {
-      return tabToIndexMap[tab];
+  const getIndexFromTab = (t: string) => {
+    if (t && t in tabToIndexMap) {
+      return tabToIndexMap[t];
     }
     return tabToIndexMap[defaultTab];
   };

--- a/src/pages/Patch.tsx
+++ b/src/pages/Patch.tsx
@@ -15,6 +15,7 @@ import { Divider } from "components/styles/Divider";
 import { useQuery } from "@apollo/react-hooks";
 import { GET_PATCH, PatchQuery } from "gql/queries/patch";
 import { getUiUrl } from "utils/getEnvironmentVariables";
+import { PatchTabs } from "pages/patch/PatchTabs";
 
 export const Patch = () => {
   const { patchID } = useParams<{ patchID: string }>();
@@ -75,7 +76,9 @@ export const Patch = () => {
           </SiderCard>
         </PageSider>
         <PageLayout>
-          <PageContent>I'm where the table will go</PageContent>
+          <PageContent>
+            <PatchTabs />
+          </PageContent>
         </PageLayout>
       </PageLayout>
     </PageWrapper>

--- a/src/pages/Patch.tsx
+++ b/src/pages/Patch.tsx
@@ -18,9 +18,9 @@ import { getUiUrl } from "utils/getEnvironmentVariables";
 import { PatchTabs } from "pages/patch/PatchTabs";
 
 export const Patch = () => {
-  const { patchID } = useParams<{ patchID: string }>();
+  const { id } = useParams<{ id: string }>();
   const { data, loading, error } = useQuery<PatchQuery>(GET_PATCH, {
-    variables: { id: patchID }
+    variables: { id: id }
   });
 
   if (loading) {
@@ -46,9 +46,7 @@ export const Patch = () => {
     <PageWrapper>
       <BreadCrumb displayName="Specific Patch" />
       <PageHeader>
-        <H1 id="patch-name">
-          {description ? description : `Patch: ${patchID}`}
-        </H1>
+        <H1 id="patch-name">{description ? description : `Patch: ${id}`}</H1>
       </PageHeader>
       <PageLayout>
         <PageSider>

--- a/src/pages/patch/PatchTabs.tsx
+++ b/src/pages/patch/PatchTabs.tsx
@@ -40,8 +40,8 @@ export const PatchTabs: React.FC = () => {
 
   return (
     <Tabs selected={selectedTab} setSelected={selectTabHandler}>
-      <Tab name="Tasks"></Tab>
-      <Tab name="Changes"></Tab>
+      <Tab name="Tasks" id="task-tab"></Tab>
+      <Tab name="Changes" id="changes-tab"></Tab>
     </Tabs>
   );
 };

--- a/src/pages/patch/PatchTabs.tsx
+++ b/src/pages/patch/PatchTabs.tsx
@@ -1,0 +1,47 @@
+import React, { useEffect, useState } from "react";
+import { Tabs, Tab } from "@leafygreen-ui/tabs";
+import { useParams, useHistory } from "react-router-dom";
+
+enum PatchTab {
+  Tasks = "tasks",
+  Changes = "changes"
+}
+const DEFAULT_TAB = PatchTab.Tasks;
+
+const mapTabToIndex = {
+  [PatchTab.Tasks]: 0,
+  [PatchTab.Changes]: 1
+};
+
+const getIndexFromTab = (tab: string) => {
+  if (tab && tab in mapTabToIndex) {
+    return mapTabToIndex[tab];
+  }
+  return mapTabToIndex[PatchTab.Tasks];
+};
+const getTabFromIndex = (index: number) =>
+  Object.keys(mapTabToIndex).find(key => mapTabToIndex[key] === index);
+
+export const PatchTabs: React.FC = () => {
+  const { tab, patchID } = useParams<{ tab?: Tab; patchID: string }>();
+  const history = useHistory();
+  const [selectedTab, setSelectedTab] = useState<number>(getIndexFromTab(tab));
+
+  const selectTabHandler = (tabIndex: number) => {
+    setSelectedTab(tabIndex);
+    history.replace(`/patch/${patchID}/${getTabFromIndex(tabIndex)}`);
+  };
+
+  useEffect(() => {
+    if (!tab || !(tab in mapTabToIndex)) {
+      history.replace(`/patch/${patchID}/${DEFAULT_TAB}`);
+    }
+  }, [tab, patchID, history]);
+
+  return (
+    <Tabs selected={selectedTab} setSelected={selectTabHandler}>
+      <Tab name="Tasks"></Tab>
+      <Tab name="Changes"></Tab>
+    </Tabs>
+  );
+};

--- a/src/pages/patch/PatchTabs.tsx
+++ b/src/pages/patch/PatchTabs.tsx
@@ -1,6 +1,7 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { Tabs, Tab } from "@leafygreen-ui/tabs";
-import { useParams, useHistory } from "react-router-dom";
+import { paths } from "contants/routes";
+import { useTabs, useDefaultPath } from "hooks";
 
 enum PatchTab {
   Tasks = "tasks",
@@ -8,40 +9,28 @@ enum PatchTab {
 }
 const DEFAULT_TAB = PatchTab.Tasks;
 
-const mapTabToIndex = {
+const tabToIndexMap = {
   [PatchTab.Tasks]: 0,
   [PatchTab.Changes]: 1
 };
 
-const getIndexFromTab = (tab: string) => {
-  if (tab && tab in mapTabToIndex) {
-    return mapTabToIndex[tab];
-  }
-  return mapTabToIndex[PatchTab.Tasks];
-};
-const getTabFromIndex = (index: number) =>
-  Object.keys(mapTabToIndex).find(key => mapTabToIndex[key] === index);
-
 export const PatchTabs: React.FC = () => {
-  const { tab, patchID } = useParams<{ tab?: Tab; patchID: string }>();
-  const history = useHistory();
-  const [selectedTab, setSelectedTab] = useState<number>(getIndexFromTab(tab));
+  useDefaultPath(tabToIndexMap, paths.patch, DEFAULT_TAB);
 
-  const selectTabHandler = (tabIndex: number) => {
-    setSelectedTab(tabIndex);
-    history.replace(`/patch/${patchID}/${getTabFromIndex(tabIndex)}`);
-  };
-
-  useEffect(() => {
-    if (!tab || !(tab in mapTabToIndex)) {
-      history.replace(`/patch/${patchID}/${DEFAULT_TAB}`);
-    }
-  }, [tab, patchID, history]);
+  const [selectedTab, selectTabHandler] = useTabs(
+    tabToIndexMap,
+    paths.patch,
+    DEFAULT_TAB
+  );
 
   return (
     <Tabs selected={selectedTab} setSelected={selectTabHandler}>
-      <Tab name="Tasks" id="task-tab"></Tab>
-      <Tab name="Changes" id="changes-tab"></Tab>
+      <Tab name="Tasks" id="task-tab">
+        I am the tasks table
+      </Tab>
+      <Tab name="Changes" id="changes-tab">
+        I am the patch code changes
+      </Tab>
     </Tabs>
   );
 };

--- a/src/pages/task/TestsTable.test.tsx
+++ b/src/pages/task/TestsTable.test.tsx
@@ -308,7 +308,7 @@ it("renders without crashing", () => {
   ReactDOM.render(
     <MemoryRouter>
       <MockedProvider mocks={mocks}>
-        <Route path="/task/:taskID/:tab?">
+        <Route path="/task/:id/:tab?">
           <TestsTable />
         </Route>
       </MockedProvider>
@@ -336,7 +336,7 @@ it("Requests descending data when clicking on active ascending tab", async () =>
       initialIndex={0}
     >
       <MockedProvider mocks={mocks}>
-        <Route path="/task/:taskID/:tab?">
+        <Route path="/task/:id/:tab?">
           <TestsTable />
         </Route>
       </MockedProvider>
@@ -374,7 +374,7 @@ it("It loads data on initial load when given valid query params", async () => {
       initialIndex={0}
     >
       <MockedProvider mocks={mocks}>
-        <Route path="/task/:taskID/:tab?">
+        <Route path="/task/:id/:tab?">
           <TestsTable />
         </Route>
       </MockedProvider>
@@ -406,7 +406,7 @@ it("It loads data with TEST_FILE ASC when given invalid query param", async () =
       initialIndex={0}
     >
       <MockedProvider mocks={mocks}>
-        <Route path="/task/:taskID/:tab?">
+        <Route path="/task/:id/:tab?">
           <TestsTable />
         </Route>
       </MockedProvider>
@@ -439,7 +439,7 @@ it("It loads second page when scrolling to the bottom of the table", async () =>
       initialIndex={0}
     >
       <MockedProvider mocks={mocks}>
-        <Route path="/task/:taskID/:tab?">
+        <Route path="/task/:id/:tab?">
           <TestsTable />
         </Route>
       </MockedProvider>

--- a/src/pages/task/TestsTableCore.tsx
+++ b/src/pages/task/TestsTableCore.tsx
@@ -138,7 +138,7 @@ export const TestsTableCore: React.FC<ValidInitialQueryParams> = ({
   initialSort,
   initialCategory
 }) => {
-  const { taskID } = useParams();
+  const { id } = useParams<{ id: string }>();
   const { search, pathname } = useLocation();
   const { replace } = useHistory();
   const { data, fetchMore, networkStatus, error } = useQuery<
@@ -146,7 +146,7 @@ export const TestsTableCore: React.FC<ValidInitialQueryParams> = ({
     TakskTestsVars
   >(GET_TASK_TESTS, {
     variables: {
-      id: taskID,
+      id,
       dir: initialSort === SortQueryParam.Asc ? "ASC" : "DESC",
       cat: initialCategory as Categories,
       pageNum: 0,


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-7485

![patch tabs](https://user-images.githubusercontent.com/15262143/75787040-20e85100-5d34-11ea-8315-ffe97baf405b.gif)

**Tabs on the patch page:**
- default tab is `Tasks`
- selecting a tab updates the url path to include selected path name
- invalid tab names are replaced with default

Introduces two new hooks: `useTabs` and `useDefaultPath` that will be used by the /patch and /task routes.
