### PR TITLE
EVG-8079 Add ability to Reset an api key

### DIFF
--- a/src/pages/preferences/preferencesTabs/cliTab/AuthenticationCard.tsx
+++ b/src/pages/preferences/preferencesTabs/cliTab/AuthenticationCard.tsx
@@ -12,9 +12,10 @@ import {
   GetUserConfigQuery,
   GetUserConfigQueryVariables,
 } from "gql/generated/types";
+import { post } from "utils/request";
 
 export const AuthenticationCard = () => {
-  const { data, loading } = useQuery<
+  const { data, loading, refetch } = useQuery<
     GetUserConfigQuery,
     GetUserConfigQueryVariables
   >(GET_USER_CONFIG);
@@ -29,6 +30,11 @@ api_key: "${config.api_key}"
 api_server_host: "${config.api_server_host}"
 ui_server_host: "${config.ui_server_host}"
 `;
+  const resetKey = async (e) => {
+    e.preventDefault();
+    await post("/settings/newkey", {});
+    refetch();
+  };
   return (
     <Container>
       <Subtitle>Authentication</Subtitle>
@@ -36,7 +42,7 @@ ui_server_host: "${config.ui_server_host}"
         <Code language="none">{authCode}</Code>
       </CodeContainer>
       <StyledButton variant={Variant.Primary}>Download File</StyledButton>
-      <Button>Reset Key</Button>
+      <Button onClick={resetKey}>Reset Key</Button>
     </Container>
   );
 };

--- a/src/utils/request.test.js
+++ b/src/utils/request.test.js
@@ -1,0 +1,33 @@
+import axios from "axios";
+import { post } from "./request";
+
+const API_URL = "/some/endpoint";
+
+const jsonMessage = "got JSON response";
+
+const mockApi = {
+  statusText: "OK",
+  data: jsonMessage,
+};
+
+jest.mock("axios");
+
+test("posts", async () => {
+  axios.post.mockImplementationOnce(() => Promise.resolve(mockApi));
+  const response = await post(API_URL, {});
+  expect(response.data).toBe(jsonMessage);
+});
+
+test("should handle a bad response", async () => {
+  const { warn } = console;
+  console.warn = jest.fn();
+
+  const errorCallback = jest.fn();
+  axios.post.mockImplementationOnce(() => Promise.resolve(jsonMessage));
+
+  expect(await post(API_URL, {}, { onFailure: errorCallback })).toBe(undefined);
+  expect(console.warn).toHaveBeenCalledTimes(1);
+  expect(errorCallback).toHaveBeenCalledTimes(1);
+
+  console.warn = warn;
+});

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -1,0 +1,43 @@
+import axios from "axios";
+import { getLoginDomain } from "utils/getEnvironmentVariables";
+
+type optionsType = {
+  onFailure?: (e) => void;
+};
+export const post = async (
+  url: string,
+  body: unknown,
+  options: optionsType = {}
+) => {
+  try {
+    const response = await axios.post(getLoginDomain() + url, {
+      body,
+    });
+    if (isBadResponse(response)) {
+      throw new Error(getErrorMessage(response, "POST"));
+    }
+    return response;
+  } catch (e) {
+    if (options.onFailure) {
+      options.onFailure(e);
+    }
+    handleError(e);
+  }
+};
+
+const isBadResponse = (response) =>
+  !response || (response && response.statusText !== "OK");
+
+type responseType = {
+  status: number;
+  statusText: string;
+};
+const getErrorMessage = (response: responseType, method: string) =>
+  response
+    ? `${method} Error: ${response.status} - ${response.statusText}`
+    : `${method} Error: Did not receive a response from the server`;
+
+const handleError = (error: string) => {
+  console.warn(error);
+  // Log the error on bugsnag
+};


### PR DESCRIPTION
Used the already existing api route for this. 

Created some request util functions for traditional post requests to evergreen.
 They wrap `axios.post()` but include some error handling and some other boiler plate code we might have to write ourselves.

Still waiting to test this on staging.