### PR TITLE
EVG-8145 Format timetaken fields in patch duration

### DIFF
--- a/src/pages/patch/Metadata.tsx
+++ b/src/pages/patch/Metadata.tsx
@@ -1,9 +1,10 @@
 import React from "react";
+import { ApolloError } from "apollo-client";
 import { P2 } from "components/Typography";
 import { StyledLink } from "components/styles";
 import { PatchQuery } from "gql/generated/types";
 import { getUiUrl } from "utils/getEnvironmentVariables";
-import { ApolloError } from "apollo-client";
+import { formatDuration } from "utils/string";
 import { MetadataCard } from "components/MetadataCard";
 import { paths } from "constants/routes";
 
@@ -27,8 +28,8 @@ export const Metadata: React.FC<Props> = ({ loading, patch, error }) => {
   const { makespan, timeTaken } = duration || {};
   return (
     <MetadataCard loading={loading} error={error} title="Patch Metadata">
-      <P2>Makespan: {makespan && makespan}</P2>
-      <P2>Time taken: {timeTaken && timeTaken}</P2>
+      <P2>Makespan: {makespan && formatDuration(makespan)}</P2>
+      <P2>Time taken: {timeTaken && formatDuration(timeTaken)}</P2>
       <P2>Submitted at: {submittedAt}</P2>
       <P2>Started: {started && started}</P2>
       <P2>Finished: {finished && finished}</P2>

--- a/src/utils/string/index.ts
+++ b/src/utils/string/index.ts
@@ -26,3 +26,6 @@ export const omitTypename = (object) =>
   JSON.parse(JSON.stringify(object), (key, value) =>
     key === "__typename" ? undefined : value
   );
+
+export const formatDuration = (duration: string): string =>
+  duration.replace(/\d*[dhms]/g, (match) => `${match} `).trim();


### PR DESCRIPTION
Dependent on 
https://github.com/evergreen-ci/evergreen/pull/3744
![image](https://user-images.githubusercontent.com/4605522/86391065-29f81900-bc67-11ea-9245-c1f3ca08b05b.png)

becomes this

![image](https://user-images.githubusercontent.com/4605522/86391099-3b412580-bc67-11ea-97d1-12461012d21b.png)
