### PR TITLE
EVG-7906: show full page error if patch has no variants or tasks

### DIFF
--- a/cypress/integration/patch-route.ts
+++ b/cypress/integration/patch-route.ts
@@ -173,10 +173,10 @@ describe("Patch route", function() {
       });
     });
 
-    it("Fetches sorted tasks when table sort headers are clicked", () => {
-      ["NAME", "STATUS", "BASE_STATUS", "VARIANT"].forEach((sortBy) =>
-        clickSorterAndAssertTasksAreFetched(sortBy)
-      );
+    ["NAME", "STATUS", "BASE_STATUS", "VARIANT"].forEach((sortBy) => {
+      it(`Fetches tasks sorted by ${sortBy} when ${sortBy} header is clicked`, () => {
+        clickSorterAndAssertTasksAreFetched(sortBy);
+      });
     });
   });
 });
@@ -219,7 +219,6 @@ const assertCorrectRequestVariables = (sortBy, sortDir) => {
 
 const clickSorterAndAssertTasksAreFetched = (patchSortBy) => {
   cy.visit(path);
-
   cy.get(`th.cy-task-table-col-${patchSortBy}`).click();
   cy.waitForGQL("PatchTasks");
   assertCorrectRequestVariables(patchSortBy, "ASC");

--- a/cypress/integration/patch/configure-patch.ts
+++ b/cypress/integration/patch/configure-patch.ts
@@ -179,7 +179,7 @@ describe("Configure Patch Page", () => {
     });
   });
   describe("Errors", () => {
-    it("Configure patch path is present in url", () => {
+    it("Shows full page error if patch project has no variants or tasks", () => {
       cy.login();
       cy.visit(`/patch/${patchWithNoVariantsOrTasks}`);
       cy.get("[data-cy=full-page-error").should("exist");

--- a/cypress/integration/patch/configure-patch.ts
+++ b/cypress/integration/patch/configure-patch.ts
@@ -46,12 +46,6 @@ describe("Configure Patch Page", () => {
       patch = data.patch;
     });
   });
-  describe("Errors", () => {
-    it("Configure patch path is present in url", () => {
-      cy.visit(`/patch/${patchWithNoVariantsOrTasks}`);
-      cy.get("[data-cy=full-page-error").should("exist");
-    });
-  });
   describe("Initial state reflects patch data", () => {
     it("Configure patch path is present in url", () => {
       cy.location().should((loc) =>
@@ -182,6 +176,13 @@ describe("Configure Patch Page", () => {
             .its("length")
             .should("eq", $tasks.length);
         });
+    });
+  });
+  describe("Errors", () => {
+    it("Configure patch path is present in url", () => {
+      cy.login();
+      cy.visit(`/patch/${patchWithNoVariantsOrTasks}`);
+      cy.get("[data-cy=full-page-error").should("exist");
     });
   });
 });

--- a/cypress/integration/patch/configure-patch.ts
+++ b/cypress/integration/patch/configure-patch.ts
@@ -36,6 +36,7 @@ interface ConfigurePatchQuery {
 describe("Configure Patch Page", () => {
   let patch: ConfigurePatchData;
   const unactivatedPatchId = "5e6bb9e23066155a993e0f1a";
+  const patchWithNoVariantsOrTasks = "5e94c2dfe3c3312519b59480";
   before(() => {
     cy.login();
     cy.visit(`/patch/${unactivatedPatchId}`);
@@ -43,6 +44,12 @@ describe("Configure Patch Page", () => {
     cy.waitForGQL("ConfigurePatch").then(({ responseBody }) => {
       const { data } = responseBody as ConfigurePatchQuery;
       patch = data.patch;
+    });
+  });
+  describe("Errors", () => {
+    it("Configure patch path is present in url", () => {
+      cy.visit(`/patch/${patchWithNoVariantsOrTasks}`);
+      cy.get("[data-cy=full-page-error").should("exist");
     });
   });
   describe("Initial state reflects patch data", () => {

--- a/src/pages/ConfigurePatch.tsx
+++ b/src/pages/ConfigurePatch.tsx
@@ -33,7 +33,7 @@ export const ConfigurePatch: React.FC = () => {
             <PageLayout>
               <div data-cy="full-page-error">
                 Something went wrong. This patch's project either has no
-                variants or tasks associated with it.{" "}
+                variants or no tasks associated with it.{" "}
               </div>
             </PageLayout>
           );

--- a/src/pages/ConfigurePatch.tsx
+++ b/src/pages/ConfigurePatch.tsx
@@ -5,8 +5,6 @@ import { GET_PATCH_CONFIGURE, PatchQuery } from "gql/queries/patch";
 import { ConfigurePatchCore } from "pages/configurePatch/ConfigurePatchCore";
 import { PatchAndTaskFullPageLoad } from "components/Loading/PatchAndTaskFullPageLoad";
 import { PageWrapper } from "components/styles";
-import get from "lodash/get";
-import { PageLayout } from "components/styles";
 
 export const ConfigurePatch: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -15,31 +13,13 @@ export const ConfigurePatch: React.FC = () => {
   });
   return (
     <PageWrapper>
-      {(function() {
-        if (loading) {
-          return <PatchAndTaskFullPageLoad />;
-        } else if (error) {
-          return (
-            <PageLayout>
-              <div>{error.message}</div>
-            </PageLayout>
-          );
-        }
-        const variants = get(data, "patch.project.variants");
-        const tasks = get(data, "patch.project.tasks");
-        if (variants.length === 0 || tasks.length === 0) {
-          return (
-            // TODO: Full page error
-            <PageLayout>
-              <div data-cy="full-page-error">
-                Something went wrong. This patch's project either has no
-                variants or no tasks associated with it.{" "}
-              </div>
-            </PageLayout>
-          );
-        }
-        return <ConfigurePatchCore patch={data.patch} />;
-      })()}
+      {loading ? (
+        <PatchAndTaskFullPageLoad />
+      ) : error ? (
+        <div>{error.message}</div>
+      ) : (
+        <ConfigurePatchCore patch={data.patch} />
+      )}
     </PageWrapper>
   );
 };

--- a/src/pages/ConfigurePatch.tsx
+++ b/src/pages/ConfigurePatch.tsx
@@ -5,6 +5,8 @@ import { GET_PATCH_CONFIGURE, PatchQuery } from "gql/queries/patch";
 import { ConfigurePatchCore } from "pages/configurePatch/ConfigurePatchCore";
 import { PatchAndTaskFullPageLoad } from "components/Loading/PatchAndTaskFullPageLoad";
 import { PageWrapper } from "components/styles";
+import get from "lodash/get";
+import { PageLayout } from "components/styles";
 
 export const ConfigurePatch: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -13,13 +15,31 @@ export const ConfigurePatch: React.FC = () => {
   });
   return (
     <PageWrapper>
-      {loading ? (
-        <PatchAndTaskFullPageLoad />
-      ) : error ? (
-        <div>{error.message}</div>
-      ) : (
-        <ConfigurePatchCore patch={data.patch} />
-      )}
+      {(function() {
+        if (loading) {
+          return <PatchAndTaskFullPageLoad />;
+        } else if (error) {
+          return (
+            <PageLayout>
+              <div>{error.message}</div>
+            </PageLayout>
+          );
+        }
+        const variants = get(data, "patch.project.variants");
+        const tasks = get(data, "patch.project.tasks");
+        if (variants.length === 0 || tasks.length === 0) {
+          return (
+            // TODO: Full page error
+            <PageLayout>
+              <div data-cy="full-page-error">
+                Something went wrong. This patch's project either has no
+                variants or tasks associated with it.{" "}
+              </div>
+            </PageLayout>
+          );
+        }
+        return <ConfigurePatchCore patch={data.patch} />;
+      })()}
     </PageWrapper>
   );
 };

--- a/src/pages/configurePatch/ConfigurePatchCore.tsx
+++ b/src/pages/configurePatch/ConfigurePatchCore.tsx
@@ -14,13 +14,14 @@ import { Input } from "antd";
 import { ConfigureTasks } from "pages/configurePatch/configurePatchCore/ConfigureTasks";
 import { ConfigureBuildVariants } from "pages/configurePatch/configurePatchCore/ConfigureBuildVariants";
 import { Body } from "@leafygreen-ui/typography";
+import get from "lodash/get";
 
 interface Props {
   patch: Patch;
 }
 export const ConfigurePatchCore: React.FC<Props> = ({ patch }) => {
   const { project, variantsTasks } = patch;
-  const { variants } = project;
+  const { variants, tasks } = project;
   const [selectedTab, selectTabHandler] = useTabs({
     tabToIndexMap,
     defaultTab: DEFAULT_TAB,
@@ -30,17 +31,26 @@ export const ConfigurePatchCore: React.FC<Props> = ({ patch }) => {
     tabToIndexMap,
     defaultPath: `${paths.patch}/${patch.id}/configure/${DEFAULT_TAB}`,
   });
-  const [selectedBuildVariant, setSelectedBuildVariant] = useState<string>(
-    variants[0].name
-  );
+  const [selectedBuildVariant, setSelectedBuildVariant] = useState<
+    string | null
+  >(get(variants[0], "name", ""));
   const [selectedVariantTasks, setSelectedVariantTasks] = useState<
     VariantTasksState
   >(convertPatchVariantTasksToStateShape(variantsTasks));
   const [descriptionValue, setdescriptionValue] = useState<string>(
-    patch.description
+    patch.description || ""
   );
   const onChangePatchName = (e: React.ChangeEvent<HTMLInputElement>) =>
     setdescriptionValue(e.target.value);
+  if (variants.length === 0 || tasks.length === 0) {
+    return (
+      // TODO: Full page error
+      <PageLayout>
+        Something went wrong. This patch's project either has no variants or
+        tasks associated with it.{" "}
+      </PageLayout>
+    );
+  }
   return (
     <>
       <StyledBody weight="medium">Patch Name</StyledBody>

--- a/src/pages/configurePatch/ConfigurePatchCore.tsx
+++ b/src/pages/configurePatch/ConfigurePatchCore.tsx
@@ -21,7 +21,7 @@ interface Props {
 }
 export const ConfigurePatchCore: React.FC<Props> = ({ patch }) => {
   const { project, variantsTasks } = patch;
-  const { variants, tasks } = project;
+  const { variants } = project;
   const [selectedTab, selectTabHandler] = useTabs({
     tabToIndexMap,
     defaultTab: DEFAULT_TAB,

--- a/src/pages/configurePatch/ConfigurePatchCore.tsx
+++ b/src/pages/configurePatch/ConfigurePatchCore.tsx
@@ -42,18 +42,6 @@ export const ConfigurePatchCore: React.FC<Props> = ({ patch }) => {
   );
   const onChangePatchName = (e: React.ChangeEvent<HTMLInputElement>) =>
     setdescriptionValue(e.target.value);
-
-  if (variants.length === 0 || tasks.length === 0) {
-    return (
-      // TODO: Full page error
-      <PageLayout>
-        <div data-cy="full-page-error">
-          Something went wrong. This patch's project either has no variants or
-          tasks associated with it.{" "}
-        </div>
-      </PageLayout>
-    );
-  }
   return (
     <>
       <StyledBody weight="medium">Patch Name</StyledBody>

--- a/src/pages/configurePatch/ConfigurePatchCore.tsx
+++ b/src/pages/configurePatch/ConfigurePatchCore.tsx
@@ -21,7 +21,7 @@ interface Props {
 }
 export const ConfigurePatchCore: React.FC<Props> = ({ patch }) => {
   const { project, variantsTasks } = patch;
-  const { variants } = project;
+  const { variants, tasks } = project;
   const [selectedTab, selectTabHandler] = useTabs({
     tabToIndexMap,
     defaultTab: DEFAULT_TAB,
@@ -42,6 +42,17 @@ export const ConfigurePatchCore: React.FC<Props> = ({ patch }) => {
   );
   const onChangePatchName = (e: React.ChangeEvent<HTMLInputElement>) =>
     setdescriptionValue(e.target.value);
+  if (variants.length === 0 || tasks.length === 0) {
+    return (
+      // TODO: Full page error
+      <PageLayout>
+        <div data-cy="full-page-error">
+          Something went wrong. This patch's project either has no variants or
+          no tasks associated with it.{" "}
+        </div>
+      </PageLayout>
+    );
+  }
   return (
     <>
       <StyledBody weight="medium">Patch Name</StyledBody>

--- a/src/pages/configurePatch/ConfigurePatchCore.tsx
+++ b/src/pages/configurePatch/ConfigurePatchCore.tsx
@@ -31,9 +31,9 @@ export const ConfigurePatchCore: React.FC<Props> = ({ patch }) => {
     tabToIndexMap,
     defaultPath: `${paths.patch}/${patch.id}/configure/${DEFAULT_TAB}`,
   });
-  const [selectedBuildVariant, setSelectedBuildVariant] = useState<
-    string | null
-  >(get(variants[0], "name", ""));
+  const [selectedBuildVariant, setSelectedBuildVariant] = useState<string>(
+    get(variants[0], "name", "")
+  );
   const [selectedVariantTasks, setSelectedVariantTasks] = useState<
     VariantTasksState
   >(convertPatchVariantTasksToStateShape(variantsTasks));

--- a/src/pages/configurePatch/ConfigurePatchCore.tsx
+++ b/src/pages/configurePatch/ConfigurePatchCore.tsx
@@ -42,12 +42,15 @@ export const ConfigurePatchCore: React.FC<Props> = ({ patch }) => {
   );
   const onChangePatchName = (e: React.ChangeEvent<HTMLInputElement>) =>
     setdescriptionValue(e.target.value);
+
   if (variants.length === 0 || tasks.length === 0) {
     return (
       // TODO: Full page error
       <PageLayout>
-        Something went wrong. This patch's project either has no variants or
-        tasks associated with it.{" "}
+        <div data-cy="full-page-error">
+          Something went wrong. This patch's project either has no variants or
+          tasks associated with it.{" "}
+        </div>
       </PageLayout>
     );
   }


### PR DESCRIPTION
#### If a patch's project has no variants or tasks then the patch itself is 1. invalid and 2. cannot be scheduled. Therefore show full page error. 

<img width="733" alt="Screen Shot 2020-04-28 at 1 44 34 PM" src="https://user-images.githubusercontent.com/15262143/80519723-6d2bc800-8956-11ea-93f2-e4af6275622f.png">

@khelif96 uncovered an error when he was redirected to the configure page for a patch whose project had no variants and no tasks. This broke the page because it expects all patches to be associated with a project that has variants and tasks. 

**It is very unlikely that this can happen in production, but I added this check to safeguard against this error.** 

#### TODO
This will be changed to a full page banner error when I do the ticket to create the banners. 