### PR TITLE
MCI-3198: staging should work now

### DIFF
--- a/src/context/auth.tsx
+++ b/src/context/auth.tsx
@@ -9,7 +9,7 @@ interface State {
 
 const defaultState: State = {
   isAuthenticated: false,
-  initialLoad: true
+  initialLoad: true,
 };
 
 type Action = { type: "authenticate" } | { type: "deauthenticate" };
@@ -30,13 +30,13 @@ const reducer = (state: State, action: Action): State => {
       return {
         ...state,
         isAuthenticated: true,
-        initialLoad: false
+        initialLoad: false,
       };
     case "deauthenticate":
       return {
         ...state,
         isAuthenticated: false,
-        initialLoad: false
+        initialLoad: false,
       };
     default:
       return state;
@@ -63,7 +63,7 @@ const login = async (
   try {
     await axios.post(`${getLoginDomain()}/login`, {
       username,
-      password
+      password,
     });
     dispatch({ type: "authenticate" });
   } catch (error) {
@@ -91,7 +91,7 @@ const AuthProvider: React.FC = ({ children }) => {
   const dispatchContext: DispatchContext = {
     login: loginHandler,
     logout: logoutHandler,
-    dispatch
+    dispatch,
   };
 
   return (

--- a/src/context/auth.tsx
+++ b/src/context/auth.tsx
@@ -45,8 +45,8 @@ const reducer = (state: State, action: Action): State => {
 
 const logout = async (dispatch: Dispatch) => {
   try {
-    await axios.get(`${getLoginDomain()}/logout`);
     dispatch({ type: "deauthenticate" });
+    await axios.get(`${getLoginDomain()}/logout`);
   } catch (error) {
     // TODO: log errors
   }


### PR DESCRIPTION
https://jira.mongodb.org/browse/MCI-3198

## Problems with staging:

All of the problems with staging were around CORS and the login/logout endpoints. 

### Going to staging site showed an endless loading screen
**Cause of problem:** UI was waiting for successful response from server before dispatching the `deauthenticate` action. Response from server was a CORS errors and therefore the ui showed a loading screen indefinitely. 

**Fix:** dispatch `deauthenticate` before receiving response from server. This way, if there is any issue communicating with the server, the ui still shows the right page instead of endlessly loading. 

### Trying to login or logout from staging resulted in CORS error

This is due to the login and logout endpoints not supporting CORS. This is fixed in an evergreen PR [here](https://github.com/evergreen-ci/evergreen/pull/3443)