### PR TITLE
EVG-7509: show patch status badge in header

### DIFF
--- a/src/components/Typography/index.ts
+++ b/src/components/Typography/index.ts
@@ -12,7 +12,7 @@ export const H1 = styled.h1`
 `;
 
 export const H2 = styled.h2`
-  font-size: 18px;
+  font-size: 20px;
   line-height: 21px;
   margin-bottom: 8px;
   color: ${gray.dark3};

--- a/src/components/Typography/index.ts
+++ b/src/components/Typography/index.ts
@@ -13,7 +13,7 @@ export const H1 = styled.h1`
 
 export const H2 = styled.h2`
   font-size: 20px;
-  line-height: 21px;
+  line-height: 23px;
   margin-bottom: 8px;
   color: ${gray.dark3};
   display: inline-flex;

--- a/src/components/styles/PageHeader.tsx
+++ b/src/components/styles/PageHeader.tsx
@@ -1,3 +1,5 @@
 import styled from "@emotion/styled/macro";
 
-export const PageHeader = styled.div``;
+export const PageHeader = styled.div`
+  margin-bottom: 11px;
+`;

--- a/src/pages/Patch.tsx
+++ b/src/pages/Patch.tsx
@@ -16,6 +16,8 @@ import { PatchTabs } from "pages/patch/PatchTabs";
 import { BuildVariants } from "pages/patch/BuildVariants";
 import get from "lodash/get";
 import { Metadata } from "pages/patch/Metadata";
+import Badge, { Variant } from "@leafygreen-ui/badge";
+import { PatchStatus } from "gql/queries/get-patch-tasks";
 
 export const Patch = () => {
   const { id } = useParams<{ id: string }>();
@@ -23,6 +25,7 @@ export const Patch = () => {
     variables: { id: id }
   });
   const patch = get(data, "patch");
+  const status = get(patch, "status");
   return (
     <PageWrapper>
       {patch && <BreadCrumb patchNumber={patch.patchNumber} />}
@@ -30,11 +33,16 @@ export const Patch = () => {
         {loading ? (
           <Skeleton active={true} paragraph={{ rows: 0 }} />
         ) : patch ? (
-          <H1 id="patch-name">
-            {patch.description
-              ? patch.description
-              : `Patch ${patch.patchNumber}`}
-          </H1>
+          <>
+            <H1 id="patch-name">
+              {patch.description
+                ? patch.description
+                : `Patch ${patch.patchNumber}`}{" "}
+            </H1>
+            <Badge variant={mapPatchStatusToBadgeVariant[status]}>
+              {status}
+            </Badge>
+          </>
         ) : null}
       </PageHeader>
       <PageLayout>
@@ -50,4 +58,13 @@ export const Patch = () => {
       </PageLayout>
     </PageWrapper>
   );
+};
+
+// const StyledBadge = styled(Badge)``;
+
+const mapPatchStatusToBadgeVariant = {
+  [PatchStatus.Created]: Variant.LightGray,
+  [PatchStatus.Failed]: Variant.Red,
+  [PatchStatus.Started]: Variant.Yellow,
+  [PatchStatus.Success]: Variant.Green
 };

--- a/src/pages/Patch.tsx
+++ b/src/pages/Patch.tsx
@@ -30,27 +30,27 @@ export const Patch = () => {
   return (
     <PageWrapper>
       {patch && <BreadCrumb patchNumber={patch.patchNumber} />}
-      <PageHeader>
-        {loading ? (
+      {loading ? (
+        <PageHeader>
           <Skeleton active={true} paragraph={{ rows: 0 }} />
-        ) : patch ? (
-          <>
-            <H2 id="patch-name">
-              <span>
-                {patch.description
-                  ? patch.description
-                  : `Patch ${patch.patchNumber}`}
-                {"  "}
-                <BadgeWrapper>
-                  <Badge variant={mapPatchStatusToBadgeVariant[status]}>
-                    {status}
-                  </Badge>
-                </BadgeWrapper>
-              </span>
-            </H2>
-          </>
-        ) : null}
-      </PageHeader>
+        </PageHeader>
+      ) : patch ? (
+        <PageHeader>
+          <H2 id="patch-name">
+            <span>
+              {patch.description
+                ? patch.description
+                : `Patch ${patch.patchNumber}`}
+              {"  "}
+              <BadgeWrapper>
+                <Badge variant={mapPatchStatusToBadgeVariant[status]}>
+                  {status}
+                </Badge>
+              </BadgeWrapper>
+            </span>
+          </H2>
+        </PageHeader>
+      ) : null}
       <PageLayout>
         <PageSider>
           <Metadata loading={loading} patch={patch} error={error} />

--- a/src/pages/Patch.tsx
+++ b/src/pages/Patch.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useParams } from "react-router-dom";
 import { Skeleton } from "antd";
 import { BreadCrumb } from "components/Breadcrumb";
-import { H1 } from "components/Typography";
+import { H2 } from "components/Typography";
 import {
   PageWrapper,
   PageHeader,
@@ -18,6 +18,7 @@ import get from "lodash/get";
 import { Metadata } from "pages/patch/Metadata";
 import Badge, { Variant } from "@leafygreen-ui/badge";
 import { PatchStatus } from "gql/queries/get-patch-tasks";
+import styled from "@emotion/styled";
 
 export const Patch = () => {
   const { id } = useParams<{ id: string }>();
@@ -34,14 +35,19 @@ export const Patch = () => {
           <Skeleton active={true} paragraph={{ rows: 0 }} />
         ) : patch ? (
           <>
-            <H1 id="patch-name">
-              {patch.description
-                ? patch.description
-                : `Patch ${patch.patchNumber}`}{" "}
-            </H1>
-            <Badge variant={mapPatchStatusToBadgeVariant[status]}>
-              {status}
-            </Badge>
+            <H2 id="patch-name">
+              <span>
+                {patch.description
+                  ? patch.description
+                  : `Patch ${patch.patchNumber}`}
+                {"  "}
+                <BadgeWrapper>
+                  <Badge variant={mapPatchStatusToBadgeVariant[status]}>
+                    {status}
+                  </Badge>
+                </BadgeWrapper>
+              </span>
+            </H2>
           </>
         ) : null}
       </PageHeader>
@@ -60,7 +66,9 @@ export const Patch = () => {
   );
 };
 
-// const StyledBadge = styled(Badge)``;
+const BadgeWrapper = styled.span`
+  display: inline-flex;
+`;
 
 const mapPatchStatusToBadgeVariant = {
   [PatchStatus.Created]: Variant.LightGray,


### PR DESCRIPTION
### Designs
<img width="1009" alt="Screen Shot 2020-03-25 at 12 06 10 PM" src="https://user-images.githubusercontent.com/15262143/77558194-0a479c80-6e91-11ea-8977-6e7cf517b221.png">

### Actual UI
<img width="1325" alt="Screen Shot 2020-03-25 at 12 13 36 PM" src="https://user-images.githubusercontent.com/15262143/77559063-154efc80-6e92-11ea-8c6d-ab0a7bfe48fd.png">

