### PR TITLE
EVG-8075 Use queried download links instead of static ones

### DIFF
--- a/src/constants/externalResources.ts
+++ b/src/constants/externalResources.ts
@@ -1,16 +1,2 @@
 export const cliDocumentationUrl =
   "https://github.com/evergreen-ci/evergreen/wiki/Using-the-Command-Line-Tool";
-
-export const cliDownloadUrls = {
-  linux_amd64: "https://evergreen.mongodb.com/clients/linux_amd64/evergreen",
-  darwin_amd64: "https://evergreen.mongodb.com/clients/darwin_amd64/evergreen",
-  windows_amd64:
-    "https://evergreen.mongodb.com/clients/windows_amd64/evergreen.exe",
-  linux_386: "https://evergreen.mongodb.com/clients/linux_386/evergreen",
-  linux_arm64: "https://evergreen.mongodb.com/clients/linux_arm64/evergreen",
-  linux_ppce64le:
-    "https://evergreen.mongodb.com/clients/linux_ppc64le/evergreen",
-  linux_s390x: "https://evergreen.mongodb.com/clients/linux_s390x/evergreen",
-  windows_386:
-    "https://evergreen.mongodb.com/clients/windows_386/evergreen.exe",
-};

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -24,6 +24,18 @@ export type Build = {
   actualMakespan: Scalars["Duration"];
 };
 
+export type ClientBinary = {
+  arch?: Maybe<Scalars["String"]>;
+  os?: Maybe<Scalars["String"]>;
+  url?: Maybe<Scalars["String"]>;
+  displayName?: Maybe<Scalars["String"]>;
+};
+
+export type ClientConfig = {
+  clientBinaries?: Maybe<Array<ClientBinary>>;
+  latestRevision?: Maybe<Scalars["String"]>;
+};
+
 export type CommitQueue = {
   projectId?: Maybe<Scalars["String"]>;
   queue?: Maybe<Array<CommitQueueItem>>;
@@ -234,6 +246,8 @@ export type Patch = {
   project?: Maybe<PatchProject>;
   builds: Array<Build>;
   commitQueuePosition?: Maybe<Scalars["Int"]>;
+  taskStatuses: Array<Scalars["String"]>;
+  baseTaskStatuses: Array<Scalars["String"]>;
 };
 
 export type PatchBuildVariant = {
@@ -310,6 +324,7 @@ export type Query = {
   commitQueue: CommitQueue;
   userSettings?: Maybe<UserSettings>;
   userConfig?: Maybe<UserConfig>;
+  clientConfig?: Maybe<ClientConfig>;
 };
 
 export type QueryUserPatchesArgs = {
@@ -678,6 +693,22 @@ export type UpdateUserSettingsMutationVariables = {
 };
 
 export type UpdateUserSettingsMutation = { updateUserSettings: boolean };
+
+export type ClientConfigQueryVariables = {};
+
+export type ClientConfigQuery = {
+  clientConfig?: Maybe<{
+    latestRevision?: Maybe<string>;
+    clientBinaries?: Maybe<
+      Array<{
+        os?: Maybe<string>;
+        displayName?: Maybe<string>;
+        url?: Maybe<string>;
+        arch?: Maybe<string>;
+      }>
+    >;
+  }>;
+};
 
 export type CodeChangesQueryVariables = {
   id: Scalars["String"];

--- a/src/gql/queries/get-client-config.ts
+++ b/src/gql/queries/get-client-config.ts
@@ -1,0 +1,15 @@
+import gql from "graphql-tag";
+
+export const GET_CLIENT_CONFIG = gql`
+  query ClientConfig {
+    clientConfig {
+      clientBinaries {
+        os
+        displayName
+        url
+        arch
+      }
+      latestRevision
+    }
+  }
+`;

--- a/src/gql/queries/index.ts
+++ b/src/gql/queries/index.ts
@@ -16,3 +16,4 @@ export {
 } from "./get-task-logs";
 export { GET_TASK_TESTS } from "./get-task-tests";
 export { GET_TASK, MetStatus, RequiredStatus } from "./get-task";
+export { GET_CLIENT_CONFIG } from "./get-client-config";

--- a/src/pages/preferences/preferencesTabs/cliTab/DownloadCard.tsx
+++ b/src/pages/preferences/preferencesTabs/cliTab/DownloadCard.tsx
@@ -1,68 +1,121 @@
 import React from "react";
+import { useQuery } from "@apollo/react-hooks";
 import { Subtitle, Body } from "@leafygreen-ui/typography";
 import styled from "@emotion/styled";
 import { uiColors } from "@leafygreen-ui/palette";
 import Button from "@leafygreen-ui/button";
+import { Skeleton } from "antd";
+import get from "lodash/get";
 import { SiderCard, StyledLink } from "components/styles";
 import { Accordian } from "components/Accordian";
+import { cliDocumentationUrl } from "constants/externalResources";
+import { GET_CLIENT_CONFIG } from "gql/queries";
 import {
-  cliDocumentationUrl,
-  cliDownloadUrls,
-} from "constants/externalResources";
+  ClientConfigQuery,
+  ClientConfigQueryVariables,
+  ClientBinary,
+} from "gql/generated/types";
 
 const { gray } = uiColors;
 
-export const DownloadCard = () => (
-  <Container>
-    <Subtitle>Command-Line Client</Subtitle>
-    <CardDescription>
-      View the <StyledLink href={cliDocumentationUrl}>documentation</StyledLink>{" "}
-      or run{" "}
-      <InlinePre>evergreen --help or evergreen [command] --help</InlinePre> for
-      additional assistance.
-    </CardDescription>
-    <CardGroup>
-      <CliDownloadBox
-        title="Linux (64-bit)"
-        link={cliDownloadUrls.linux_amd64}
+export const DownloadCard = () => {
+  const { data, loading } = useQuery<
+    ClientConfigQuery,
+    ClientConfigQueryVariables
+  >(GET_CLIENT_CONFIG);
+
+  if (loading) {
+    return <Skeleton active paragraph={{ rows: 6 }} />;
+  }
+  const clientBinaries = get(data, "clientConfig.clientBinaries", []);
+  return (
+    <Container>
+      <Subtitle>Command-Line Client</Subtitle>
+      <CardDescription>
+        <Body>
+          View the{" "}
+          <StyledLink href={cliDocumentationUrl}>documentation</StyledLink> or
+          run{" "}
+        </Body>
+        <InlinePre>evergreen --help or evergreen [command] --help</InlinePre>{" "}
+        <Body>for additional assistance.</Body>
+      </CardDescription>
+      <CardGroup>
+        <CliDownloadBox
+          title="Linux (64-bit)"
+          link={getBinaryUrl("linux", "amd64", clientBinaries)}
+        />
+        <CliDownloadBox
+          title="MacOS"
+          link={getBinaryUrl("darwin", "amd64", clientBinaries)}
+        />
+        <CliDownloadBox
+          title="Windows"
+          link={getBinaryUrl("windows", "amd64", clientBinaries)}
+        />
+      </CardGroup>
+      <Accordian
+        title={<StyledLink>Show More</StyledLink>}
+        toggledTitle={<StyledLink>Show Less</StyledLink>}
+        contents={<ExpandableLinkContents clientBinaries={clientBinaries} />}
+        toggleFromBottom
+        showCaret={false}
       />
-      <CliDownloadBox title="MacOS" link={cliDownloadUrls.darwin_amd64} />
-      <CliDownloadBox title="Windows" link={cliDownloadUrls.windows_amd64} />
-    </CardGroup>
-    <Accordian
-      title={<StyledLink>Show More</StyledLink>}
-      toggledTitle={<StyledLink>Show Less</StyledLink>}
-      contents={<ExpandableLinkContents />}
-      toggleFromBottom
-      showCaret={false}
-    />
-  </Container>
-);
+    </Container>
+  );
+};
 
 interface CliDownloadBoxProps {
   title: string;
-  link: string;
+  link: string | null;
 }
 const CliDownloadBox: React.FC<CliDownloadBoxProps> = ({ title, link }) => (
   <CliDownloadCard>
     <CliDownloadTitle>{title}</CliDownloadTitle>
-    <CliDownloadButton href={link} as="a">
+    <CliDownloadButton href={link} disabled={link === null} as="a">
       Download
     </CliDownloadButton>
   </CliDownloadCard>
 );
 
-const ExpandableLinkContents = () => (
+interface ExpandableLinkContentsProps {
+  clientBinaries: ClientBinary[];
+}
+const ExpandableLinkContents: React.FC<ExpandableLinkContentsProps> = ({
+  clientBinaries,
+}) => (
   <LinkContainer>
-    <StyledLink href={cliDownloadUrls.linux_arm64}>Linux ARM 64-bit</StyledLink>
-    <StyledLink href={cliDownloadUrls.linux_s390x}>Linux zSeries</StyledLink>
-    <StyledLink href={cliDownloadUrls.linux_386}>Linux 32-bit</StyledLink>
-    <StyledLink href={cliDownloadUrls.linux_ppce64le}>
+    <StyledLink href={getBinaryUrl("linux", "arm64", clientBinaries)}>
+      Linux ARM 64-bit
+    </StyledLink>
+    <StyledLink href={getBinaryUrl("linux", "s390x", clientBinaries)}>
+      Linux zSeries
+    </StyledLink>
+    <StyledLink href={getBinaryUrl("linux", "386", clientBinaries)}>
+      Linux 32-bit
+    </StyledLink>
+    <StyledLink href={getBinaryUrl("linux", "ppce64le", clientBinaries)}>
       Linux PowerPC 64-bit
     </StyledLink>
-    <StyledLink href={cliDownloadUrls.windows_386}>Windows 32-bit</StyledLink>
+    <StyledLink href={getBinaryUrl("windows", "386", clientBinaries)}>
+      Windows 32-bit
+    </StyledLink>
   </LinkContainer>
 );
+
+const getBinaryUrl = (
+  os: string,
+  arch: string,
+  clientBinaries: ClientBinary[]
+) => {
+  let url = null;
+  clientBinaries.forEach((binary) => {
+    if (binary.os === os && binary.arch === arch) {
+      url = binary.url;
+    }
+  });
+  return url;
+};
 const Container = styled(SiderCard)`
   padding-left: 20px;
   padding-top: 20px;
@@ -89,9 +142,9 @@ const CliDownloadTitle = styled(Subtitle)`
   font-weight: bold;
   padding-bottom: 45px;
 `;
-const CardDescription = styled(Body)`
+const CardDescription = styled.div`
   font-size: 14px;
-  padding-bottom: 40px;
+  margin-bottom: 40px;
 `;
 
 const InlinePre = styled("pre")`

--- a/src/pages/preferences/preferencesTabs/cliTab/DownloadCard.tsx
+++ b/src/pages/preferences/preferencesTabs/cliTab/DownloadCard.tsx
@@ -72,7 +72,7 @@ interface CliDownloadBoxProps {
 const CliDownloadBox: React.FC<CliDownloadBoxProps> = ({ title, link }) => (
   <CliDownloadCard>
     <CliDownloadTitle>{title}</CliDownloadTitle>
-    <CliDownloadButton href={link} disabled={link === null} as="a">
+    <CliDownloadButton href={link} disabled={!link} as="a">
       Download
     </CliDownloadButton>
   </CliDownloadCard>
@@ -108,14 +108,12 @@ const getBinaryUrl = (
   arch: string,
   clientBinaries: ClientBinary[]
 ) => {
-  let url = null;
-  clientBinaries.forEach((binary) => {
-    if (binary.os === os && binary.arch === arch) {
-      url = binary.url;
-    }
-  });
-  return url;
+  const binary = clientBinaries.find(
+    (clientBinary) => clientBinary.os === os && clientBinary.arch === arch
+  );
+  return binary ? binary.url : null;
 };
+
 const Container = styled(SiderCard)`
   padding-left: 20px;
   padding-top: 20px;

--- a/src/pages/preferences/preferencesTabs/cliTab/DownloadCard.tsx
+++ b/src/pages/preferences/preferencesTabs/cliTab/DownloadCard.tsx
@@ -97,8 +97,10 @@ const prettyDisplayName = {
   "Linux 64-bit": "Linux (64-bit)",
 };
 
-const filterBinaries = (binary: ClientBinary) =>
-  Object.keys(prettyDisplayName).includes(binary.displayName);
+const filterBinaries = (binary: ClientBinary) => {
+  const topBinaries = ["OSX 64-bit", "Windows 64-bit", "Linux 64-bit"];
+  return topBinaries.includes(binary.displayName);
+};
 
 const Container = styled(SiderCard)`
   padding-left: 20px;

--- a/src/pages/preferences/preferencesTabs/cliTab/DownloadCard.tsx
+++ b/src/pages/preferences/preferencesTabs/cliTab/DownloadCard.tsx
@@ -28,6 +28,10 @@ export const DownloadCard = () => {
     return <Skeleton active paragraph={{ rows: 6 }} />;
   }
   const clientBinaries = get(data, "clientConfig.clientBinaries", []);
+  const topBinaries = clientBinaries.filter(filterBinaries);
+  const otherBinaries = clientBinaries.filter(
+    (binary) => !filterBinaries(binary)
+  );
   return (
     <Container>
       <Subtitle>Command-Line Client</Subtitle>
@@ -41,23 +45,17 @@ export const DownloadCard = () => {
         <Body>for additional assistance.</Body>
       </CardDescription>
       <CardGroup>
-        <CliDownloadBox
-          title="Linux (64-bit)"
-          link={getBinaryUrl("linux", "amd64", clientBinaries)}
-        />
-        <CliDownloadBox
-          title="MacOS"
-          link={getBinaryUrl("darwin", "amd64", clientBinaries)}
-        />
-        <CliDownloadBox
-          title="Windows"
-          link={getBinaryUrl("windows", "amd64", clientBinaries)}
-        />
+        {topBinaries.map((binary) => (
+          <CliDownloadBox
+            title={prettyDisplayName[binary.displayName] || binary.displayName}
+            link={binary.url}
+          />
+        ))}
       </CardGroup>
       <Accordian
         title={<StyledLink>Show More</StyledLink>}
         toggledTitle={<StyledLink>Show Less</StyledLink>}
-        contents={<ExpandableLinkContents clientBinaries={clientBinaries} />}
+        contents={<ExpandableLinkContents clientBinaries={otherBinaries} />}
         toggleFromBottom
         showCaret={false}
       />
@@ -85,34 +83,22 @@ const ExpandableLinkContents: React.FC<ExpandableLinkContentsProps> = ({
   clientBinaries,
 }) => (
   <LinkContainer>
-    <StyledLink href={getBinaryUrl("linux", "arm64", clientBinaries)}>
-      Linux ARM 64-bit
-    </StyledLink>
-    <StyledLink href={getBinaryUrl("linux", "s390x", clientBinaries)}>
-      Linux zSeries
-    </StyledLink>
-    <StyledLink href={getBinaryUrl("linux", "386", clientBinaries)}>
-      Linux 32-bit
-    </StyledLink>
-    <StyledLink href={getBinaryUrl("linux", "ppce64le", clientBinaries)}>
-      Linux PowerPC 64-bit
-    </StyledLink>
-    <StyledLink href={getBinaryUrl("windows", "386", clientBinaries)}>
-      Windows 32-bit
-    </StyledLink>
+    {clientBinaries.map((binary) => (
+      <StyledLink href={binary.url}>
+        {prettyDisplayName[binary.displayName] || binary.displayName}
+      </StyledLink>
+    ))}
   </LinkContainer>
 );
 
-const getBinaryUrl = (
-  os: string,
-  arch: string,
-  clientBinaries: ClientBinary[]
-) => {
-  const binary = clientBinaries.find(
-    (clientBinary) => clientBinary.os === os && clientBinary.arch === arch
-  );
-  return binary ? binary.url : null;
+const prettyDisplayName = {
+  "OSX 64-bit": "MacOS",
+  "Windows 64-bit": "Windows",
+  "Linux 64-bit": "Linux (64-bit)",
 };
+
+const filterBinaries = (binary: ClientBinary) =>
+  Object.keys(prettyDisplayName).includes(binary.displayName);
 
 const Container = styled(SiderCard)`
   padding-left: 20px;


### PR DESCRIPTION
The download links for the cli binaries are now fetched from the evergreen backend. Since not every one has the same evergreen binaries on their system some download links will be disabled locally. Prod should have all the evergreen binaries and all the download links should work. 

Dependent on this.
https://github.com/evergreen-ci/evergreen/pull/3637