### PR TITLE
EVG-12613: hosts page barebones table

### DIFF
--- a/cypress/integration/hosts/hosts-page-default.ts
+++ b/cypress/integration/hosts/hosts-page-default.ts
@@ -1,0 +1,68 @@
+describe("Hosts Page", () => {
+  before(() => {
+    cy.login();
+  });
+
+  beforeEach(() => {
+    cy.preserveCookies();
+    cy.listenGQL();
+    cy.visit("/hosts");
+  });
+
+  it("Renders hosts table with hosts sorted by status by default", () => {
+    cy.get("tr.ant-table-row").each(($el, index) =>
+      cy.wrap($el).contains(defaultHostsOrder[index])
+    );
+  });
+
+  it("ID column value links to host page", () => {
+    cy.get("tr.ant-table-row")
+      .first()
+      .within(() => {
+        cy.dataCy("host-id-link")
+          .should("have.attr", "href")
+          .and("eq", "/host/i-06f80fa6e28f93b7d");
+      });
+  });
+
+  it("Current Task column value links to task page", () => {
+    cy.get("tr.ant-table-row")
+      .first()
+      .within(() => {
+        cy.dataCy("current-task-link")
+          .should("have.attr", "href")
+          .and("eq", `/task/${taskId}`);
+      });
+  });
+
+  // FUTURE TESTS
+  // test pagination
+  // first page of results
+  // second page of results
+  // can go forward and back using the pagination ui
+  // can change number of hosts rendered by adjusting limit
+
+  // test filtering
+  // for each of the filterable headers, i click on a filter, input filter, and filtered hosts are rendered
+  // i can reset the filter
+  // url params are updated to reflect filter values
+
+  // test sorting
+  // clicking on table header sorts hosts in ascending and descending order
+  // url param is updated with sortBy and sortDirection values
+});
+
+const defaultHostsOrder = [
+  "i-06f80fa6e28f93b7d",
+  "i-0fb9fe0592ea38150",
+  "macos-1014-68.macstadium.build.10gen.cc",
+  "ubuntu1804-ppc-3.pic.build.10gen.cc",
+  "build10.ny.cbi.10gen.cc",
+  "i-0d0ae8b83366d22be",
+  "i-0f81a2d39744003dd",
+  "rhel71-ppc-1.pic.build.10gen.cc",
+  "ubuntu1604-ppc-1.pic.build.10gen.cc",
+];
+
+const taskId =
+  "mongo_tools_ubuntu1604_qa_dump_restore_with_archiving_current_patch_b7227e1b7aeaaa6283d53b32fc03968a46b19c2d_5f15ad3c3627e07772ab2d01_20_07_20_14_42_05";

--- a/src/components/Content/index.tsx
+++ b/src/components/Content/index.tsx
@@ -5,6 +5,7 @@ import { Patch } from "pages/Patch";
 import { UserPatches } from "pages/UserPatches";
 import { Login } from "pages/Login";
 import { CommitQueue } from "pages/CommitQueue";
+import { Hosts } from "pages/Hosts";
 import { PrivateRoute } from "components/PrivateRoute";
 import { Navbar } from "components/Navbar";
 import { SiteBanner } from "components/Banners";
@@ -52,6 +53,7 @@ export const Content: React.FC = () => {
         <PrivateRoute path={routes.configurePatch} component={ConfigurePatch} />
         <PrivateRoute path={routes.patch} component={PatchRedirect} />
         <PrivateRoute path={routes.version} component={Patch} />
+        <PrivateRoute path={routes.hosts} component={Hosts} />
         <PrivateRoute exact path={routes.myPatches} component={MyPatches} />
         <PrivateRoute path={routes.userPatches} component={UserPatches} />
         <PrivateRoute

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -12,6 +12,7 @@ export const paths = {
   commitQueue: "/commit-queue",
   preferences: "/preferences",
   user: "/user",
+  hosts: "/hosts",
 };
 
 export const routes = {
@@ -24,6 +25,7 @@ export const routes = {
   preferences: `${paths.preferences}/:tab?`,
   userPatches: `${paths.user}/:id/${PageNames.Patches}`,
   version: `${paths.version}/:id/:tab?`,
+  hosts: paths.hosts,
 };
 
 export enum PatchTab {
@@ -48,3 +50,7 @@ export const getUserPatchesRoute = (userId: string): string =>
 
 export const getVersionRoute = (versionId: string, tab?: PatchTab) =>
   `${paths.version}/${versionId}/${tab ?? DEFAULT_PATCH_TAB}`;
+
+export const getHostRoute = (hostId: string) => `/host/${hostId}`;
+
+export const getTaskRoute = (taskId: string) => `/task/${taskId}`;

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -13,6 +13,7 @@ export const paths = {
   preferences: "/preferences",
   user: "/user",
   hosts: "/hosts",
+  host: "/host",
 };
 
 export const routes = {
@@ -51,6 +52,6 @@ export const getUserPatchesRoute = (userId: string): string =>
 export const getVersionRoute = (versionId: string, tab?: PatchTab) =>
   `${paths.version}/${versionId}/${tab ?? DEFAULT_PATCH_TAB}`;
 
-export const getHostRoute = (hostId: string) => `/host/${hostId}`;
+export const getHostRoute = (hostId: string) => `${paths.host}/${hostId}`;
 
-export const getTaskRoute = (taskId: string) => `/task/${taskId}`;
+export const getTaskRoute = (taskId: string) => `${paths.task}/${taskId}`;

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -94,6 +94,35 @@ export type GroupedProjects = {
   projects: Array<Project>;
 };
 
+export type Host = {
+  id: Scalars["ID"];
+  hostUrl: Scalars["String"];
+  distroId?: Maybe<Scalars["String"]>;
+  status: Scalars["String"];
+  runningTask?: Maybe<TaskInfo>;
+  totalIdleTime?: Maybe<Scalars["Duration"]>;
+  uptime?: Maybe<Scalars["Time"]>;
+  elapsed?: Maybe<Scalars["Time"]>;
+  startedBy: Scalars["String"];
+};
+
+export enum HostSortBy {
+  Id = "ID",
+  Distro = "DISTRO",
+  CurrentTask = "CURRENT_TASK",
+  Status = "STATUS",
+  Elapsed = "ELAPSED",
+  Uptime = "UPTIME",
+  IdleTime = "IDLE_TIME",
+  Owner = "OWNER",
+}
+
+export type HostsResponse = {
+  filteredHostsCount?: Maybe<Scalars["Int"]>;
+  totalHostsCount: Scalars["Int"];
+  hosts: Array<Host>;
+};
+
 export type LogMessage = {
   type?: Maybe<Scalars["String"]>;
   severity?: Maybe<Scalars["String"]>;
@@ -328,6 +357,7 @@ export type Query = {
   userConfig?: Maybe<UserConfig>;
   clientConfig?: Maybe<ClientConfig>;
   siteBanner: SiteBanner;
+  hosts: HostsResponse;
 };
 
 export type QueryUserPatchesArgs = {
@@ -341,6 +371,7 @@ export type QueryUserPatchesArgs = {
 
 export type QueryTaskArgs = {
   taskId: Scalars["String"];
+  execution?: Maybe<Scalars["Int"]>;
 };
 
 export type QueryPatchArgs = {
@@ -361,6 +392,7 @@ export type QueryPatchTasksArgs = {
 
 export type QueryTaskTestsArgs = {
   taskId: Scalars["String"];
+  execution?: Maybe<Scalars["Int"]>;
   sortCategory?: Maybe<TestSortCategory>;
   sortDirection?: Maybe<SortDirection>;
   page?: Maybe<Scalars["Int"]>;
@@ -371,6 +403,7 @@ export type QueryTaskTestsArgs = {
 
 export type QueryTaskFilesArgs = {
   taskId: Scalars["String"];
+  execution?: Maybe<Scalars["Int"]>;
 };
 
 export type QueryTaskLogsArgs = {
@@ -383,6 +416,18 @@ export type QueryPatchBuildVariantsArgs = {
 
 export type QueryCommitQueueArgs = {
   id: Scalars["String"];
+};
+
+export type QueryHostsArgs = {
+  hostId?: Maybe<Scalars["String"]>;
+  distroId?: Maybe<Scalars["String"]>;
+  currentTaskId?: Maybe<Scalars["String"]>;
+  statuses?: Maybe<Array<Scalars["String"]>>;
+  startedBy?: Maybe<Scalars["String"]>;
+  sortBy?: Maybe<HostSortBy>;
+  sortDir?: Maybe<SortDirection>;
+  page?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars["Int"]>;
 };
 
 export type RecentTaskLogs = {
@@ -476,6 +521,7 @@ export type Task = {
   canSchedule: Scalars["Boolean"];
   canUnschedule: Scalars["Boolean"];
   canSetPriority: Scalars["Boolean"];
+  estimatedStart?: Maybe<Scalars["Duration"]>;
 };
 
 export type TaskEndDetail = {
@@ -504,6 +550,11 @@ export type TaskEventLogEntry = {
 export type TaskFiles = {
   fileCount: Scalars["Int"];
   groupedFiles: Array<GroupedFiles>;
+};
+
+export type TaskInfo = {
+  id?: Maybe<Scalars["ID"]>;
+  name?: Maybe<Scalars["String"]>;
 };
 
 export type TaskLogLinks = {
@@ -1065,6 +1116,28 @@ export type GetUserSettingsQuery = {
 export type GetUserQueryVariables = {};
 
 export type GetUserQuery = { user: { userId: string; displayName: string } };
+
+export type HostsQueryVariables = {
+  hostId?: Maybe<Scalars["String"]>;
+};
+
+export type HostsQuery = {
+  hosts: {
+    filteredHostsCount?: Maybe<number>;
+    totalHostsCount: number;
+    hosts: Array<{
+      id: string;
+      distroId?: Maybe<string>;
+      status: string;
+      startedBy: string;
+      hostUrl: string;
+      totalIdleTime?: Maybe<number>;
+      uptime?: Maybe<Date>;
+      elapsed?: Maybe<Date>;
+      runningTask?: Maybe<{ id?: Maybe<string>; name?: Maybe<string> }>;
+    }>;
+  };
+};
 
 export type UserPatchesQueryVariables = {
   page?: Maybe<Scalars["Int"]>;

--- a/src/gql/queries/hosts.ts
+++ b/src/gql/queries/hosts.ts
@@ -1,0 +1,24 @@
+import gql from "graphql-tag";
+
+export const HOSTS = gql`
+  query Hosts($hostId: String) {
+    hosts(hostId: $hostId) {
+      filteredHostsCount
+      totalHostsCount
+      hosts {
+        id
+        distroId
+        status
+        startedBy
+        hostUrl
+        totalIdleTime
+        uptime
+        elapsed
+        runningTask {
+          id
+          name
+        }
+      }
+    }
+  }
+`;

--- a/src/gql/queries/index.ts
+++ b/src/gql/queries/index.ts
@@ -21,3 +21,4 @@ export { GET_CLIENT_CONFIG } from "./get-client-config";
 export { GET_PATCH_TASK_STATUSES } from "./get-patch-task-statuses";
 export { AWS_REGIONS } from "./aws-regions";
 export { GET_SITE_BANNER } from "./get-site-banner";
+export { HOSTS } from "./hosts";

--- a/src/pages/Hosts.tsx
+++ b/src/pages/Hosts.tsx
@@ -22,6 +22,7 @@ import { Host, HostsQuery, HostsQueryVariables } from "gql/generated/types";
 import { HOSTS } from "gql/queries";
 import { getHostRoute, getTaskRoute } from "constants/routes";
 import { useDisableTableSortersIfLoading, usePollQuery } from "hooks";
+import { formatDistanceToNow } from "date-fns";
 
 const Hosts: React.FC = () => {
   const dispatchBanner = useBannerDispatchContext();
@@ -107,7 +108,7 @@ const columnsTemplate: Array<ColumnProps<Host>> = [
   },
   {
     title: "Distro",
-    dataIndex: "distro",
+    dataIndex: "distroId",
     key: TableColumnHeader.Distro,
     sorter: true,
     className: "cy-task-table-col-DISTRO",
@@ -140,6 +141,8 @@ const columnsTemplate: Array<ColumnProps<Host>> = [
     key: TableColumnHeader.Elapsed,
     sorter: true,
     className: "cy-task-table-col-ELAPSED",
+    render: (_, { elapsed }) =>
+      elapsed ? formatDistanceToNow(new Date(elapsed)) : "N/A",
   },
   {
     title: "Uptime",
@@ -147,6 +150,8 @@ const columnsTemplate: Array<ColumnProps<Host>> = [
     key: TableColumnHeader.Uptime,
     sorter: true,
     className: "cy-task-table-col-UPTIME",
+    render: (_, { uptime }) =>
+      uptime ? formatDistanceToNow(new Date(uptime)) : "N/A",
   },
   {
     title: "Idle Time",
@@ -154,6 +159,8 @@ const columnsTemplate: Array<ColumnProps<Host>> = [
     key: TableColumnHeader.IdleTime,
     sorter: true,
     className: "cy-task-table-col-IDLE-TIME",
+    render: (_, { totalIdleTime }) =>
+      totalIdleTime ? formatDistanceToNow(new Date(totalIdleTime)) : "N/A",
   },
   {
     title: "Owner",

--- a/src/pages/Hosts.tsx
+++ b/src/pages/Hosts.tsx
@@ -1,0 +1,171 @@
+import React from "react";
+import { Table, Skeleton } from "antd";
+import { useQuery } from "@apollo/react-hooks";
+import { useLocation } from "react-router-dom";
+import { ColumnProps } from "antd/es/table";
+import {
+  TableContainer,
+  TableControlOuterRow,
+  TableControlInnerRow,
+  StyledRouterLink,
+} from "components/styles";
+import { withBannersContext } from "hoc/withBannersContext";
+import { Banners } from "components/Banners";
+import { PageWrapper } from "components/styles";
+import {
+  useBannerDispatchContext,
+  useBannerStateContext,
+} from "context/banners";
+import { H2 } from "@leafygreen-ui/typography";
+import { ErrorBoundary } from "components/ErrorBoundary";
+import { Host, HostsQuery, HostsQueryVariables } from "gql/generated/types";
+import { HOSTS } from "gql/queries";
+import { getHostRoute, getTaskRoute } from "constants/routes";
+import { useDisableTableSortersIfLoading, usePollQuery } from "hooks";
+
+const Hosts: React.FC = () => {
+  const dispatchBanner = useBannerDispatchContext();
+  const bannersState = useBannerStateContext();
+
+  const { data: hostsData, networkStatus, refetch } = useQuery<
+    HostsQuery,
+    HostsQueryVariables
+  >(HOSTS, {
+    variables: { hostId: null },
+    notifyOnNetworkStatusChange: true,
+    fetchPolicy: "network-only",
+  });
+
+  useDisableTableSortersIfLoading(networkStatus);
+
+  const { search } = useLocation();
+
+  const { showSkeleton } = usePollQuery({
+    networkStatus,
+    getQueryVariables,
+    refetch,
+    search,
+  });
+
+  return (
+    <PageWrapper data-cy="hosts-page">
+      <Banners
+        banners={bannersState}
+        removeBanner={dispatchBanner.removeBanner}
+      />
+      <H2>Evergreen Hosts</H2>
+      <ErrorBoundary>
+        <TableControlOuterRow>
+          <TableControlInnerRow>
+            {/** TODO: Put pagination here */}
+          </TableControlInnerRow>
+        </TableControlOuterRow>
+        <TableContainer hide={showSkeleton}>
+          <Table
+            data-test-id="tasks-table"
+            rowKey={rowKey}
+            pagination={false}
+            columns={columnsTemplate}
+            dataSource={hostsData?.hosts?.hosts ?? []}
+            onChange={() => undefined}
+          />
+        </TableContainer>
+        {showSkeleton && (
+          <Skeleton active title={false} paragraph={{ rows: 8 }} />
+        )}
+      </ErrorBoundary>
+    </PageWrapper>
+  );
+};
+
+// TODO: include query parameters
+const getQueryVariables = (): HostsQueryVariables => ({
+  hostId: null,
+});
+
+enum TableColumnHeader {
+  Id = "ID",
+  Distro = "DISTRO",
+  Status = "STATUS",
+  CurrentTask = "CURRENT_TASK",
+  Elapsed = "ELAPSED",
+  Uptime = "UPTIME",
+  IdleTime = "IDLE_TIME",
+  Owner = "OWNER",
+}
+
+const columnsTemplate: Array<ColumnProps<Host>> = [
+  {
+    title: "ID",
+    dataIndex: "id",
+    key: TableColumnHeader.Id,
+    sorter: true,
+    className: "cy-hosts-table-col-ID",
+    render: (name: string, { id }: Host): JSX.Element => (
+      <StyledRouterLink to={getHostRoute(id)}>{id}</StyledRouterLink>
+    ),
+  },
+  {
+    title: "Distro",
+    dataIndex: "distro",
+    key: TableColumnHeader.Distro,
+    sorter: true,
+    className: "cy-task-table-col-DISTRO",
+  },
+  {
+    title: "Status",
+    dataIndex: "status",
+    key: TableColumnHeader.Status,
+    sorter: true,
+    className: "cy-task-table-col-STATUS",
+  },
+  {
+    title: "Current Task",
+    dataIndex: "currentTask",
+    key: TableColumnHeader.CurrentTask,
+    sorter: true,
+    className: "cy-task-table-col-CURRENT-TASK",
+    render: (name: string, { runningTask }: Host) =>
+      runningTask?.id !== null ? (
+        <StyledRouterLink to={getTaskRoute(runningTask?.id)}>
+          {runningTask?.name}
+        </StyledRouterLink>
+      ) : (
+        ""
+      ),
+  },
+  {
+    title: "Elapsed",
+    dataIndex: "elapsed",
+    key: TableColumnHeader.Elapsed,
+    sorter: true,
+    className: "cy-task-table-col-ELAPSED",
+  },
+  {
+    title: "Uptime",
+    dataIndex: "uptime",
+    key: TableColumnHeader.Uptime,
+    sorter: true,
+    className: "cy-task-table-col-UPTIME",
+  },
+  {
+    title: "Idle Time",
+    dataIndex: "totalIdleTime",
+    key: TableColumnHeader.IdleTime,
+    sorter: true,
+    className: "cy-task-table-col-IDLE-TIME",
+  },
+  {
+    title: "Owner",
+    dataIndex: "startedBy",
+    key: TableColumnHeader.Owner,
+    sorter: true,
+    className: "cy-task-table-col-OWNER",
+  },
+];
+
+const rowKey = ({ id }: { id: string }): string => id;
+
+const HostsWithBannersContext = withBannersContext(Hosts);
+
+export { HostsWithBannersContext as Hosts };

--- a/src/pages/Hosts.tsx
+++ b/src/pages/Hosts.tsx
@@ -102,8 +102,10 @@ const columnsTemplate: Array<ColumnProps<Host>> = [
     key: TableColumnHeader.Id,
     sorter: true,
     className: "cy-hosts-table-col-ID",
-    render: (name: string, { id }: Host): JSX.Element => (
-      <StyledRouterLink to={getHostRoute(id)}>{id}</StyledRouterLink>
+    render: (_, { id }: Host): JSX.Element => (
+      <StyledRouterLink data-cy="host-id-link" to={getHostRoute(id)}>
+        {id}
+      </StyledRouterLink>
     ),
   },
   {
@@ -126,9 +128,12 @@ const columnsTemplate: Array<ColumnProps<Host>> = [
     key: TableColumnHeader.CurrentTask,
     sorter: true,
     className: "cy-task-table-col-CURRENT-TASK",
-    render: (name: string, { runningTask }: Host) =>
+    render: (_, { runningTask }: Host) =>
       runningTask?.id !== null ? (
-        <StyledRouterLink to={getTaskRoute(runningTask?.id)}>
+        <StyledRouterLink
+          data-cy="current-task-link"
+          to={getTaskRoute(runningTask?.id)}
+        >
           {runningTask?.name}
         </StyledRouterLink>
       ) : (

--- a/src/pages/Patch.tsx
+++ b/src/pages/Patch.tsx
@@ -31,7 +31,6 @@ const PatchCore: React.FC = () => {
   const { id } = useParams<{ id: string }>();
 
   const dispatchBanner = useBannerDispatchContext();
-
   const bannersState = useBannerStateContext();
 
   const router = useHistory();

--- a/src/pages/patch/patchTabs/Tasks.tsx
+++ b/src/pages/patch/patchTabs/Tasks.tsx
@@ -42,16 +42,21 @@ interface Props {
 
 export const Tasks: React.FC<Props> = ({ taskCount }) => {
   const { id: resourceId } = useParams<{ id: string }>();
+
   const { search } = useLocation();
+
   const [initialQueryVariables] = useState(
     getQueryVariables(search, resourceId)
   );
+
   const { sortBy, sortDir } = initialQueryVariables;
+
   const columns = useSetColumnDefaultSortOrder<TaskResult>(
     columnsTemplate,
     sortBy,
     sortDir
   );
+
   const { data, error, networkStatus, refetch } = useQuery<
     PatchTasksQuery,
     PatchTasksQueryVariables
@@ -60,19 +65,24 @@ export const Tasks: React.FC<Props> = ({ taskCount }) => {
     notifyOnNetworkStatusChange: true,
     fetchPolicy: "network-only",
   });
+
   useDisableTableSortersIfLoading(networkStatus);
+
   const { showSkeleton } = usePollQuery({
     networkStatus,
     getQueryVariables,
     refetch,
     search,
   });
+
   const patchAnalytics = usePatchAnalytics();
 
   if (error) {
     return <div>{error.message}</div>;
   }
+
   const { limit, page } = getQueryVariables(search, resourceId);
+
   return (
     <ErrorBoundary>
       <TaskFilters />


### PR DESCRIPTION
### This PR includes

1. Hosts route
2. Hosts page minimal layout (page title & table)
3. GQL query to fetch hosts - pagination and filtering coming in subsequent PRs
4. E2E tests for the default hosts page - renders hosts sorted by status

### Hosts Page Pull Request Timeline
I will be doing the PRs for the hosts page in as small fragments as possible, beginning with this barebones hosts page that includes the title and hosts table. 

Subsequent PRs include pagination, sorting, filtering and all the other UI represented in these beautiful mockups: https://mongodb.invisionapp.com/share/C2WKQWRWG5Y#/screens/424885145

I will also be merging the unfinished page into master. There is no link or entry point to the hosts page in the new UI so I do not expect users to accidentally stumble onto it. 

### WARNING - TESTS WILL FAIL
The tests in this PR depend on local evergreen hosts data being merged into evergreen backend. I am waiting on @john-m-liu  to finish "scrambled eggs" so that i can merge the local data PR for hosts data. 

<img width="1405" alt="Screen Shot 2020-07-21 at 1 34 00 PM" src="https://user-images.githubusercontent.com/15262143/88093031-69779e00-cb5f-11ea-8d1d-af0bd40973fb.png">