### PR TITLE
EVG-7395: Task page title and status badge

### DIFF
--- a/cypress/integration/patch-route.js
+++ b/cypress/integration/patch-route.js
@@ -35,7 +35,7 @@ describe("Patch route", function() {
 
   it("Renders patch info", function() {
     cy.visit(`/patch/${patch.id}`);
-    cy.get(["data-cy=page-title"]).within(hasText);
+    cy.get("[data-cy=page-title]").within(hasText);
     cy.get("#task-count").within(hasText);
   });
 

--- a/cypress/integration/patch-route.js
+++ b/cypress/integration/patch-route.js
@@ -35,7 +35,7 @@ describe("Patch route", function() {
 
   it("Renders patch info", function() {
     cy.visit(`/patch/${patch.id}`);
-    cy.get("#patch-name").within(hasText);
+    cy.get(["data-cy=page-title"]).within(hasText);
     cy.get("#task-count").within(hasText);
   });
 

--- a/src/components/PageTitle.tsx
+++ b/src/components/PageTitle.tsx
@@ -34,6 +34,8 @@ export const PageTitle: React.FC<Props> = ({
 
 const BadgeWrapper = styled.span`
   display: inline-flex;
+  position: relative;
+  top: -2px;
 `;
 
 const PageHeader = styled.div`

--- a/src/components/PageTitle.tsx
+++ b/src/components/PageTitle.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { Skeleton } from "antd";
+import { PageHeader } from "./styles";
+import { H2 } from "./Typography";
+import styled from "@emotion/styled";
+
+interface Props {
+  loading: boolean;
+  hasData: boolean;
+  title: string;
+  badge: JSX.Element;
+}
+
+export const PageTitle: React.FC<Props> = ({
+  loading,
+  hasData,
+  title,
+  badge
+}) =>
+  loading ? (
+    <PageHeader>
+      <Skeleton active={true} paragraph={{ rows: 0 }} />
+    </PageHeader>
+  ) : hasData ? (
+    <PageHeader>
+      <H2 data-cy="page-title">
+        <span>
+          {title}
+          {"  "}
+          <BadgeWrapper>{badge}</BadgeWrapper>
+        </span>
+      </H2>
+    </PageHeader>
+  ) : null;
+
+const BadgeWrapper = styled.span`
+  display: inline-flex;
+`;

--- a/src/components/PageTitle.tsx
+++ b/src/components/PageTitle.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { Skeleton } from "antd";
-import { PageHeader } from "./styles";
 import { H2 } from "./Typography";
 import styled from "@emotion/styled";
 
@@ -35,4 +34,8 @@ export const PageTitle: React.FC<Props> = ({
 
 const BadgeWrapper = styled.span`
   display: inline-flex;
+`;
+
+const PageHeader = styled.div`
+  margin-bottom: 11px;
 `;

--- a/src/components/TaskStatusBadge.tsx
+++ b/src/components/TaskStatusBadge.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import Badge, { Variant } from "@leafygreen-ui/badge";
+import { TaskStatus } from "types/task";
+import styled from "@emotion/styled/macro";
+
+const mapTaskStatusToBadgeVariant = {
+  [TaskStatus.Inactive]: Variant.LightGray,
+  [TaskStatus.Unstarted]: Variant.LightGray,
+  [TaskStatus.Undispatched]: Variant.LightGray,
+  [TaskStatus.Started]: Variant.Yellow,
+  [TaskStatus.Dispatched]: Variant.Yellow,
+  [TaskStatus.Succeeded]: Variant.Green,
+  [TaskStatus.Failed]: Variant.Red,
+  [TaskStatus.StatusBlocked]: Variant.DarkGray,
+  [TaskStatus.StatusPending]: Variant.LightGray
+};
+
+const failureColors = {
+  text: "#800080",
+  border: "#CC99CC",
+  fill: "#E6CCE6"
+};
+
+// the status colors that are not supported by the leafygreen Badge variants
+const mapUnsupportedBadgeColors = {
+  [TaskStatus.SystemFailed]: failureColors,
+  [TaskStatus.TestTimedOut]: failureColors,
+  [TaskStatus.SetupFailed]: {
+    border: "#E7DBEC",
+    fill: "#F3EDF5",
+    text: "#877290"
+  }
+};
+
+interface BadgeColorProps {
+  border: string;
+  fill: string;
+  text: string;
+}
+
+// only use for statuses whose color is not supported by leafygreen badge variants, i.e. SystemFailed, TestTimedOut, SetupFailed
+const StyledBadge = styled(Badge)`
+  border-color: ${(props: BadgeColorProps) => props.border} !important;
+  background-color: ${(props: BadgeColorProps) => props.fill} !important;
+  color: ${(props: BadgeColorProps) => props.text} !important;
+`;
+
+export const TaskStatusBadge = ({ status }: { status: string }) => {
+  if (status in mapTaskStatusToBadgeVariant) {
+    return (
+      <Badge key={status} variant={mapTaskStatusToBadgeVariant[status]}>
+        {status}
+      </Badge>
+    );
+  } else if (status in mapUnsupportedBadgeColors) {
+    return (
+      <StyledBadge key={status} {...mapUnsupportedBadgeColors[status]}>
+        {status}
+      </StyledBadge>
+    );
+  }
+  throw new Error(`Status '${status}' is not a valid task status`);
+};

--- a/src/components/styles/PageHeader.tsx
+++ b/src/components/styles/PageHeader.tsx
@@ -1,5 +1,0 @@
-import styled from "@emotion/styled/macro";
-
-export const PageHeader = styled.div`
-  margin-bottom: 11px;
-`;

--- a/src/components/styles/index.ts
+++ b/src/components/styles/index.ts
@@ -1,6 +1,5 @@
 import { Divider } from "./Divider";
 import { PageContent, PageLayout, PageSider } from "./Layout";
-import { PageHeader } from "./PageHeader";
 import { PageWrapper } from "./PageWrapper";
 import { StyledLink, StyledRouterLink } from "./StyledLink";
 import { SiderCard } from "./SiderCard";
@@ -10,7 +9,6 @@ export {
   Divider,
   PageContent,
   PageLayout,
-  PageHeader,
   PageSider,
   PageWrapper,
   StyledLink,

--- a/src/pages/Patch.tsx
+++ b/src/pages/Patch.tsx
@@ -66,13 +66,13 @@ export const Patch = () => {
   );
 };
 
-const BadgeWrapper = styled.span`
-  display: inline-flex;
-`;
-
 const mapPatchStatusToBadgeVariant = {
   [PatchStatus.Created]: Variant.LightGray,
   [PatchStatus.Failed]: Variant.Red,
   [PatchStatus.Started]: Variant.Yellow,
   [PatchStatus.Success]: Variant.Green
 };
+
+export const BadgeWrapper = styled.span`
+  display: inline-flex;
+`;

--- a/src/pages/Patch.tsx
+++ b/src/pages/Patch.tsx
@@ -1,12 +1,9 @@
 import React from "react";
 import { useParams } from "react-router-dom";
-import { Skeleton } from "antd";
 import { BreadCrumb } from "components/Breadcrumb";
 import { PageTitle } from "components/PageTitle";
-import { H2 } from "components/Typography";
 import {
   PageWrapper,
-  PageHeader,
   PageContent,
   PageLayout,
   PageSider
@@ -19,7 +16,6 @@ import get from "lodash/get";
 import { Metadata } from "pages/patch/Metadata";
 import Badge, { Variant } from "@leafygreen-ui/badge";
 import { PatchStatus } from "gql/queries/get-patch-tasks";
-import styled from "@emotion/styled";
 
 export const Patch = () => {
   const { id } = useParams<{ id: string }>();
@@ -55,10 +51,6 @@ export const Patch = () => {
     </PageWrapper>
   );
 };
-
-const BadgeWrapper = styled.span`
-  display: inline-flex;
-`;
 
 const mapPatchStatusToBadgeVariant = {
   [PatchStatus.Created]: Variant.LightGray,

--- a/src/pages/Patch.tsx
+++ b/src/pages/Patch.tsx
@@ -66,13 +66,13 @@ export const Patch = () => {
   );
 };
 
+export const BadgeWrapper = styled.span`
+  display: inline-flex;
+`;
+
 const mapPatchStatusToBadgeVariant = {
   [PatchStatus.Created]: Variant.LightGray,
   [PatchStatus.Failed]: Variant.Red,
   [PatchStatus.Started]: Variant.Yellow,
   [PatchStatus.Success]: Variant.Green
 };
-
-export const BadgeWrapper = styled.span`
-  display: inline-flex;
-`;

--- a/src/pages/Patch.tsx
+++ b/src/pages/Patch.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { useParams } from "react-router-dom";
 import { Skeleton } from "antd";
 import { BreadCrumb } from "components/Breadcrumb";
+import { PageTitle } from "components/PageTitle";
 import { H2 } from "components/Typography";
 import {
   PageWrapper,
@@ -27,30 +28,19 @@ export const Patch = () => {
   });
   const patch = get(data, "patch");
   const status = get(patch, "status");
+  const description = get(patch, "description");
   return (
     <PageWrapper>
       {patch && <BreadCrumb patchNumber={patch.patchNumber} />}
-      {loading ? (
-        <PageHeader>
-          <Skeleton active={true} paragraph={{ rows: 0 }} />
-        </PageHeader>
-      ) : patch ? (
-        <PageHeader>
-          <H2 id="patch-name">
-            <span>
-              {patch.description
-                ? patch.description
-                : `Patch ${patch.patchNumber}`}
-              {"  "}
-              <BadgeWrapper>
-                <Badge variant={mapPatchStatusToBadgeVariant[status]}>
-                  {status}
-                </Badge>
-              </BadgeWrapper>
-            </span>
-          </H2>
-        </PageHeader>
-      ) : null}
+      <PageTitle
+        loading={loading}
+        hasData={!!data}
+        title={description ? description : `Patch ${get(patch, "patchNumber")}`}
+        badge={
+          <Badge variant={mapPatchStatusToBadgeVariant[status]}>{status}</Badge>
+        }
+      />
+
       <PageLayout>
         <PageSider>
           <Metadata loading={loading} patch={patch} error={error} />

--- a/src/pages/Patch.tsx
+++ b/src/pages/Patch.tsx
@@ -30,7 +30,7 @@ export const Patch = () => {
       {patch && <BreadCrumb patchNumber={patch.patchNumber} />}
       <PageTitle
         loading={loading}
-        hasData={!!data}
+        hasData={!!patch}
         title={description ? description : `Patch ${get(patch, "patchNumber")}`}
         badge={
           <Badge variant={mapPatchStatusToBadgeVariant[status]}>{status}</Badge>

--- a/src/pages/Patch.tsx
+++ b/src/pages/Patch.tsx
@@ -66,7 +66,7 @@ export const Patch = () => {
   );
 };
 
-export const BadgeWrapper = styled.span`
+const BadgeWrapper = styled.span`
   display: inline-flex;
 `;
 

--- a/src/pages/Task.tsx
+++ b/src/pages/Task.tsx
@@ -8,7 +8,6 @@ import { PageTitle } from "components/PageTitle";
 import { Logs } from "pages/task/Logs";
 import gql from "graphql-tag";
 import { useQuery } from "@apollo/react-hooks";
-import { H2 } from "components/Typography";
 import { ErrorBoundary } from "components/ErrorBoundary";
 import {
   PageWrapper,
@@ -21,7 +20,6 @@ import { useDefaultPath, useTabs } from "hooks";
 import { Tab } from "@leafygreen-ui/tabs";
 import { StyledTabs } from "components/styles/StyledTabs";
 import { paths } from "contants/routes";
-import styled from "@emotion/styled";
 
 enum TaskTab {
   Logs = "logs",

--- a/src/pages/Task.tsx
+++ b/src/pages/Task.tsx
@@ -8,6 +8,7 @@ import { Logs } from "pages/task/Logs";
 import gql from "graphql-tag";
 import { useQuery } from "@apollo/react-hooks";
 import { H2 } from "components/Typography";
+import { ErrorBoundary } from "components/ErrorBoundary";
 import {
   PageWrapper,
   SiderCard,
@@ -96,7 +97,9 @@ export const Task: React.FC = () => {
           <H2 id="task-name">{displayName}</H2>
           {"  "}
           <BadgeWrapper>
-            <TaskStatusBadge status={status} />
+            <ErrorBoundary>
+              <TaskStatusBadge status={status} />
+            </ErrorBoundary>
           </BadgeWrapper>
         </PageHeader>
       ) : null}

--- a/src/pages/Task.tsx
+++ b/src/pages/Task.tsx
@@ -92,11 +92,9 @@ export const Task: React.FC = () => {
         hasData={!!(displayName && status)}
         title={displayName}
         badge={
-          <BadgeWrapper>
-            <ErrorBoundary>
-              <TaskStatusBadge status={status} />
-            </ErrorBoundary>
-          </BadgeWrapper>
+          <ErrorBoundary>
+            <TaskStatusBadge status={status} />
+          </ErrorBoundary>
         }
       />
       <PageLayout>
@@ -123,8 +121,3 @@ export const Task: React.FC = () => {
     </PageWrapper>
   );
 };
-
-const BadgeWrapper = styled.span`
-  top: -2px;
-  position: relative;
-`;

--- a/src/pages/Task.tsx
+++ b/src/pages/Task.tsx
@@ -3,10 +3,11 @@ import { useParams } from "react-router-dom";
 import { TestsTable } from "pages/task/TestsTable";
 import { FilesTables } from "./task/FilesTables";
 import { BreadCrumb } from "components/Breadcrumb";
+import { TaskStatusBadge } from "components/TaskStatusBadge";
 import { Logs } from "pages/task/Logs";
 import gql from "graphql-tag";
 import { useQuery } from "@apollo/react-hooks";
-import { H1 } from "components/Typography";
+import { H2 } from "components/Typography";
 import {
   PageWrapper,
   SiderCard,
@@ -19,6 +20,8 @@ import { useDefaultPath, useTabs } from "hooks";
 import { Tab } from "@leafygreen-ui/tabs";
 import { StyledTabs } from "components/styles/StyledTabs";
 import { paths } from "contants/routes";
+import { Skeleton } from "antd";
+import styled from "@emotion/styled";
 
 enum TaskTab {
   Logs = "logs",
@@ -40,6 +43,7 @@ const GET_TASK = gql`
       version
       displayName
       patchNumber
+      status
     }
   }
 `;
@@ -49,6 +53,7 @@ interface TaskQuery {
     version: string;
     displayName: string;
     patchNumber: number;
+    status: string;
   };
 }
 
@@ -72,7 +77,7 @@ export const Task: React.FC = () => {
     return <div>{error.message}</div>;
   }
   const {
-    task: { displayName, version, patchNumber }
+    task: { displayName, version, patchNumber, status }
   } = data;
 
   return (
@@ -82,9 +87,19 @@ export const Task: React.FC = () => {
         versionId={version}
         patchNumber={patchNumber}
       />
-      <PageHeader>
-        <H1>Current Task Name</H1>
-      </PageHeader>
+      {loading ? (
+        <PageHeader>
+          <Skeleton active={true} paragraph={{ rows: 0 }} />
+        </PageHeader>
+      ) : displayName || status ? (
+        <PageHeader>
+          <H2 id="task-name">{displayName}</H2>
+          {"  "}
+          <BadgeWrapper>
+            <TaskStatusBadge status={status} />
+          </BadgeWrapper>
+        </PageHeader>
+      ) : null}
       <PageLayout>
         <PageSider>
           <SiderCard>Patch Metadata</SiderCard>
@@ -109,3 +124,8 @@ export const Task: React.FC = () => {
     </PageWrapper>
   );
 };
+
+const BadgeWrapper = styled.span`
+  top: -3px;
+  position: relative;
+`;

--- a/src/pages/Task.tsx
+++ b/src/pages/Task.tsx
@@ -4,6 +4,7 @@ import { TestsTable } from "pages/task/TestsTable";
 import { FilesTables } from "./task/FilesTables";
 import { BreadCrumb } from "components/Breadcrumb";
 import { TaskStatusBadge } from "components/TaskStatusBadge";
+import { PageTitle } from "components/PageTitle";
 import { Logs } from "pages/task/Logs";
 import gql from "graphql-tag";
 import { useQuery } from "@apollo/react-hooks";
@@ -12,7 +13,6 @@ import { ErrorBoundary } from "components/ErrorBoundary";
 import {
   PageWrapper,
   SiderCard,
-  PageHeader,
   PageContent,
   PageLayout,
   PageSider
@@ -21,7 +21,6 @@ import { useDefaultPath, useTabs } from "hooks";
 import { Tab } from "@leafygreen-ui/tabs";
 import { StyledTabs } from "components/styles/StyledTabs";
 import { paths } from "contants/routes";
-import { Skeleton } from "antd";
 import styled from "@emotion/styled";
 
 enum TaskTab {
@@ -88,21 +87,18 @@ export const Task: React.FC = () => {
         versionId={version}
         patchNumber={patchNumber}
       />
-      {loading ? (
-        <PageHeader>
-          <Skeleton active={true} paragraph={{ rows: 0 }} />
-        </PageHeader>
-      ) : displayName || status ? (
-        <PageHeader>
-          <H2 id="task-name">{displayName}</H2>
-          {"  "}
+      <PageTitle
+        loading={loading}
+        hasData={!!(displayName && status)}
+        title={displayName}
+        badge={
           <BadgeWrapper>
             <ErrorBoundary>
               <TaskStatusBadge status={status} />
             </ErrorBoundary>
           </BadgeWrapper>
-        </PageHeader>
-      ) : null}
+        }
+      />
       <PageLayout>
         <PageSider>
           <SiderCard>Patch Metadata</SiderCard>
@@ -129,6 +125,6 @@ export const Task: React.FC = () => {
 };
 
 const BadgeWrapper = styled.span`
-  top: -3px;
+  top: -2px;
   position: relative;
 `;

--- a/src/pages/patch/patchTabs/tasks/TasksTable.tsx
+++ b/src/pages/patch/patchTabs/tasks/TasksTable.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { loader } from "components/Loading/Loader";
+import { TaskStatusBadge } from "components/TaskStatusBadge";
 import { TaskResult } from "gql/queries/get-patch-tasks";
 import { InfinityTable } from "antd-table-infinity";
-import Badge, { Variant } from "@leafygreen-ui/badge";
 import { ColumnProps } from "antd/es/table";
 import { NetworkStatus } from "apollo-client";
 import { StyledRouterLink } from "components/styles/StyledLink";
@@ -10,8 +10,6 @@ import { PatchTasksQueryParams, TableOnChange } from "types/task";
 import { useHistory, useLocation } from "react-router-dom";
 import queryString from "query-string";
 import { TaskSortDir } from "gql/queries/get-patch-tasks";
-import { TaskStatus } from "types/task";
-import styled from "@emotion/styled/macro";
 
 interface Props {
   networkStatus: NetworkStatus;
@@ -64,65 +62,6 @@ const getSortDirFromOrder = (order: "ascend" | "descend") =>
 
 const rowKey = ({ id }: { id: string }): string => id;
 
-const mapTaskStatusToBadgeVariant = {
-  [TaskStatus.Inactive]: Variant.LightGray,
-  [TaskStatus.Unstarted]: Variant.LightGray,
-  [TaskStatus.Undispatched]: Variant.LightGray,
-  [TaskStatus.Started]: Variant.Yellow,
-  [TaskStatus.Dispatched]: Variant.Yellow,
-  [TaskStatus.Succeeded]: Variant.Green,
-  [TaskStatus.Failed]: Variant.Red,
-  [TaskStatus.StatusBlocked]: Variant.DarkGray,
-  [TaskStatus.StatusPending]: Variant.LightGray
-};
-
-const failureColors = {
-  text: "#800080",
-  border: "#CC99CC",
-  fill: "#E6CCE6"
-};
-
-// the status colors that are not supported by the leafygreen Badge variants
-const mapUnsupportedBadgeColors = {
-  [TaskStatus.SystemFailed]: failureColors,
-  [TaskStatus.TestTimedOut]: failureColors,
-  [TaskStatus.SetupFailed]: {
-    border: "#E7DBEC",
-    fill: "#F3EDF5",
-    text: "#877290"
-  }
-};
-
-interface BadgeColorProps {
-  border: string;
-  fill: string;
-  text: string;
-}
-
-// only use for statuses whose color is not supported by leafygreen badge variants, i.e. SystemFailed, TestTimedOut, SetupFailed
-const StyledBadge = styled(Badge)`
-  border-color: ${(props: BadgeColorProps) => props.border} !important;
-  background-color: ${(props: BadgeColorProps) => props.fill} !important;
-  color: ${(props: BadgeColorProps) => props.text} !important;
-`;
-
-const renderStatusBadge = (status: string) => {
-  if (status in mapTaskStatusToBadgeVariant) {
-    return (
-      <Badge key={status} variant={mapTaskStatusToBadgeVariant[status]}>
-        {status}
-      </Badge>
-    );
-  } else if (status in mapUnsupportedBadgeColors) {
-    return (
-      <StyledBadge key={status} {...mapUnsupportedBadgeColors[status]}>
-        {status}
-      </StyledBadge>
-    );
-  }
-  throw new Error(`Status '${status}' is not a valid task status`);
-};
-
 enum TableColumnHeader {
   Name = "NAME",
   Status = "STATUS",
@@ -130,6 +69,7 @@ enum TableColumnHeader {
   Variant = "VARIANT"
 }
 
+const renderStatusBadge = status => <TaskStatusBadge status={status} />;
 const columns: Array<ColumnProps<TaskResult>> = [
   {
     title: "Name",


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-7395

This PR is mostly refactoring the TaskStatusBadge so we can use it on the task page as well as the task table. 

<img width="451" alt="Screen Shot 2020-03-26 at 2 50 52 PM" src="https://user-images.githubusercontent.com/10734386/77685120-4fdb9680-6f71-11ea-9d5d-7feb7a344d40.png">
