### PR TITLE
EVG-12534 Fix log wrapper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "spruce",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spruce",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "dependencies": {
     "@apollo/react-hooks": "3.1.3",

--- a/src/pages/Task.tsx
+++ b/src/pages/Task.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from "react";
+import styled from "@emotion/styled";
 import { useParams } from "react-router-dom";
 import { TestsTable } from "pages/task/TestsTable";
 import { FilesTables } from "pages/task/FilesTables";
@@ -143,7 +144,7 @@ const TaskCore: React.FC = () => {
         <PageSider>
           <Metadata data={data} loading={loading} error={error} />
         </PageSider>
-        <PageLayout>
+        <LogWrapper>
           <PageContent>
             <StyledTabs selected={selectedTab} setSelected={selectTabHandler}>
               <Tab name="Logs" id="task-logs-tab">
@@ -189,10 +190,14 @@ const TaskCore: React.FC = () => {
               </Tab>
             </StyledTabs>
           </PageContent>
-        </PageLayout>
+        </LogWrapper>
       </PageLayout>
     </PageWrapper>
   );
 };
 
 export const Task = withBannersContext(TaskCore);
+
+const LogWrapper = styled(PageLayout)`
+  width: 100%;
+`;


### PR DESCRIPTION
Fixes an issue where really long log lines causes the page to overflow.
before: 
![image](https://user-images.githubusercontent.com/4605522/87472291-b1da0d80-c5ed-11ea-88b3-82c645d88304.png)

after:
![image](https://user-images.githubusercontent.com/4605522/87472120-6fb0cc00-c5ed-11ea-9c6e-555a22927479.png)

Testing instructions:

Easiest way to test this would be to checkout this branch.
Use the version of the `.cmdrc.json` that lets you access prod data locally.
 open a task with long logs and to compare what is currently in prod to what shows up locally 
The version on this branch should not have a horizontal page scroll

Prod task with a line with really long logs.
https://spruce.mongodb.com/task/sqlproxy_full_matrix__os_full_matrix~osx_mongodb_version~latest_mongodb_topology~standalone_module_tests_patch_129f80fcf3b75ecb4f8f24ecbb1ba2b5d7dc1a3e_5efa177e3e8e86592c495ab0_20_06_29_16_32_00/logs

Same task but viewable locally (You need to be using prod backend)

[http://localhost:3000/task/sqlproxy_full_matrix__os_full_matrix~osx_mongodb_version~latest_mongodb_topology~standalone_module_tests_patch_129f80fcf3b75ecb4f8f24ecbb1ba2b5d7dc1a3e_5efa177e3e8e86592c495ab0_20_06_29_16_32_00/logs](http://localhost:3000/task/sqlproxy_full_matrix__os_full_matrix~osx_mongodb_version~latest_mongodb_topology~standalone_module_tests_patch_129f80fcf3b75ecb4f8f24ecbb1ba2b5d7dc1a3e_5efa177e3e8e86592c495ab0_20_06_29_16_32_00/logs)

