### PR TITLE
EVG-7605: patch header and metadata loading and error views

### DIFF
--- a/src/components/Breadcrumb/index.tsx
+++ b/src/components/Breadcrumb/index.tsx
@@ -51,5 +51,5 @@ const StyledP1 = styled(P1)`
 `;
 
 const StyledBreadcrumb = styled(Breadcrumb)`
-  margin-bottom: 24px;
+  margin-bottom: 16px;
 `;

--- a/src/gql/queries/patch.ts
+++ b/src/gql/queries/patch.ts
@@ -1,6 +1,6 @@
 import gql from "graphql-tag";
 
-interface Patch {
+export interface Patch {
   id: string;
   description: string;
   projectID: string;

--- a/src/pages/Patch.tsx
+++ b/src/pages/Patch.tsx
@@ -23,20 +23,19 @@ export const Patch = () => {
     variables: { id: id }
   });
   const patch = get(data, "patch");
-
   return (
     <PageWrapper>
       {patch && <BreadCrumb patchNumber={patch.patchNumber} />}
       <PageHeader>
         {loading ? (
           <Skeleton active={true} paragraph={{ rows: 0 }} />
-        ) : (
+        ) : patch ? (
           <H1 id="patch-name">
             {patch.description
               ? patch.description
               : `Patch ${patch.patchNumber}`}
           </H1>
-        )}
+        ) : null}
       </PageHeader>
       <PageLayout>
         <PageSider>

--- a/src/pages/Patch.tsx
+++ b/src/pages/Patch.tsx
@@ -1,77 +1,46 @@
 import React from "react";
 import { useParams } from "react-router-dom";
+import { Skeleton } from "antd";
 import { BreadCrumb } from "components/Breadcrumb";
-import { H1, H3, P2 } from "components/Typography";
+import { H1 } from "components/Typography";
 import {
   PageWrapper,
-  SiderCard,
   PageHeader,
-  StyledLink,
   PageContent,
   PageLayout,
   PageSider
 } from "components/styles";
-import { Divider } from "components/styles/Divider";
 import { useQuery } from "@apollo/react-hooks";
 import { GET_PATCH, PatchQuery } from "gql/queries/patch";
-import { getUiUrl } from "utils/getEnvironmentVariables";
 import { PatchTabs } from "pages/patch/PatchTabs";
 import { BuildVariants } from "pages/patch/BuildVariants";
+import get from "lodash/get";
+import { Metadata } from "pages/patch/Metadata";
 
 export const Patch = () => {
   const { id } = useParams<{ id: string }>();
   const { data, loading, error } = useQuery<PatchQuery>(GET_PATCH, {
     variables: { id: id }
   });
-
-  if (loading) {
-    return <div>Loading...</div>;
-  }
-  if (error) {
-    // TODO: replace with proper error page
-    return <div id="patch-error">{error.message}</div>;
-  }
-
-  const {
-    patch: {
-      description,
-      author,
-      githash,
-      version,
-      patchNumber,
-      time: { submittedAt, started, finished },
-      duration: { makespan, timeTaken }
-    }
-  } = data;
+  const patch = get(data, "patch");
 
   return (
     <PageWrapper>
-      <BreadCrumb patchNumber={patchNumber} />
+      {patch && <BreadCrumb patchNumber={patch.patchNumber} />}
       <PageHeader>
-        <H1 id="patch-name">
-          {description ? description : `Patch ${patchNumber}`}
-        </H1>
+        {loading ? (
+          <Skeleton active={true} paragraph={{ rows: 0 }} />
+        ) : (
+          <H1 id="patch-name">
+            {patch.description
+              ? patch.description
+              : `Patch ${patch.patchNumber}`}
+          </H1>
+        )}
       </PageHeader>
       <PageLayout>
         <PageSider>
-          <SiderCard>
-            <H3>Patch Metadata</H3>
-            <Divider />
-            <P2>Makespan: {makespan && makespan}</P2>
-            <P2>Time taken: {timeTaken && timeTaken}</P2>
-            <P2>Submitted at: {submittedAt}</P2>
-            <P2>Started: {started && started}</P2>
-            <P2>Finished: {finished && finished}</P2>
-            <P2>{`Submitted by: ${author}`}</P2>
-            <P2>
-              <StyledLink
-                id="patch-base-commit"
-                href={`${getUiUrl()}/version/${version}`}
-              >
-                Base commit: {githash.slice(0, 10)}
-              </StyledLink>
-            </P2>
-          </SiderCard>
+          <Metadata loading={loading} patch={patch} error={error} />
           <BuildVariants />
         </PageSider>
         <PageLayout>

--- a/src/pages/patch/Metadata.tsx
+++ b/src/pages/patch/Metadata.tsx
@@ -22,12 +22,8 @@ export const Metadata: React.FC<Props> = ({ loading, patch, error }) => {
     );
   }
   if (error) {
-    return (
-      <MetadataCard>
-        // TODO: replace with actual error message display
-        {error.message}
-      </MetadataCard>
-    );
+    // TODO: replace with actual error message display
+    return <MetadataCard>{error.message}</MetadataCard>;
   }
   const {
     author,

--- a/src/pages/patch/Metadata.tsx
+++ b/src/pages/patch/Metadata.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { Skeleton } from "antd";
+import { P2 } from "components/Typography";
+import { StyledLink } from "components/styles";
+import { Patch } from "gql/queries/patch";
+import { getUiUrl } from "utils/getEnvironmentVariables";
+import { ApolloError } from "apollo-client";
+import { MetadataCard } from "pages/patch/metadata/MetadataCard";
+
+interface Props {
+  loading: boolean;
+  error: ApolloError;
+  patch: Patch;
+}
+
+export const Metadata: React.FC<Props> = ({ loading, patch, error }) => {
+  if (loading) {
+    return (
+      <MetadataCard>
+        <Skeleton active={true} title={false} paragraph={{ rows: 4 }} />
+      </MetadataCard>
+    );
+  }
+  if (error) {
+    return (
+      <MetadataCard>
+        // TODO: replace with actual error message display
+        {error.message}
+      </MetadataCard>
+    );
+  }
+  const {
+    author,
+    githash,
+    version,
+    time: { submittedAt, started, finished },
+    duration: { makespan, timeTaken }
+  } = patch;
+
+  return (
+    <MetadataCard>
+      <P2>Makespan: {makespan && makespan}</P2>
+      <P2>Time taken: {timeTaken && timeTaken}</P2>
+      <P2>Submitted at: {submittedAt}</P2>
+      <P2>Started: {started && started}</P2>
+      <P2>Finished: {finished && finished}</P2>
+      <P2>{`Submitted by: ${author}`}</P2>
+      <P2>
+        <StyledLink
+          id="patch-base-commit"
+          href={`${getUiUrl()}/version/${version}`}
+        >
+          Base commit: {githash.slice(0, 10)}
+        </StyledLink>
+      </P2>
+    </MetadataCard>
+  );
+};

--- a/src/pages/patch/Metadata.tsx
+++ b/src/pages/patch/Metadata.tsx
@@ -23,7 +23,9 @@ export const Metadata: React.FC<Props> = ({ loading, patch, error }) => {
   }
   if (error) {
     // TODO: replace with actual error message display
-    return <MetadataCard>{error.message}</MetadataCard>;
+    return (
+      <MetadataCard>{<div id="patch-error">{error.message}</div>}</MetadataCard>
+    );
   }
   const {
     author,

--- a/src/pages/patch/metadata/MetadataCard.tsx
+++ b/src/pages/patch/metadata/MetadataCard.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { H3 } from "components/Typography";
+import { SiderCard } from "components/styles";
+import { Divider } from "components/styles/Divider";
+
+export const MetadataCard: React.FC = ({ children }) => (
+  <SiderCard>
+    <H3>Patch Metadata</H3>
+    <Divider />
+    {children}
+  </SiderCard>
+);

--- a/src/pages/patch/patchTabs/tasks/TasksTable.tsx
+++ b/src/pages/patch/patchTabs/tasks/TasksTable.tsx
@@ -45,19 +45,17 @@ export const TasksTable: React.FC<Props> = ({ networkStatus, data }) => {
   };
 
   return (
-    <>
-      <InfinityTable
-        key="key"
-        loading={networkStatus < NetworkStatus.ready}
-        pageSize={10000}
-        loadingIndicator={loader}
-        columns={columns}
-        scroll={{ y: 350 }}
-        dataSource={data}
-        onChange={tableChangeHandler}
-        rowKey={rowKey}
-      />
-    </>
+    <InfinityTable
+      key="key"
+      loading={networkStatus < NetworkStatus.ready}
+      pageSize={10000}
+      loadingIndicator={loader}
+      columns={columns}
+      scroll={{ y: 350 }}
+      dataSource={data}
+      onChange={tableChangeHandler}
+      rowKey={rowKey}
+    />
   );
 };
 


### PR DESCRIPTION
### When patch query is loading
Show loading skeletons on patch header and in metadata card

![patch loading](https://user-images.githubusercontent.com/15262143/77071113-dddbde00-69c1-11ea-8710-d650c3106864.gif)

### When patch query errored
Display error message in metadata card and do NOT render breadcrumb and header

<img width="967" alt="Screen Shot 2020-03-19 at 9 08 55 AM" src="https://user-images.githubusercontent.com/15262143/77071158-f0eeae00-69c1-11ea-8233-14fe153770fc.png">

### When patch query is successful
Normal view

<img width="1303" alt="Screen Shot 2020-03-19 at 9 12 17 AM" src="https://user-images.githubusercontent.com/15262143/77071280-21364c80-69c2-11ea-8112-f67d9ac7036c.png">
