### PR TITLE
EVG-7645: Log errors to bugsnag and new relic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1135,15 +1135,67 @@
         "to-fast-properties": "^2.0.0"
       }
     },
-    "@bugsnag/browser": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@bugsnag/browser/-/browser-6.5.0.tgz",
-      "integrity": "sha512-BBUK4XlCkzRsAwFbdAOBPSa353EqDmGuVvbnXom0xG1D2IySGyNmYdPBproTRNKp+h0XuCkXeBrjsyC9Wph6+g=="
+    "@bugsnag/core": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@bugsnag/core/-/core-7.1.1.tgz",
+      "integrity": "sha512-PWj2JQJIIbv4lP1YBR88hA9fS3UbGLwn+1ZxxUK5xxcUbTpViMIaoMGdQflfxHh7xfH6YmtwgA5mg2zDZGHCBw==",
+      "requires": {
+        "@bugsnag/cuid": "^3.0.0",
+        "@bugsnag/safe-json-stringify": "^5.0.0",
+        "error-stack-parser": "^2.0.3",
+        "iserror": "0.0.2",
+        "stack-generator": "^2.0.3"
+      }
+    },
+    "@bugsnag/cuid": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/cuid/-/cuid-3.0.0.tgz",
+      "integrity": "sha512-LOt8aaBI+KvOQGneBtpuCz3YqzyEAehd1f3nC5yr9TIYW1+IzYKa2xWS4EiMz5pPOnRPHkyyS5t/wmSmN51Gjg=="
+    },
+    "@bugsnag/js": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@bugsnag/js/-/js-7.1.1.tgz",
+      "integrity": "sha512-pa7d3kRt398hvrhjKvEzMBKE+m1JOJpwW7c8+Btu6HrjCxBcLj7SeSzzN2mbDmT/DfPU4hjeZ+oXGTWVWjUkgQ==",
+      "requires": {
+        "@bugsnag/browser": "^7.1.1",
+        "@bugsnag/node": "^7.1.1"
+      },
+      "dependencies": {
+        "@bugsnag/browser": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/@bugsnag/browser/-/browser-7.1.1.tgz",
+          "integrity": "sha512-9LjNsSVhnHizEtixPa8XnB1LYWAfdSf7spKwVW8UBBt1yfa9h/q0AhU6CrxEPi/uehkQaHx5k/2ZvaMP5G5SAA==",
+          "requires": {
+            "@bugsnag/core": "^7.1.1"
+          }
+        }
+      }
+    },
+    "@bugsnag/node": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@bugsnag/node/-/node-7.1.1.tgz",
+      "integrity": "sha512-1ciecltpLBfr1kPTrSoHt8umPDZXxHAWdgVE1jx4QyTl1+e5WIpMvp5cs36jisIR+dbOKBB5Y3hgv6VOX5u50A==",
+      "requires": {
+        "@bugsnag/core": "^7.1.1",
+        "byline": "^5.0.0",
+        "error-stack-parser": "^2.0.2",
+        "iserror": "^0.0.2",
+        "pump": "^3.0.0",
+        "stack-generator": "^2.0.3"
+      }
     },
     "@bugsnag/plugin-react": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@bugsnag/plugin-react/-/plugin-react-6.5.0.tgz",
-      "integrity": "sha512-kbyFSnQ4QLGjN04t9MbuD5KLWI2qQpjrgKrJvJNKM8xyeVIJYpkjx//TsDzG4ujNFVkwaP3bT48j85rf4EJNqA=="
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@bugsnag/plugin-react/-/plugin-react-7.1.1.tgz",
+      "integrity": "sha512-bxz3hZa0Our7OO42sVsHWgzEuw0vdTC2cCVG1vXKQUeFQqgggMizC8yzSbxCGaqyj04Dui/YzlYnAGV3MRoUjQ==",
+      "requires": {
+        "@bugsnag/core": "^7.1.1"
+      }
+    },
+    "@bugsnag/safe-json-stringify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/safe-json-stringify/-/safe-json-stringify-5.0.0.tgz",
+      "integrity": "sha512-EdGnA7n2UmX9Z0e2tIU0biKz8tCgtjbY69KoyH3yiMzm7Q9sriIlN9bZjqhTOKzM0GdLSGrkyKWif08xWKyucA=="
     },
     "@cnakazawa/watch": {
       "version": "1.0.4",
@@ -9813,6 +9865,11 @@
       "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
     },
+    "byline": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
+      "integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE="
+    },
     "bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
@@ -12184,6 +12241,14 @@
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "requires": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "error-stack-parser": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.6.tgz",
+      "integrity": "sha512-d51brTeqC+BHlwF0BhPtcYgF5nlzf9ZZ0ZIUQNZpc9ZB9qw5IJ2diTrBY9jlCJkTLITYPjmiX6OWCwH+fuyNgQ==",
+      "requires": {
+        "stackframe": "^1.1.1"
       }
     },
     "es-abstract": {
@@ -15307,6 +15372,11 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+    },
+    "iserror": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/iserror/-/iserror-0.0.2.tgz",
+      "integrity": "sha1-vVNFH+L2aLnyQCwZZnh6qix8C/U="
     },
     "isexe": {
       "version": "2.0.0",
@@ -23775,10 +23845,23 @@
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
       "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
     },
+    "stack-generator": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.5.tgz",
+      "integrity": "sha512-/t1ebrbHkrLrDuNMdeAcsvynWgoH/i4o8EGGfX7dEYDoTXOYVAkEpFdtshlvabzc6JlJ8Kf9YdFEoz7JkzGN9Q==",
+      "requires": {
+        "stackframe": "^1.1.1"
+      }
+    },
     "stack-utils": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
       "integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA=="
+    },
+    "stackframe": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.0.tgz",
+      "integrity": "sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA=="
     },
     "static-extend": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "dependencies": {
     "@apollo/react-hooks": "3.1.3",
-    "@bugsnag/browser": "6.5.0",
-    "@bugsnag/plugin-react": "6.5.0",
+    "@bugsnag/js": "7.1.1",
+    "@bugsnag/plugin-react": "7.1.1",
     "@emotion/core": "10.0.27",
     "@emotion/styled": "10.0.27",
     "@leafygreen-ui/badge": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test  --transformIgnorePatterns \"node_modules/(?!antd)/\" --watchAll=false",
+    "test": "react-scripts test --browser true --transformIgnorePatterns \"node_modules/(?!antd)/\" --watchAll=false",
     "test:watch": "react-scripts test --verbose",
     "eject": "react-scripts eject",
     "build:staging": "env-cmd -e staging -r config/.cmdrc.json npm run build",

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -5,6 +5,8 @@ import App from "App";
 import wait from "waait";
 
 it("renders without crashing", async () => {
+  // add this line to get bugsnag to play nice with jest: https://github.com/bugsnag/bugsnag-js/issues/452
+  setTimeout().__proto__.unref = function() {};
   const div = document.createElement("div");
   ReactDOM.render(<App />, div);
   await act(async () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,14 +28,13 @@ import "antd/es/select/style/css";
 import "antd/es/skeleton/style/css";
 import "antd/es/spin/style/css";
 import "antd/es/table/style/css";
-
 import { ContextProviders } from "context/Providers";
+
 Bugsnag.start({
   apiKey: getBugsnagApiKey(),
   plugins: [new BugsnagPluginReact()],
 });
 const ErrorBoundary = Bugsnag.getPlugin("react").createErrorBoundary(React);
-
 const App: React.FC = () => (
   <ErrorBoundary>
     <ContextProviders>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
-import bugsnag from "@bugsnag/browser";
-import bugsnagReact from "@bugsnag/plugin-react";
+import Bugsnag from "@bugsnag/js";
+import BugsnagPluginReact from "@bugsnag/plugin-react";
 import { Global, css } from "@emotion/core";
 import GQLWrapper from "gql/GQLWrapper";
 import { BrowserRouter as Router } from "react-router-dom";
@@ -30,10 +30,11 @@ import "antd/es/spin/style/css";
 import "antd/es/table/style/css";
 
 import { ContextProviders } from "context/Providers";
-
-const bugsnagClient = bugsnag(getBugsnagApiKey());
-bugsnagClient.use(bugsnagReact, React);
-const ErrorBoundary = bugsnagClient.getPlugin("react");
+Bugsnag.start({
+  apiKey: getBugsnagApiKey(),
+  plugins: [new BugsnagPluginReact()],
+});
+const ErrorBoundary = Bugsnag.getPlugin("react").createErrorBoundary(React);
 
 const App: React.FC = () => (
   <ErrorBoundary>

--- a/src/components/Content/index.tsx
+++ b/src/components/Content/index.tsx
@@ -18,16 +18,18 @@ import { PageDoesNotExist } from "pages/404";
 import { ConfigurePatch } from "pages/ConfigurePatch";
 import { Preferences } from "pages/Preferences";
 import { MyPatches } from "pages/MyPatches";
+import get from "lodash/get";
 
 export const Content: React.FC = () => {
-  const { isAuthenticated, initialLoad } = useAuthStateContext();
+  useAuthStateContext();
 
   // this top-level query is required for authentication to work
   // afterware is used at apollo link level to authenticate or deauthenticate user based on response to query
   // therefore this could be any query as long as it is top-level
-  useQuery<GetUserQuery>(GET_USER);
+  const { data, loading } = useQuery<GetUserQuery>(GET_USER);
+  localStorage.setItem("userId", get(data, "user.userId", ""));
 
-  if (!isAuthenticated && initialLoad) {
+  if (loading) {
     return <FullPageLoad />;
   }
 

--- a/src/components/NotificationModal.tsx
+++ b/src/components/NotificationModal.tsx
@@ -50,7 +50,6 @@ export const NotificationModal: React.FC<ModalProps> = ({
       dispatchBanner.errorBanner(
         `Error adding your subscription: '${err.message}'`
       );
-      // TODO: save error
     },
   });
   const {

--- a/src/components/TaskStatusBadge.tsx
+++ b/src/components/TaskStatusBadge.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import Badge, { Variant } from "@leafygreen-ui/badge";
 import { TaskStatus } from "types/task";
 import styled from "@emotion/styled/macro";
+import { reportError } from "utils/errorReporting";
 
 const mapTaskStatusToBadgeVariant = {
   [TaskStatus.Inactive]: Variant.LightGray,
@@ -60,5 +61,7 @@ export const TaskStatusBadge: React.FC<{ status: string }> = ({ status }) => {
       </StyledBadge>
     );
   }
-  throw new Error(`Status '${status}' is not a valid task status`);
+  const err = new Error(`Status '${status}' is not a valid task status`);
+  reportError(err).severe();
+  throw err;
 };

--- a/src/context/auth.tsx
+++ b/src/context/auth.tsx
@@ -1,6 +1,7 @@
 import React, { useContext, useReducer, useCallback } from "react";
 import axios from "axios";
 import { getLoginDomain } from "utils/getEnvironmentVariables";
+import { reportError } from "utils/errorReporting";
 
 interface State {
   isAuthenticated: boolean;
@@ -56,7 +57,7 @@ const logout = async (dispatch: Dispatch): Promise<void> => {
     dispatch({ type: "deauthenticate" });
     await axios.get(`${getLoginDomain()}/logout`);
   } catch (error) {
-    // TODO: log errors
+    reportError(error).warning();
   }
 };
 
@@ -75,7 +76,7 @@ const login = async (
     });
     dispatch({ type: "authenticate" });
   } catch (error) {
-    // TODO: log errors
+    // TODO: log errors if/when this is used in production
   }
 };
 

--- a/src/pages/commitqueue/CommitQueueCard.tsx
+++ b/src/pages/commitqueue/CommitQueueCard.tsx
@@ -41,16 +41,12 @@ export const CommitQueueCard: React.FC<Props> = ({
     RemovePatchFromCommitQueueMutation,
     RemovePatchFromCommitQueueMutationVariables
   >(REMOVE_PATCH_FROM_COMMIT_QUEUE);
-  const handleEnroll = async (e): Promise<void> => {
+  const handleEnroll = (e) => {
     e.preventDefault();
-    try {
-      await removePatchFromCommitQueue({
-        variables: { patchId, commitQueueId },
-        refetchQueries: ["CommitQueue"],
-      });
-    } catch (err) {
-      // console.log(err); // TODO: Replace this with better error handling
-    }
+    removePatchFromCommitQueue({
+      variables: { patchId, commitQueueId },
+      refetchQueries: ["CommitQueue"],
+    });
   };
   return (
     <Card data-cy="commit-queue-card">

--- a/src/pages/configurePatch/ConfigurePatchCore.tsx
+++ b/src/pages/configurePatch/ConfigurePatchCore.tsx
@@ -60,19 +60,14 @@ export const ConfigurePatchCore: React.FC<Props> = ({ patch }) => {
   const onChangePatchName = (e: React.ChangeEvent<HTMLInputElement>): void =>
     setdescriptionValue(e.target.value);
 
-  const onClickSchedule = async (): Promise<void> => {
+  const onClickSchedule = () => {
     const configurePatchParam: PatchReconfigure = {
       description: descriptionValue,
       variantsTasks: getGqlVariantTasksParamFromState(selectedVariantTasks),
     };
-    try {
-      await schedulePatch({
-        variables: { patchId: id, reconfigure: configurePatchParam },
-      });
-    } catch (error) {
-      // TODO: log this error
-      // console.error(error);
-    }
+    schedulePatch({
+      variables: { patchId: id, reconfigure: configurePatchParam },
+    });
   };
   const scheduledPatchId = get(data, "schedulePatch.id");
   if (scheduledPatchId) {

--- a/src/pages/patch/patchTabs/Tasks.tsx
+++ b/src/pages/patch/patchTabs/Tasks.tsx
@@ -174,7 +174,11 @@ const renderStatusBadge = (status): null | JSX.Element => {
   if (status === "" || !status) {
     return null;
   }
-  return <TaskStatusBadge status={status} />;
+  return (
+    <ErrorBoundary>
+      <TaskStatusBadge status={status} />
+    </ErrorBoundary>
+  );
 };
 
 const columnsTemplate: Array<ColumnProps<TaskResult>> = [

--- a/src/utils/errorReporting.test.ts
+++ b/src/utils/errorReporting.test.ts
@@ -27,7 +27,7 @@ describe("error reporting", () => {
     expect(noticeError).toHaveBeenCalledTimes(0);
   });
 
-  test("Returns a map of functions that call Bugsnag.notify and newrelic.noticeError when environment is Production", () => {
+  test("Returns a map of functions that call Bugsnag.notify and newrelic.noticeError with an error object when environment is Production", () => {
     const noticeError = jest.fn();
     window["newrelic"] = { noticeError };
     process.env.NODE_ENV = "production";
@@ -35,9 +35,13 @@ describe("error reporting", () => {
     const result = reportError(err);
     result.severe();
     expect(notifySpy).toHaveBeenCalledTimes(1);
+    expect(notifySpy.mock.calls[0][0]).toBe(err);
     expect(noticeError).toHaveBeenCalledTimes(1);
+    expect(noticeError.mock.calls[0][0]).toBe(err);
     result.warning();
     expect(notifySpy).toHaveBeenCalledTimes(2);
+    expect(notifySpy.mock.calls[1][0]).toBe(err);
     expect(noticeError).toHaveBeenCalledTimes(2);
+    expect(noticeError.mock.calls[1][0]).toBe(err);
   });
 });

--- a/src/utils/errorReporting.test.ts
+++ b/src/utils/errorReporting.test.ts
@@ -1,0 +1,36 @@
+import { reportError } from "utils/errorReporting";
+import Bugsnag from "@bugsnag/js";
+
+const err = new Error("test error");
+describe("error reporting", () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules(); // this is important - it clears the cache
+    process.env = { ...OLD_ENV };
+    delete process.env.NODE_ENV;
+  });
+
+  afterEach(() => {
+    process.env = OLD_ENV;
+  });
+
+  test("Returns a map of empty functions when environment is not Production", async () => {
+    // spy on Bugsnag.notify becuase that is called when the functions are not empty
+    const notifySpy = jest.spyOn(Bugsnag, "notify");
+    const result = reportError(err);
+    result.severe();
+    result.warning();
+    expect(notifySpy).toHaveBeenCalledTimes(0);
+  });
+
+  test("Calls returned functions call Bugsnag.notify when environment is Production", () => {
+    process.env.NODE_ENV = "production";
+    const notifySpy = jest.spyOn(Bugsnag, "notify");
+    const result = reportError(err);
+    result.severe();
+    expect(notifySpy).toHaveBeenCalledTimes(1);
+    result.warning();
+    expect(notifySpy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/utils/errorReporting.test.ts
+++ b/src/utils/errorReporting.test.ts
@@ -16,21 +16,28 @@ describe("error reporting", () => {
   });
 
   test("Returns a map of empty functions when environment is not Production", async () => {
-    // spy on Bugsnag.notify becuase that is called when the functions are not empty
+    // spy on Bugsnag.notify and newrelic.noticeError becuase that is called when the functions are not empty
+    const noticeError = jest.fn();
+    window["newrelic"] = { noticeError };
     const notifySpy = jest.spyOn(Bugsnag, "notify");
     const result = reportError(err);
     result.severe();
     result.warning();
     expect(notifySpy).toHaveBeenCalledTimes(0);
+    expect(noticeError).toHaveBeenCalledTimes(0);
   });
 
-  test("Calls returned functions call Bugsnag.notify when environment is Production", () => {
+  test("Returns a map of functions that call Bugsnag.notify and newrelic.noticeError when environment is Production", () => {
+    const noticeError = jest.fn();
+    window["newrelic"] = { noticeError };
     process.env.NODE_ENV = "production";
     const notifySpy = jest.spyOn(Bugsnag, "notify");
     const result = reportError(err);
     result.severe();
     expect(notifySpy).toHaveBeenCalledTimes(1);
+    expect(noticeError).toHaveBeenCalledTimes(1);
     result.warning();
     expect(notifySpy).toHaveBeenCalledTimes(2);
+    expect(noticeError).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/utils/errorReporting.ts
+++ b/src/utils/errorReporting.ts
@@ -1,0 +1,40 @@
+import { isProduction } from "utils/getEnvironmentVariables";
+import Bugsnag, { Event, NotifiableError } from "@bugsnag/js";
+
+interface reportErrorResult {
+  severe: () => void;
+  warning: () => void;
+}
+
+export const reportError = (err: NotifiableError): reportErrorResult => {
+  if (!isProduction()) {
+    return {
+      severe: () => {},
+      warning: () => {},
+    };
+  }
+
+  return {
+    severe: () => {
+      sendError(err, "error");
+    },
+    warning: () => {
+      sendError(err, "warning");
+    },
+  };
+};
+
+const sendError = (err: NotifiableError, severity: Event["severity"]) => {
+  const userId = localStorage.getItem("userId");
+  const newrelic = window["newrelic"];
+  if (newrelic) {
+    newrelic.noticeError(err, {
+      severity,
+      userId,
+    });
+  }
+  Bugsnag.notify(err, (event) => {
+    event.severity = severity;
+    event.setUser(userId);
+  });
+};

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -1,5 +1,6 @@
 import axios from "axios";
 import { getLoginDomain } from "utils/getEnvironmentVariables";
+import { reportError } from "utils/errorReporting";
 
 type optionsType = {
   onFailure?: (e) => void;
@@ -39,5 +40,5 @@ const getErrorMessage = (response: responseType, method: string) =>
 
 const handleError = (error: string) => {
   console.warn(error);
-  // Log the error on bugsnag
+  reportError(error).warning();
 };


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-7645
This PR logs errors to bugsnag and new relic. The userId of the logged in user is set in localStorage so it is available to the error logging functions. This approach is ideal because it would be unreliable to depend on app architecture to consume the userId in the case of an error. Unhandled errors may not be passed on to New Relic since Bugsnag comes with an ErrorBoundary to handle all unhandled errors. I expect we will remove one of these implementations once we decide which UX we like best.  
I also simplified the FullPageLoad condition in `Content`.  