### PR TITLE
EVG-7481: use local evergreen in e2e ci tests

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -228,7 +228,7 @@ tasks:
     - func: get-evergreen-project
     - func: setup-mongodb
     - func: copy-cmdrc
-    - func: run-make
+    - func: run-make-background
       vars:
         target: local-evergreen
     - func: npm-install

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -230,10 +230,7 @@ tasks:
     - func: copy-cmdrc
     - func: run-make
       vars:
-        target: load-smoke-data
-    - func: run-make-background
-      vars:
-        target: smoke-start-server
+        target: local-evergreen
     - func: npm-install
     - func: npm-start
     - func: run-cypress-tests

--- a/cypress/integration/breadcrumbs.js
+++ b/cypress/integration/breadcrumbs.js
@@ -10,24 +10,24 @@ describe("TaskBreadcrumb", function() {
 
   it("Shows tasks display name", function() {
     cy.visit(taskRoute);
-    cy.get("span[id=bc-task]").should("include.text", "generate-lint");
+    cy.get("#bc-task").should("include.text", "generate-lint");
   });
 
   it("Shows the patches name", function() {
-    cy.get("span[id=bc-patch]").should("include.text", "Patch 2567");
+    cy.get("#bc-patch").should("include.text", "Patch 2567");
   });
 
   it("Clicking on the patch breadcrumb goes to patch for task", function() {
     cy.login();
     cy.visit(taskRoute);
-    cy.get("span[id=bc-patch]").click();
+    cy.get("#bc-patch").click();
     cy.url().should("include", "/patch/5e4ff3abe3c3317e352062e4");
   });
 
   it("Clicking 'My Patches' breadcrumb goes to /my-patches route", function() {
     cy.login();
     cy.visit(taskRoute);
-    cy.get("span[id=bc-my-patches]").click();
+    cy.get("#bc-my-patches").click();
     cy.url().should("include", "/my-patches");
   });
 });
@@ -39,11 +39,11 @@ describe("PatchBreadcrumb", function() {
 
   it("Shows the patches name", function() {
     cy.visit("/patch/5e4ff3abe3c3317e352062e4");
-    cy.get("span[id=bc-patch]").should("include.text", "Patch 2567");
+    cy.get("#bc-patch").should("include.text", "Patch 2567");
   });
 
   it("Clicking 'My Patches' goes to /my-patches route", function() {
-    cy.get("span[id=bc-my-patches]").click();
+    cy.get("#bc-my-patches").click();
     cy.url().should("include", "/my-patches");
   });
 });

--- a/cypress/integration/test_table.js
+++ b/cypress/integration/test_table.js
@@ -84,7 +84,15 @@ describe("tests table", function() {
   it("Buttons in log column should have target=_blank attribute", () => {
     cy.visit(TESTS_ROUTE);
     waitForTestsQuery();
-    cy.get("#htmlBtn0").should("have.attr", "target", "_blank");
-    cy.get("#rawBtn0").should("have.attr", "target", "_blank");
+    cy.get("#htmlBtn-356534666634326434653838666165613761393066306666").should(
+      "have.attr",
+      "target",
+      "_blank"
+    );
+    cy.get("#rawBtn-356534666634326434653838666165613761393066306666").should(
+      "have.attr",
+      "target",
+      "_blank"
+    );
   });
 });

--- a/cypress/integration/test_table.js
+++ b/cypress/integration/test_table.js
@@ -4,7 +4,7 @@ import { waitForGQL } from "../utils/networking";
 const TABLE_SORT_SELECTOR = ".ant-table-column-title";
 const waitForTestsQuery = () => waitForGQL("@gqlQuery", "taskTests");
 const TESTS_ROUTE =
-  "/task/logkeeper_ubuntu_test_edd78c1d581bf757a880777b00685321685a8e67_16_10_20_21_58_58/tests";
+  "/task/evergreen_ubuntu1604_test_model_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48/tests";
 describe("tests table", function() {
   beforeEach(() => {
     cy.server();

--- a/cypress/integration/test_table_route.js
+++ b/cypress/integration/test_table_route.js
@@ -1,7 +1,7 @@
 /// <reference types="Cypress" />
 
 const taskID =
-  "performance_linux_mmap_standalone_insert_37cb7ea09393e88662e3139bd20fa29e59f2a1a3_18_01_11_00_01_36";
+  "evergreen_ubuntu1604_test_model_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48";
 
 const taskPath = `/task/${taskID}/tests`;
 

--- a/src/components/Breadcrumb/index.tsx
+++ b/src/components/Breadcrumb/index.tsx
@@ -21,22 +21,22 @@ export const BreadCrumb: React.FC<Props> = ({
   return (
     <StyledBreadcrumb>
       <Breadcrumb.Item>
-        <P1 id="bc-my-patches">
-          <StyledRouterLink to={paths.myPatches}>My Patches</StyledRouterLink>
+        <P1>
+          <StyledRouterLink id="bc-my-patches" to={paths.myPatches}>
+            My Patches
+          </StyledRouterLink>
         </P1>
       </Breadcrumb.Item>
       <Breadcrumb.Item>
-        <span id="bc-patch">
-          {taskName ? (
-            <P1>
-              <StyledRouterLink to={`${paths.patch}/${versionId}`}>
-                {patch}
-              </StyledRouterLink>
-            </P1>
-          ) : (
-            <H3>{patch}</H3>
-          )}
-        </span>
+        {taskName ? (
+          <P1>
+            <StyledRouterLink id="bc-patch" to={`${paths.patch}/${versionId}`}>
+              {patch}
+            </StyledRouterLink>
+          </P1>
+        ) : (
+          <H3 id="bc-patch">{patch}</H3>
+        )}
       </Breadcrumb.Item>
       {taskName && (
         <Breadcrumb.Item>

--- a/src/gql/queries/get-task-tests.ts
+++ b/src/gql/queries/get-task-tests.ts
@@ -4,7 +4,7 @@ export const GET_TASK_TESTS = gql`
   query taskTests(
     $dir: SortDirection
     $id: String!
-    $cat: TaskSortCategory
+    $cat: TestSortCategory
     $pageNum: Int
     $limitNum: Int
   ) {

--- a/src/pages/task/testsTable/TestsTableCore.tsx
+++ b/src/pages/task/testsTable/TestsTableCore.tsx
@@ -89,14 +89,14 @@ const columns: Array<ColumnProps<TaskTestsData>> = [
         htmlDisplayURL,
         rawDisplayURL
       }: { htmlDisplayURL: string; rawDisplayURL: string },
-      index
+      { id }
     ): JSX.Element => {
       return (
         <>
           {htmlDisplayURL && (
             <ButtonWrapper>
               <Button
-                id={`htmlBtn${index}`}
+                id={`htmlBtn-${id}`}
                 size="small"
                 target="_blank"
                 variant="default"
@@ -108,7 +108,7 @@ const columns: Array<ColumnProps<TaskTestsData>> = [
           )}
           {rawDisplayURL && (
             <Button
-              id={`rawBtn${index}`}
+              id={`rawBtn-${id}`}
               size="small"
               target="_blank"
               variant="default"


### PR DESCRIPTION
`make local-evergreen` now seeds the `evergreen_local` db with all the data required to run e2e tests in ci. `make local-evergreen` is the db we will use from now on. 

[This back end PR](https://github.com/evergreen-ci/evergreen/pull/3271) must be merged before this front end PR