### PR TITLE
EVG-7795: (patch) change patch success status to `succeeded`

### DIFF
--- a/src/gql/queries/get-patch-tasks.ts
+++ b/src/gql/queries/get-patch-tasks.ts
@@ -56,7 +56,7 @@ export enum TaskSortBy {
 export enum PatchStatus {
   Created = "created",
   Started = "started",
-  Success = "success",
+  Success = "succeeded",
   Failed = "failed",
 }
 


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-7795

![Screen Shot 2020-04-13 at 4 11 05 PM](https://user-images.githubusercontent.com/15262143/79156994-d1b92580-7da1-11ea-9dc8-336331a92963.png)

Patch status badge for success was showing gray color because the `Patch.Success` enum value was set to 'success'. 

Fix: 'success' => 'succeeded'

See an example in staging: 
http://evergreen-staging.spruce.s3-website-us-east-1.amazonaws.com/patch/5e8f413097b1d363114d60ad/tasks