### PR TITLE
EVG-12503: Task checkboxes remain unselected after clicking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18152,6 +18152,11 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
     },
+    "lodash.every": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.every/-/lodash.every-4.6.0.tgz",
+      "integrity": "sha1-64mYS+vENkJ5uzrvu9HKGb+mxqc="
+    },
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "js-cookie": "2.2.1",
     "linkifyjs": "2.1.9",
     "lodash.debounce": "4.0.8",
+    "lodash.every": "4.6.0",
     "lodash.get": "4.4.2",
     "lodash.isequal": "4.5.0",
     "lodash.set": "4.3.2",

--- a/src/pages/configurePatch/ConfigurePatchCore.tsx
+++ b/src/pages/configurePatch/ConfigurePatchCore.tsx
@@ -152,19 +152,21 @@ export const ConfigurePatchCore: React.FC<Props> = ({ patch }) => {
 const getGqlVariantTasksParamFromState = (
   selectedVariantTasks: VariantTasksState
 ): VariantTasks[] =>
-  Object.keys(selectedVariantTasks).map((variantName) => {
-    const tasksObj = selectedVariantTasks[variantName];
-    const tasksArr = Object.keys(tasksObj);
-    const variantTasks: VariantTasks = {
-      variant: variantName,
-      tasks: tasksArr,
-      displayTasks: [],
-    };
-    return variantTasks;
-  });
+  Object.entries(selectedVariantTasks)
+    .map(([variantName, tasksObj]) => {
+      const tasksArr = Object.entries(tasksObj)
+        .filter((entry) => entry[1])
+        .map((entry) => entry[0]);
+      return {
+        variant: variantName,
+        tasks: tasksArr,
+        displayTasks: [],
+      };
+    })
+    .filter(({ tasks }) => tasks.length);
 
 interface TasksState {
-  [task: string]: true;
+  [task: string]: boolean;
 }
 export interface VariantTasksState {
   [variant: string]: TasksState;

--- a/src/pages/configurePatch/configurePatchCore/ConfigureBuildVariants.tsx
+++ b/src/pages/configurePatch/configurePatchCore/ConfigureBuildVariants.tsx
@@ -31,6 +31,26 @@ export const ConfigureBuildVariants: React.FC<Props> = ({
       setSelectedBuildVariant(
         updatedBuildVariants.length > 0 ? updatedBuildVariants : [variantName]
       );
+    } else if (e.shiftKey) {
+      const variantNames = variants.map(({ name }) => name);
+      const clickIndex = variantNames.indexOf(variantName);
+      const anchorIndex = variants.reduce(
+        (accum, { name }, index) =>
+          accum > -1 || !selectedBuildVariant.includes(name) ? accum : index,
+        -1
+      );
+      if (clickIndex === anchorIndex) {
+        return;
+      }
+      const startIndex = anchorIndex < clickIndex ? anchorIndex : clickIndex;
+      const endIndex = anchorIndex < clickIndex ? clickIndex : anchorIndex;
+      const nextSelectedBuildVariants = Array.from(
+        new Set([
+          ...variantNames.slice(startIndex, endIndex + 1),
+          ...selectedBuildVariant,
+        ])
+      );
+      setSelectedBuildVariant(nextSelectedBuildVariants);
     } else {
       setSelectedBuildVariant([variantName]);
     }
@@ -43,7 +63,7 @@ export const ConfigureBuildVariants: React.FC<Props> = ({
       </Container>
       {variants.map(({ displayName, name }) => {
         const taskCount = selectedVariantTasks[name]
-          ? Object.keys(selectedVariantTasks[name]).length
+          ? Object.values(selectedVariantTasks[name]).filter((v) => v).length
           : null;
         const isSelected = selectedBuildVariant.includes(name);
         return (
@@ -106,6 +126,7 @@ const BuildVariant = styled.div`
 const VariantName = styled.div`
   word-break: break-all;
   white-space: normal;
+  user-select: none;
 `;
 const StyledBadge = styled(Badge)`
   margin-left: 8px;

--- a/src/pages/configurePatch/configurePatchCore/ConfigureTasks.tsx
+++ b/src/pages/configurePatch/configurePatchCore/ConfigureTasks.tsx
@@ -190,9 +190,15 @@ const getTaskCheckboxState = (
   selectedBuildVariantTasks: VariantTasksState,
   variants: ProjectBuildVariant[]
 ): CheckboxState => {
-  const checkedCb = (allChecked: boolean, buildVariantName: string): boolean =>
-    allChecked &&
-    !!get(selectedBuildVariantTasks, [buildVariantName, taskName], false);
+  const checkedCb = (
+    allChecked: boolean,
+    buildVariantName: string
+  ): boolean => {
+    const isTaskSelected =
+      selectedBuildVariantTasks[buildVariantName] &&
+      selectedBuildVariantTasks[buildVariantName][taskName];
+    return allChecked && isTaskSelected;
+  };
   const checked: boolean = selectedBuildVariants
     .filter((buildVariantName) =>
       taskExistsInVariant(taskName, buildVariantName, variants)
@@ -203,9 +209,12 @@ const getTaskCheckboxState = (
     return "checked";
   }
 
-  const uncheckedCb = (allUnchecked: boolean, buildVariantName: string) =>
-    allUnchecked &&
-    !get(selectedBuildVariantTasks, [buildVariantName, taskName], false);
+  const uncheckedCb = (allUnchecked: boolean, buildVariantName: string) => {
+    const isTaskSelected =
+      selectedBuildVariantTasks[buildVariantName] &&
+      selectedBuildVariantTasks[buildVariantName][taskName];
+    return allUnchecked && !isTaskSelected;
+  };
   const unchecked: boolean = selectedBuildVariants.reduce(uncheckedCb, true);
 
   if (unchecked) {

--- a/src/pages/configurePatch/configurePatchCore/ConfigureTasks.tsx
+++ b/src/pages/configurePatch/configurePatchCore/ConfigureTasks.tsx
@@ -192,11 +192,7 @@ const getTaskCheckboxState = (
 ): CheckboxState => {
   const checkedCb = (allChecked: boolean, buildVariantName: string): boolean =>
     allChecked &&
-    !!get(
-      selectedBuildVariantTasks,
-      [buildVariantName, taskName], // need to see that build variant has task to begin with...
-      false
-    );
+    !!get(selectedBuildVariantTasks, [buildVariantName, taskName], false);
   const checked: boolean = selectedBuildVariants
     .filter((buildVariantName) =>
       taskExistsInVariant(taskName, buildVariantName, variants)

--- a/src/pages/configurePatch/configurePatchCore/ConfigureTasks.tsx
+++ b/src/pages/configurePatch/configurePatchCore/ConfigureTasks.tsx
@@ -194,7 +194,7 @@ const getTaskCheckboxState = (
     allChecked &&
     !!get(
       selectedBuildVariantTasks,
-      `[${buildVariantName}][${taskName}]`, // need to see that build variant has task to begin with...
+      [buildVariantName, taskName], // need to see that build variant has task to begin with...
       false
     );
   const checked: boolean = selectedBuildVariants
@@ -209,11 +209,7 @@ const getTaskCheckboxState = (
 
   const uncheckedCb = (allUnchecked: boolean, buildVariantName: string) =>
     allUnchecked &&
-    !get(
-      selectedBuildVariantTasks,
-      `[${buildVariantName}][${taskName}]`,
-      false
-    );
+    !get(selectedBuildVariantTasks, [buildVariantName, taskName], false);
   const unchecked: boolean = selectedBuildVariants.reduce(uncheckedCb, true);
 
   if (unchecked) {

--- a/src/pages/configurePatch/configurePatchCore/ConfigureTasks.tsx
+++ b/src/pages/configurePatch/configurePatchCore/ConfigureTasks.tsx
@@ -7,6 +7,8 @@ import Checkbox from "@leafygreen-ui/checkbox";
 import { css } from "@emotion/core";
 import isEmpty from "lodash/isEmpty";
 import { Button } from "components/Button";
+import get from "lodash/get";
+import every from "lodash.every";
 
 interface Props {
   variants: ProjectBuildVariant[];
@@ -18,9 +20,6 @@ interface Props {
   loading: boolean;
   onClickSchedule: () => void;
 }
-interface TasksState {
-  [task: string]: true;
-}
 
 export const ConfigureTasks: React.FC<Props> = ({
   variants,
@@ -30,75 +29,73 @@ export const ConfigureTasks: React.FC<Props> = ({
   loading,
   onClickSchedule,
 }) => {
-  const buildVariantCount = Object.keys(selectedVariantTasks).length;
-  const taskCount = Object.values(selectedVariantTasks).reduce(
-    (prev, curr) => prev + Object.values(curr).length,
+  const buildVariantCount = Object.values(selectedVariantTasks).reduce(
+    (count, taskOb) =>
+      count +
+      (every(Object.values(taskOb), (isSelected) => !isSelected) ? 0 : 1),
     0
   );
+  const taskCount = Object.values(selectedVariantTasks).reduce(
+    (count, taskObj) => count + Object.values(taskObj).filter((v) => v).length,
+    0
+  );
+  // represents tasks from selected build variants
+  const currentTasks = Array.from(
+    new Set(
+      variants
+        .filter((v) => selectedBuildVariant.includes(v.name))
+        .reduce<string[]>((accum, { tasks }) => [...accum, ...tasks], [])
+    )
+  );
 
-  const projectVariantTasksMap: {
-    [variant: string]: string[];
-  } = variants.reduce((prev, { name, tasks }) => {
-    prev[name] = tasks; // eslint-disable-line no-param-reassign
-    return prev;
-  }, {});
-  const temp = selectedBuildVariant.map((buildVariant) => ({
-    buildVariant,
-    tasks: projectVariantTasksMap[buildVariant || variants[0].name],
-  }));
-  const currentTasks = [];
-  for (let i = 0; i < temp.length; i++) {
-    currentTasks.push(temp[i]);
-  }
-  const onClickSelectAll = () => {
-    const variantTasks = selectedBuildVariant.map((buildVariant) =>
-      variants.find((element) => element.name === buildVariant)
+  const onChangeCheckbox = (taskName: string): void => {
+    const valueToSet =
+      getTaskCheckboxState(
+        taskName,
+        selectedBuildVariant,
+        selectedVariantTasks,
+        variants
+      ) === "unchecked";
+
+    setSelectedVariantTasks(
+      selectedBuildVariant.reduce((accum, buildVariantName) => {
+        const variantHasTask = taskExistsInVariant(
+          taskName,
+          buildVariantName,
+          variants
+        );
+        return variantHasTask
+          ? {
+              ...accum,
+              [buildVariantName]: {
+                ...(accum[buildVariantName] ?? {}),
+                [taskName]: valueToSet,
+              },
+            }
+          : accum;
+      }, selectedVariantTasks)
     );
-    const checkAllTasks = (tasks: string[]) => {
-      const checkedTasks = {};
-      for (let i = 0; i < tasks.length; i++) {
-        checkedTasks[tasks[i]] = true;
-      }
-      return checkedTasks;
-    };
-    const selectedTasks = {};
-    for (let i = 0; i < variantTasks.length; i++) {
-      selectedTasks[variantTasks[i].name] = checkAllTasks(
-        variantTasks[i].tasks
-      );
-    }
-    setSelectedVariantTasks({ ...selectedVariantTasks, ...selectedTasks });
   };
 
-  const onClickDeselectAll = (): void => {
-    const tempSelectedVariantTasks = { ...selectedVariantTasks };
-    for (let i = 0; i < selectedBuildVariant.length; i++) {
-      delete tempSelectedVariantTasks[selectedBuildVariant[i]];
-    }
-    setSelectedVariantTasks({ ...tempSelectedVariantTasks });
+  const selectAllCheckboxState = getSelectAllCheckboxState(
+    selectedBuildVariant,
+    selectedVariantTasks,
+    variants
+  );
+
+  const selectAllCheckboxCopy = `Select all tasks in ${
+    selectedBuildVariant.length > 1 ? "these variants" : "this variant"
+  }`;
+
+  const onClickSelectAll = () => {
+    setSelectedVariantTasks(
+      selectedBuildVariant.reduce(
+        getSetAllCb(selectAllCheckboxState !== "checked", variants),
+        selectedVariantTasks
+      )
+    );
   };
-  const getTaskCheckboxChangeHandler = (task: string, variant: string) => (
-    e: React.ChangeEvent<HTMLInputElement>
-  ): void => {
-    const { checked } = e.target;
-    const nextVariantTasks = { ...selectedVariantTasks[variant] };
-    if (checked) {
-      setSelectedVariantTasks({
-        ...selectedVariantTasks,
-        [variant]: { ...nextVariantTasks, [task]: true },
-      });
-    } else {
-      delete nextVariantTasks[task];
-      const nextSelectedVariantTasks = {
-        ...selectedVariantTasks,
-        [variant]: nextVariantTasks,
-      };
-      if (isEmpty(nextVariantTasks)) {
-        delete nextSelectedVariantTasks[variant];
-      }
-      setSelectedVariantTasks(nextSelectedVariantTasks);
-    }
-  };
+
   return (
     <TabContentWrapper>
       <Actions>
@@ -111,18 +108,14 @@ export const ConfigureTasks: React.FC<Props> = ({
         >
           Schedule
         </Button>
-        <ButtonLink
+        <Checkbox
           data-cy="configurePatch-selectAll"
-          onClick={onClickSelectAll}
-        >
-          Select All
-        </ButtonLink>
-        <ButtonLink
-          data-cy="configurePatch-deselectAll"
-          onClick={onClickDeselectAll}
-        >
-          Deselect All
-        </ButtonLink>
+          data-checked={`selectAll-${selectAllCheckboxState}`}
+          indeterminate={selectAllCheckboxState === "indeterminate"}
+          onChange={onClickSelectAll}
+          label={selectAllCheckboxCopy}
+          checked={selectAllCheckboxState === "checked"}
+        />
       </Actions>
       <StyledDisclaimer data-cy="x-tasks-across-y-variants">
         {`${taskCount} task${
@@ -132,33 +125,27 @@ export const ConfigureTasks: React.FC<Props> = ({
         }`}
       </StyledDisclaimer>
       <Tasks data-cy="configurePatch-tasks">
-        {currentTasks.map((currentTask) =>
-          currentTask.tasks.map((task) => {
-            let checked = false;
-            for (let i = 0; i < selectedBuildVariant.length; i++) {
-              if (checked === true) {
-                break;
-              } else {
-                checked =
-                  !!selectedVariantTasks[selectedBuildVariant[i]] &&
-                  selectedVariantTasks[selectedBuildVariant[i]][task] === true;
-              }
-            }
-            return (
-              <Checkbox
-                data-cy={`configurePatch-${task}`}
-                data-checked={checked}
-                key={task}
-                onChange={getTaskCheckboxChangeHandler(
-                  task,
-                  currentTask.buildVariant
-                )}
-                label={task}
-                checked={checked}
-              />
-            );
-          })
-        )}
+        {currentTasks.map((task) => {
+          const checkboxState = getTaskCheckboxState(
+            task,
+            selectedBuildVariant,
+            selectedVariantTasks,
+            variants
+          );
+          const isChecked = checkboxState === "checked";
+          return (
+            <Checkbox
+              data-cy={`configurePatch-${task}`}
+              data-checked={`task-checkbox-${checkboxState}`}
+              data-name-checked={`task-checkbox-${task}-${checkboxState}`}
+              key={task}
+              indeterminate={checkboxState === "indeterminate"}
+              onChange={() => onChangeCheckbox(task)}
+              label={task}
+              checked={isChecked}
+            />
+          );
+        })}
       </Tasks>
     </TabContentWrapper>
   );
@@ -184,9 +171,6 @@ const Tasks = styled.div`
   grid-column-gap: 30px;
   grid-row-gap: 12px;
 `;
-const ButtonLink = styled.div`
-  cursor: pointer;
-`;
 const StyledDisclaimer = styled(Disclaimer)`
   margin-bottom: 8px;
 `;
@@ -197,3 +181,123 @@ export const cardSidePadding = css`
 const TabContentWrapper = styled.div`
   ${cardSidePadding}
 `;
+
+type CheckboxState = "checked" | "unchecked" | "indeterminate";
+
+const getTaskCheckboxState = (
+  taskName: string,
+  selectedBuildVariants: string[],
+  selectedBuildVariantTasks: VariantTasksState,
+  variants: ProjectBuildVariant[]
+): CheckboxState => {
+  const checkedCb = (allChecked: boolean, buildVariantName: string): boolean =>
+    allChecked &&
+    !!get(
+      selectedBuildVariantTasks,
+      `[${buildVariantName}][${taskName}]`, // need to see that build variant has task to begin with...
+      false
+    );
+  const checked: boolean = selectedBuildVariants
+    .filter((buildVariantName) =>
+      taskExistsInVariant(taskName, buildVariantName, variants)
+    )
+    .reduce(checkedCb, true);
+
+  if (checked) {
+    return "checked";
+  }
+
+  const uncheckedCb = (allUnchecked: boolean, buildVariantName: string) =>
+    allUnchecked &&
+    !get(
+      selectedBuildVariantTasks,
+      `[${buildVariantName}][${taskName}]`,
+      false
+    );
+  const unchecked: boolean = selectedBuildVariants.reduce(uncheckedCb, true);
+
+  if (unchecked) {
+    return "unchecked";
+  }
+
+  return "indeterminate";
+};
+
+const getSetAllCb = (value: boolean, variants: ProjectBuildVariant[]) => (
+  variantAccum,
+  buildVariantName: string
+) => {
+  const allTasks: string[] = get(
+    variants.find(({ name }) => name === buildVariantName),
+    "tasks",
+    []
+  );
+
+  const tasks = allTasks.reduce(
+    (taskObAccum, taskName) => ({
+      ...taskObAccum,
+      [taskName]: value,
+    }),
+    {}
+  );
+
+  return {
+    ...variantAccum,
+    [buildVariantName]: tasks,
+  };
+};
+
+const getSelectAllCheckboxState = (
+  selectedBuildVariants: string[],
+  selectedBuildVariantTasks: VariantTasksState,
+  variants: ProjectBuildVariant[]
+): CheckboxState => {
+  const checkedCb = (allChecked: boolean, buildVariantName: string) => {
+    const buildVariantTasksValues = Object.values(
+      get(selectedBuildVariantTasks, buildVariantName, {})
+    );
+    return (
+      allChecked &&
+      buildVariantTasksValues.reduce(
+        (allTasksChecked, taskVal) => allTasksChecked && taskVal,
+        true
+      ) &&
+      buildVariantTasksValues.length ===
+        get(
+          variants.find(({ name }) => name === buildVariantName),
+          "tasks",
+          []
+        ).length
+    );
+  };
+  const checked: boolean = selectedBuildVariants.reduce(checkedCb, true);
+
+  if (checked) {
+    return "checked";
+  }
+
+  const uncheckedCb = (allUnchecked: boolean, buildVariantName: string) =>
+    allUnchecked &&
+    Object.values(get(selectedBuildVariantTasks, buildVariantName, {})).reduce(
+      (allTasksUnchecked, taskVal) => allTasksUnchecked && !taskVal,
+      true
+    );
+  const unchecked: boolean = selectedBuildVariants.reduce(uncheckedCb, true);
+
+  if (unchecked) {
+    return "unchecked";
+  }
+
+  return "indeterminate";
+};
+
+const taskExistsInVariant = (
+  taskName: string,
+  variantName: string,
+  allVariants: ProjectBuildVariant[]
+): boolean =>
+  get(
+    allVariants.find(({ name }) => name === variantName),
+    "tasks",
+    []
+  ).includes(taskName);

--- a/src/pages/patch/patchTabs/Tasks.tsx
+++ b/src/pages/patch/patchTabs/Tasks.tsx
@@ -20,7 +20,7 @@ import get from "lodash.get";
 import { ErrorBoundary } from "components/ErrorBoundary";
 import { TaskFilters } from "pages/patch/patchTabs/tasks/TaskFilters";
 import { PatchTasksQueryParams, TaskStatus } from "types/task";
-import every from "lodash/every";
+import every from "lodash.every";
 import { PageSizeSelector } from "components/PageSizeSelector";
 import {
   TableContainer,


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-12503
These code changes fix a bug where the task checkboxes remain unselected after clicking a checkbox.
This bug was being caused by passing an improperly formatted 2nd parameter to `lodash.get` in the `getTaskCheckboxState` state function which caused the `getTaskCheckboxState` to always return "unchecked" for task names with periods. 