### PR TITLE
Remove console statements from request test

### DIFF
--- a/src/utils/request.test.js
+++ b/src/utils/request.test.js
@@ -19,15 +19,15 @@ test("posts", async () => {
 });
 
 test("should handle a bad response", async () => {
-  const { warn } = console;
-  console.warn = jest.fn();
+  // const { warn } = console;
+  // console.warn = jest.fn();
 
   const errorCallback = jest.fn();
   axios.post.mockImplementationOnce(() => Promise.resolve(jsonMessage));
 
   expect(await post(API_URL, {}, { onFailure: errorCallback })).toBe(undefined);
-  expect(console.warn).toHaveBeenCalledTimes(1);
+  // expect(console.warn).toHaveBeenCalledTimes(1);
   expect(errorCallback).toHaveBeenCalledTimes(1);
 
-  console.warn = warn;
+  // console.warn = warn;
 });

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -21,7 +21,7 @@ export const post = async (
     if (options.onFailure) {
       options.onFailure(e);
     }
-    handleError(e);
+    handleError();
   }
 };
 
@@ -37,7 +37,6 @@ const getErrorMessage = (response: responseType, method: string) =>
     ? `${method} Error: ${response.status} - ${response.statusText}`
     : `${method} Error: Did not receive a response from the server`;
 
-const handleError = (error: string) => {
-  console.warn(error);
+const handleError = () => {
   // Log the error on bugsnag
 };


### PR DESCRIPTION
Fix failing tests for #206 

Updated these tests to remove their dependency on console.log()