### PR TITLE
EVG-8235 Build variant tooltip doesn't appear over variant square

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3081,16 +3081,15 @@
       "integrity": "sha512-QA7MKgg46RH+SRJIlSa1ebbrCr1Iijeo7FL3wAG+2vEKoPolpOd165p+q/awGaTe0COj2r1FMu93JvVZ3LJPsQ=="
     },
     "@leafygreen-ui/popover": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/popover/-/popover-3.0.2.tgz",
-      "integrity": "sha512-DouTFhDe7sp8FgX+SdK3pl3JwkmmzOfdlQOvzl4SjYFi6fjceLAwy/76kLDJDtK77yWLMWD3IL/PTNnyFoY5Hw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/popover/-/popover-5.1.0.tgz",
+      "integrity": "sha512-52dhhOTey7E1+vmz+OFdq6zWVgC00bKvNPwnk6guo10G7s6tv6Fkn/FFM40qCq42fJ7tCEj8KXZz8OXiUecL0A==",
       "requires": {
-        "@leafygreen-ui/hooks": "^2.0.0",
+        "@leafygreen-ui/hooks": "^2.1.0",
         "@leafygreen-ui/lib": "^4.2.0",
         "@leafygreen-ui/portal": "^2.0.0",
-        "@leafygreen-ui/theme": "^2.0.0",
         "lodash": "^4.17.11",
-        "react-transition-group": "^4.2.1"
+        "react-transition-group": "^4.4.1"
       }
     },
     "@leafygreen-ui/portal": {
@@ -3198,14 +3197,14 @@
       }
     },
     "@leafygreen-ui/tooltip": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tooltip/-/tooltip-3.1.0.tgz",
-      "integrity": "sha512-BPENWFn150RXK1TycxnG6imUVCnsgRK9TfMS1lDMA9hSN/ZEj9/UDBWhpMK2Uxm2cImGUxgqwRdcgqZnUh7l5A==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tooltip/-/tooltip-3.2.2.tgz",
+      "integrity": "sha512-D+/00Ivj69LjVgIHAsWeVBFP3B0bf+8kjE8HxiBGjb+m/g1O07XvMGCIeD1Ab4KVT20BufxK4e2y2FgvJew6ug==",
       "requires": {
-        "@leafygreen-ui/hooks": "^2.0.1",
+        "@leafygreen-ui/hooks": "^2.1.0",
         "@leafygreen-ui/lib": "^4.2.0",
         "@leafygreen-ui/palette": "^2.0.0",
-        "@leafygreen-ui/popover": "^3.0.2",
+        "@leafygreen-ui/popover": "^5.0.1",
         "lodash": "^4.17.15"
       }
     },
@@ -22631,9 +22630,9 @@
       }
     },
     "react-transition-group": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.3.0.tgz",
-      "integrity": "sha512-1qRV1ZuVSdxPlPf4O8t7inxUGpdyO5zG9IoNfJxSO0ImU2A1YWkEQvFPuIPZmMLkg5hYs7vv5mMOyfgSkvAwvw==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.1.tgz",
+      "integrity": "sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==",
       "requires": {
         "@babel/runtime": "^7.5.5",
         "dom-helpers": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@leafygreen-ui/tabs": "2.0.0",
     "@leafygreen-ui/text-input": "1.1.1",
     "@leafygreen-ui/toggle": "3.0.1",
-    "@leafygreen-ui/tooltip": "^3.2.2",
+    "@leafygreen-ui/tooltip": "3.2.2",
     "@leafygreen-ui/typography": "1.0.1",
     "ansi-to-html": "0.6.14",
     "antd": "3.26.7",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@leafygreen-ui/tabs": "2.0.0",
     "@leafygreen-ui/text-input": "1.1.1",
     "@leafygreen-ui/toggle": "3.0.1",
-    "@leafygreen-ui/tooltip": "3.1.0",
+    "@leafygreen-ui/tooltip": "^3.2.2",
     "@leafygreen-ui/typography": "1.0.1",
     "ansi-to-html": "0.6.14",
     "antd": "3.26.7",


### PR DESCRIPTION
[EVG-8235](https://jira.mongodb.org/browse/EVG-8235)
Updated leafygreen tooltip to 3.3.2

![image](https://user-images.githubusercontent.com/13104717/87342283-fd6eb780-c518-11ea-9a9d-d588635069aa.png)

the following warning appeared when upgrading:
![image](https://user-images.githubusercontent.com/13104717/87338641-79fe9780-c513-11ea-8096-a2c5f0e65401.png)
