### PR TITLE
EVG-8178 Navigating to "RAW" link in patch configuration does not open new window and clears task selections

### DIFF
--- a/src/pages/patch/patchTabs/CodeChanges.tsx
+++ b/src/pages/patch/patchTabs/CodeChanges.tsx
@@ -43,6 +43,7 @@ export const CodeChanges: React.FC = () => {
               size="small"
               title="Open diff as html file"
               href={modCodeChange.htmlLink}
+              target="_blank"
             >
               HTML
             </StyledButton>
@@ -51,6 +52,7 @@ export const CodeChanges: React.FC = () => {
               size="small"
               title="Open diff as raw file"
               href={modCodeChange.rawLink}
+              target="_blank"
             >
               Raw
             </StyledButton>


### PR DESCRIPTION
[EVG-8178](https://jira.mongodb.org/browse/EVG-8178)
