### PR TITLE
EVG-8105: Task page: set max width on display name part of tables

### DIFF
--- a/src/pages/task/testsTable/TestsTableCore.tsx
+++ b/src/pages/task/testsTable/TestsTableCore.tsx
@@ -154,6 +154,7 @@ const columnsTemplate: ColumnProps<TestResult>[] = [
     title: "Name",
     dataIndex: "testFile",
     key: TestSortCategory.TestName,
+    width: "40%",
     sorter: true,
   },
   {


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-8105
sometimes the name column is wide enough to make the other columns unreadable and unusable. this issue only occurred for the tests table not the tasks table, code changes nor files table
before:
<img width="1351" alt="Screen Shot 2020-07-07 at 3 07 12 PM" src="https://user-images.githubusercontent.com/10734386/86830765-1502f780-c064-11ea-8a6a-87193507190a.png">

after:
<img width="1347" alt="Screen Shot 2020-07-07 at 3 06 06 PM" src="https://user-images.githubusercontent.com/10734386/86830758-13393400-c064-11ea-9721-c7fe393dedac.png">