### PR TITLE
EVG-7757: (task table) show no status badge if status is empty

### DIFF
--- a/src/pages/patch/patchTabs/tasks/TasksTable.tsx
+++ b/src/pages/patch/patchTabs/tasks/TasksTable.tsx
@@ -20,7 +20,7 @@ interface Props {
 export const TasksTable: React.FC<Props> = ({
   networkStatus,
   data = [],
-  onFetch
+  onFetch,
 }) => {
   const { replace } = useHistory();
   const { search, pathname } = useLocation();
@@ -33,7 +33,7 @@ export const TasksTable: React.FC<Props> = ({
         {
           ...queryString.parse(search, { arrayFormat }),
           [PatchTasksQueryParams.SortDir]: getSortDirFromOrder(order),
-          [PatchTasksQueryParams.SortBy]: columnKey
+          [PatchTasksQueryParams.SortBy]: columnKey,
         },
         { arrayFormat }
       )}`
@@ -60,7 +60,7 @@ const arrayFormat = "comma";
 
 const orderKeyToSortParam = {
   ascend: TaskSortDir.Asc,
-  descend: TaskSortDir.Desc
+  descend: TaskSortDir.Desc,
 };
 const getSortDirFromOrder = (order: "ascend" | "descend") =>
   orderKeyToSortParam[order];
@@ -71,10 +71,15 @@ enum TableColumnHeader {
   Name = "NAME",
   Status = "STATUS",
   BaseStatus = "BASE_STATUS",
-  Variant = "VARIANT"
+  Variant = "VARIANT",
 }
 
-const renderStatusBadge = status => <TaskStatusBadge status={status} />;
+const renderStatusBadge = (status) => {
+  if (status === "" || !status) {
+    return null;
+  }
+  return <TaskStatusBadge status={status} />;
+};
 const columns: Array<ColumnProps<TaskResult>> = [
   {
     title: "Name",
@@ -85,7 +90,7 @@ const columns: Array<ColumnProps<TaskResult>> = [
     className: "cy-task-table-col-NAME",
     render: (name: string, { id }: TaskResult) => (
       <StyledRouterLink to={`/task/${id}`}>{name}</StyledRouterLink>
-    )
+    ),
   },
   {
     title: "Patch Status",
@@ -93,7 +98,7 @@ const columns: Array<ColumnProps<TaskResult>> = [
     key: TableColumnHeader.Status,
     sorter: true,
     className: "cy-task-table-col-STATUS",
-    render: renderStatusBadge
+    render: renderStatusBadge,
   },
   {
     title: "Base Status",
@@ -101,13 +106,13 @@ const columns: Array<ColumnProps<TaskResult>> = [
     key: TableColumnHeader.BaseStatus,
     sorter: true,
     className: "cy-task-table-col-BASE_STATUS",
-    render: renderStatusBadge
+    render: renderStatusBadge,
   },
   {
     title: "Variant",
     dataIndex: "buildVariant",
     key: TableColumnHeader.Variant,
     sorter: true,
-    className: "cy-task-table-col-VARIANT"
-  }
+    className: "cy-task-table-col-VARIANT",
+  },
 ];


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-7757

#### A base status for a task will not exist when someone patches a new task before they add it to the config. Therefore a base status not existing needs to be accounted for in UI. 

<img width="691" alt="Screen Shot 2020-04-13 at 3 49 19 PM" src="https://user-images.githubusercontent.com/15262143/79155153-b6005000-7d9e-11ea-9701-3698a66cd78d.png">

**View an example in staging:** 
http://evergreen-staging.spruce.s3-website-us-east-1.amazonaws.com/patch/5e8e501db2373609ecbd7000/tasks

