### PR TITLE
EVG-8114: massively decrease amount of rows shown for loading table

### DIFF
--- a/src/pages/patch/patchTabs/Tasks.tsx
+++ b/src/pages/patch/patchTabs/Tasks.tsx
@@ -117,7 +117,7 @@ export const Tasks: React.FC<Props> = ({ taskCount }) => {
       <TableContainer hide={isLoading}>
         <TasksTable columns={columns} data={get(data, "patchTasks", [])} />
       </TableContainer>
-      {isLoading && <Skeleton active title={false} paragraph={{ rows: 80 }} />}
+      {isLoading && <Skeleton active title={false} paragraph={{ rows: 8 }} />}
     </ErrorBoundary>
   );
 };

--- a/src/pages/task/testsTable/TestsTableCore.tsx
+++ b/src/pages/task/testsTable/TestsTableCore.tsx
@@ -142,7 +142,7 @@ export const TestsTableCore: React.FC = () => {
           onChange={tableChangeHandler}
         />
       </TableContainer>
-      {isLoading && <Skeleton active title={false} paragraph={{ rows: 80 }} />}
+      {isLoading && <Skeleton active title={false} paragraph={{ rows: 8 }} />}
     </>
   );
 };


### PR DESCRIPTION
Descreased from 80 to 8. 80 is way too many and was causing the page to jump when using the filters because it would increase the size of the page. 