### PR TITLE
EVG-7511: render commit queue position in patch metadata

### DIFF
--- a/cypress/integration/patch-route.ts
+++ b/cypress/integration/patch-route.ts
@@ -55,6 +55,12 @@ describe("Patch route", function() {
     cy.get("#task-count").within(hasText);
   });
 
+  it("Shows commit queue position in metadata if patch is on commit queue", function() {
+    cy.visit(`/patch/${patch.id}`);
+    cy.dataCy("commit-queue-position").click();
+    cy.location("pathname").should("eq", "/commit-queue/mongodb-mongo-test");
+  });
+
   it("'Base commit' link in metadata links to version page of legacy UI", function() {
     cy.visit(`/patch/${patch.id}`);
     cy.get("#patch-base-commit")

--- a/cypress/integration/patch-route.ts
+++ b/cypress/integration/patch-route.ts
@@ -30,7 +30,7 @@ const hasText = ($el) => {
   expect($el.text.length > 0).to.eq(true);
 };
 
-describe("Patch route", function() {
+describe("Patch route", () => {
   before(() => {
     cy.login();
   });
@@ -49,19 +49,19 @@ describe("Patch route", function() {
     });
   });
 
-  it("Renders patch info", function() {
+  it("Renders patch info", () => {
     cy.visit(`/patch/${patch.id}`);
     cy.dataCy("page-title").within(hasText);
     cy.get("#task-count").within(hasText);
   });
 
-  it("Shows commit queue position in metadata if patch is on commit queue", function() {
+  it("Shows commit queue position in metadata if patch is on commit queue", () => {
     cy.visit(`/patch/${patch.id}`);
     cy.dataCy("commit-queue-position").click();
     cy.location("pathname").should("eq", "/commit-queue/mongodb-mongo-test");
   });
 
-  it("'Base commit' link in metadata links to version page of legacy UI", function() {
+  it("'Base commit' link in metadata links to version page of legacy UI", () => {
     cy.visit(`/patch/${patch.id}`);
     cy.get("#patch-base-commit")
       .should("have.attr", "href")

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -1,23 +1,21 @@
 import React from "react";
 import styled from "@emotion/styled/macro";
 import { useAuthDispatchContext, useAuthStateContext } from "context/auth";
-import { ProjectSelect, ProjectSelectProps } from "components/ProjectSelect";
+import { ProjectSelectProps } from "components/ProjectSelect";
 import { Layout } from "antd";
 
 const { Header } = Layout;
 
-export const Navbar: React.FC<ProjectSelectProps> = ({ data, loading }) => {
+export const Navbar: React.FC<ProjectSelectProps> = () => {
   const { logout } = useAuthDispatchContext();
   const { isAuthenticated } = useAuthStateContext();
 
   if (!isAuthenticated) {
     return null;
   }
-
   return (
     <StyledHeader>
       <InnerWrapper>
-        <ProjectSelect data={data} loading={loading} />
         <LogoutButton id="logout" onClick={logout}>
           Logout
         </LogoutButton>
@@ -31,14 +29,12 @@ const StyledHeader = styled(Header)`
   background: #20313c;
   margin-bottom: 16px;
 `;
-
 const InnerWrapper = styled.div`
   display: flex;
   align-items: center;
   justify-content: flex-end;
   height: 100%;
 `;
-
 const LogoutButton = styled.div`
   cursor: pointer;
 `;

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -1,21 +1,23 @@
 import React from "react";
 import styled from "@emotion/styled/macro";
 import { useAuthDispatchContext, useAuthStateContext } from "context/auth";
-import { ProjectSelectProps } from "components/ProjectSelect";
+import { ProjectSelect, ProjectSelectProps } from "components/ProjectSelect";
 import { Layout } from "antd";
 
 const { Header } = Layout;
 
-export const Navbar: React.FC<ProjectSelectProps> = () => {
+export const Navbar: React.FC<ProjectSelectProps> = ({ data, loading }) => {
   const { logout } = useAuthDispatchContext();
   const { isAuthenticated } = useAuthStateContext();
 
   if (!isAuthenticated) {
     return null;
   }
+
   return (
     <StyledHeader>
       <InnerWrapper>
+        <ProjectSelect data={data} loading={loading} />
         <LogoutButton id="logout" onClick={logout}>
           Logout
         </LogoutButton>
@@ -29,12 +31,14 @@ const StyledHeader = styled(Header)`
   background: #20313c;
   margin-bottom: 16px;
 `;
+
 const InnerWrapper = styled.div`
   display: flex;
   align-items: center;
   justify-content: flex-end;
   height: 100%;
 `;
+
 const LogoutButton = styled.div`
   cursor: pointer;
 `;

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -64,6 +64,11 @@ export type FileDiff = {
   diffLink: Scalars['String'];
 };
 
+export type GithubUser = {
+  uid?: Maybe<Scalars['Int']>;
+  lastKnownAs?: Maybe<Scalars['String']>;
+};
+
 export type GroupedFiles = {
   taskName?: Maybe<Scalars['String']>;
   files?: Maybe<Array<File>>;
@@ -111,6 +116,7 @@ export type Mutation = {
   restartTask: Task;
   saveSubscription: Scalars['Boolean'];
   removePatchFromCommitQueue?: Maybe<Scalars['String']>;
+  restartPatch?: Maybe<Scalars['String']>;
 };
 
 
@@ -166,6 +172,20 @@ export type MutationRemovePatchFromCommitQueueArgs = {
   patchId: Scalars['String'];
 };
 
+
+export type MutationRestartPatchArgs = {
+  patchId: Scalars['String'];
+};
+
+export type Notifications = {
+  buildBreak?: Maybe<Scalars['String']>;
+  patchFinish?: Maybe<Scalars['String']>;
+  patchFirstFailure?: Maybe<Scalars['String']>;
+  spawnHostExpiration?: Maybe<Scalars['String']>;
+  spawnHostOutcome?: Maybe<Scalars['String']>;
+  commitQueue?: Maybe<Scalars['String']>;
+};
+
 export type Patch = {
   createTime?: Maybe<Scalars['Time']>;
   id: Scalars['ID'];
@@ -188,6 +208,7 @@ export type Patch = {
   moduleCodeChanges: Array<ModuleCodeChange>;
   project?: Maybe<PatchProject>;
   builds: Array<Build>;
+  commitQueuePosition?: Maybe<Scalars['Int']>;
 };
 
 export type PatchBuildVariant = {
@@ -262,6 +283,7 @@ export type Query = {
   taskLogs: RecentTaskLogs;
   patchBuildVariants: Array<PatchBuildVariant>;
   commitQueue: CommitQueue;
+  userSettings?: Maybe<UserSettings>;
 };
 
 
@@ -501,6 +523,14 @@ export type UserPatches = {
   filteredPatchCount: Scalars['Int'];
 };
 
+export type UserSettings = {
+  timezone?: Maybe<Scalars['String']>;
+  region?: Maybe<Scalars['String']>;
+  githubUser?: Maybe<GithubUser>;
+  slackUsername?: Maybe<Scalars['String']>;
+  notifications?: Maybe<Notifications>;
+};
+
 export type VariantTask = {
   name: Scalars['String'];
   tasks: Array<Scalars['String']>;
@@ -647,7 +677,7 @@ export type PatchQueryVariables = {
 };
 
 
-export type PatchQuery = { patch: { id: string, description: string, projectID: string, githash: string, patchNumber: number, author: string, version: string, status: string, activated: boolean, alias: string, taskCount?: Maybe<number>, duration?: Maybe<{ makespan?: Maybe<string>, timeTaken?: Maybe<string> }>, time?: Maybe<{ started?: Maybe<string>, submittedAt: string, finished?: Maybe<string> }>, variantsTasks: Array<Maybe<{ name: string, tasks: Array<string> }>> } };
+export type PatchQuery = { patch: { id: string, description: string, projectID: string, githash: string, patchNumber: number, author: string, version: string, status: string, activated: boolean, alias: string, taskCount?: Maybe<number>, commitQueuePosition?: Maybe<number>, duration?: Maybe<{ makespan?: Maybe<string>, timeTaken?: Maybe<string> }>, time?: Maybe<{ started?: Maybe<string>, submittedAt: string, finished?: Maybe<string> }>, variantsTasks: Array<Maybe<{ name: string, tasks: Array<string> }>> } };
 
 export type ConfigurePatchQueryVariables = {
   id: Scalars['String'];

--- a/src/gql/queries/patch.ts
+++ b/src/gql/queries/patch.ts
@@ -14,6 +14,7 @@ export const GET_PATCH = gql`
       activated
       alias
       taskCount
+      commitQueuePosition
       duration {
         makespan
         timeTaken

--- a/src/pages/patch/Metadata.tsx
+++ b/src/pages/patch/Metadata.tsx
@@ -41,7 +41,7 @@ export const Metadata: React.FC<Props> = ({ loading, patch, error }) => {
           Base commit: {githash ? githash.slice(0, 10) : ""}
         </StyledLink>
       </P2>
-      {commitQueuePosition && (
+      {commitQueuePosition !== null && (
         <P2>
           <StyledLink
             data-cy="commit-queue-position"

--- a/src/pages/patch/Metadata.tsx
+++ b/src/pages/patch/Metadata.tsx
@@ -5,6 +5,7 @@ import { PatchQuery } from "gql/generated/types";
 import { getUiUrl } from "utils/getEnvironmentVariables";
 import { ApolloError } from "apollo-client";
 import { MetadataCard } from "components/MetadataCard";
+import { paths } from "constants/routes";
 
 interface Props {
   loading: boolean;
@@ -13,10 +14,17 @@ interface Props {
 }
 
 export const Metadata: React.FC<Props> = ({ loading, patch, error }) => {
-  const { author, githash, version, time, duration } = patch || {};
+  const {
+    author,
+    githash,
+    version,
+    time,
+    duration,
+    projectID,
+    commitQueuePosition,
+  } = patch || {};
   const { submittedAt, started, finished } = time || {};
   const { makespan, timeTaken } = duration || {};
-
   return (
     <MetadataCard loading={loading} error={error} title="Patch Metadata">
       <P2>Makespan: {makespan && makespan}</P2>
@@ -33,6 +41,16 @@ export const Metadata: React.FC<Props> = ({ loading, patch, error }) => {
           Base commit: {githash ? githash.slice(0, 10) : ""}
         </StyledLink>
       </P2>
+      {commitQueuePosition && (
+        <P2>
+          <StyledLink
+            data-cy="commit-queue-position"
+            href={`${paths.commitQueue}/${projectID}`}
+          >
+            Commit queue position: {commitQueuePosition}
+          </StyledLink>
+        </P2>
+      )}
     </MetadataCard>
   );
 };


### PR DESCRIPTION
Show commit queue position and link to commit queue page

![cq-position](https://user-images.githubusercontent.com/15262143/81094413-762a1580-8ed1-11ea-8df5-9c34360d1544.gif)

### Failing tests
Due to cq data not being in local evergreen
[This PR](https://github.com/evergreen-ci/evergreen/pull/3558) must be merged for tests to pass