### PR TITLE
EVG-7547, EVG-7548: search input for patch name & dropdown menu for statuses

### DIFF
--- a/cypress/integration/my_patches.js
+++ b/cypress/integration/my_patches.js
@@ -11,18 +11,6 @@ describe("My Patches Page", () => {
     cy.listenGQL();
   });
 
-  it("Initial load should make a userPatches gql query with default query params when none are specified in the URL", () => {
-    cy.visit(MY_PATCHES_ROUTE);
-    cy.waitForGQL("userPatches", {
-      "request.body.variables.$includeCommitQueue": (v) => v == true,
-      "request.body.variables.$limit": (v) => v === 10,
-      "request.body.variables.$page": (v) => v === 0,
-      "request.body.variables.$patchName": (v) => v === "",
-      "request.body.variables.$statuses": (v) =>
-        Array.isArray(v) && v.length === 0,
-    }).then((xhr) => console.log(xhr));
-  });
-
   describe("Show commit queue checkbox", () => {
     beforeEach(() => {
       cy.preserveCookies();

--- a/cypress/integration/my_patches.js
+++ b/cypress/integration/my_patches.js
@@ -1,23 +1,46 @@
 /// <reference types="Cypress" />
 
 const MY_PATCHES_ROUTE = "/my-patches";
-describe("my patches page", function () {
-  beforeEach(() => {
-    cy.server();
+describe("My Patches Page", () => {
+  before(() => {
     cy.login();
   });
 
-  it("Should render with Show Commit Queue box checked when commitQueue not indicated in URL query param", () => {
-    cy.visit(MY_PATCHES_ROUTE);
-    cy.get("[data-cy=commit-queue-checkbox]").should("be.checked");
+  beforeEach(() => {
+    cy.preserveCookies();
+    cy.listenGQL();
   });
 
-  it("Should render with Show Commit Queue box unchecked when commitQueue is false in URL query param", () => {
-    cy.visit(`${MY_PATCHES_ROUTE}?commitQueue=false`);
-    cy.get("[data-cy=commit-queue-checkbox]").should("not.be.checked");
+  it("Initial load should make a userPatches gql query with default query params when none are specified in the URL", () => {
+    cy.visit(MY_PATCHES_ROUTE);
+    cy.waitForGQL("userPatches", {
+      "request.body.variables.$includeCommitQueue": (v) => v == true,
+      "request.body.variables.$limit": (v) => v === 10,
+      "request.body.variables.$page": (v) => v === 0,
+      "request.body.variables.$patchName": (v) => v === "",
+      "request.body.variables.$statuses": (v) =>
+        Array.isArray(v) && v.length === 0,
+    }).then((xhr) => console.log(xhr));
   });
-  it("Should render with Show Commit Queue box checked when commitQueue is true in URL query param", () => {
-    cy.visit(`${MY_PATCHES_ROUTE}?commitQueue=true`);
-    cy.get("[data-cy=commit-queue-checkbox]").should("be.checked");
+
+  describe("Show commit queue checkbox", () => {
+    beforeEach(() => {
+      cy.preserveCookies();
+    });
+
+    it("Should render with Show Commit Queue box checked when commitQueue not indicated in URL query param", () => {
+      cy.visit(MY_PATCHES_ROUTE);
+      cy.dataCy("commit-queue-checkbox").should("be.checked");
+    });
+
+    it("Should render with Show Commit Queue box unchecked when commitQueue is false in URL query param", () => {
+      cy.visit(`${MY_PATCHES_ROUTE}?commitQueue=false`);
+      cy.dataCy("commit-queue-checkbox").should("not.be.checked");
+    });
+
+    it("Should render with Show Commit Queue box checked when commitQueue is true in URL query param", () => {
+      cy.visit(`${MY_PATCHES_ROUTE}?commitQueue=true`);
+      cy.dataCy("commit-queue-checkbox").should("be.checked");
+    });
   });
 });

--- a/src/components/styles/Layout.tsx
+++ b/src/components/styles/Layout.tsx
@@ -1,6 +1,7 @@
 import styled from "@emotion/styled/macro";
 import { Layout } from "antd";
 import { css } from "@emotion/core";
+import { H2 } from "@leafygreen-ui/typography";
 
 const { Content, Sider } = Layout;
 
@@ -26,4 +27,8 @@ export const PageSider = styled(Sider)`
   width: ${siderWidth} !important;
   max-width: ${siderWidth} !important;
   min-width: ${siderWidth} !important;
+`;
+
+export const SimplePageTitle = styled(H2)`
+  margin-bottom: 16px;
 `;

--- a/src/components/styles/Layout.tsx
+++ b/src/components/styles/Layout.tsx
@@ -29,6 +29,6 @@ export const PageSider = styled(Sider)`
   min-width: ${siderWidth} !important;
 `;
 
-export const SimplePageTitle = styled(H2)`
+export const PageTitle = styled(H2)`
   margin-bottom: 16px;
 `;

--- a/src/components/styles/filters.tsx
+++ b/src/components/styles/filters.tsx
@@ -4,7 +4,13 @@ import { Input } from "antd";
 export const FiltersWrapper = styled.div`
   display: flex;
   margin-bottom: 12px;
+  align-items: center;
 `;
+
+export const FiltersWrapperSpaceBetween = styled(FiltersWrapper)`
+  justify-content: space-between;
+`;
+
 export const StyledInput = styled(Input)`
   max-width: 500px;
   margin-right: 40px;

--- a/src/components/styles/filters.tsx
+++ b/src/components/styles/filters.tsx
@@ -7,10 +7,6 @@ export const FiltersWrapper = styled.div`
   align-items: center;
 `;
 
-export const FiltersWrapperSpaceBetween = styled(FiltersWrapper)`
-  justify-content: space-between;
-`;
-
 export const StyledInput = styled(Input)`
   max-width: 500px;
   margin-right: 40px;

--- a/src/components/styles/index.ts
+++ b/src/components/styles/index.ts
@@ -3,7 +3,11 @@ import { PageContent, PageLayout, PageSider } from "./Layout";
 import { PageWrapper } from "./PageWrapper";
 import { BoldStyledLink, StyledLink, StyledRouterLink } from "./StyledLink";
 import { SiderCard } from "./SiderCard";
-import { FiltersWrapper, StyledInput } from "./filters";
+import {
+  FiltersWrapper,
+  FiltersWrapperSpaceBetween,
+  StyledInput,
+} from "./filters";
 
 export {
   Divider,
@@ -16,5 +20,6 @@ export {
   SiderCard,
   StyledRouterLink,
   FiltersWrapper,
+  FiltersWrapperSpaceBetween,
   StyledInput,
 };

--- a/src/components/styles/index.ts
+++ b/src/components/styles/index.ts
@@ -3,11 +3,7 @@ import { PageContent, PageLayout, PageSider, PageTitle } from "./Layout";
 import { PageWrapper } from "./PageWrapper";
 import { BoldStyledLink, StyledLink, StyledRouterLink } from "./StyledLink";
 import { SiderCard } from "./SiderCard";
-import {
-  FiltersWrapper,
-  FiltersWrapperSpaceBetween,
-  StyledInput,
-} from "./filters";
+import { FiltersWrapper, StyledInput } from "./filters";
 
 export {
   Divider,
@@ -20,7 +16,6 @@ export {
   SiderCard,
   StyledRouterLink,
   FiltersWrapper,
-  FiltersWrapperSpaceBetween,
   StyledInput,
   PageTitle,
 };

--- a/src/components/styles/index.ts
+++ b/src/components/styles/index.ts
@@ -1,5 +1,5 @@
 import { Divider } from "./Divider";
-import { PageContent, PageLayout, PageSider } from "./Layout";
+import { PageContent, PageLayout, PageSider, SimplePageTitle } from "./Layout";
 import { PageWrapper } from "./PageWrapper";
 import { BoldStyledLink, StyledLink, StyledRouterLink } from "./StyledLink";
 import { SiderCard } from "./SiderCard";
@@ -22,4 +22,5 @@ export {
   FiltersWrapper,
   FiltersWrapperSpaceBetween,
   StyledInput,
+  SimplePageTitle,
 };

--- a/src/components/styles/index.ts
+++ b/src/components/styles/index.ts
@@ -1,5 +1,5 @@
 import { Divider } from "./Divider";
-import { PageContent, PageLayout, PageSider, SimplePageTitle } from "./Layout";
+import { PageContent, PageLayout, PageSider, PageTitle } from "./Layout";
 import { PageWrapper } from "./PageWrapper";
 import { BoldStyledLink, StyledLink, StyledRouterLink } from "./StyledLink";
 import { SiderCard } from "./SiderCard";
@@ -22,5 +22,5 @@ export {
   FiltersWrapper,
   FiltersWrapperSpaceBetween,
   StyledInput,
-  SimplePageTitle,
+  PageTitle,
 };

--- a/src/gql/queries/get-patch-tasks.ts
+++ b/src/gql/queries/get-patch-tasks.ts
@@ -1,4 +1,5 @@
 import gql from "graphql-tag";
+import { PatchStatus } from "types/patch";
 import { SortDir } from "gql/queries/get-task-tests";
 
 export const PATCH_TASKS_LIMIT = 10;

--- a/src/gql/queries/get-patch-tasks.ts
+++ b/src/gql/queries/get-patch-tasks.ts
@@ -53,13 +53,6 @@ export enum TaskSortBy {
   Variant = "VARIANT",
 }
 
-export enum PatchStatus {
-  Created = "created",
-  Started = "started",
-  Success = "succeeded",
-  Failed = "failed",
-}
-
 export enum TaskSortDir {
   Desc = "DESC",
   Asc = "ASC",

--- a/src/gql/queries/my-patches.ts
+++ b/src/gql/queries/my-patches.ts
@@ -1,0 +1,56 @@
+import gql from "graphql-tag";
+
+export const GET_MY_PATCHES = gql`
+  query userPatches(
+    $page: Int
+    $limit: Int
+    $statuses: [String!]!
+    $patchName: String
+    $includeCommitQueue: Boolean
+  ) {
+    userPatches(
+      page: $page
+      limit: $limit
+      statuses: $statuses
+      patchName: $patchName
+      includeCommitQueue: $includeCommitQueue
+    ) {
+      projectID
+      description
+      status
+      createTime
+      builds {
+        id
+        buildVariant
+        status
+        predictedMakespan
+        actualMakespan
+      }
+    }
+  }
+`;
+
+export interface Build {
+  id: string;
+  buildVariant: string;
+  status: string;
+  predictedMakespan: number;
+  actualMakespan: number;
+}
+export interface UserPatchesVars {
+  $page: number;
+  $limit: number;
+  $statuses: string[];
+  $patchName: string;
+  $includeCommitQueue: boolean;
+}
+export interface Patch {
+  projectID: string;
+  description: string;
+  status: string;
+  createTime: string;
+  builds: Build[];
+}
+export interface UserPatchesData {
+  userPatches: Patch[];
+}

--- a/src/gql/queries/my-patches.ts
+++ b/src/gql/queries/my-patches.ts
@@ -1,4 +1,6 @@
 import gql from "graphql-tag";
+import { PatchStatus } from "types/patch";
+import { BuildStatus } from "types/build";
 
 export const GET_USER_PATCHES = gql`
   query userPatches(
@@ -33,7 +35,7 @@ export const GET_USER_PATCHES = gql`
 export interface Build {
   id: string;
   buildVariant: string;
-  status: string;
+  status: BuildStatus;
   predictedMakespan: number;
   actualMakespan: number;
 }
@@ -47,7 +49,7 @@ export interface UserPatchesVars {
 export interface Patch {
   projectID: string;
   description: string;
-  status: string;
+  status: PatchStatus;
   createTime: string;
   builds: Build[];
 }

--- a/src/gql/queries/my-patches.ts
+++ b/src/gql/queries/my-patches.ts
@@ -1,6 +1,6 @@
 import gql from "graphql-tag";
 
-export const GET_MY_PATCHES = gql`
+export const GET_USER_PATCHES = gql`
   query userPatches(
     $page: Int
     $limit: Int

--- a/src/gql/queries/my-patches.ts
+++ b/src/gql/queries/my-patches.ts
@@ -4,7 +4,7 @@ export const GET_USER_PATCHES = gql`
   query userPatches(
     $page: Int
     $limit: Int
-    $statuses: [String!]!
+    $statuses: [String!]
     $patchName: String
     $includeCommitQueue: Boolean
   ) {

--- a/src/pages/MyPatches.tsx
+++ b/src/pages/MyPatches.tsx
@@ -8,7 +8,7 @@ import {
 import { useLocation, useHistory } from "react-router-dom";
 import queryString from "query-string";
 import Checkbox from "@leafygreen-ui/checkbox";
-import { MyPatchesQueryParams, PatchStatus } from "types/patch";
+import { MyPatchesQueryParams, ALL_PATCH_STATUS } from "types/patch";
 import Icon from "@leafygreen-ui/icon";
 import {
   UserPatchesVars,
@@ -115,7 +115,7 @@ const getQueryVariables = (search: string) => {
   const $statuses = (Array.isArray(rawStatuses)
     ? rawStatuses
     : [rawStatuses]
-  ).filter((v) => v && v !== PatchStatus.All);
+  ).filter((v) => v && v !== ALL_PATCH_STATUS);
 
   return {
     $includeCommitQueue,

--- a/src/pages/MyPatches.tsx
+++ b/src/pages/MyPatches.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import {
   PageWrapper,
   StyledInput,
-  FiltersWrapperSpaceBetween,
+  FiltersWrapper,
   PageTitle,
 } from "components/styles";
 import { useLocation, useHistory } from "react-router-dom";
@@ -128,4 +128,8 @@ const getQueryVariables = (search: string) => {
 const FlexRow = styled.div`
   display: flex;
   flex-grow: 2;
+`;
+
+const FiltersWrapperSpaceBetween = styled(FiltersWrapper)`
+  justify-content: space-between;
 `;

--- a/src/pages/MyPatches.tsx
+++ b/src/pages/MyPatches.tsx
@@ -3,7 +3,7 @@ import {
   PageWrapper,
   StyledInput,
   FiltersWrapperSpaceBetween,
-  SimplePageTitle,
+  PageTitle,
 } from "components/styles";
 import { useLocation, useHistory } from "react-router-dom";
 import queryString from "query-string";
@@ -79,7 +79,7 @@ export const MyPatches = () => {
 
   return (
     <PageWrapper>
-      <SimplePageTitle>My Patches</SimplePageTitle>
+      <PageTitle>My Patches</PageTitle>
       <FiltersWrapperSpaceBetween>
         <FlexRow>
           <StyledInput

--- a/src/pages/MyPatches.tsx
+++ b/src/pages/MyPatches.tsx
@@ -1,16 +1,24 @@
 import React, { useState, useEffect } from "react";
-import { PageWrapper } from "components/styles";
+import {
+  PageWrapper,
+  StyledInput,
+  FiltersWrapperSpaceBetween,
+} from "components/styles";
 import { useLocation, useHistory } from "react-router-dom";
 import queryString from "query-string";
 import Checkbox from "@leafygreen-ui/checkbox";
 import { MyPatchesQueryParams, PatchStatus } from "types/patch";
+import Icon from "@leafygreen-ui/icon";
 import { H2 } from "@leafygreen-ui/typography";
 import {
   UserPatchesVars,
   UserPatchesData,
   GET_USER_PATCHES,
 } from "gql/queries/my-patches";
+import { StatusSelector } from "pages/my-patches/StatusSelector";
 import { useQuery } from "@apollo/react-hooks";
+import { useFilterInputChangeHandler } from "hooks";
+import styled from "@emotion/styled";
 
 export const MyPatches = () => {
   const { replace, listen } = useHistory();
@@ -19,6 +27,10 @@ export const MyPatches = () => {
     $page: 0,
     ...getQueryVariables(search),
   });
+  const [
+    patchNameFilterValue,
+    patchNameFilterValueOnChange,
+  ] = useFilterInputChangeHandler(MyPatchesQueryParams.PatchName);
   const { data, fetchMore, networkStatus, error } = useQuery<
     UserPatchesData,
     UserPatchesVars
@@ -68,12 +80,25 @@ export const MyPatches = () => {
   return (
     <PageWrapper>
       <H2>My Patches</H2>
-      <Checkbox
-        data-cy="commit-queue-checkbox"
-        onChange={onCheckboxChange}
-        label="Show Commit Queue"
-        checked={getQueryVariables(search).$includeCommitQueue}
-      />
+      <FiltersWrapperSpaceBetween>
+        <FlexRow>
+          <StyledInput
+            placeholder="Search Test Names"
+            onChange={patchNameFilterValueOnChange}
+            suffix={<Icon glyph="MagnifyingGlass" />}
+            value={patchNameFilterValue}
+            data-cy="patchname-input"
+            width="25%"
+          />
+          <StatusSelector />
+        </FlexRow>
+        <Checkbox
+          data-cy="commit-queue-checkbox"
+          onChange={onCheckboxChange}
+          label="Show Commit Queue"
+          checked={getQueryVariables(search).$includeCommitQueue}
+        />
+      </FiltersWrapperSpaceBetween>
     </PageWrapper>
   );
 };
@@ -99,3 +124,7 @@ const getQueryVariables = (search: string) => {
     $limit: LIMIT,
   };
 };
+
+const FlexRow = styled.div`
+  display: flex;
+`;

--- a/src/pages/MyPatches.tsx
+++ b/src/pages/MyPatches.tsx
@@ -3,13 +3,13 @@ import {
   PageWrapper,
   StyledInput,
   FiltersWrapperSpaceBetween,
+  SimplePageTitle,
 } from "components/styles";
 import { useLocation, useHistory } from "react-router-dom";
 import queryString from "query-string";
 import Checkbox from "@leafygreen-ui/checkbox";
 import { MyPatchesQueryParams, PatchStatus } from "types/patch";
 import Icon from "@leafygreen-ui/icon";
-import { H2 } from "@leafygreen-ui/typography";
 import {
   UserPatchesVars,
   UserPatchesData,
@@ -79,7 +79,7 @@ export const MyPatches = () => {
 
   return (
     <PageWrapper>
-      <H2>My Patches</H2>
+      <SimplePageTitle>My Patches</SimplePageTitle>
       <FiltersWrapperSpaceBetween>
         <FlexRow>
           <StyledInput
@@ -127,4 +127,5 @@ const getQueryVariables = (search: string) => {
 
 const FlexRow = styled.div`
   display: flex;
+  flex-grow: 2;
 `;

--- a/src/pages/MyPatches.tsx
+++ b/src/pages/MyPatches.tsx
@@ -1,23 +1,66 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import { PageWrapper } from "components/styles";
 import { useLocation, useHistory } from "react-router-dom";
 import queryString from "query-string";
 import Checkbox from "@leafygreen-ui/checkbox";
-import { MyPatchesQueryParams } from "types/patch";
+import { MyPatchesQueryParams, PatchStatus } from "types/patch";
 import { H2 } from "@leafygreen-ui/typography";
+import {
+  UserPatchesVars,
+  UserPatchesData,
+  GET_USER_PATCHES,
+} from "gql/queries/my-patches";
+import { useQuery } from "@apollo/react-hooks";
 
 export const MyPatches = () => {
+  const { replace, listen } = useHistory();
   const { search, pathname } = useLocation();
-  const { replace } = useHistory();
-  const parsed = queryString.parse(search);
-  const showCommitQueue =
-    parsed.commitQueue === "true" || parsed.commitQueue === undefined;
+  const [initialQueryVariables] = useState<UserPatchesVars>({
+    $page: 0,
+    ...getQueryVariables(search),
+  });
+  const { data, fetchMore, networkStatus, error } = useQuery<
+    UserPatchesData,
+    UserPatchesVars
+  >(GET_USER_PATCHES, {
+    variables: initialQueryVariables,
+    notifyOnNetworkStatusChange: true,
+  });
+
+  useEffect(() => {
+    return listen(async (loc) => {
+      try {
+        await fetchMore({
+          variables: {
+            pageNum: 0,
+            ...getQueryVariables(loc.search),
+          },
+          updateQuery: (
+            prev: UserPatchesData,
+            { fetchMoreResult }: { fetchMoreResult: UserPatchesData }
+          ) => {
+            if (!fetchMoreResult) {
+              return prev;
+            }
+            return fetchMoreResult;
+          },
+        });
+      } catch (e) {
+        // empty block
+      }
+    });
+  }, [networkStatus, error, fetchMore, listen]);
+
+  if (error) {
+    return <div>{error.message}</div>;
+  }
 
   const onCheckboxChange = () => {
     replace(
       `${pathname}?${queryString.stringify({
         ...queryString.parse(search),
-        [MyPatchesQueryParams.CommitQueue]: !showCommitQueue,
+        [MyPatchesQueryParams.CommitQueue]: !getQueryVariables(search)
+          .$includeCommitQueue,
       })}`
     );
   };
@@ -29,8 +72,30 @@ export const MyPatches = () => {
         data-cy="commit-queue-checkbox"
         onChange={onCheckboxChange}
         label="Show Commit Queue"
-        checked={showCommitQueue}
+        checked={getQueryVariables(search).$includeCommitQueue}
       />
     </PageWrapper>
   );
+};
+
+const arrayFormat = "comma";
+const LIMIT = 10;
+const getQueryVariables = (search: string) => {
+  const parsed = queryString.parse(search, { arrayFormat });
+  const $includeCommitQueue =
+    parsed[MyPatchesQueryParams.CommitQueue] === "true" ||
+    parsed[MyPatchesQueryParams.CommitQueue] === undefined;
+  const $patchName = (parsed[MyPatchesQueryParams.PatchName] || "").toString();
+  const rawStatuses = parsed[MyPatchesQueryParams.Statuses];
+  const $statuses = (Array.isArray(rawStatuses)
+    ? rawStatuses
+    : [rawStatuses]
+  ).filter((v) => v && v !== PatchStatus.All);
+
+  return {
+    $includeCommitQueue,
+    $patchName,
+    $statuses,
+    $limit: LIMIT,
+  };
 };

--- a/src/pages/Patch.tsx
+++ b/src/pages/Patch.tsx
@@ -15,7 +15,7 @@ import { BuildVariants } from "pages/patch/BuildVariants";
 import get from "lodash/get";
 import { Metadata } from "pages/patch/Metadata";
 import Badge, { Variant } from "@leafygreen-ui/badge";
-import { PatchStatus } from "gql/queries/get-patch-tasks";
+import { PatchStatus } from "types/patch";
 
 export const Patch = () => {
   const { id } = useParams<{ id: string }>();

--- a/src/pages/my-patches/StatusSelector.tsx
+++ b/src/pages/my-patches/StatusSelector.tsx
@@ -36,12 +36,12 @@ const treeData = [
     key: PatchStatus.Created,
   },
   {
-    title: "Started",
+    title: "Running",
     value: PatchStatus.Started,
     key: PatchStatus.Started,
   },
   {
-    title: "Success",
+    title: "Succeeded",
     value: PatchStatus.Success,
     key: PatchStatus.Success,
   },

--- a/src/pages/my-patches/StatusSelector.tsx
+++ b/src/pages/my-patches/StatusSelector.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { MyPatchesQueryParams, PatchStatus } from "types/patch";
+import { TreeSelect } from "components/TreeSelect";
+import { useStatusesFilter } from "hooks";
+
+export const StatusSelector = () => {
+  const [statusVal, statusValOnChange] = useStatusesFilter(
+    MyPatchesQueryParams.Statuses
+  );
+
+  return (
+    <TreeSelect
+      onChange={statusValOnChange}
+      state={statusVal}
+      tData={treeData}
+      inputLabel="Patch status:  "
+      dataCy="test-status-select"
+      width="25%"
+    />
+  );
+};
+
+const treeData = [
+  {
+    title: "All",
+    value: PatchStatus.All,
+    key: PatchStatus.All,
+  },
+  {
+    title: "Created",
+    value: PatchStatus.Created,
+    key: PatchStatus.Created,
+  },
+  {
+    title: "Started",
+    value: PatchStatus.Started,
+    key: PatchStatus.Started,
+  },
+  {
+    title: "Success",
+    value: PatchStatus.Success,
+    key: PatchStatus.Success,
+  },
+  {
+    title: "Failed",
+    value: PatchStatus.Failed,
+    key: PatchStatus.Failed,
+  },
+];

--- a/src/pages/my-patches/StatusSelector.tsx
+++ b/src/pages/my-patches/StatusSelector.tsx
@@ -1,5 +1,9 @@
 import React from "react";
-import { MyPatchesQueryParams, PatchStatus } from "types/patch";
+import {
+  MyPatchesQueryParams,
+  PatchStatus,
+  ALL_PATCH_STATUS,
+} from "types/patch";
 import { TreeSelect } from "components/TreeSelect";
 import { useStatusesFilter } from "hooks";
 
@@ -23,8 +27,8 @@ export const StatusSelector = () => {
 const treeData = [
   {
     title: "All",
-    value: PatchStatus.All,
-    key: PatchStatus.All,
+    value: ALL_PATCH_STATUS,
+    key: ALL_PATCH_STATUS,
   },
   {
     title: "Created",

--- a/src/types/build.ts
+++ b/src/types/build.ts
@@ -1,0 +1,7 @@
+export enum BuildStatus {
+  All = "all",
+  Started = "started",
+  Created = "created",
+  Failed = "failed",
+  Succeeded = "success",
+}

--- a/src/types/patch.ts
+++ b/src/types/patch.ts
@@ -1,5 +1,7 @@
 export enum MyPatchesQueryParams {
   CommitQueue = "commitQueue",
+  PatchName = "patchName",
+  Statuses = "statuses",
 }
 
 export enum PatchStatus {

--- a/src/types/patch.ts
+++ b/src/types/patch.ts
@@ -6,8 +6,9 @@ export enum MyPatchesQueryParams {
 
 export enum PatchStatus {
   Created = "created",
+  Failed = "failed",
   Started = "started",
   Success = "succeeded",
-  Failed = "failed",
-  All = "all",
 }
+
+export const ALL_PATCH_STATUS = "all";

--- a/src/types/patch.ts
+++ b/src/types/patch.ts
@@ -1,3 +1,11 @@
 export enum MyPatchesQueryParams {
   CommitQueue = "commitQueue",
 }
+
+export enum PatchStatus {
+  Created = "created",
+  Started = "started",
+  Success = "succeeded",
+  Failed = "failed",
+  All = "all",
+}


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-7547
https://jira.mongodb.org/browse/EVG-7548

URL will update when inputs are interacted with and GQL query will be made. 

There are not many e2e tests for these code changes because the My Patches page is still being developed. The PR to include the virtualized list and Patch card 
(https://jira.mongodb.org/browse/EVG-7552 & https://jira.mongodb.org/browse/EVG-7551) will allow me to test the full user story in cypress - from input interaction -> url update -> rendered results.  

<img width="1058" alt="Screen Shot 2020-04-22 at 5 32 10 PM" src="https://user-images.githubusercontent.com/10734386/80036179-3e79a180-84bf-11ea-8abd-ccfe053bf126.png">

