### PR TITLE
EVG-8154: prevent loading skeleton persisting

### DIFF
--- a/cypress/integration/patch/task-table.ts
+++ b/cypress/integration/patch/task-table.ts
@@ -18,6 +18,16 @@ describe("Task table", () => {
     cy.preserveCookies();
   });
 
+  it("Loading skeleton does not persist when you navigate to Patch page from My Patches and adjust a filter", () => {
+    cy.visit("user/patches");
+    cy.dataCy("patch-card-patch-link")
+      .first()
+      .click();
+    cy.dataTestId("tasks-table-page-size-selector").click();
+    cy.dataTestId("tasks-table-page-size-selector-20").click();
+    cy.dataTestId("tasks-table").should("exist");
+  });
+
   it("Updates the url when column headers are clicked", () => {
     cy.visit(pathTasks);
 

--- a/src/hooks/usePollQuery.ts
+++ b/src/hooks/usePollQuery.ts
@@ -61,7 +61,6 @@ export const usePollQuery = <ApolloQueryVariables, ApolloQueryResultType>({
         resourceId,
       });
     }
-    return () => clearInterval(intervalId);
   }, [
     intervalId,
     refetch,
@@ -70,13 +69,6 @@ export const usePollQuery = <ApolloQueryVariables, ApolloQueryResultType>({
     resourceId,
     setIntervalId,
   ]);
-
-  // clears the interval when the page changes/component unmounts
-  useEffect(() => {
-    if (pathname !== initialPathname) {
-      clearInterval(intervalId);
-    }
-  }, [pathname, initialPathname, intervalId]);
 
   // reponsible for clearing the current polling query and
   // starting a new polling query based on new query variables
@@ -134,7 +126,11 @@ const pollQuery = <V, T>({
 }: PollQueryParams<V, T>) => {
   const queryVariables = getQueryVariables(search, resourceId);
   const intervalId = window.setInterval(() => {
-    refetch(queryVariables);
+    try {
+      refetch(queryVariables);
+    } catch {
+      clearInterval(intervalId);
+    }
   }, pollInterval);
   setIntervalId(intervalId);
 };

--- a/src/hooks/usePollQuery.ts
+++ b/src/hooks/usePollQuery.ts
@@ -4,9 +4,10 @@ import {
   NetworkStatus,
 } from "apollo-client/core/networkStatus";
 import { usePrevious } from "hooks";
-import { useParams, useLocation } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import { ApolloQueryResult } from "apollo-client";
 import isEqual from "lodash.isequal";
+
 interface Params<ApolloQueryVariables, ApolloQueryResultType> {
   networkStatus: NetworkStatus;
   getQueryVariables: (search: string, id?: string) => ApolloQueryVariables;
@@ -24,8 +25,6 @@ export const usePollQuery = <ApolloQueryVariables, ApolloQueryResultType>({
 }: Params<ApolloQueryVariables, ApolloQueryResultType>): {
   showSkeleton: boolean;
 } => {
-  const { pathname } = useLocation();
-  const [initialPathname] = useState(pathname);
   const { id: resourceId } = useParams<{ id: string }>();
   const [intervalId, setIntervalId] = useState<number>();
   // this variable is true when query variables have changed and the query is loading
@@ -61,6 +60,7 @@ export const usePollQuery = <ApolloQueryVariables, ApolloQueryResultType>({
         resourceId,
       });
     }
+    return () => clearInterval(intervalId);
   }, [
     intervalId,
     refetch,
@@ -73,11 +73,7 @@ export const usePollQuery = <ApolloQueryVariables, ApolloQueryResultType>({
   // reponsible for clearing the current polling query and
   // starting a new polling query based on new query variables
   useEffect(() => {
-    if (
-      intervalId &&
-      !isEqual(currentQueryVariables, prevQueryVariables) &&
-      pathname === initialPathname
-    ) {
+    if (intervalId && !isEqual(currentQueryVariables, prevQueryVariables)) {
       clearInterval(intervalId);
       refetch(currentQueryVariables);
       pollQuery({
@@ -97,8 +93,6 @@ export const usePollQuery = <ApolloQueryVariables, ApolloQueryResultType>({
     resourceId,
     getQueryVariables,
     search,
-    pathname,
-    initialPathname,
   ]);
 
   return {

--- a/src/pages/UserPatches.tsx
+++ b/src/pages/UserPatches.tsx
@@ -51,6 +51,7 @@ const UserPatchesComponent: React.FC = () => {
   >(GET_USER_PATCHES, {
     variables: initialQueryVariables,
     notifyOnNetworkStatusChange: true,
+    fetchPolicy: "network-only",
   });
   const { showSkeleton } = usePollQuery({
     networkStatus,

--- a/src/pages/patch/patchTabs/Tasks.tsx
+++ b/src/pages/patch/patchTabs/Tasks.tsx
@@ -57,6 +57,7 @@ export const Tasks: React.FC<Props> = ({ taskCount }) => {
   >(GET_PATCH_TASKS, {
     variables: initialQueryVariables as PatchTasksQueryVariables,
     notifyOnNetworkStatusChange: true,
+    fetchPolicy: "network-only",
   });
   useDisableTableSortersIfLoading(networkStatus);
   const { showSkeleton } = usePollQuery({

--- a/src/pages/task/testsTable/TestsTableCore.tsx
+++ b/src/pages/task/testsTable/TestsTableCore.tsx
@@ -40,9 +40,9 @@ export const TestsTableCore: React.FC = () => {
   const { id: resourceId } = useParams<{ id: string }>();
   const { replace } = useHistory();
   const { search, pathname } = useLocation();
-  const [initialQueryVariables] = useState<TaskTestsQueryVariables>({
-    ...getQueryVariables(search, resourceId),
-  });
+  const [initialQueryVariables] = useState<TaskTestsQueryVariables>(
+    getQueryVariables(search, resourceId)
+  );
   const { cat, dir } = initialQueryVariables;
   const columns = useSetColumnDefaultSortOrder<TestResult>(
     columnsTemplate,
@@ -55,6 +55,7 @@ export const TestsTableCore: React.FC = () => {
   >(GET_TASK_TESTS, {
     variables: initialQueryVariables,
     notifyOnNetworkStatusChange: true,
+    fetchPolicy: "network-only",
   });
   useDisableTableSortersIfLoading(networkStatus);
   const { showSkeleton } = usePollQuery({

--- a/src/pages/userPatches/PatchCard.tsx
+++ b/src/pages/userPatches/PatchCard.tsx
@@ -34,7 +34,10 @@ export const PatchCard: React.FC<Props> = ({
   return (
     <CardWrapper data-cy="patch-card">
       <Left>
-        <DescriptionLink href={`${paths.patch}/${id}`}>
+        <DescriptionLink
+          data-cy="patch-card-patch-link"
+          href={`${paths.patch}/${id}`}
+        >
           {description || "no description"}
         </DescriptionLink>
         <TimeAndProject>


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-8154
the loading state for tables using the usePollQuery hook is true from the time a diff occurs query variables to when the loading state goes from true to false. the loading skeleton was being persisted because the loading state never went from true to false. 
the condition on line 87 prevented a new query from being created in scenarios where we push a default path the URL. this was here originally to prevent dispatching queries on the wrong page but I see now that it didn't work as intended.
something interesting about the apollo useQuery refetch function is that it will throw an error if called when the parent component with the useQuery hook unmounts. I added a clearInterval in the catch block to make sure we always stop the active query when the useQuery hook unmounts.

This PR also changes the fetchPolicy for all pages that depend on use usePollQuery to make sure we are always presenting fresh data