### PR TITLE
EVG-8021: dynamically show patch task statuses in dropdown

### DIFF
--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -775,6 +775,18 @@ export type PatchBuildVariantsQuery = {
   }>;
 };
 
+export type GetPatchTaskStatusesQueryVariables = {
+  id: Scalars["String"];
+};
+
+export type GetPatchTaskStatusesQuery = {
+  patch: {
+    id: string;
+    taskStatuses: Array<string>;
+    baseTaskStatuses: Array<string>;
+  };
+};
+
 export type PatchTasksQueryVariables = {
   patchId: Scalars["String"];
   sortBy?: Maybe<TaskSortCategory>;
@@ -1019,17 +1031,6 @@ export type UserPatchesQuery = {
       createTime?: Maybe<Date>;
       builds: Array<{ id: string; buildVariant: string; status: string }>;
     }>;
-  };
-};
-
-export type PatchBuildVariantsAndStatusQueryVariables = {
-  id: Scalars["String"];
-};
-
-export type PatchBuildVariantsAndStatusQuery = {
-  patch: {
-    status: string;
-    builds: Array<{ id: string; buildVariant: string; status: string }>;
   };
 };
 

--- a/src/gql/queries/get-patch-task-statuses.ts
+++ b/src/gql/queries/get-patch-task-statuses.ts
@@ -1,0 +1,11 @@
+import gql from "graphql-tag";
+
+export const GET_PATCH_TASK_STATUSES = gql`
+  query GetPatchTaskStatuses($id: String!) {
+    patch(id: $id) {
+      id
+      taskStatuses
+      baseTaskStatuses
+    }
+  }
+`;

--- a/src/gql/queries/index.ts
+++ b/src/gql/queries/index.ts
@@ -18,3 +18,4 @@ export { GET_TASK_TESTS } from "./get-task-tests";
 export { GET_TASK, MetStatus, RequiredStatus } from "./get-task";
 export { GET_USER } from "./get-user";
 export { GET_CLIENT_CONFIG } from "./get-client-config";
+export { GET_PATCH_TASK_STATUSES } from "./get-patch-task-statuses";

--- a/src/utils/statuses/getCurrentStatuses.test.ts
+++ b/src/utils/statuses/getCurrentStatuses.test.ts
@@ -1,0 +1,185 @@
+import { Status } from "pages/patch/patchTabs/tasks/TaskFilters";
+import { TaskStatus } from "types/task";
+import { getCurrentStatuses } from "./getCurrentStatuses";
+
+test("Matches status keys to status tree data", () => {
+  const statuses = [
+    TaskStatus.Failed,
+    TaskStatus.Succeeded,
+    TaskStatus.Dispatched,
+  ];
+  expect(getCurrentStatuses(statuses, statusesTreeData)).toStrictEqual([
+    {
+      title: "All",
+      value: "all",
+      key: "all",
+    },
+    {
+      title: "Failed",
+      value: TaskStatus.Failed,
+      key: TaskStatus.Failed,
+    },
+    {
+      title: "Success",
+      value: TaskStatus.Succeeded,
+      key: TaskStatus.Succeeded,
+    },
+    {
+      title: "Running",
+      value: TaskStatus.Dispatched,
+      key: TaskStatus.Dispatched,
+    },
+  ]);
+});
+
+test("Returns only All for no statuses", () => {
+  expect(getCurrentStatuses([], statusesTreeData)).toStrictEqual([
+    {
+      title: "All",
+      value: "all",
+      key: "all",
+    },
+  ]);
+});
+
+test("Returns one child status if parent only has one matching child", () => {
+  const statuses = [
+    TaskStatus.TestTimedOut,
+    TaskStatus.Undispatched,
+    TaskStatus.SystemFailed,
+  ];
+  expect(getCurrentStatuses(statuses, statusesTreeData)).toStrictEqual([
+    {
+      title: "All",
+      value: "all",
+      key: "all",
+    },
+    {
+      title: "Test Timed Out",
+      value: TaskStatus.TestTimedOut,
+      key: TaskStatus.TestTimedOut,
+    },
+    {
+      title: "Undispatched",
+      value: TaskStatus.Undispatched,
+      key: TaskStatus.Undispatched,
+    },
+    {
+      title: "System Failed",
+      value: TaskStatus.SystemFailed,
+      key: TaskStatus.SystemFailed,
+    },
+  ]);
+});
+
+test("Returns child statuses as parent's children if there are two or more", () => {
+  const statuses = [TaskStatus.Failed, TaskStatus.TestTimedOut];
+  expect(getCurrentStatuses(statuses, statusesTreeData)).toStrictEqual([
+    {
+      title: "All",
+      value: "all",
+      key: "all",
+    },
+    {
+      title: "Failures",
+      value: "all-failures",
+      key: "all-failures",
+      children: [
+        {
+          title: "Failed",
+          value: TaskStatus.Failed,
+          key: TaskStatus.Failed,
+        },
+        {
+          title: "Test Timed Out",
+          value: TaskStatus.TestTimedOut,
+          key: TaskStatus.TestTimedOut,
+        },
+      ],
+    },
+  ]);
+});
+
+const statusesTreeData: Status[] = [
+  {
+    title: "All",
+    value: "all",
+    key: "all",
+  },
+  {
+    title: "Failures",
+    value: "all-failures",
+    key: "all-failures",
+    children: [
+      {
+        title: "Failed",
+        value: TaskStatus.Failed,
+        key: TaskStatus.Failed,
+      },
+      {
+        title: "Test Timed Out",
+        value: TaskStatus.TestTimedOut,
+        key: TaskStatus.TestTimedOut,
+      },
+    ],
+  },
+  {
+    title: "Success",
+    value: TaskStatus.Succeeded,
+    key: TaskStatus.Succeeded,
+  },
+  {
+    title: "Running",
+    value: TaskStatus.Dispatched,
+    key: TaskStatus.Dispatched,
+  },
+  {
+    title: "Started",
+    value: TaskStatus.Started,
+    key: TaskStatus.Started,
+  },
+  {
+    title: "Scheduled",
+    value: "scheduled",
+    key: "scheduled",
+    children: [
+      {
+        title: "Unstarted",
+        value: TaskStatus.Unstarted,
+        key: TaskStatus.Unstarted,
+      },
+      {
+        title: "Undispatched",
+        value: TaskStatus.Undispatched,
+        key: TaskStatus.Undispatched,
+      },
+    ],
+  },
+  {
+    title: "System Issues",
+    value: "system-issues",
+    key: "system-issues",
+    children: [
+      {
+        title: "System Failed",
+        value: TaskStatus.SystemFailed,
+        key: TaskStatus.SystemFailed,
+      },
+    ],
+  },
+  {
+    title: "Setup Failed",
+    value: TaskStatus.SetupFailed,
+    key: TaskStatus.SetupFailed,
+  },
+  {
+    title: "Blocked",
+    value: TaskStatus.StatusBlocked,
+    key: TaskStatus.StatusBlocked,
+  },
+  {
+    title: "Won't Run",
+    value: TaskStatus.Inactive,
+    key: TaskStatus.Inactive,
+  },
+];

--- a/src/utils/statuses/getCurrentStatuses.ts
+++ b/src/utils/statuses/getCurrentStatuses.ts
@@ -1,0 +1,28 @@
+import { Status } from "pages/patch/patchTabs/tasks/TaskFilters";
+
+const allKey = "all";
+
+export const getCurrentStatuses = (statuses: string[], treeData: Status[]) => {
+  const currentStatuses = [];
+  treeData.forEach((status) => {
+    const { key, children } = status;
+    if (key === allKey) {
+      currentStatuses.push(status);
+    }
+    if (children) {
+      const currentChildStatuses = getCurrentStatuses(statuses, children);
+      if (currentChildStatuses.length > 1) {
+        const newStatus = { ...status };
+        newStatus.children = currentChildStatuses;
+        currentStatuses.push(newStatus);
+      }
+      if (currentChildStatuses.length === 1) {
+        currentStatuses.push(currentChildStatuses[0]);
+      }
+    }
+    if (statuses.includes(key)) {
+      currentStatuses.push(status);
+    }
+  });
+  return currentStatuses;
+};


### PR DESCRIPTION
Only show patch task statuses that are relevant to the patch. As the task statuses change, so do the dropdown options. 

I made `getCurrentStatuses` a util so it can be used for the task dropdown filters too