### PR TITLE
EVG-7633: adjust to taskFiles query schema changes

### DIFF
--- a/src/gql/queries/get-task-files.ts
+++ b/src/gql/queries/get-task-files.ts
@@ -30,6 +30,7 @@ export interface TaskFilesVars {
 interface TaskFilesData {
   groupedFiles: GroupedFiles[];
 }
+
 export interface TaskFilesResponse {
   taskFiles: TaskFilesData;
 }

--- a/src/gql/queries/get-task-files.ts
+++ b/src/gql/queries/get-task-files.ts
@@ -3,10 +3,12 @@ import gql from "graphql-tag";
 export const GET_TASK_FILES = gql`
   query taskFiles($id: String!) {
     taskFiles(taskId: $id) {
-      taskName
-      files {
-        name
-        link
+      groupedFiles {
+        taskName
+        files {
+          name
+          link
+        }
       }
     }
   }
@@ -16,15 +18,18 @@ export interface File {
   link: string;
 }
 
-export interface TaskFilesData {
+export interface GroupedFiles {
   taskName: string;
-  files: [File];
+  files: File[];
 }
 
 export interface TaskFilesVars {
   id: string;
 }
 
+interface TaskFilesData {
+  groupedFiles: GroupedFiles[];
+}
 export interface TaskFilesResponse {
-  taskFiles: [TaskFilesData];
+  taskFiles: TaskFilesData;
 }

--- a/src/pages/task/FilesTables.tsx
+++ b/src/pages/task/FilesTables.tsx
@@ -15,7 +15,6 @@ import Icon from "@leafygreen-ui/icon";
 import { Input } from "antd";
 import debounce from "lodash.debounce";
 import { SortOrder } from "antd/es/table/interface";
-import get from "lodash/get";
 
 const columns = [
   {

--- a/src/pages/task/FilesTables.tsx
+++ b/src/pages/task/FilesTables.tsx
@@ -4,7 +4,7 @@ import {
   GET_TASK_FILES,
   TaskFilesResponse,
   TaskFilesVars,
-  TaskFilesData
+  GroupedFiles
 } from "gql/queries/get-task-files";
 import { H3 } from "components/Typography";
 import { useParams } from "react-router-dom";
@@ -15,6 +15,7 @@ import Icon from "@leafygreen-ui/icon";
 import { Input } from "antd";
 import debounce from "lodash.debounce";
 import { SortOrder } from "antd/es/table/interface";
+import get from "lodash/get";
 
 const columns = [
   {
@@ -49,19 +50,19 @@ export const FilesTables: React.FC = () => {
     }
   );
   const [filterStr, setFilterStr] = useState("");
-  const [filteredData, setFilteredData] = useState<[TaskFilesData]>();
+  const [filteredData, setFilteredData] = useState<[GroupedFiles]>();
 
   useEffect(
     debounce(() => {
       if (data) {
-        const nextData = data.taskFiles.map(currVal => ({
+        const nextData = data.taskFiles.groupedFiles.map(currVal => ({
           taskName: currVal.taskName,
           files: filterStr.length
             ? currVal.files.filter(({ name }) =>
                 name.toLowerCase().includes(filterStr.toLowerCase())
               )
             : currVal.files
-        })) as [TaskFilesData];
+        })) as [GroupedFiles];
         setFilteredData(nextData);
       }
     }, 300),


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-7633
These frontend changes reflect gql schema changes to include the fileCount in the taskFiles query result. Backend PR can be viewed here: https://github.com/evergreen-ci/evergreen/pull/3384