### PR TITLE
EVG-7617: Make url query params between patch and task pages the same

### DIFF
--- a/cypress/integration/patch-route.js
+++ b/cypress/integration/patch-route.js
@@ -153,7 +153,6 @@ describe("Patch route", function() {
             scrollToBottomOfTasksTable();
             waitForGQL("@gqlQuery", "PatchTasks");
             cy.get("@gqlQuery").then($xhr => {
-              console.log("$xhr", $xhr);
               cy.get("[data-cy=current-task-count]")
                 .invoke("text")
                 .then($newTaskCount => {

--- a/cypress/integration/test_table.js
+++ b/cypress/integration/test_table.js
@@ -2,8 +2,8 @@
 import { waitForGQL } from "../utils/networking";
 
 const TABLE_SORT_SELECTOR = ".ant-table-column-title";
-const DESCEND_PARAM = "sort=DESC";
-const ASCEND_PARAM = "sort=ASC";
+const DESCEND_PARAM = "sortDir=DESC";
+const ASCEND_PARAM = "sortDir=ASC";
 const waitForTestsQuery = () => waitForGQL("@gqlQuery", "taskTests");
 
 const TESTS_ROUTE =
@@ -37,35 +37,35 @@ describe("Tests Table", function() {
     cy.contains(TABLE_SORT_SELECTOR, "Name").click();
     cy.location().should(loc => {
       expect(loc.pathname).to.equal(TESTS_ROUTE);
-      expect(loc.search).to.include("category=TEST_NAME");
+      expect(loc.search).to.include("sortBy=TEST_NAME");
       expect(loc.search).to.include(DESCEND_PARAM);
     });
     waitForTestsQuery();
     cy.contains(TABLE_SORT_SELECTOR, "Status").click();
     cy.location().should(loc => {
       expect(loc.pathname).to.equal(TESTS_ROUTE);
-      expect(loc.search).to.include("category=STATUS");
+      expect(loc.search).to.include("sortBy=STATUS");
       expect(loc.search).to.include(ASCEND_PARAM);
     });
     waitForTestsQuery();
     cy.contains(TABLE_SORT_SELECTOR, "Status").click();
     cy.location().should(loc => {
       expect(loc.pathname).to.equal(TESTS_ROUTE);
-      expect(loc.search).to.include("category=STATUS");
+      expect(loc.search).to.include("sortBy=STATUS");
       expect(loc.search).to.include(DESCEND_PARAM);
     });
     waitForTestsQuery();
     cy.contains(TABLE_SORT_SELECTOR, "Time").click();
     cy.location().should(loc => {
       expect(loc.pathname).to.equal(TESTS_ROUTE);
-      expect(loc.search).to.include("category=DURATION");
+      expect(loc.search).to.include("sortBy=DURATION");
       expect(loc.search).to.include(ASCEND_PARAM);
     });
     waitForTestsQuery();
     cy.contains(TABLE_SORT_SELECTOR, "Time").click();
     cy.location().should(loc => {
       expect(loc.pathname).to.equal(TESTS_ROUTE);
-      expect(loc.search).to.include("category=DURATION");
+      expect(loc.search).to.include("sortBy=DURATION");
       expect(loc.search).to.include(DESCEND_PARAM);
     });
   });
@@ -74,7 +74,7 @@ describe("Tests Table", function() {
     const assertInitialURLState = () =>
       cy.location().should(loc => {
         expect(loc.pathname).to.equal(TESTS_ROUTE);
-        expect(loc.search).to.include("category=TEST_NAME");
+        expect(loc.search).to.include("sortBy=TEST_NAME");
         expect(loc.search).to.include(ASCEND_PARAM);
       });
     cy.visit(TESTS_ROUTE);

--- a/cypress/integration/test_table.js
+++ b/cypress/integration/test_table.js
@@ -2,7 +2,10 @@
 import { waitForGQL } from "../utils/networking";
 
 const TABLE_SORT_SELECTOR = ".ant-table-column-title";
+const DESCEND_PARAM = "sort=DESC";
+const ASCEND_PARAM = "sort=ASC";
 const waitForTestsQuery = () => waitForGQL("@gqlQuery", "taskTests");
+
 const TESTS_ROUTE =
   "/task/evergreen_ubuntu1604_test_model_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48/tests";
 describe("Tests Table", function() {
@@ -35,35 +38,35 @@ describe("Tests Table", function() {
     cy.location().should(loc => {
       expect(loc.pathname).to.equal(TESTS_ROUTE);
       expect(loc.search).to.include("category=TEST_NAME");
-      expect(loc.search).to.include("sort=-1");
+      expect(loc.search).to.include(DESCEND_PARAM);
     });
     waitForTestsQuery();
     cy.contains(TABLE_SORT_SELECTOR, "Status").click();
     cy.location().should(loc => {
       expect(loc.pathname).to.equal(TESTS_ROUTE);
       expect(loc.search).to.include("category=STATUS");
-      expect(loc.search).to.include("sort=1");
+      expect(loc.search).to.include(ASCEND_PARAM);
     });
     waitForTestsQuery();
     cy.contains(TABLE_SORT_SELECTOR, "Status").click();
     cy.location().should(loc => {
       expect(loc.pathname).to.equal(TESTS_ROUTE);
       expect(loc.search).to.include("category=STATUS");
-      expect(loc.search).to.include("sort=-1");
+      expect(loc.search).to.include(DESCEND_PARAM);
     });
     waitForTestsQuery();
     cy.contains(TABLE_SORT_SELECTOR, "Time").click();
     cy.location().should(loc => {
       expect(loc.pathname).to.equal(TESTS_ROUTE);
       expect(loc.search).to.include("category=DURATION");
-      expect(loc.search).to.include("sort=1");
+      expect(loc.search).to.include(ASCEND_PARAM);
     });
     waitForTestsQuery();
     cy.contains(TABLE_SORT_SELECTOR, "Time").click();
     cy.location().should(loc => {
       expect(loc.pathname).to.equal(TESTS_ROUTE);
       expect(loc.search).to.include("category=DURATION");
-      expect(loc.search).to.include("sort=-1");
+      expect(loc.search).to.include(DESCEND_PARAM);
     });
   });
 
@@ -72,7 +75,7 @@ describe("Tests Table", function() {
       cy.location().should(loc => {
         expect(loc.pathname).to.equal(TESTS_ROUTE);
         expect(loc.search).to.include("category=TEST_NAME");
-        expect(loc.search).to.include("sort=1");
+        expect(loc.search).to.include(ASCEND_PARAM);
       });
     cy.visit(TESTS_ROUTE);
     assertInitialURLState();

--- a/cypress/integration/test_table_route.js
+++ b/cypress/integration/test_table_route.js
@@ -4,12 +4,12 @@ const taskID =
   "evergreen_ubuntu1604_test_model_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48";
 
 const taskPath = `/task/${taskID}/tests`;
-const DESCEND_PARAM = "sort=DESC";
-const ASCEND_PARAM = "sort=ASC";
+const DESCEND_PARAM = "sortBy=DESC";
+const ASCEND_PARAM = "sortBy=ASC";
 
 const fallbackLocation = loc => {
   expect(loc.pathname).to.equal(`/task/${taskID}/tests`);
-  expect(loc.search).to.include("category=TEST_NAME");
+  expect(loc.search).to.include("sortBy=TEST_NAME");
   expect(loc.search).to.include(ASCEND_PARAM);
 };
 
@@ -24,67 +24,67 @@ describe("Tests Table Route", function() {
   });
 
   it("Default query params are set when some required query params exist", function() {
-    cy.visit(`${taskPath}?category=TEST_NAME`);
+    cy.visit(`${taskPath}?sortBy=TEST_NAME`);
     cy.location().should(fallbackLocation);
   });
 
   it("Default query params are not changed when all required query params exist and are valid", function() {
-    cy.visit(`${taskPath}?category=DURATION&sort=DESC`);
+    cy.visit(`${taskPath}?sortBy=DURATION&sort=DESC`);
     cy.location().should(loc => {
       expect(loc.pathname).to.equal(taskPath);
-      expect(loc.search).to.include("category=DURATION");
+      expect(loc.search).to.include("sortBy=DURATION");
       expect(loc.search).to.include(DESCEND_PARAM);
     });
   });
 
-  it("Category query param is case insensitve", function() {
-    cy.visit(`${taskPath}?category=DuRaTiOn&${DESCEND_PARAM}`);
+  it("sortBy query param is case insensitve", function() {
+    cy.visit(`${taskPath}?sortBy=DuRaTiOn&${DESCEND_PARAM}`);
     cy.location().should(loc => {
       expect(loc.pathname).to.equal(taskPath);
-      expect(loc.search).to.include("category=DuRaTiOn");
+      expect(loc.search).to.include("sortBy=DuRaTiOn");
       expect(loc.search).to.include(DESCEND_PARAM);
     });
   });
 
   describe("Page and Limit must be positive numbers", () => {
     it("Page cannot be less than 0", function() {
-      cy.visit(`${taskPath}?category=TEST_NAME&${ASCEND_PARAM}`);
+      cy.visit(`${taskPath}?sortBy=TEST_NAME&${ASCEND_PARAM}`);
       cy.location().should(fallbackLocation);
     });
 
     it("Limit cannot be less than 0", function() {
-      cy.visit(`${taskPath}?category=TEST_NAME&${ASCEND_PARAM}`);
+      cy.visit(`${taskPath}?sortBy=TEST_NAME&${ASCEND_PARAM}`);
       cy.location().should(fallbackLocation);
     });
 
     it("Page will truncate if it's a float", function() {
-      cy.visit(`${taskPath}?category=TEST_NAME&${ASCEND_PARAM}`);
+      cy.visit(`${taskPath}?sortBy=TEST_NAME&${ASCEND_PARAM}`);
       cy.location().should(loc => {
         expect(loc.pathname).to.equal(taskPath);
-        expect(loc.search).to.include("category=TEST_NAME");
+        expect(loc.search).to.include("sortBy=TEST_NAME");
         expect(loc.search).to.include(ASCEND_PARAM);
       });
     });
 
     it("Limit will truncate if it's a float", function() {
-      cy.visit(`${taskPath}?category=TEST_NAME&${ASCEND_PARAM}`);
+      cy.visit(`${taskPath}?sortBy=TEST_NAME&${ASCEND_PARAM}`);
       cy.location().should(loc => {
         expect(loc.pathname).to.equal(taskPath);
-        expect(loc.search).to.include("category=TEST_NAME");
+        expect(loc.search).to.include("sortBy=TEST_NAME");
         expect(loc.search).to.include(ASCEND_PARAM);
       });
     });
 
     it("Default query params are set if page query param is an array", function() {
       cy.visit(
-        `${taskPath}?category=TEST_NAME&page=[0,1,3,4]&limit=4&${ASCEND_PARAM}`
+        `${taskPath}?sortBy=TEST_NAME&page=[0,1,3,4]&limit=4&${ASCEND_PARAM}`
       );
       cy.location().should(fallbackLocation);
     });
 
     it("Default query params are set if limit query param is an array", function() {
       cy.visit(
-        `${taskPath}?category=TEST_NAME&page=0&limit=[4,3,4]&${ASCEND_PARAM}]`
+        `${taskPath}?sortBy=TEST_NAME&page=0&limit=[4,3,4]&${ASCEND_PARAM}]`
       );
       cy.location().should(fallbackLocation);
     });

--- a/cypress/integration/test_table_route.js
+++ b/cypress/integration/test_table_route.js
@@ -4,14 +4,16 @@ const taskID =
   "evergreen_ubuntu1604_test_model_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48";
 
 const taskPath = `/task/${taskID}/tests`;
+const DESCEND_PARAM = "sort=DESC";
+const ASCEND_PARAM = "sort=ASC";
 
 const fallbackLocation = loc => {
   expect(loc.pathname).to.equal(`/task/${taskID}/tests`);
   expect(loc.search).to.include("category=TEST_NAME");
-  expect(loc.search).to.include("sort=1");
+  expect(loc.search).to.include(ASCEND_PARAM);
 };
 
-describe("Test Table Route", function() {
+describe("Tests Table Route", function() {
   beforeEach(() => {
     cy.login();
   });
@@ -27,59 +29,63 @@ describe("Test Table Route", function() {
   });
 
   it("Default query params are not changed when all required query params exist and are valid", function() {
-    cy.visit(`${taskPath}?category=DURATION&sort=-1`);
+    cy.visit(`${taskPath}?category=DURATION&sort=DESC`);
     cy.location().should(loc => {
       expect(loc.pathname).to.equal(taskPath);
       expect(loc.search).to.include("category=DURATION");
-      expect(loc.search).to.include("sort=-1");
+      expect(loc.search).to.include(DESCEND_PARAM);
     });
   });
 
   it("Category query param is case insensitve", function() {
-    cy.visit(`${taskPath}?category=DuRaTiOn&sort=-1`);
+    cy.visit(`${taskPath}?category=DuRaTiOn&${DESCEND_PARAM}`);
     cy.location().should(loc => {
       expect(loc.pathname).to.equal(taskPath);
       expect(loc.search).to.include("category=DuRaTiOn");
-      expect(loc.search).to.include("sort=-1");
+      expect(loc.search).to.include(DESCEND_PARAM);
     });
   });
 
   describe("Page and Limit must be positive numbers", () => {
     it("Page cannot be less than 0", function() {
-      cy.visit(`${taskPath}?category=TEST_NAME&sort=1`);
+      cy.visit(`${taskPath}?category=TEST_NAME&${ASCEND_PARAM}`);
       cy.location().should(fallbackLocation);
     });
 
     it("Limit cannot be less than 0", function() {
-      cy.visit(`${taskPath}?category=TEST_NAME&sort=1`);
+      cy.visit(`${taskPath}?category=TEST_NAME&${ASCEND_PARAM}`);
       cy.location().should(fallbackLocation);
     });
 
     it("Page will truncate if it's a float", function() {
-      cy.visit(`${taskPath}?category=TEST_NAME&sort=1`);
+      cy.visit(`${taskPath}?category=TEST_NAME&${ASCEND_PARAM}`);
       cy.location().should(loc => {
         expect(loc.pathname).to.equal(taskPath);
         expect(loc.search).to.include("category=TEST_NAME");
-        expect(loc.search).to.include("sort=1");
+        expect(loc.search).to.include(ASCEND_PARAM);
       });
     });
 
     it("Limit will truncate if it's a float", function() {
-      cy.visit(`${taskPath}?category=TEST_NAME&sort=1`);
+      cy.visit(`${taskPath}?category=TEST_NAME&${ASCEND_PARAM}`);
       cy.location().should(loc => {
         expect(loc.pathname).to.equal(taskPath);
         expect(loc.search).to.include("category=TEST_NAME");
-        expect(loc.search).to.include("sort=1");
+        expect(loc.search).to.include(ASCEND_PARAM);
       });
     });
 
     it("Default query params are set if page query param is an array", function() {
-      cy.visit(`${taskPath}?category=TEST_NAME&page=[0,1,3,4]&limit=4&sort=1`);
+      cy.visit(
+        `${taskPath}?category=TEST_NAME&page=[0,1,3,4]&limit=4&${ASCEND_PARAM}`
+      );
       cy.location().should(fallbackLocation);
     });
 
     it("Default query params are set if limit query param is an array", function() {
-      cy.visit(`${taskPath}?category=TEST_NAME&page=0&limit=[4,3,4]&sort=1]`);
+      cy.visit(
+        `${taskPath}?category=TEST_NAME&page=0&limit=[4,3,4]&${ASCEND_PARAM}]`
+      );
       cy.location().should(fallbackLocation);
     });
   });

--- a/cypress/integration/test_table_route.js
+++ b/cypress/integration/test_table_route.js
@@ -4,8 +4,8 @@ const taskID =
   "evergreen_ubuntu1604_test_model_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48";
 
 const taskPath = `/task/${taskID}/tests`;
-const DESCEND_PARAM = "sortBy=DESC";
-const ASCEND_PARAM = "sortBy=ASC";
+const DESCEND_PARAM = "sortDir=DESC";
+const ASCEND_PARAM = "sortDir=ASC";
 
 const fallbackLocation = loc => {
   expect(loc.pathname).to.equal(`/task/${taskID}/tests`);
@@ -29,7 +29,7 @@ describe("Tests Table Route", function() {
   });
 
   it("Default query params are not changed when all required query params exist and are valid", function() {
-    cy.visit(`${taskPath}?sortBy=DURATION&sort=DESC`);
+    cy.visit(`${taskPath}?sortBy=DURATION&${DESCEND_PARAM}`);
     cy.location().should(loc => {
       expect(loc.pathname).to.equal(taskPath);
       expect(loc.search).to.include("sortBy=DURATION");

--- a/src/pages/task/TestsTable.test.tsx
+++ b/src/pages/task/TestsTable.test.tsx
@@ -340,7 +340,7 @@ it("Requests descending data when clicking on active ascending tab", async () =>
         {
           pathname:
             "/task/mci_windows_test_agent_8a4f834ba24ddf91f93d0a96b90452e9653f4138_17_10_23_21_58_33/tests",
-          search: "?category=STATUS&sort=ASC",
+          search: "?sortBy=STATUS&sortDir=ASC",
           hash: "",
           key: "djuhdk"
         }
@@ -378,7 +378,7 @@ xit("It loads data on initial load when given valid query params", async () => {
         {
           pathname:
             "/task/mci_windows_test_agent_8a4f834ba24ddf91f93d0a96b90452e9653f4138_17_10_23_21_58_33/tests",
-          search: "?category=STATUS&sort=ASC",
+          search: "?sortBy=STATUS&sortBy=ASC",
           hash: "",
           key: "djuhdk"
         }

--- a/src/pages/task/TestsTable.test.tsx
+++ b/src/pages/task/TestsTable.test.tsx
@@ -340,7 +340,7 @@ it("Requests descending data when clicking on active ascending tab", async () =>
         {
           pathname:
             "/task/mci_windows_test_agent_8a4f834ba24ddf91f93d0a96b90452e9653f4138_17_10_23_21_58_33/tests",
-          search: "?category=STATUS&sort=1",
+          search: "?category=STATUS&sort=ASC",
           hash: "",
           key: "djuhdk"
         }
@@ -378,7 +378,7 @@ xit("It loads data on initial load when given valid query params", async () => {
         {
           pathname:
             "/task/mci_windows_test_agent_8a4f834ba24ddf91f93d0a96b90452e9653f4138_17_10_23_21_58_33/tests",
-          search: "?category=STATUS&sort=1",
+          search: "?category=STATUS&sort=ASC",
           hash: "",
           key: "djuhdk"
         }

--- a/src/pages/task/TestsTable.tsx
+++ b/src/pages/task/TestsTable.tsx
@@ -15,7 +15,7 @@ import { Categories } from "gql/queries/get-task-tests";
 import queryString from "query-string";
 
 enum DefaultQueryParams {
-  Sort = "1",
+  Sort = "ASC",
   Category = "TEST_NAME"
 }
 const arrayFormat = "comma";

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -15,8 +15,8 @@ export enum RequiredQueryParams {
 }
 
 export enum SortQueryParam {
-  Desc = "-1",
-  Asc = "1"
+  Desc = "DESC",
+  Asc = "ASC"
 }
 
 export enum PatchTasksQueryParams {

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -8,8 +8,8 @@ export interface ValidInitialQueryParams {
 }
 
 export enum RequiredQueryParams {
-  Sort = "sort",
-  Category = "category",
+  Sort = "sortDir",
+  Category = "sortBy",
   Statuses = "statuses",
   TestName = "testname"
 }


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-7617
Tests table now uses sortBy, sortDir and ASC/DESC instead of category, sort and 1/-1