### PR TITLE
EVG-8106: hide logs and html buttons when no logs found or gql error occurs

### DIFF
--- a/cypress/integration/task_logs.ts
+++ b/cypress/integration/task_logs.ts
@@ -19,21 +19,23 @@ describe("task logs view", () => {
 
   it("HTML button should link to the html logs", () => {
     cy.visit(LOGS_ROUTE);
+    cy.get("#cy-system-radio").check();
     cy.dataCy("html-log-btn")
       .should("have.attr", "href")
       .and(
         "includes",
-        "/task_log_raw/evergreen_ubuntu1604_test_model_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48/0?type=T"
+        "task_log_raw/evergreen_ubuntu1604_test_model_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48/0?type=S"
       );
   });
 
   it("Raw button should link to the raw logs", () => {
     cy.visit(LOGS_ROUTE);
+    cy.get("#cy-system-radio").check();
     cy.dataCy("raw-log-btn")
       .should("have.attr", "href")
       .and(
         "includes",
-        "/task_log_raw/evergreen_ubuntu1604_test_model_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48/0?type=T&text=true"
+        "/task_log_raw/evergreen_ubuntu1604_test_model_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48/0?type=S&text=true"
       );
   });
 
@@ -46,9 +48,7 @@ describe("task logs view", () => {
 
   it("Should update logtype query param to agent after checking agent radio button", () => {
     cy.visit(LOGS_ROUTE);
-    cy.get("#cy-agent-radio")
-      .check()
-      .should("be.checked");
+    cy.get("#cy-agent-radio").check();
     cy.location().should((loc) => {
       expect(loc.pathname).to.equal(LOGS_ROUTE);
       expect(loc.search).to.include("logtype=agent");
@@ -57,9 +57,7 @@ describe("task logs view", () => {
 
   it("Should update logtype query param to event after checking event radio button", () => {
     cy.visit(LOGS_ROUTE);
-    cy.get("#cy-event-radio")
-      .check()
-      .should("be.checked");
+    cy.get("#cy-event-radio").check();
     cy.location().should((loc) => {
       expect(loc.pathname).to.equal(LOGS_ROUTE);
       expect(loc.search).to.include("logtype=event");
@@ -68,9 +66,7 @@ describe("task logs view", () => {
 
   it("Should update logtype query param to system after checking system radio button", () => {
     cy.visit(LOGS_ROUTE);
-    cy.get("#cy-system-radio")
-      .check()
-      .should("be.checked");
+    cy.get("#cy-system-radio").check();
     cy.location().should((loc) => {
       expect(loc.pathname).to.equal(LOGS_ROUTE);
       expect(loc.search).to.include("logtype=system");
@@ -107,8 +103,10 @@ describe("task logs view", () => {
       .should("be.checked");
   });
 
-  it("Should display 'No logs' when no logs found", () => {
+  it("Should display 'No logs' and hide HTML and Raw buttons when no logs found", () => {
     cy.visit(LOGS_ROUTE);
     cy.get("#cy-no-logs").contains("No logs");
+    cy.dataCy("html-log-btn").should("not.exist");
+    cy.dataCy("raw-log-btn").should("not.exist");
   });
 });

--- a/src/pages/task/Logs.tsx
+++ b/src/pages/task/Logs.tsx
@@ -1,33 +1,24 @@
 import React, { useEffect, useState } from "react";
-import { Radio, RadioGroup } from "@leafygreen-ui/radio-group";
-import { useLocation, useHistory } from "react-router-dom";
+import { useLocation } from "react-router-dom";
 import queryString from "query-string";
-import styled from "@emotion/styled/macro";
+
 import {
   EventLog,
   AgentLog,
   SystemLog,
   TaskLog,
+  LogTypes,
+  QueryParams,
 } from "pages/task/logs/LogTypes";
 import Maybe from "graphql/tsutils/Maybe";
-import { Button } from "components/Button";
 
-enum LogTypes {
-  Agent = "agent",
-  System = "system",
-  Task = "task",
-  Event = "event",
-}
 const DEFAULT_LOG_TYPE = LogTypes.Task;
-enum QueryParams {
-  LogType = "logtype",
-}
 
 const options = {
-  [LogTypes.Agent]: <AgentLog />,
-  [LogTypes.System]: <SystemLog />,
-  [LogTypes.Task]: <TaskLog />,
-  [LogTypes.Event]: <EventLog />,
+  [LogTypes.Agent]: AgentLog,
+  [LogTypes.System]: SystemLog,
+  [LogTypes.Task]: TaskLog,
+  [LogTypes.Event]: EventLog,
 };
 
 interface LogLinks {
@@ -42,8 +33,7 @@ interface Props {
   logLinks: LogLinks;
 }
 export const Logs: React.FC<Props> = ({ logLinks }) => {
-  const { search, pathname } = useLocation();
-  const { replace } = useHistory();
+  const { search } = useLocation();
   const [currentLog, setCurrentLog] = useState<LogTypes>(DEFAULT_LOG_TYPE);
   const parsed = queryString.parse(search);
   const logTypeParam = (parsed[QueryParams.LogType] || "")
@@ -64,63 +54,14 @@ export const Logs: React.FC<Props> = ({ logLinks }) => {
     }
   }, [logTypeParam]);
 
-  const onChangeLog = (event: React.ChangeEvent<HTMLInputElement>): void => {
-    const nextLogType = event.target.value as LogTypes;
-    replace(
-      `${pathname}?${queryString.stringify(
-        {
-          [QueryParams.LogType]: nextLogType,
-        },
-        { arrayFormat: "comma" }
-      )}`
-    );
-  };
   const { htmlLink, rawLink } = getLinks(logLinks, currentLog);
-  return (
-    <div>
-      <StyledRadioGroup
-        variant="default"
-        onChange={onChangeLog}
-        value={currentLog}
-        name="log-select"
-      >
-        <ButtonContainer>
-          {htmlLink && (
-            <Button dataCy="html-log-btn" target="_blank" href={htmlLink}>
-              HTML
-            </Button>
-          )}
-          {rawLink && (
-            <Button dataCy="raw-log-btn" target="_blank" href={rawLink}>
-              Raw
-            </Button>
-          )}
-        </ButtonContainer>
-        <Radio id="cy-task-radio" value={LogTypes.Task}>
-          Task Logs
-        </Radio>
-        <Radio id="cy-agent-radio" value={LogTypes.Agent}>
-          Agent Logs
-        </Radio>
-        <Radio id="cy-system-radio" value={LogTypes.System}>
-          System Logs
-        </Radio>
-        <Radio id="cy-event-radio" value={LogTypes.Event}>
-          Event Logs
-        </Radio>
-      </StyledRadioGroup>
-      {options[currentLog] || <></>}
-    </div>
+  const LogComp = options[currentLog];
+  return LogComp ? (
+    <LogComp htmlLink={htmlLink} rawLink={rawLink} currentLog={currentLog} />
+  ) : (
+    <></>
   );
 };
-
-const StyledRadioGroup = styled(RadioGroup)`
-  display: flex;
-  align-items: center;
-  label {
-    margin-left: 24px;
-  }
-`;
 
 interface GetLinksResult {
   htmlLink?: string;
@@ -146,9 +87,3 @@ const getLinks = (logLinks: LogLinks, logType: LogTypes): GetLinksResult => {
   }
   return { htmlLink: url, rawLink: `${url}&text=true` };
 };
-
-const ButtonContainer = styled.div`
-  a:first-of-type {
-    margin-right: 8px;
-  }
-`;


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-8106
instead of rendering a gql error message that results from the TaskLogs query, print "No logs found"