### PR TITLE
EVG-12636 Remove horizontal line scroll

### DIFF
--- a/src/pages/task/logs/logTypes/logMessageLine/LogLines.tsx
+++ b/src/pages/task/logs/logTypes/logMessageLine/LogLines.tsx
@@ -2,7 +2,6 @@ import styled from "@emotion/styled/macro";
 
 const getLogLineComp = (color: string): React.FC => styled.div`
   color: ${color};
-  overflow-x: scroll;
 `;
 
 export const getLogLineWrapper = (severity: string): React.FC => {


### PR DESCRIPTION
In response to a [slack thread](https://mongodb.slack.com/archives/C014R0J5XM4/p1594767665200100) some users complained about the horizontal line scroll on log lines. This changes the behavior of the logs so that there will be a horizontal scroll on the log container if text within it overflows. instead of on a per line basis.

![image](https://user-images.githubusercontent.com/4605522/87559585-7d675f80-c688-11ea-96cd-d0630907c627.png)
This is now a side scrollable surface