### PR TITLE
EVG-7646: Change `npm run start:dev-server` to `npm run dev`

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -85,7 +85,7 @@ functions:
     params:
       working_dir: spruce
       background: true
-      command: npm run start:dev-server
+      command: npm run dev
 
   npm-install:
     command: shell.exec

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You can find the most recent version of this guide [here](https://github.com/fac
 - Clone the evergreen repo into your go path
 - Run `make local-evergreen`
 
-4. Run `npm run dev`. This will launch the app and point it at the local evergreen server you just ran.
+5. Run `npm run dev`. This will launch the app and point it at the local evergreen server you just ran.
 
 ### Storybook
 

--- a/README.md
+++ b/README.md
@@ -17,11 +17,14 @@ You can find the most recent version of this guide [here](https://github.com/fac
 ### Running Locally
 
 1. Clone the Spruce Github repository
-2. Run `npm install`
-3. To launch the app, run one these three commands with .cmdrc.json file set described in the next section:
-   `npm run start:dev-server` will make requests to a GQL server at http://localhost:9090/graphql/query
-   `npm run start:mock-instrospect-schema` will obtain a GQL schema via intropspection from http://localhost:9090/graphql/query and mock GQL responses
-   `npm run start:mock-custom-schema` will obtain the schema from .build-dev-cmdrc.json and mock GQL responses
+2. Ask a colleague for their .cmdrc.json file and follow the instructions [here](#environment-variables)
+3. Run `npm install`
+4. Start a local evergreen server by doing the following:
+
+- Clone the evergreen repo into your go path
+- Run `make local-evergreen`
+
+4. Run `npm run dev`. This will launch the app and point it at the local evergreen server you just ran.
 
 ### Storybook
 

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "build:prod": "env-cmd -e prod -r config/.cmdrc.json npm run build",
     "cy:open": "cypress open",
     "cy:run": "cypress run",
-    "start:dev-server": "env-cmd -e devServer -r config/.cmdrc.json npm run start",
+    "dev": "env-cmd -e devServer -r config/.cmdrc.json npm run start",
     "start:mock-instrospect-schema": "env-cmd -e mockIntrospectSchema -r config/.cmdrc.json npm run start",
     "start:mock-custom-schema": "env-cmd -e mockCustomSchema -r config/.cmdrc.json npm run start",
     "deploy": "aws s3 sync build/ s3://${BUCKET}/ --acl public-read --follow-symlinks --delete --exclude config.json",


### PR DESCRIPTION
`npm run start:dev-server` is just too darn long. I updated the README too with more explicit setup instructions.