### PR TITLE
EVG-7416: Render Code Changes in Patch page

### DIFF
--- a/cypress/integration/code_changes_table.js
+++ b/cypress/integration/code_changes_table.js
@@ -1,0 +1,36 @@
+/// <reference types="Cypress" />
+import { waitForGQL } from "../utils/networking";
+
+const patchWithChanges = "5e4ff3abe3c3317e352062e4";
+const CODE_CHANGES_ROUTE = `patch/${patchWithChanges}/changes`;
+const NO_CODE_CHANGES_ROUTE = "patch/5e6bb9e23066155a993e0f1a/changes";
+describe("task logs view", function() {
+  beforeEach(() => {
+    cy.server();
+    cy.login();
+    cy.route("POST", "/graphql/query").as("gqlQuery");
+  });
+
+  it("HTML and Raw buttons should have href when there are code changes", () => {
+    cy.visit(CODE_CHANGES_ROUTE);
+    waitForGQL("@gqlQuery", "Patch");
+    cy.get(".cy-html-diff-btn")
+      .should("have.attr", "href")
+      .and("include", `filediff/${patchWithChanges}`);
+    cy.get(".cy-raw-diff-btn")
+      .should("have.attr", "href")
+      .and("include", `rawdiff/${patchWithChanges}`);
+  });
+
+  it("Should display at least one table when there are code changes", () => {
+    cy.visit(CODE_CHANGES_ROUTE);
+    waitForGQL("@gqlQuery", "Patch");
+    cy.get(".cy-code-changes-table").should("exist");
+  });
+
+  it("Should display 'No code changes' when there are no code changes", () => {
+    cy.visit(NO_CODE_CHANGES_ROUTE);
+    waitForGQL("@gqlQuery", "Patch");
+    cy.contains("No code changes");
+  });
+});

--- a/cypress/integration/code_changes_table.js
+++ b/cypress/integration/code_changes_table.js
@@ -33,4 +33,12 @@ describe("task logs view", function() {
     waitForGQL("@gqlQuery", "Patch");
     cy.contains("No code changes");
   });
+
+  it("File names in table should have href", () => {
+    cy.visit(CODE_CHANGES_ROUTE);
+    waitForGQL("@gqlQuery", "Patch");
+    cy.get(".fileLink")
+      .should("have.attr", "href")
+      .and("include", `filediff/${patchWithChanges}`);
+  });
 });

--- a/src/gql/queries/get-code-changes.ts
+++ b/src/gql/queries/get-code-changes.ts
@@ -1,6 +1,6 @@
 import gql from "graphql-tag";
 
-interface FileDiff {
+export interface FileDiff {
   fileName: string;
   additions: number;
   deletions: number;

--- a/src/gql/queries/get-code-changes.ts
+++ b/src/gql/queries/get-code-changes.ts
@@ -1,21 +1,22 @@
 import gql from "graphql-tag";
 
 interface FileDiff {
-  fileName: String;
-  additions: Number;
-  deletions: Number;
-  diffLink: String;
+  fileName: string;
+  additions: number;
+  deletions: number;
+  diffLink: string;
 }
 
 interface ModuleCodeChange {
-  branchName: String;
-  htmlLink: String;
-  rawLink: String;
+  branchName: string;
+  htmlLink: string;
+  rawLink: string;
   fileDiffs: FileDiff[];
 }
 
 export interface Patch {
   moduleCodeChanges: ModuleCodeChange[];
+  id: string;
 }
 
 export interface GetCodeChangesQuery {
@@ -25,6 +26,7 @@ export interface GetCodeChangesQuery {
 export const GET_CODE_CHANGES = gql`
   query Patch($id: String!) {
     patch(id: $id) {
+      id
       moduleCodeChanges {
         branchName
         htmlLink

--- a/src/gql/queries/get-code-changes.ts
+++ b/src/gql/queries/get-code-changes.ts
@@ -1,0 +1,41 @@
+import gql from "graphql-tag";
+
+interface FileDiff {
+  fileName: String;
+  additions: Number;
+  deletions: Number;
+  diffLink: String;
+}
+
+interface ModuleCodeChange {
+  branchName: String;
+  htmlLink: String;
+  rawLink: String;
+  fileDiffs: FileDiff[];
+}
+
+export interface Patch {
+  moduleCodeChanges: ModuleCodeChange[];
+}
+
+export interface GetCodeChangesQuery {
+  patch: Patch;
+}
+
+export const GET_CODE_CHANGES = gql`
+  query Patch($id: String!) {
+    patch(id: $id) {
+      moduleCodeChanges {
+        branchName
+        htmlLink
+        rawLink
+        fileDiffs {
+          fileName
+          additions
+          deletions
+          diffLink
+        }
+      }
+    }
+  }
+`;

--- a/src/pages/patch/PatchTabs.tsx
+++ b/src/pages/patch/PatchTabs.tsx
@@ -3,6 +3,7 @@ import { Tab } from "@leafygreen-ui/tabs";
 import { paths } from "contants/routes";
 import { useTabs, useDefaultPath } from "hooks";
 import { Tasks } from "pages/patch/patchTabs/Tasks";
+import { CodeChanges } from "pages/patch/patchTabs/CodeChanges";
 import { StyledTabs } from "components/styles/StyledTabs";
 
 enum PatchTab {
@@ -32,10 +33,10 @@ export const PatchTabs: React.FC<Props> = ({ taskCount }) => {
   return (
     <StyledTabs selected={selectedTab} setSelected={selectTabHandler}>
       <Tab name="Tasks" id="task-tab">
-        <Tasks taskCount={taskCount}/>
+        <Tasks taskCount={taskCount} />
       </Tab>
       <Tab name="Changes" id="changes-tab">
-        I am the patch code changes
+        <CodeChanges />
       </Tab>
     </StyledTabs>
   );

--- a/src/pages/patch/patchTabs/CodeChanges.tsx
+++ b/src/pages/patch/patchTabs/CodeChanges.tsx
@@ -1,14 +1,17 @@
 import React from "react";
 import { useQuery } from "@apollo/react-hooks";
 import { useParams } from "react-router-dom";
-import { Skeleton } from "antd";
+import { Skeleton, Table } from "antd";
 import { H2 } from "components/Typography";
+import { uiColors } from "@leafygreen-ui/palette";
 import {
   GET_CODE_CHANGES,
-  GetCodeChangesQuery
+  GetCodeChangesQuery,
+  FileDiff
 } from "gql/queries/get-code-changes";
 import Button from "@leafygreen-ui/button";
 import styled from "@emotion/styled";
+import { SortOrder } from "antd/es/table";
 
 export const CodeChanges = () => {
   const { id } = useParams<{ id: string }>();
@@ -26,22 +29,29 @@ export const CodeChanges = () => {
   }
   const content = data.patch.moduleCodeChanges.map(modCodeChange => {
     return (
-      <div>
+      <div key={modCodeChange.branchName}>
         <H2>Changes on {modCodeChange.branchName}: </H2>
         <StyledButton
           size="small"
-          title="Create an item"
+          title="Open diff as html file"
           href={modCodeChange.htmlLink}
         >
           HTML
         </StyledButton>
         <StyledButton
           size="small"
-          title="Create an item"
+          title="Open diff as raw file"
           href={modCodeChange.rawLink}
         >
           RAW
         </StyledButton>
+        <StyledTable
+          rowKey={rowKey}
+          columns={columns}
+          dataSource={modCodeChange.fileDiffs}
+          pagination={false}
+          scroll={{ y: 196 }}
+        />
       </div>
     );
   });
@@ -50,4 +60,67 @@ export const CodeChanges = () => {
 
 const StyledButton = styled(Button)`
   margin-left: 16px;
+`;
+
+const columns = [
+  {
+    title: "File",
+    dataIndex: "fileName",
+    key: "fileName",
+    render: (text: string, record: FileDiff): JSX.Element => {
+      return (
+        <a
+          className="fileLink"
+          href={record.diffLink}
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          {text}
+        </a>
+      );
+    },
+    defaultSortOrder: "ascend" as SortOrder,
+    sorter: (a: FileDiff, b: FileDiff): number =>
+      a.fileName.localeCompare(b.fileName)
+  },
+  {
+    title: "Additions",
+    dataIndex: "additions",
+    key: "additions",
+    sorter: (a: FileDiff, b: FileDiff): number =>
+      a.additions < b.additions ? -1 : 1,
+    render: (text: number) => {
+      if (text === 0) {
+        return text;
+      }
+      return <Addition>+{text}</Addition>;
+    }
+  },
+  {
+    title: "Deletions",
+    dataIndex: "deletions",
+    key: "deletions",
+    sorter: (a: FileDiff, b: FileDiff): number =>
+      a.deletions < b.deletions ? -1 : 1,
+    render: (text: number) => {
+      if (text === 0) {
+        return text;
+      }
+      return <Deletion>-{text}</Deletion>;
+    }
+  }
+];
+
+const rowKey = (record: FileDiff): string => record.fileName;
+
+const Addition = styled.span`
+  color: ${uiColors.green.base};
+`;
+
+const Deletion = styled.span`
+  color: ${uiColors.red.base};
+`;
+
+const StyledTable = styled(Table)`
+  margin-top: 13px;
 `;

--- a/src/pages/patch/patchTabs/CodeChanges.tsx
+++ b/src/pages/patch/patchTabs/CodeChanges.tsx
@@ -27,34 +27,36 @@ export const CodeChanges = () => {
   if (error) {
     return <div id="patch-error">{error.message}</div>;
   }
-  <div>
-    {data.patch.moduleCodeChanges.map(modCodeChange => (
-      <div key={modCodeChange.branchName}>
-        <H2>Changes on {modCodeChange.branchName}: </H2>
-        <StyledButton
-          size="small"
-          title="Open diff as html file"
-          href={modCodeChange.htmlLink}
-        >
-          HTML
-        </StyledButton>
-        <StyledButton
-          size="small"
-          title="Open diff as raw file"
-          href={modCodeChange.rawLink}
-        >
-          RAW
-        </StyledButton>
-        <StyledTable
-          rowKey={rowKey}
-          columns={columns}
-          dataSource={modCodeChange.fileDiffs}
-          pagination={false}
-          scroll={{ y: 196 }}
-        />
-      </div>
-    ))}
-  </div>;
+  return (
+    <div>
+      {data.patch.moduleCodeChanges.map(modCodeChange => (
+        <div key={modCodeChange.branchName}>
+          <H2>Changes on {modCodeChange.branchName}: </H2>
+          <StyledButton
+            size="small"
+            title="Open diff as html file"
+            href={modCodeChange.htmlLink}
+          >
+            HTML
+          </StyledButton>
+          <StyledButton
+            size="small"
+            title="Open diff as raw file"
+            href={modCodeChange.rawLink}
+          >
+            Raw
+          </StyledButton>
+          <StyledTable
+            rowKey={rowKey}
+            columns={columns}
+            dataSource={modCodeChange.fileDiffs}
+            pagination={false}
+            scroll={{ y: 196 }}
+          />
+        </div>
+      ))}
+    </div>
+  );
 };
 
 const columns = [
@@ -95,18 +97,15 @@ const columns = [
     title: "Deletions",
     dataIndex: "deletions",
     key: "deletions",
-    sorter: (a: FileDiff, b: FileDiff): number =>
-      a.deletions < b.deletions ? -1 : 1,
-    render: (text: number) => {
-      if (text === 0) {
-        return text;
-      }
-      return <Deletion>-{text}</Deletion>;
-    }
+    sorter: (a: FileDiff, b: FileDiff): number => {
+      console.log(a.deletions, b.deletions);
+      return a.deletions < b.deletions ? 1 : -1;
+    },
+    render: (text: number) => (text === 0 ? text : <Deletion>-{text}</Deletion>)
   }
 ];
 
-const rowKey = (record: FileDiff): string => record.fileName;
+const rowKey = (record: FileDiff, index: number): string => `${index}`;
 
 const StyledButton = styled(Button)`
   margin-left: 16px;

--- a/src/pages/patch/patchTabs/CodeChanges.tsx
+++ b/src/pages/patch/patchTabs/CodeChanges.tsx
@@ -29,32 +29,37 @@ export const CodeChanges = () => {
   }
   return (
     <div>
-      {data.patch.moduleCodeChanges.map(modCodeChange => (
-        <div key={modCodeChange.branchName}>
-          <H2>Changes on {modCodeChange.branchName}: </H2>
-          <StyledButton
-            size="small"
-            title="Open diff as html file"
-            href={modCodeChange.htmlLink}
-          >
-            HTML
-          </StyledButton>
-          <StyledButton
-            size="small"
-            title="Open diff as raw file"
-            href={modCodeChange.rawLink}
-          >
-            Raw
-          </StyledButton>
-          <StyledTable
-            rowKey={rowKey}
-            columns={columns}
-            dataSource={modCodeChange.fileDiffs}
-            pagination={false}
-            scroll={{ y: 196 }}
-          />
-        </div>
-      ))}
+      {data.patch.moduleCodeChanges.map(modCodeChange => {
+        const sortedFileDiffs = [...modCodeChange.fileDiffs].sort((a, b) =>
+          a.fileName.localeCompare(b.fileName)
+        );
+        return (
+          <div key={modCodeChange.branchName}>
+            <H2>Changes on {modCodeChange.branchName}: </H2>
+            <StyledButton
+              size="small"
+              title="Open diff as html file"
+              href={modCodeChange.htmlLink}
+            >
+              HTML
+            </StyledButton>
+            <StyledButton
+              size="small"
+              title="Open diff as raw file"
+              href={modCodeChange.rawLink}
+            >
+              Raw
+            </StyledButton>
+            <StyledTable
+              rowKey={rowKey}
+              columns={columns}
+              dataSource={sortedFileDiffs}
+              pagination={false}
+              scroll={{ y: 300 }}
+            />
+          </div>
+        );
+      })}
     </div>
   );
 };
@@ -75,17 +80,12 @@ const columns = [
           {text}
         </a>
       );
-    },
-    defaultSortOrder: "ascend" as SortOrder,
-    sorter: (a: FileDiff, b: FileDiff): number =>
-      a.fileName.localeCompare(b.fileName)
+    }
   },
   {
     title: "Additions",
     dataIndex: "additions",
     key: "additions",
-    sorter: (a: FileDiff, b: FileDiff): number =>
-      a.additions < b.additions ? -1 : 1,
     render: (text: number) => {
       if (text === 0) {
         return text;
@@ -97,10 +97,6 @@ const columns = [
     title: "Deletions",
     dataIndex: "deletions",
     key: "deletions",
-    sorter: (a: FileDiff, b: FileDiff): number => {
-      console.log(a.deletions, b.deletions);
-      return a.deletions < b.deletions ? 1 : -1;
-    },
     render: (text: number) => (text === 0 ? text : <Deletion>-{text}</Deletion>)
   }
 ];

--- a/src/pages/patch/patchTabs/CodeChanges.tsx
+++ b/src/pages/patch/patchTabs/CodeChanges.tsx
@@ -1,5 +1,26 @@
 import React from "react";
+import { useQuery } from "@apollo/react-hooks";
+import { useParams } from "react-router-dom";
+import { Skeleton } from "antd";
+import {
+  GET_CODE_CHANGES,
+  GetCodeChangesQuery
+} from "gql/queries/get-code-changes";
 
 export const CodeChanges = () => {
+  const { id } = useParams<{ id: string }>();
+  const { data, loading, error } = useQuery<GetCodeChangesQuery>(
+    GET_CODE_CHANGES,
+    {
+      variables: { id: id }
+    }
+  );
+  if (loading) {
+    return <Skeleton active={true} title={true} paragraph={{ rows: 8 }} />;
+  }
+  if (error) {
+    return <div id="patch-error">{error.message}</div>;
+  }
+  console.log(data);
   return <div>Code changes 4 lyfe</div>;
 };

--- a/src/pages/patch/patchTabs/CodeChanges.tsx
+++ b/src/pages/patch/patchTabs/CodeChanges.tsx
@@ -17,7 +17,7 @@ export const CodeChanges = () => {
   const { data, loading, error } = useQuery<GetCodeChangesQuery>(
     GET_CODE_CHANGES,
     {
-      variables: { id: id }
+      variables: { id }
     }
   );
   if (loading) {
@@ -27,7 +27,7 @@ export const CodeChanges = () => {
     return <div id="patch-error">{error.message}</div>;
   }
   if (!data.patch.moduleCodeChanges.length) {
-    return <div className="cy-no-code-changes">No code changes</div>;
+    return <Title className="cy-no-code-changes">No code changes</Title>;
   }
   return (
     <div>
@@ -37,7 +37,7 @@ export const CodeChanges = () => {
         );
         return (
           <div key={modCodeChange.branchName}>
-            <H2>Changes on {modCodeChange.branchName}: </H2>
+            <Title>Changes on {modCodeChange.branchName}: </Title>
             <StyledButton
               className="cy-html-diff-btn"
               size="small"
@@ -123,4 +123,8 @@ const Deletion = styled.span`
 const StyledTable = styled(Table)`
   margin-top: 13px;
   margin-bottom: 13px;
+`;
+
+const Title = styled(H2)`
+  font-weight: normal;
 `;

--- a/src/pages/patch/patchTabs/CodeChanges.tsx
+++ b/src/pages/patch/patchTabs/CodeChanges.tsx
@@ -27,8 +27,8 @@ export const CodeChanges = () => {
   if (error) {
     return <div id="patch-error">{error.message}</div>;
   }
-  const content = data.patch.moduleCodeChanges.map(modCodeChange => {
-    return (
+  <div>
+    {data.patch.moduleCodeChanges.map(modCodeChange => (
       <div key={modCodeChange.branchName}>
         <H2>Changes on {modCodeChange.branchName}: </H2>
         <StyledButton
@@ -53,14 +53,9 @@ export const CodeChanges = () => {
           scroll={{ y: 196 }}
         />
       </div>
-    );
-  });
-  return <div>{content}</div>;
+    ))}
+  </div>;
 };
-
-const StyledButton = styled(Button)`
-  margin-left: 16px;
-`;
 
 const columns = [
   {
@@ -112,6 +107,10 @@ const columns = [
 ];
 
 const rowKey = (record: FileDiff): string => record.fileName;
+
+const StyledButton = styled(Button)`
+  margin-left: 16px;
+`;
 
 const Addition = styled.span`
   color: ${uiColors.green.base};

--- a/src/pages/patch/patchTabs/CodeChanges.tsx
+++ b/src/pages/patch/patchTabs/CodeChanges.tsx
@@ -117,4 +117,5 @@ const Deletion = styled.span`
 
 const StyledTable = styled(Table)`
   margin-top: 13px;
+  margin-bottom: 13px;
 `;

--- a/src/pages/patch/patchTabs/CodeChanges.tsx
+++ b/src/pages/patch/patchTabs/CodeChanges.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export const CodeChanges = () => {
+  return <div>Code changes 4 lyfe</div>;
+};

--- a/src/pages/patch/patchTabs/CodeChanges.tsx
+++ b/src/pages/patch/patchTabs/CodeChanges.tsx
@@ -11,7 +11,6 @@ import {
 } from "gql/queries/get-code-changes";
 import Button from "@leafygreen-ui/button";
 import styled from "@emotion/styled";
-import { SortOrder } from "antd/es/table";
 
 export const CodeChanges = () => {
   const { id } = useParams<{ id: string }>();
@@ -27,6 +26,9 @@ export const CodeChanges = () => {
   if (error) {
     return <div id="patch-error">{error.message}</div>;
   }
+  if (!data.patch.moduleCodeChanges.length) {
+    return <div className="cy-no-code-changes">No code changes</div>;
+  }
   return (
     <div>
       {data.patch.moduleCodeChanges.map(modCodeChange => {
@@ -37,6 +39,7 @@ export const CodeChanges = () => {
           <div key={modCodeChange.branchName}>
             <H2>Changes on {modCodeChange.branchName}: </H2>
             <StyledButton
+              className="cy-html-diff-btn"
               size="small"
               title="Open diff as html file"
               href={modCodeChange.htmlLink}
@@ -44,6 +47,7 @@ export const CodeChanges = () => {
               HTML
             </StyledButton>
             <StyledButton
+              className="cy-raw-diff-btn"
               size="small"
               title="Open diff as raw file"
               href={modCodeChange.rawLink}
@@ -51,6 +55,7 @@ export const CodeChanges = () => {
               Raw
             </StyledButton>
             <StyledTable
+              className="cy-code-changes-table"
               rowKey={rowKey}
               columns={columns}
               dataSource={sortedFileDiffs}

--- a/src/pages/patch/patchTabs/CodeChanges.tsx
+++ b/src/pages/patch/patchTabs/CodeChanges.tsx
@@ -2,10 +2,13 @@ import React from "react";
 import { useQuery } from "@apollo/react-hooks";
 import { useParams } from "react-router-dom";
 import { Skeleton } from "antd";
+import { H2 } from "components/Typography";
 import {
   GET_CODE_CHANGES,
   GetCodeChangesQuery
 } from "gql/queries/get-code-changes";
+import Button from "@leafygreen-ui/button";
+import styled from "@emotion/styled";
 
 export const CodeChanges = () => {
   const { id } = useParams<{ id: string }>();
@@ -21,6 +24,30 @@ export const CodeChanges = () => {
   if (error) {
     return <div id="patch-error">{error.message}</div>;
   }
-  console.log(data);
-  return <div>Code changes 4 lyfe</div>;
+  const content = data.patch.moduleCodeChanges.map(modCodeChange => {
+    return (
+      <div>
+        <H2>Changes on {modCodeChange.branchName}: </H2>
+        <StyledButton
+          size="small"
+          title="Create an item"
+          href={modCodeChange.htmlLink}
+        >
+          HTML
+        </StyledButton>
+        <StyledButton
+          size="small"
+          title="Create an item"
+          href={modCodeChange.rawLink}
+        >
+          RAW
+        </StyledButton>
+      </div>
+    );
+  });
+  return <div>{content}</div>;
 };
+
+const StyledButton = styled(Button)`
+  margin-left: 16px;
+`;


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-7416
These code changes render code changes in the Patch page. The table does not have any pagination or sort capabilities. 
Check it out here: http://localhost:3000/patch/5e4ff3abe3c3317e352062e4/changes

Spruce:
<img width="1388" alt="Screen Shot 2020-03-23 at 6 01 08 PM" src="https://user-images.githubusercontent.com/10734386/77367364-55966980-6d30-11ea-8f4e-a83380e7fbc4.png">

Design: 
<img width="1205" alt="Screen Shot 2020-03-23 at 6 02 38 PM" src="https://user-images.githubusercontent.com/10734386/77367597-e0776400-6d30-11ea-839a-8b7fb682fc05.png">

Next I'm working on the task page metadata panel.