### PR TITLE
EVG-7489: fetch sorted tasks when patch headers are clicked

### DIFF
--- a/cypress/integration/patch-route.js
+++ b/cypress/integration/patch-route.js
@@ -113,31 +113,31 @@ describe("Patch route", function() {
         cy.visit(path);
       });
 
-      it("updates the url when column headers are clicked", () => {
+      it("Updates the url when column headers are clicked", () => {
         cy.visit(path);
 
-        cy.get("th.cy-task-table-col-name").click();
+        cy.get("th.cy-task-table-col-NAME").click();
         locationHasUpdatedParams("NAME", "ASC");
 
-        cy.get("th.cy-task-table-col-name").click();
+        cy.get("th.cy-task-table-col-NAME").click();
         locationHasUpdatedParams("NAME", "DESC");
 
-        cy.get("th.cy-task-table-col-name").click();
+        cy.get("th.cy-task-table-col-NAME").click();
         locationHasUpdatedParams("NAME");
 
-        cy.get("th.cy-task-table-col-variant").click();
+        cy.get("th.cy-task-table-col-VARIANT").click();
         locationHasUpdatedParams("VARIANT", "ASC");
 
-        cy.get("th.cy-task-table-col-variant").click();
+        cy.get("th.cy-task-table-col-VARIANT").click();
         locationHasUpdatedParams("VARIANT", "DESC");
 
-        cy.get("th.cy-task-table-col-variant").click();
+        cy.get("th.cy-task-table-col-VARIANT").click();
         locationHasUpdatedParams("VARIANT");
       });
 
       it("clicking task name goes to task page for that task", () => {
         cy.visit(path);
-        cy.get("td.cy-task-table-col-name:first").within(() => {
+        cy.get("td.cy-task-table-col-NAME:first").within(() => {
           cy.get("a")
             .should("have.attr", "href")
             .and("include", "/task");
@@ -154,30 +154,34 @@ describe("Patch route", function() {
         });
       });
 
-      it("Updates url and fetches new tasks when table sort headers are clicked", () => {
-        cy.visit(path);
-
-        cy.get("th.cy-task-table-col-name").click();
-        locationHasUpdatedParams("NAME", "ASC");
-        waitForGQL("@gqlQuery", "PatchBuildVariants");
-
-        cy.get("@gqlQuery")
-          .its("requestBody.operationName")
-          .should("equal", "PatchTasks")
-          .its("requestBody.variables.sortBy")
-          .should("equal", "NAME")
-          .its("requestBody.variables.sortDir")
-          .should("equal", "ASC");
-
-        cy.get("th.cy-task-table-col-name").click();
-        waitForGQL("@gqlQuery", "PatchBuildVariants");
-
-        cy.get("@gqlQuery")
-          .its("requestBody.operationName")
-          .should("equal", "PatchTasks")
-          .its("requestBody.variables.sortDir")
-          .should("equal", "DESC");
+      it("Fetches sorted tasks when table sort headers are clicked", () => {
+        ["NAME", "STATUS"].forEach(sortBy =>
+          clickSorterAndAssertTasksAreFetched(sortBy)
+        );
       });
     });
   });
 });
+
+const assertCorrectRequestVariabls = (sortBy, sortDir) => {
+  cy.get("@gqlQuery")
+    .its("requestBody.operationName")
+    .should("equal", "PatchTasks");
+  cy.get("@gqlQuery")
+    .its("requestBody.variables.sortBy")
+    .should("equal", sortBy);
+  cy.get("@gqlQuery")
+    .its("requestBody.variables.sortDir")
+    .should("equal", sortDir);
+};
+
+const clickSorterAndAssertTasksAreFetched = patchSortBy => {
+  cy.visit(path);
+
+  cy.get(`th.cy-task-table-col-${patchSortBy}`).click();
+  waitForGQL("@gqlQuery", "PatchBuildVariants");
+  assertCorrectRequestVariabls(patchSortBy, "ASC");
+
+  cy.get(`th.cy-task-table-col-${patchSortBy}`).click();
+  assertCorrectRequestVariabls(patchSortBy, "DESC");
+};

--- a/cypress/integration/patch-route.js
+++ b/cypress/integration/patch-route.js
@@ -157,7 +157,7 @@ describe("Patch route", function() {
       });
 
       it("Fetches sorted tasks when table sort headers are clicked", () => {
-        ["NAME", "STATUS"].forEach(sortBy =>
+        ["NAME", "STATUS", "BASE_STATUS", "VARIANT"].forEach(sortBy =>
           clickSorterAndAssertTasksAreFetched(sortBy)
         );
       });
@@ -165,7 +165,7 @@ describe("Patch route", function() {
   });
 });
 
-const assertCorrectRequestVariabls = (sortBy, sortDir) => {
+const assertCorrectRequestVariables = (sortBy, sortDir) => {
   cy.get("@gqlQuery")
     .its("requestBody.operationName")
     .should("equal", "PatchTasks");
@@ -182,8 +182,8 @@ const clickSorterAndAssertTasksAreFetched = patchSortBy => {
 
   cy.get(`th.cy-task-table-col-${patchSortBy}`).click();
   waitForGQL("@gqlQuery", "PatchBuildVariants");
-  assertCorrectRequestVariabls(patchSortBy, "ASC");
+  assertCorrectRequestVariables(patchSortBy, "ASC");
 
   cy.get(`th.cy-task-table-col-${patchSortBy}`).click();
-  assertCorrectRequestVariabls(patchSortBy, "DESC");
+  assertCorrectRequestVariables(patchSortBy, "DESC");
 };

--- a/cypress/integration/patch-route.js
+++ b/cypress/integration/patch-route.js
@@ -1,6 +1,7 @@
 /// <reference types="Cypress" />
 import { waitForGQL } from "../utils/networking";
 
+const TABLE_SORT_SELECTOR = ".ant-table-column-title";
 const patch = {
   id: "5e4ff3abe3c3317e352062e4"
 };
@@ -134,6 +135,16 @@ describe("Patch route", function() {
           cy.get("a")
             .should("have.attr", "href")
             .and("include", "/task");
+        });
+      });
+
+      it("Should have sort buttons disabled when fetching data", () => {
+        cy.visit(path);
+        cy.contains(TABLE_SORT_SELECTOR, "Name").click();
+        cy.once("fail", err => {
+          expect(err.message).to.include(
+            "'pointer-events: none' prevents user mouse interaction."
+          );
         });
       });
     });

--- a/src/gql/GQLWrapper.tsx
+++ b/src/gql/GQLWrapper.tsx
@@ -125,8 +125,8 @@ export const getGQLClient = async ({
     link: authenticateIfSuccessfulLink(dispatch)
       .concat(authLink(logout))
       .concat(retryLink)
-      .concat(link)
       .concat(timeoutLink)
+      .concat(link)
   });
   return client;
 };

--- a/src/gql/queries/get-patch-tasks.ts
+++ b/src/gql/queries/get-patch-tasks.ts
@@ -52,13 +52,10 @@ export enum TaskSortDir {
   Asc = "ASC"
 }
 
-export interface PatchUrlSearchKeys {
+export interface PatchTasksVariables {
+  patchId: string;
   sortBy?: TaskSortBy;
   sortDir?: SortDir;
   page?: number;
   statuses?: [PatchStatus];
-}
-
-export interface PatchTasksVariables extends PatchUrlSearchKeys {
-  patchId: string;
 }

--- a/src/gql/queries/get-patch-tasks.ts
+++ b/src/gql/queries/get-patch-tasks.ts
@@ -1,8 +1,22 @@
 import gql from "graphql-tag";
+import { SortDir } from "gql/queries/get-task-tests";
 
 export const GET_PATCH_TASKS = gql`
-  query PatchTasks($patchId: String!) {
-    patchTasks(patchId: $patchId, limit: 25) {
+  query PatchTasks(
+    $patchId: String!
+    $sortBy: TaskSortCategory
+    $sortDir: SortDirection
+    $page: Int
+    $statuses: [String!]
+  ) {
+    patchTasks(
+      patchId: $patchId
+      limit: 10
+      page: $page
+      statuses: $statuses
+      sortDir: $sortDir
+      sortBy: $sortBy
+    ) {
       id
       status
       baseStatus
@@ -24,6 +38,27 @@ export interface PatchTasksQuery {
   patchTasks: [TaskResult];
 }
 
-export interface PatchTasksVariables {
+type TaskSortBy = "NAME" | "STATUS" | "BASE_STATUS" | "VARIANT";
+
+export enum PatchStatus {
+  Created = "created",
+  Started = "started",
+  Success = "success",
+  Failed = "failed"
+}
+
+export enum TaskSortDir {
+  Desc = "DESC",
+  Asc = "ASC"
+}
+
+export interface PatchUrlSearchKeys {
+  sortBy?: TaskSortBy;
+  sortDir?: SortDir;
+  page?: Number;
+  statuses?: [PatchStatus];
+}
+
+export interface PatchTasksVariables extends PatchUrlSearchKeys {
   patchId: string;
 }

--- a/src/gql/queries/get-patch-tasks.ts
+++ b/src/gql/queries/get-patch-tasks.ts
@@ -55,7 +55,7 @@ export enum TaskSortDir {
 export interface PatchUrlSearchKeys {
   sortBy?: TaskSortBy;
   sortDir?: SortDir;
-  page?: Number;
+  page?: number;
   statuses?: [PatchStatus];
 }
 

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react";
 import { useTabs } from "hooks/useTabs";
 import { useDefaultPath } from "hooks/useDefaultPath";
+import { useDisableTableSortersIfLoading } from "hooks/useDisableTableSortersIfLoading";
 
 export const usePrevious = <T>(state: T): T | undefined => {
   const ref = useRef<T>();
@@ -10,4 +11,4 @@ export const usePrevious = <T>(state: T): T | undefined => {
   return ref.current;
 };
 
-export { useTabs, useDefaultPath };
+export { useTabs, useDefaultPath, useDisableTableSortersIfLoading };

--- a/src/hooks/useDisableTableSortersIfLoading.ts
+++ b/src/hooks/useDisableTableSortersIfLoading.ts
@@ -1,0 +1,21 @@
+import { useEffect } from "react";
+import { NetworkStatus } from "apollo-client";
+
+export const useDisableTableSortersIfLoading = (
+  networkStatus: NetworkStatus
+) => {
+  useEffect(() => {
+    const elements = document.querySelectorAll(
+      "th.ant-table-column-has-actions.ant-table-column-has-sorters"
+    );
+    if (networkStatus < NetworkStatus.ready) {
+      elements.forEach(el => {
+        (el as HTMLElement).style["pointer-events"] = "none";
+      });
+    } else {
+      elements.forEach(el => {
+        (el as HTMLElement).style["pointer-events"] = "auto";
+      });
+    }
+  }, [networkStatus]);
+};

--- a/src/pages/patch/patchTabs/Tasks.tsx
+++ b/src/pages/patch/patchTabs/Tasks.tsx
@@ -43,24 +43,26 @@ export const Tasks: React.FC = () => {
   useDisableTableSortersIfLoading(networkStatus);
 
   // fetch tasks when url params change
-  useEffect(() => {
-    history.listen(({ search }) => {
-      if (networkStatus === NetworkStatus.ready && !error) {
-        fetchMore({
-          variables: getQueryVariablesFromUrlSearch(id, search),
-          updateQuery: (
-            prev: PatchTasksQuery,
-            { fetchMoreResult }: { fetchMoreResult: PatchTasksQuery }
-          ) => {
-            if (!fetchMoreResult) {
-              return prev;
+  useEffect(
+    () =>
+      history.listen(({ search }) => {
+        if (networkStatus === NetworkStatus.ready && !error) {
+          fetchMore({
+            variables: getQueryVariablesFromUrlSearch(id, search),
+            updateQuery: (
+              prev: PatchTasksQuery,
+              { fetchMoreResult }: { fetchMoreResult: PatchTasksQuery }
+            ) => {
+              if (!fetchMoreResult) {
+                return prev;
+              }
+              return fetchMoreResult;
             }
-            return fetchMoreResult;
-          }
-        });
-      }
-    });
-  }, [history, fetchMore, id, error, networkStatus]);
+          });
+        }
+      }),
+    [history, fetchMore, id, error, networkStatus]
+  );
 
   if (error) {
     return <div>{error.message}</div>;

--- a/src/pages/patch/patchTabs/Tasks.tsx
+++ b/src/pages/patch/patchTabs/Tasks.tsx
@@ -1,25 +1,74 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { useQuery } from "@apollo/react-hooks";
-import { useParams } from "react-router-dom";
+import { useParams, useHistory, useLocation } from "react-router-dom";
 import {
   GET_PATCH_TASKS,
   PatchTasksQuery,
-  PatchTasksVariables
+  PatchTasksVariables,
+  PatchUrlSearchKeys,
+  PatchStatus
 } from "gql/queries/get-patch-tasks";
 import { TasksTable } from "pages/patch/patchTabs/tasks/TasksTable";
+import queryString from "query-string";
+import { useDisableTableSortersIfLoading } from "hooks";
+import { NetworkStatus } from "apollo-client";
+import { Skeleton } from "antd";
+
+const getQueryVariablesFromUrlSearch = (
+  patchId: string,
+  search: string
+): PatchTasksVariables => {
+  // TODO: add 'statuses' var here when the UI is implemented
+  const { sortBy, sortDir, page } = queryString.parse(
+    search
+  ) as PatchUrlSearchKeys;
+  return {
+    patchId,
+    sortBy,
+    sortDir,
+    page
+  } as PatchTasksVariables;
+};
 
 export const Tasks: React.FC = () => {
+  const history = useHistory();
   const { id } = useParams<{ id: string }>();
-  const { data, loading, error, networkStatus } = useQuery<
+  const { search } = useLocation();
+
+  const variables = getQueryVariablesFromUrlSearch(id, search);
+  console.log("variables :", variables);
+
+  const { data, loading, error, networkStatus, fetchMore } = useQuery<
     PatchTasksQuery,
     PatchTasksVariables
   >(GET_PATCH_TASKS, {
-    variables: { patchId: id },
+    variables: getQueryVariablesFromUrlSearch(id, search),
     notifyOnNetworkStatusChange: true
   });
+  useDisableTableSortersIfLoading(networkStatus);
 
+  useEffect(() => {
+    history.listen(({ search }) => {
+      if (networkStatus === NetworkStatus.ready && !error) {
+        fetchMore({
+          variables: getQueryVariablesFromUrlSearch(id, search),
+          updateQuery: (
+            prev: PatchTasksQuery,
+            { fetchMoreResult }: { fetchMoreResult: PatchTasksQuery }
+          ) => {
+            if (!fetchMoreResult) {
+              return prev;
+            }
+            return fetchMoreResult;
+          }
+        });
+      }
+    });
+  }, [history, fetchMore, id]);
+
+  // || networkStatus < NetworkStatus.ready
   if (loading) {
-    return <div>Loading...</div>;
+    return <Skeleton active={true} title={false} paragraph={{ rows: 10 }} />;
   }
   if (error) {
     return <div>{error.message}</div>;

--- a/src/pages/patch/patchTabs/Tasks.tsx
+++ b/src/pages/patch/patchTabs/Tasks.tsx
@@ -80,13 +80,12 @@ export const Tasks: React.FC<Props> = ({ taskCount }) => {
   if (error) {
     return <div>{error.message}</div>;
   }
+
+  const count = get(data, "patchTasks.length", "-");
+  const total = taskCount || "-";
   return (
     <>
-      {taskCount && !loading && (
-        <P2 id="task-count">
-          {get(data, "patchTasks.length", 0)}/{taskCount} tasks
-        </P2>
-      )}
+      <P2 id="task-count">{`${count} / ${total}`}</P2>
       <TasksTable
         fullTableLoad={fullTableLoad}
         loading={loading}

--- a/src/pages/patch/patchTabs/Tasks.tsx
+++ b/src/pages/patch/patchTabs/Tasks.tsx
@@ -93,5 +93,5 @@ const getQueryVariablesFromUrlSearch = (
     sortBy,
     sortDir,
     page
-  } as PatchTasksVariables;
+  };
 };

--- a/src/pages/patch/patchTabs/Tasks.tsx
+++ b/src/pages/patch/patchTabs/Tasks.tsx
@@ -31,9 +31,6 @@ export const Tasks: React.FC<Props> = ({ taskCount }) => {
     ) as PatchTasksVariables,
     notifyOnNetworkStatusChange: true
   });
-  if (error) {
-    return <div>{error.message}</div>;
-  }
   useDisableTableSortersIfLoading(networkStatus);
 
   // fetch tasks when url params change
@@ -56,6 +53,9 @@ export const Tasks: React.FC<Props> = ({ taskCount }) => {
     });
   }, [history, fetchMore, id, error, networkStatus]);
 
+  if (error) {
+    return <div>{error.message}</div>;
+  }
   const count = get(data, "patchTasks.length", "-");
   const total = taskCount || "-";
   return (

--- a/src/pages/patch/patchTabs/Tasks.tsx
+++ b/src/pages/patch/patchTabs/Tasks.tsx
@@ -35,10 +35,10 @@ export const Tasks: React.FC<Props> = ({ taskCount }) => {
 
   // fetch tasks when url params change
   useEffect(() => {
-    history.listen(({ search }) => {
+    history.listen(location => {
       if (networkStatus === NetworkStatus.ready && !error) {
         fetchMore({
-          variables: getQueryVariablesFromUrlSearch(id, search),
+          variables: getQueryVariablesFromUrlSearch(id, location.search),
           updateQuery: (
             prev: PatchTasksQuery,
             { fetchMoreResult }: { fetchMoreResult: PatchTasksQuery }

--- a/src/pages/patch/patchTabs/Tasks.tsx
+++ b/src/pages/patch/patchTabs/Tasks.tsx
@@ -14,22 +14,6 @@ import { NetworkStatus } from "apollo-client";
 import get from "lodash.get";
 import { P2 } from "components/Typography";
 
-const getQueryVariablesFromUrlSearch = (
-  patchId: string,
-  search: string
-): PatchTasksVariables => {
-  // TODO: add 'statuses' var here when the UI is implemented
-  const { sortBy, sortDir, page } = queryString.parse(
-    search
-  ) as PatchUrlSearchKeys;
-  return {
-    patchId,
-    sortBy,
-    sortDir,
-    page
-  } as PatchTasksVariables;
-};
-
 interface Props {
   taskCount: string;
 }
@@ -94,4 +78,20 @@ export const Tasks: React.FC<Props> = ({ taskCount }) => {
       />
     </>
   );
+};
+
+const getQueryVariablesFromUrlSearch = (
+  patchId: string,
+  search: string
+): PatchTasksVariables => {
+  // TODO: add 'statuses' var here when the UI is implemented
+  const { sortBy, sortDir, page } = queryString.parse(
+    search
+  ) as PatchUrlSearchKeys;
+  return {
+    patchId,
+    sortBy,
+    sortDir,
+    page
+  } as PatchTasksVariables;
 };

--- a/src/pages/patch/patchTabs/Tasks.tsx
+++ b/src/pages/patch/patchTabs/Tasks.tsx
@@ -5,8 +5,7 @@ import {
   GET_PATCH_TASKS,
   PatchTasksQuery,
   PatchTasksVariables,
-  PatchUrlSearchKeys,
-  PatchStatus
+  PatchUrlSearchKeys
 } from "gql/queries/get-patch-tasks";
 import { TasksTable } from "pages/patch/patchTabs/tasks/TasksTable";
 import queryString from "query-string";
@@ -34,10 +33,6 @@ export const Tasks: React.FC = () => {
   const history = useHistory();
   const { id } = useParams<{ id: string }>();
   const { search } = useLocation();
-
-  const variables = getQueryVariablesFromUrlSearch(id, search);
-  console.log("variables :", variables);
-
   const { data, loading, error, networkStatus, fetchMore } = useQuery<
     PatchTasksQuery,
     PatchTasksVariables
@@ -47,6 +42,7 @@ export const Tasks: React.FC = () => {
   });
   useDisableTableSortersIfLoading(networkStatus);
 
+  // fetch tasks when url params change
   useEffect(() => {
     history.listen(({ search }) => {
       if (networkStatus === NetworkStatus.ready && !error) {
@@ -64,7 +60,7 @@ export const Tasks: React.FC = () => {
         });
       }
     });
-  }, [history, fetchMore, id]);
+  }, [history, fetchMore, id, error, networkStatus]);
 
   if (error) {
     return <div>{error.message}</div>;

--- a/src/pages/patch/patchTabs/Tasks.tsx
+++ b/src/pages/patch/patchTabs/Tasks.tsx
@@ -31,10 +31,7 @@ export const Tasks: React.FC<Props> = ({ taskCount }) => {
   });
   useDisableTableSortersIfLoading(networkStatus);
 
-  const [fullTableLoad, setFullTableLoad] = React.useState(false);
-
   const fetchMoreTasks = async (search: string) => {
-    setFullTableLoad(true);
     await fetchMore({
       variables: getQueryVariablesFromUrlSearch(id, search),
       updateQuery: (
@@ -47,7 +44,6 @@ export const Tasks: React.FC<Props> = ({ taskCount }) => {
         return fetchMoreResult;
       }
     });
-    setFullTableLoad(false);
   };
 
   // fetch tasks when url params change
@@ -71,7 +67,6 @@ export const Tasks: React.FC<Props> = ({ taskCount }) => {
     <>
       <P2 id="task-count">{`${count} / ${total}`}</P2>
       <TasksTable
-        fullTableLoad={fullTableLoad}
         loading={loading}
         networkStatus={networkStatus}
         data={get(data, "patchTasks", [])}

--- a/src/pages/patch/patchTabs/Tasks.tsx
+++ b/src/pages/patch/patchTabs/Tasks.tsx
@@ -82,9 +82,9 @@ export const Tasks: React.FC<Props> = ({ taskCount }) => {
   }
   return (
     <>
-      {taskCount && (
+      {taskCount && !loading && (
         <P2 id="task-count">
-          {data.patchTasks.length}/{taskCount} tasks
+          {get(data, "patchTasks.length", 0)}/{taskCount} tasks
         </P2>
       )}
       <TasksTable

--- a/src/pages/patch/patchTabs/Tasks.tsx
+++ b/src/pages/patch/patchTabs/Tasks.tsx
@@ -12,7 +12,7 @@ import { TasksTable } from "pages/patch/patchTabs/tasks/TasksTable";
 import queryString from "query-string";
 import { useDisableTableSortersIfLoading } from "hooks";
 import { NetworkStatus } from "apollo-client";
-import { Skeleton } from "antd";
+import get from "lodash.get";
 
 const getQueryVariablesFromUrlSearch = (
   patchId: string,
@@ -66,16 +66,16 @@ export const Tasks: React.FC = () => {
     });
   }, [history, fetchMore, id]);
 
-  // || networkStatus < NetworkStatus.ready
-  if (loading) {
-    return <Skeleton active={true} title={false} paragraph={{ rows: 10 }} />;
-  }
   if (error) {
     return <div>{error.message}</div>;
   }
   return (
     <>
-      <TasksTable networkStatus={networkStatus} data={data.patchTasks} />
+      <TasksTable
+        loading={loading}
+        networkStatus={networkStatus}
+        data={get(data, "patchTasks", [])}
+      />
     </>
   );
 };

--- a/src/pages/patch/patchTabs/Tasks.tsx
+++ b/src/pages/patch/patchTabs/Tasks.tsx
@@ -65,7 +65,7 @@ export const Tasks: React.FC<Props> = ({ taskCount }) => {
   const total = taskCount || "-";
   return (
     <>
-      <P2 id="task-count">{`${count} / ${total}`}</P2>
+      <P2 id="task-count">{`${count} / ${total} tasks`}</P2>
       <TasksTable
         loading={loading}
         networkStatus={networkStatus}

--- a/src/pages/patch/patchTabs/Tasks.tsx
+++ b/src/pages/patch/patchTabs/Tasks.tsx
@@ -31,8 +31,8 @@ export const Tasks: React.FC<Props> = ({ taskCount }) => {
   });
   useDisableTableSortersIfLoading(networkStatus);
 
-  const fetchMoreTasks = async (search: string) => {
-    await fetchMore({
+  const fetchMoreTasks = (search: string) => {
+    fetchMore({
       variables: getQueryVariablesFromUrlSearch(id, search),
       updateQuery: (
         prev: PatchTasksQuery,

--- a/src/pages/patch/patchTabs/tasks/TasksTable.tsx
+++ b/src/pages/patch/patchTabs/tasks/TasksTable.tsx
@@ -14,14 +14,9 @@ import { TaskSortDir } from "gql/queries/get-patch-tasks";
 interface Props {
   networkStatus: NetworkStatus;
   data?: [TaskResult];
-  loading: boolean;
 }
 
-export const TasksTable: React.FC<Props> = ({
-  networkStatus,
-  data = [],
-  loading
-}) => {
+export const TasksTable: React.FC<Props> = ({ networkStatus, data = [] }) => {
   const { replace } = useHistory();
   const { search, pathname } = useLocation();
 
@@ -40,7 +35,7 @@ export const TasksTable: React.FC<Props> = ({
   return (
     <InfinityTable
       key="key"
-      loading={networkStatus < NetworkStatus.ready || loading}
+      loading={networkStatus < NetworkStatus.ready}
       pageSize={10000}
       loadingIndicator={loader}
       columns={columns}

--- a/src/pages/patch/patchTabs/tasks/TasksTable.tsx
+++ b/src/pages/patch/patchTabs/tasks/TasksTable.tsx
@@ -39,12 +39,10 @@ export const TasksTable: React.FC<Props> = ({
     );
   };
 
-  const isLoading = networkStatus < NetworkStatus.ready || loading;
-
   return (
     <InfinityTable
       key="key"
-      loading={networkStatus < NetworkStatus.ready}
+      loading={networkStatus < NetworkStatus.ready || loading}
       pageSize={10000}
       loadingIndicator={loader}
       columns={columns}

--- a/src/pages/patch/patchTabs/tasks/TasksTable.tsx
+++ b/src/pages/patch/patchTabs/tasks/TasksTable.tsx
@@ -15,14 +15,12 @@ interface Props {
   networkStatus: NetworkStatus;
   data?: [TaskResult];
   loading: boolean;
-  fullTableLoad: boolean;
 }
 
 export const TasksTable: React.FC<Props> = ({
   networkStatus,
   data = [],
-  loading,
-  fullTableLoad
+  loading
 }) => {
   const { replace } = useHistory();
   const { search, pathname } = useLocation();

--- a/src/pages/patch/patchTabs/tasks/TasksTable.tsx
+++ b/src/pages/patch/patchTabs/tasks/TasksTable.tsx
@@ -81,7 +81,7 @@ const columns: Array<ColumnProps<TaskResult>> = [
     key: TableColumnHeader.Name,
     sorter: true,
     width: "50%",
-    className: "cy-task-table-col-name",
+    className: "cy-task-table-col-NAME",
     render: (name: string, { id }: TaskResult) => (
       <StyledRouterLink to={`/task/${id}`}>{name}</StyledRouterLink>
     )
@@ -91,7 +91,7 @@ const columns: Array<ColumnProps<TaskResult>> = [
     dataIndex: "status",
     key: TableColumnHeader.Status,
     sorter: true,
-    className: "cy-task-table-col-status",
+    className: "cy-task-table-col-STATUS",
     render: (tag: string): JSX.Element => <Badge key={tag}>{tag}</Badge>
   },
   {
@@ -99,7 +99,7 @@ const columns: Array<ColumnProps<TaskResult>> = [
     dataIndex: "baseStatus",
     key: TableColumnHeader.BaseStatus,
     sorter: true,
-    className: "cy-task-table-col-base-status",
+    className: "cy-task-table-col-BASE_STATUS",
     render: (tag: string): JSX.Element => <Badge key={tag}>{tag}</Badge>
   },
   {
@@ -108,6 +108,6 @@ const columns: Array<ColumnProps<TaskResult>> = [
     dataIndex: "buildVariant",
     key: TableColumnHeader.Variant,
     sorter: true,
-    className: "cy-task-table-col-variant"
+    className: "cy-task-table-col-VARIANT"
   }
 ];

--- a/src/pages/patch/patchTabs/tasks/TasksTable.tsx
+++ b/src/pages/patch/patchTabs/tasks/TasksTable.tsx
@@ -15,21 +15,14 @@ interface Props {
   networkStatus: NetworkStatus;
   data?: [TaskResult];
   loading: boolean;
+  fullTableLoad: boolean;
 }
-
-const orderKeyToSortParam = {
-  ascend: TaskSortDir.Asc,
-  descend: TaskSortDir.Desc
-};
-const getSortDirFromOrder = (order: "ascend" | "descend") =>
-  orderKeyToSortParam[order];
-
-const rowKey = ({ id }: { id: string }): string => id;
 
 export const TasksTable: React.FC<Props> = ({
   networkStatus,
   data = [],
-  loading
+  loading,
+  fullTableLoad
 }) => {
   const { replace } = useHistory();
   const { search, pathname } = useLocation();
@@ -46,22 +39,33 @@ export const TasksTable: React.FC<Props> = ({
     );
   };
 
+  const isLoading = networkStatus < NetworkStatus.ready || loading;
+
   return (
     <>
       <InfinityTable
         key="key"
-        loading={networkStatus < NetworkStatus.ready || loading}
+        loading={isLoading}
         pageSize={10000}
         loadingIndicator={loader}
         columns={columns}
         scroll={{ y: 350 }}
-        dataSource={data}
+        dataSource={fullTableLoad ? [] : data}
         onChange={tableChangeHandler}
         rowKey={rowKey}
       />
     </>
   );
 };
+
+const orderKeyToSortParam = {
+  ascend: TaskSortDir.Asc,
+  descend: TaskSortDir.Desc
+};
+const getSortDirFromOrder = (order: "ascend" | "descend") =>
+  orderKeyToSortParam[order];
+
+const rowKey = ({ id }: { id: string }): string => id;
 
 enum TableColumnHeader {
   Name = "NAME",

--- a/src/pages/patch/patchTabs/tasks/TasksTable.tsx
+++ b/src/pages/patch/patchTabs/tasks/TasksTable.tsx
@@ -6,13 +6,10 @@ import Badge from "@leafygreen-ui/badge";
 import { ColumnProps } from "antd/es/table";
 import { NetworkStatus } from "apollo-client";
 import { StyledRouterLink } from "components/styles/StyledLink";
-import {
-  SortQueryParam,
-  PatchTasksQueryParams,
-  TableOnChange
-} from "types/task";
+import { PatchTasksQueryParams, TableOnChange } from "types/task";
 import { useHistory, useLocation } from "react-router-dom";
 import queryString from "query-string";
+import { TaskSortDir } from "gql/queries/get-patch-tasks";
 
 interface Props {
   networkStatus: NetworkStatus;
@@ -20,8 +17,8 @@ interface Props {
 }
 
 const orderKeyToSortParam = {
-  ascend: SortQueryParam.Asc,
-  descend: SortQueryParam.Desc
+  ascend: TaskSortDir.Asc,
+  descend: TaskSortDir.Desc
 };
 const getSortDirFromOrder = (order: "ascend" | "descend") =>
   orderKeyToSortParam[order];

--- a/src/pages/patch/patchTabs/tasks/TasksTable.tsx
+++ b/src/pages/patch/patchTabs/tasks/TasksTable.tsx
@@ -13,7 +13,8 @@ import { TaskSortDir } from "gql/queries/get-patch-tasks";
 
 interface Props {
   networkStatus: NetworkStatus;
-  data: [TaskResult];
+  data?: [TaskResult];
+  loading: boolean;
 }
 
 const orderKeyToSortParam = {
@@ -25,7 +26,11 @@ const getSortDirFromOrder = (order: "ascend" | "descend") =>
 
 const rowKey = ({ id }: { id: string }): string => id;
 
-export const TasksTable: React.FC<Props> = ({ networkStatus, data }) => {
+export const TasksTable: React.FC<Props> = ({
+  networkStatus,
+  data = [],
+  loading
+}) => {
   const { replace } = useHistory();
   const { search, pathname } = useLocation();
 
@@ -45,7 +50,7 @@ export const TasksTable: React.FC<Props> = ({ networkStatus, data }) => {
     <>
       <InfinityTable
         key="key"
-        loading={networkStatus < NetworkStatus.ready}
+        loading={networkStatus < NetworkStatus.ready || loading}
         pageSize={10000}
         loadingIndicator={loader}
         columns={columns}

--- a/src/pages/task/testsTable/TestsTableCore.tsx
+++ b/src/pages/task/testsTable/TestsTableCore.tsx
@@ -25,6 +25,7 @@ import {
 } from "types/task";
 import get from "lodash.get";
 import queryString from "query-string";
+import { useDisableTableSortersIfLoading } from "hooks";
 import { NetworkStatus } from "apollo-client";
 
 const LIMIT = 10;
@@ -144,6 +145,8 @@ export const TestsTableCore: React.FC<ValidInitialQueryParams> = ({
     },
     notifyOnNetworkStatusChange: true
   });
+  useDisableTableSortersIfLoading(networkStatus);
+
   const parsed = queryString.parse(search);
   const category = (parsed[RequiredQueryParams.Category] || "")
     .toString()
@@ -151,20 +154,7 @@ export const TestsTableCore: React.FC<ValidInitialQueryParams> = ({
   const sort = parsed[RequiredQueryParams.Sort];
   const prevCategory = usePrevious(category);
   const prevSort = usePrevious(sort);
-  useEffect(() => {
-    const elements = document.querySelectorAll(
-      "th.ant-table-column-has-actions.ant-table-column-has-sorters"
-    );
-    if (networkStatus < NetworkStatus.ready) {
-      elements.forEach(el => {
-        (el as HTMLElement).style["pointer-events"] = "none";
-      });
-    } else {
-      elements.forEach(el => {
-        (el as HTMLElement).style["pointer-events"] = "auto";
-      });
-    }
-  }, [networkStatus]);
+
   if (
     (sort !== prevSort || category !== prevCategory) &&
     networkStatus === NetworkStatus.ready &&


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-7489

![test table](https://user-images.githubusercontent.com/15262143/77207675-5c26a600-6ad0-11ea-82c3-64e51b4d8e3f.gif)

### Summary
#### User stories 
- When I click a task table header, sorted tasks are fetched and displayed corresponding to the clicked header

#### How this is achieved technically
- `history.listen` is used to listen to updates to the url location
- when url location changes, the query params in url `search` are parsed and then fed to the gql `patchTasks` query as sorters
- new tasks are fetched with `fetchMore` from `useQuery` and the tasks table is updated with the new tasks

### Up next

Fetch more tasks when user scrolls table: https://jira.mongodb.org/browse/EVG-7490
