### PR TITLE
EVG-7935 use plain logger for get update

### DIFF
--- a/src/pages/preferences/preferencesTabs/cliTab/VerifyCard.tsx
+++ b/src/pages/preferences/preferencesTabs/cliTab/VerifyCard.tsx
@@ -3,7 +3,6 @@ import { useQuery } from "@apollo/react-hooks";
 import { uiColors } from "@leafygreen-ui/palette";
 import { Body } from "@leafygreen-ui/typography";
 import styled from "@emotion/styled";
-import { format } from "date-fns";
 import get from "lodash/get";
 import { SiderCard } from "components/styles";
 import Code from "@leafygreen-ui/code";

--- a/src/pages/preferences/preferencesTabs/cliTab/VerifyCard.tsx
+++ b/src/pages/preferences/preferencesTabs/cliTab/VerifyCard.tsx
@@ -21,7 +21,9 @@ export const VerifyCard = () => {
   );
 
   const latestRevision = get(data, "clientConfig.latestRevision", "");
-  const verificationCode = "Binary is already up to date - not updating.";
+  const verificationCode = `
+"[message='Binary is already up to date - not updating.' revision='${latestRevision}']"`;
+
   return (
     <Container>
       <Body>At the command line, type &quot;</Body>

--- a/src/pages/preferences/preferencesTabs/cliTab/VerifyCard.tsx
+++ b/src/pages/preferences/preferencesTabs/cliTab/VerifyCard.tsx
@@ -21,11 +21,7 @@ export const VerifyCard = () => {
   );
 
   const latestRevision = get(data, "clientConfig.latestRevision", "");
-  const verificationCode = `
-"[evergreen] ${format(new Date(), "yyyy/MM/dd hh:mm:ss")} [p=notice]:
-[message='Binary is already up to date - not updating.'
-revision='${latestRevision}']"
-  `;
+  const verificationCode = "Binary is already up to date - not updating.";
   return (
     <Container>
       <Body>At the command line, type &quot;</Body>


### PR DESCRIPTION
Because of https://github.com/evergreen-ci/evergreen/commit/59f50141ee548614ee33feabcdeefd5e9e79cd6d we no longer will have this metadata from get-update.

First spruce PR!! 😱 