### PR TITLE
EVG-7838: set initial state for table sorters 

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -7,6 +7,7 @@ import { useFilterInputChangeHandler } from "hooks/useFilterInputChangeHandler";
 import { useStatusesFilter } from "hooks/useStatusesFilter";
 import { usePatchStatusSelect } from "hooks/usePatchStatusSelect";
 import { useNotificationModal } from "hooks/useNotificationModal";
+import { useSetColumnDefaultSortOrder } from "hooks/useSetColumnDefaultSortOrder";
 
 export const usePrevious = <T>(state: T): T | undefined => {
   const ref = useRef<T>();
@@ -25,4 +26,5 @@ export {
   useStatusesFilter,
   usePatchStatusSelect,
   useNotificationModal,
+  useSetColumnDefaultSortOrder,
 };

--- a/src/hooks/tests/useSetColumnDefaultSortOrder.test.ts
+++ b/src/hooks/tests/useSetColumnDefaultSortOrder.test.ts
@@ -1,0 +1,81 @@
+import { renderHook } from "@testing-library/react-hooks";
+import { useSetColumnDefaultSortOrder } from "hooks";
+import { ColumnProps } from "antd/lib/table";
+import { TestResult, SortDirection } from "gql/generated/types";
+
+test("Should add defaultSortOrder key with supplied direction to column item with matching category", () => {
+  const columns: ColumnProps<TestResult>[] = [
+    {
+      title: "Name",
+      dataIndex: "testFile",
+      key: "testName",
+      sorter: true,
+    },
+    {
+      title: "Status",
+      dataIndex: "status",
+      key: "status",
+      sorter: true,
+      width: "20%",
+    },
+  ];
+
+  renderHook(() =>
+    useSetColumnDefaultSortOrder(columns, "testName", SortDirection.Asc)
+  );
+
+  expect(columns).toStrictEqual([
+    {
+      title: "Name",
+      dataIndex: "testFile",
+      key: "testName",
+      sorter: true,
+      defaultSortOrder: "ascend",
+    },
+    {
+      title: "Status",
+      dataIndex: "status",
+      key: "status",
+      sorter: true,
+      width: "20%",
+    },
+  ]);
+});
+
+test("Should not make any changes to columns if the supplied category is not found", () => {
+  const columns: ColumnProps<TestResult>[] = [
+    {
+      title: "Name",
+      dataIndex: "testFile",
+      key: "testName",
+      sorter: true,
+    },
+    {
+      title: "Status",
+      dataIndex: "status",
+      key: "status",
+      sorter: true,
+      width: "20%",
+    },
+  ];
+
+  renderHook(() =>
+    useSetColumnDefaultSortOrder(columns, "crazy stuff", SortDirection.Asc)
+  );
+
+  expect(columns).toStrictEqual([
+    {
+      title: "Name",
+      dataIndex: "testFile",
+      key: "testName",
+      sorter: true,
+    },
+    {
+      title: "Status",
+      dataIndex: "status",
+      key: "status",
+      sorter: true,
+      width: "20%",
+    },
+  ]);
+});

--- a/src/hooks/tests/useSetColumnDefaultSortOrder.test.ts
+++ b/src/hooks/tests/useSetColumnDefaultSortOrder.test.ts
@@ -20,11 +20,11 @@ test("Should add a defaultSortOrder key with the supplied direction to the colum
     },
   ];
 
-  renderHook(() =>
+  const { result } = renderHook(() =>
     useSetColumnDefaultSortOrder(columns, "testName", SortDirection.Asc)
   );
 
-  expect(columns).toStrictEqual([
+  expect(result.current).toStrictEqual([
     {
       title: "Name",
       dataIndex: "testFile",
@@ -59,11 +59,11 @@ test("Should not make any changes to columns if the supplied category is not fou
     },
   ];
 
-  renderHook(() =>
+  const { result } = renderHook(() =>
     useSetColumnDefaultSortOrder(columns, "crazy stuff", SortDirection.Asc)
   );
 
-  expect(columns).toStrictEqual([
+  expect(result.current).toStrictEqual([
     {
       title: "Name",
       dataIndex: "testFile",

--- a/src/hooks/tests/useSetColumnDefaultSortOrder.test.ts
+++ b/src/hooks/tests/useSetColumnDefaultSortOrder.test.ts
@@ -4,22 +4,6 @@ import { ColumnProps } from "antd/lib/table";
 import { TestResult, SortDirection } from "gql/generated/types";
 
 test("Should add a defaultSortOrder key with the supplied direction to the column item with a key matching the supplied category", () => {
-  const columns: ColumnProps<TestResult>[] = [
-    {
-      title: "Name",
-      dataIndex: "testFile",
-      key: "testName",
-      sorter: true,
-    },
-    {
-      title: "Status",
-      dataIndex: "status",
-      key: "status",
-      sorter: true,
-      width: "20%",
-    },
-  ];
-
   const { result } = renderHook(() =>
     useSetColumnDefaultSortOrder(columns, "testName", SortDirection.Asc)
   );
@@ -43,22 +27,6 @@ test("Should add a defaultSortOrder key with the supplied direction to the colum
 });
 
 test("Should not make any changes to columns if the supplied category is not found", () => {
-  const columns: ColumnProps<TestResult>[] = [
-    {
-      title: "Name",
-      dataIndex: "testFile",
-      key: "testName",
-      sorter: true,
-    },
-    {
-      title: "Status",
-      dataIndex: "status",
-      key: "status",
-      sorter: true,
-      width: "20%",
-    },
-  ];
-
   const { result } = renderHook(() =>
     useSetColumnDefaultSortOrder(columns, "crazy stuff", SortDirection.Asc)
   );
@@ -79,3 +47,19 @@ test("Should not make any changes to columns if the supplied category is not fou
     },
   ]);
 });
+
+const columns: ColumnProps<TestResult>[] = [
+  {
+    title: "Name",
+    dataIndex: "testFile",
+    key: "testName",
+    sorter: true,
+  },
+  {
+    title: "Status",
+    dataIndex: "status",
+    key: "status",
+    sorter: true,
+    width: "20%",
+  },
+];

--- a/src/hooks/tests/useSetColumnDefaultSortOrder.test.ts
+++ b/src/hooks/tests/useSetColumnDefaultSortOrder.test.ts
@@ -3,7 +3,7 @@ import { useSetColumnDefaultSortOrder } from "hooks";
 import { ColumnProps } from "antd/lib/table";
 import { TestResult, SortDirection } from "gql/generated/types";
 
-test("Should add defaultSortOrder key with supplied direction to column item with matching category", () => {
+test("Should add a defaultSortOrder key with the supplied direction to the column item with a key matching the supplied category", () => {
   const columns: ColumnProps<TestResult>[] = [
     {
       title: "Name",

--- a/src/hooks/useSetColumnDefaultSortOrder.ts
+++ b/src/hooks/useSetColumnDefaultSortOrder.ts
@@ -1,0 +1,15 @@
+import { SortDirection } from "gql/generated/types";
+import { ColumnProps } from "antd/es/table";
+
+export const useSetColumnDefaultSortOrder = <T>(
+  columns: ColumnProps<T>[],
+  category: string,
+  direction: string
+) => {
+  const targetColumnHeader = columns.find(({ key }) => key === category);
+  if (targetColumnHeader) {
+    // eslint-disable-next-line no-param-reassign
+    targetColumnHeader.defaultSortOrder =
+      direction === SortDirection.Asc ? "ascend" : "descend";
+  }
+};

--- a/src/hooks/useSetColumnDefaultSortOrder.ts
+++ b/src/hooks/useSetColumnDefaultSortOrder.ts
@@ -1,15 +1,24 @@
 import { SortDirection } from "gql/generated/types";
 import { ColumnProps } from "antd/es/table";
+import { useState } from "react";
+import { SortOrder } from "antd/lib/table";
 
 export const useSetColumnDefaultSortOrder = <T>(
   columns: ColumnProps<T>[],
   category: string,
   direction: string
 ) => {
-  const targetColumnHeader = columns.find(({ key }) => key === category);
-  if (targetColumnHeader) {
-    // eslint-disable-next-line no-param-reassign
-    targetColumnHeader.defaultSortOrder =
-      direction === SortDirection.Asc ? "ascend" : "descend";
+  const [modifiedColumns, setModifiedColumns] = useState<ColumnProps<T>[]>();
+  if (!modifiedColumns) {
+    const columnsClone = columns.map((c) => ({
+      ...c,
+      ...(c.key === category && {
+        defaultSortOrder: (direction === SortDirection.Asc
+          ? "ascend"
+          : "descend") as SortOrder,
+      }),
+    }));
+    setModifiedColumns(columnsClone);
   }
+  return modifiedColumns;
 };

--- a/src/pages/patch/patchTabs/Tasks.tsx
+++ b/src/pages/patch/patchTabs/Tasks.tsx
@@ -49,11 +49,8 @@ export const Tasks: React.FC<Props> = ({ taskCount }) => {
     patchId: id,
     ...getQueryVariables(search),
   });
-  useSetColumnDefaultSortOrder<TaskResult>(
-    columns,
-    initialQueryVariables.sortBy,
-    initialQueryVariables.sortDir
-  );
+  const { sortBy, sortDir } = initialQueryVariables;
+  useSetColumnDefaultSortOrder<TaskResult>(columns, sortBy, sortDir);
   const { data, error, networkStatus, fetchMore } = useQuery<
     PatchTasksQuery,
     PatchTasksQueryVariables

--- a/src/pages/patch/patchTabs/Tasks.tsx
+++ b/src/pages/patch/patchTabs/Tasks.tsx
@@ -2,10 +2,18 @@ import React, { useEffect, useState } from "react";
 import { useQuery } from "@apollo/react-hooks";
 import { useParams, useHistory, useLocation } from "react-router-dom";
 import { GET_PATCH_TASKS } from "gql/queries/get-patch-tasks";
-import { PatchTasksQuery, PatchTasksQueryVariables } from "gql/generated/types";
+import {
+  PatchTasksQuery,
+  PatchTasksQueryVariables,
+  TaskResult,
+  SortDirection,
+} from "gql/generated/types";
 import { TasksTable } from "pages/patch/patchTabs/tasks/TasksTable";
 import queryString from "query-string";
-import { useDisableTableSortersIfLoading } from "hooks";
+import {
+  useDisableTableSortersIfLoading,
+  useSetColumnDefaultSortOrder,
+} from "hooks";
 import get from "lodash.get";
 import { ErrorBoundary } from "components/ErrorBoundary";
 import { TaskFilters } from "pages/patch/patchTabs/tasks/TaskFilters";
@@ -20,11 +28,14 @@ import {
   TableContainer,
   TableControlOuterRow,
   TableControlInnerRow,
+  StyledRouterLink,
 } from "components/styles";
 import { Pagination } from "components/Pagination";
 import { ResultCountLabel } from "components/ResultCountLabel";
 import { Skeleton } from "antd";
 import { isNetworkRequestInFlight } from "apollo-client/core/networkStatus";
+import { TaskStatusBadge } from "components/TaskStatusBadge";
+import { ColumnProps } from "antd/lib/table";
 
 interface Props {
   taskCount: number;
@@ -38,6 +49,11 @@ export const Tasks: React.FC<Props> = ({ taskCount }) => {
     patchId: id,
     ...getQueryVariables(search),
   });
+  useSetColumnDefaultSortOrder<TaskResult>(
+    columns,
+    initialQueryVariables.sortBy,
+    initialQueryVariables.sortDir
+  );
   const { data, error, networkStatus, fetchMore } = useQuery<
     PatchTasksQuery,
     PatchTasksQueryVariables
@@ -101,7 +117,7 @@ export const Tasks: React.FC<Props> = ({ taskCount }) => {
         </TableControlInnerRow>
       </TableControlOuterRow>
       <TableContainer hide={isLoading}>
-        <TasksTable data={get(data, "patchTasks", [])} />
+        <TasksTable columns={columns} data={get(data, "patchTasks", [])} />
       </TableContainer>
       {isLoading && <Skeleton active title={false} paragraph={{ rows: 80 }} />}
     </ErrorBoundary>
@@ -142,6 +158,13 @@ const getStatuses = (rawStatuses: string[] | string): string[] => {
   return statuses;
 };
 
+enum TableColumnHeader {
+  Name = "NAME",
+  Status = "STATUS",
+  BaseStatus = "BASE_STATUS",
+  Variant = "VARIANT",
+}
+
 const getQueryVariables = (
   search: string
 ): {
@@ -169,8 +192,8 @@ const getQueryVariables = (
   const limitNum = parseInt(getString(limit), 10);
 
   return {
-    sortBy: getString(sortBy),
-    sortDir: getString(sortDir),
+    sortBy: getString(sortBy) ?? TableColumnHeader.Status,
+    sortDir: getString(sortDir) ?? SortDirection.Asc,
     variant: getString(variant),
     taskName: getString(taskName),
     statuses: getStatuses(rawStatuses),
@@ -182,3 +205,47 @@ const getQueryVariables = (
         : DEFAULT_PAGE_SIZE,
   };
 };
+
+const renderStatusBadge = (status): null | JSX.Element => {
+  if (status === "" || !status) {
+    return null;
+  }
+  return <TaskStatusBadge status={status} />;
+};
+
+const columns: Array<ColumnProps<TaskResult>> = [
+  {
+    title: "Name",
+    dataIndex: "displayName",
+    key: TableColumnHeader.Name,
+    sorter: true,
+    width: "40%",
+    className: "cy-task-table-col-NAME",
+    render: (name: string, { id }: TaskResult): JSX.Element => (
+      <StyledRouterLink to={`/task/${id}`}>{name}</StyledRouterLink>
+    ),
+  },
+  {
+    title: "Patch Status",
+    dataIndex: "status",
+    key: TableColumnHeader.Status,
+    sorter: true,
+    className: "cy-task-table-col-STATUS",
+    render: renderStatusBadge,
+  },
+  {
+    title: "Base Status",
+    dataIndex: "baseStatus",
+    key: TableColumnHeader.BaseStatus,
+    sorter: true,
+    className: "cy-task-table-col-BASE_STATUS",
+    render: renderStatusBadge,
+  },
+  {
+    title: "Variant",
+    dataIndex: "buildVariant",
+    key: TableColumnHeader.Variant,
+    sorter: true,
+    className: "cy-task-table-col-VARIANT",
+  },
+];

--- a/src/pages/patch/patchTabs/Tasks.tsx
+++ b/src/pages/patch/patchTabs/Tasks.tsx
@@ -50,7 +50,11 @@ export const Tasks: React.FC<Props> = ({ taskCount }) => {
     ...getQueryVariables(search),
   });
   const { sortBy, sortDir } = initialQueryVariables;
-  useSetColumnDefaultSortOrder<TaskResult>(columns, sortBy, sortDir);
+  const columns = useSetColumnDefaultSortOrder<TaskResult>(
+    columnsTemplate,
+    sortBy,
+    sortDir
+  );
   const { data, error, networkStatus, fetchMore } = useQuery<
     PatchTasksQuery,
     PatchTasksQueryVariables
@@ -210,7 +214,7 @@ const renderStatusBadge = (status): null | JSX.Element => {
   return <TaskStatusBadge status={status} />;
 };
 
-const columns: Array<ColumnProps<TaskResult>> = [
+const columnsTemplate: Array<ColumnProps<TaskResult>> = [
   {
     title: "Name",
     dataIndex: "displayName",

--- a/src/pages/patch/patchTabs/tasks/TasksTable.tsx
+++ b/src/pages/patch/patchTabs/tasks/TasksTable.tsx
@@ -1,7 +1,5 @@
 import React from "react";
-import { TaskStatusBadge } from "components/TaskStatusBadge";
 import { TaskResult, SortDirection, PatchTasks } from "gql/generated/types";
-import { StyledRouterLink } from "components/styles/StyledLink";
 import { PatchTasksQueryParams, TableOnChange } from "types/task";
 import { useHistory, useLocation } from "react-router-dom";
 import queryString from "query-string";
@@ -11,9 +9,10 @@ import get from "lodash/get";
 
 interface Props {
   data?: PatchTasks;
+  columns: Array<ColumnProps<TaskResult>>;
 }
 
-export const TasksTable: React.FC<Props> = ({ data }) => {
+export const TasksTable: React.FC<Props> = ({ data, columns }) => {
   const { replace } = useHistory();
   const { search, pathname } = useLocation();
 
@@ -50,53 +49,3 @@ export const TasksTable: React.FC<Props> = ({ data }) => {
 const arrayFormat = "comma";
 
 const rowKey = ({ id }: { id: string }): string => id;
-
-enum TableColumnHeader {
-  Name = "NAME",
-  Status = "STATUS",
-  BaseStatus = "BASE_STATUS",
-  Variant = "VARIANT",
-}
-
-const renderStatusBadge = (status): null | JSX.Element => {
-  if (status === "" || !status) {
-    return null;
-  }
-  return <TaskStatusBadge status={status} />;
-};
-const columns: Array<ColumnProps<TaskResult>> = [
-  {
-    title: "Name",
-    dataIndex: "displayName",
-    key: TableColumnHeader.Name,
-    sorter: true,
-    width: "40%",
-    className: "cy-task-table-col-NAME",
-    render: (name: string, { id }: TaskResult): JSX.Element => (
-      <StyledRouterLink to={`/task/${id}`}>{name}</StyledRouterLink>
-    ),
-  },
-  {
-    title: "Patch Status",
-    dataIndex: "status",
-    key: TableColumnHeader.Status,
-    sorter: true,
-    className: "cy-task-table-col-STATUS",
-    render: renderStatusBadge,
-  },
-  {
-    title: "Base Status",
-    dataIndex: "baseStatus",
-    key: TableColumnHeader.BaseStatus,
-    sorter: true,
-    className: "cy-task-table-col-BASE_STATUS",
-    render: renderStatusBadge,
-  },
-  {
-    title: "Variant",
-    dataIndex: "buildVariant",
-    key: TableColumnHeader.Variant,
-    sorter: true,
-    className: "cy-task-table-col-VARIANT",
-  },
-];

--- a/src/pages/task/testsTable/TestsTableCore.tsx
+++ b/src/pages/task/testsTable/TestsTableCore.tsx
@@ -50,7 +50,11 @@ export const TestsTableCore: React.FC = () => {
     ...getQueryVariables(search),
   });
   const { cat, dir } = initialQueryVariables;
-  useSetColumnDefaultSortOrder<TestResult>(columns, cat, dir);
+  const columns = useSetColumnDefaultSortOrder<TestResult>(
+    columnsTemplate,
+    cat,
+    dir
+  );
   const { data, fetchMore, networkStatus, error } = useQuery<
     TaskTestsQuery,
     TaskTestsQueryVariables
@@ -158,7 +162,7 @@ const statusCopy = {
   [TestStatus.Skip]: "Skip",
   [TestStatus.SilentFail]: "Silent Fail",
 };
-const columns: ColumnProps<TestResult>[] = [
+const columnsTemplate: ColumnProps<TestResult>[] = [
   {
     title: "Name",
     dataIndex: "testFile",

--- a/src/pages/task/testsTable/TestsTableCore.tsx
+++ b/src/pages/task/testsTable/TestsTableCore.tsx
@@ -33,6 +33,7 @@ import {
 import { ColumnProps } from "antd/es/table";
 import { Table, Skeleton } from "antd";
 import { isNetworkRequestInFlight } from "apollo-client/core/networkStatus";
+import { useSetColumnDefaultSortOrder } from "hooks/useSetColumnDefaultSortOrder";
 
 const arrayFormat = "comma";
 
@@ -48,7 +49,11 @@ export const TestsTableCore: React.FC = () => {
     id,
     ...getQueryVariables(search),
   });
-
+  useSetColumnDefaultSortOrder<TestResult>(
+    columns,
+    initialQueryVariables.cat,
+    initialQueryVariables.dir
+  );
   const { data, fetchMore, networkStatus, error } = useQuery<
     TaskTestsQuery,
     TaskTestsQueryVariables
@@ -57,7 +62,6 @@ export const TestsTableCore: React.FC = () => {
     notifyOnNetworkStatusChange: true,
   });
   useDisableTableSortersIfLoading(networkStatus);
-
   // this fetch is when url params change (sort direction, sort category, status list)
   // and the page num is set to 0
   useEffect(
@@ -104,10 +108,8 @@ export const TestsTableCore: React.FC = () => {
   };
 
   // initial table sort button state to reflect initial URL query params
-  const { cat, dir, pageNum, limitNum } = getQueryVariables(search);
+  const { pageNum, limitNum } = getQueryVariables(search);
 
-  columns.find(({ key }) => key === cat).defaultSortOrder =
-    dir === SortDirection.Asc ? "ascend" : "descend";
   const isLoading = isNetworkRequestInFlight(networkStatus);
   return (
     <>

--- a/src/pages/task/testsTable/TestsTableCore.tsx
+++ b/src/pages/task/testsTable/TestsTableCore.tsx
@@ -49,11 +49,8 @@ export const TestsTableCore: React.FC = () => {
     id,
     ...getQueryVariables(search),
   });
-  useSetColumnDefaultSortOrder<TestResult>(
-    columns,
-    initialQueryVariables.cat,
-    initialQueryVariables.dir
-  );
+  const { cat, dir } = initialQueryVariables;
+  useSetColumnDefaultSortOrder<TestResult>(columns, cat, dir);
   const { data, fetchMore, networkStatus, error } = useQuery<
     TaskTestsQuery,
     TaskTestsQueryVariables


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-7838
useSetColumnDefaultSortOrder handles setting the defaultSortOrder for the antd table column prop. I refactored the TasksTable so getQueryVariables is available in the same file as the columns in order to get the sort direction and sort category for the defaultSortOrder.