### PR TITLE
EVG-12527: reusable table filters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2924,9 +2924,9 @@
       }
     },
     "@leafygreen-ui/checkbox": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@leafygreen-ui/checkbox/-/checkbox-4.0.0.tgz",
-      "integrity": "sha512-vvkwBHv2AE8/2F/XnNSIgYpPc0R+6qNPVDprSd6istFpz8Xe7Hzcp0xD1olYOeWm2fqPu3EXJDkAq+9YzBVScQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/checkbox/-/checkbox-4.0.1.tgz",
+      "integrity": "sha512-Y5CQ/rO1RwyDYrHP7hsndtYpYMpDtYkpPmTJLRBlZpyKLmw7rcDrv+rgnWBWLmzdwj7zGdC+JxTy1wJJQelx2A==",
       "requires": {
         "@leafygreen-ui/lib": "^4.0.0",
         "@leafygreen-ui/theme": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@leafygreen-ui/badge": "3.0.0",
     "@leafygreen-ui/button": "4.1.0",
     "@leafygreen-ui/card": "2.0.0",
-    "@leafygreen-ui/checkbox": "4.0.0",
+    "@leafygreen-ui/checkbox": "^4.0.1",
     "@leafygreen-ui/code": "3.4.4",
     "@leafygreen-ui/icon": "4.1.0",
     "@leafygreen-ui/leafygreen-provider": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@leafygreen-ui/badge": "3.0.0",
     "@leafygreen-ui/button": "4.1.0",
     "@leafygreen-ui/card": "2.0.0",
-    "@leafygreen-ui/checkbox": "^4.0.1",
+    "@leafygreen-ui/checkbox": "4.0.1",
     "@leafygreen-ui/code": "3.4.4",
     "@leafygreen-ui/icon": "4.1.0",
     "@leafygreen-ui/leafygreen-provider": "1.1.1",

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -34,6 +34,7 @@ export const Button: React.FC<Props> = ({
   glyph,
   href,
   target,
+  size,
 }) => (
   <LeafyGreenButton
     data-cy={dataCy}
@@ -43,6 +44,7 @@ export const Button: React.FC<Props> = ({
     glyph={loading ? <StyledIcon type="loading" /> : glyph}
     href={href}
     target={target}
+    size={size}
   >
     {children}
   </LeafyGreenButton>

--- a/src/components/Checkbox/CheckboxGroup.tsx
+++ b/src/components/Checkbox/CheckboxGroup.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import styled from "@emotion/styled";
+import Checkbox from "@leafygreen-ui/checkbox";
+import { TreeDataEntry } from "components/TreeSelect";
+
+interface CheckboxesProps {
+  data: TreeDataEntry[];
+  value: string[];
+  onChange: (e: React.ChangeEvent<HTMLInputElement>, key: string) => void;
+}
+
+export const CheckboxGroup: React.FC<CheckboxesProps> = ({
+  data,
+  value,
+  onChange = () => undefined,
+}) => (
+  <CheckboxesWrapper>
+    {data.map(({ key, title, value: checkboxValue }) => (
+      <Checkbox
+        key={key}
+        className="cy-checkbox"
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) => onChange(e, key)}
+        label={title}
+        checked={value.includes(checkboxValue)}
+        bold={false}
+        data-testid={title}
+      />
+    ))}
+  </CheckboxesWrapper>
+);
+
+const CheckboxesWrapper = styled.div`
+  padding: 4px;
+`;

--- a/src/components/Checkbox/CheckboxGroup.tsx
+++ b/src/components/Checkbox/CheckboxGroup.tsx
@@ -16,7 +16,7 @@ export const CheckboxGroup: React.FC<CheckboxesProps> = ({
 }) => (
   <CheckboxesWrapper>
     {data.map(({ key, title, value: checkboxValue }) => (
-      <Checkbox
+      <StyledCheckbox
         key={key}
         className="cy-checkbox"
         onChange={(e: React.ChangeEvent<HTMLInputElement>) => onChange(e, key)}
@@ -31,4 +31,11 @@ export const CheckboxGroup: React.FC<CheckboxesProps> = ({
 
 const CheckboxesWrapper = styled.div`
   padding: 4px;
+`;
+const StyledCheckbox = styled(Checkbox)`
+  margin-bottom: 8px;
+
+  :last-of-type {
+    margin-bottom: 0;
+  }
 `;

--- a/src/components/Checkbox/index.ts
+++ b/src/components/Checkbox/index.ts
@@ -1,0 +1,1 @@
+export { CheckboxGroup } from "./CheckboxGroup";

--- a/src/components/Table/Filters.tsx
+++ b/src/components/Table/Filters.tsx
@@ -99,7 +99,7 @@ export const CheckboxFilter: React.FC<CheckboxFilterProps> = ({
   </FilterWrapper>
 );
 
-export const getColumnTreeSelectFilterProps = ({
+export const getColumnCheckboxFilterProps = ({
   statuses,
   value,
   onChange,

--- a/src/components/Table/Filters.tsx
+++ b/src/components/Table/Filters.tsx
@@ -24,7 +24,6 @@ export const InputFilter: React.FC<InputFilterProps> = ({
 }) => (
   <FilterWrapper>
     <Input
-      aria-label="chicken"
       data-cy={dataCy}
       placeholder={placeholder}
       value={value}

--- a/src/components/Table/Filters.tsx
+++ b/src/components/Table/Filters.tsx
@@ -4,6 +4,7 @@ import { Button } from "components/Button";
 import { TreeDataEntry } from "components/TreeSelect";
 import { CheckboxGroup } from "components/Checkbox";
 import styled from "@emotion/styled";
+import { uiColors } from "@leafygreen-ui/palette";
 
 export interface InputFilterProps {
   dataCy?: string;
@@ -63,7 +64,10 @@ export const getColumnSearchFilterProps = ({
     />
   ),
   filterIcon: () => (
-    <Icon type="search" style={{ color: value ? "#1890ff" : undefined }} />
+    <Icon
+      type="search"
+      style={{ color: value ? uiColors.blue.base : undefined }}
+    />
   ),
 });
 
@@ -122,7 +126,7 @@ export const getColumnCheckboxFilterProps = ({
   filterIcon: () => (
     <Icon
       type="filter"
-      style={{ color: value.length ? "#1890ff" : undefined }}
+      style={{ color: value.length ? uiColors.blue.base : undefined }}
     />
   ),
 });

--- a/src/components/Table/Filters.tsx
+++ b/src/components/Table/Filters.tsx
@@ -1,0 +1,142 @@
+import React from "react";
+import { Input, Icon } from "antd";
+import { Button } from "components/Button";
+import { TreeDataEntry } from "components/TreeSelect";
+import { CheckboxGroup } from "components/Checkbox";
+import styled from "@emotion/styled";
+
+export interface InputFilterProps {
+  dataCy?: string;
+  placeholder: string;
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  updateUrlParam: () => void;
+  resetUrlParam: () => void;
+}
+
+export const InputFilter: React.FC<InputFilterProps> = ({
+  placeholder,
+  value,
+  onChange,
+  dataCy,
+  updateUrlParam,
+  resetUrlParam,
+}) => (
+  <FilterWrapper>
+    <Input
+      aria-label="chicken"
+      data-cy={dataCy}
+      placeholder={placeholder}
+      value={value}
+      onChange={onChange}
+    />
+    <ButtonsWrapper>
+      <ButtonWrapper>
+        <Button size="small" onClick={resetUrlParam}>
+          Reset
+        </Button>
+      </ButtonWrapper>
+      <Button size="small" variant="primary" onClick={updateUrlParam}>
+        Search
+      </Button>
+    </ButtonsWrapper>
+  </FilterWrapper>
+);
+
+export const getColumnSearchFilterProps = ({
+  dataCy,
+  placeholder,
+  value,
+  onChange,
+  updateUrlParam,
+  resetUrlParam,
+}: InputFilterProps) => ({
+  filterDropdown: () => (
+    <InputFilter
+      {...{
+        dataCy,
+        placeholder,
+        value,
+        onChange,
+        updateUrlParam,
+        resetUrlParam,
+      }}
+    />
+  ),
+  filterIcon: () => (
+    <Icon type="search" style={{ color: value ? "#1890ff" : undefined }} />
+  ),
+});
+
+export interface CheckboxFilterProps {
+  dataCy?: string;
+  statuses: TreeDataEntry[];
+  value: string[];
+  onChange: (e: React.ChangeEvent<HTMLInputElement>, key: string) => void;
+  updateUrlParam: () => void;
+  resetUrlParam: () => void;
+}
+
+export const CheckboxFilter: React.FC<CheckboxFilterProps> = ({
+  dataCy,
+  statuses,
+  value,
+  onChange,
+  updateUrlParam,
+  resetUrlParam,
+}) => (
+  <FilterWrapper data-cy={dataCy}>
+    <CheckboxGroup value={value} data={statuses} onChange={onChange} />
+    <ButtonsWrapper>
+      <ButtonWrapper>
+        <Button onClick={resetUrlParam} size="small">
+          Reset
+        </Button>
+      </ButtonWrapper>
+      <Button size="small" variant="primary" onClick={updateUrlParam}>
+        Filter
+      </Button>
+    </ButtonsWrapper>
+  </FilterWrapper>
+);
+
+export const getColumnTreeSelectFilterProps = ({
+  statuses,
+  value,
+  onChange,
+  updateUrlParam,
+  resetUrlParam,
+  dataCy,
+}: CheckboxFilterProps) => ({
+  filterDropdown: () => (
+    <CheckboxFilter
+      {...{
+        statuses,
+        value,
+        onChange,
+        updateUrlParam,
+        resetUrlParam,
+        dataCy,
+      }}
+    />
+  ),
+  filterIcon: () => (
+    <Icon
+      type="filter"
+      style={{ color: value.length ? "#1890ff" : undefined }}
+    />
+  ),
+});
+
+const FilterWrapper = styled.div`
+  padding: 12px;
+`;
+const ButtonsWrapper = styled.div`
+  display: flex;
+  flex-wrap: nowrap;
+  justify-content: flex-end;
+  margin-top: 32px;
+`;
+const ButtonWrapper = styled.div`
+  margin-right: 8px;
+`;

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -16,7 +16,7 @@ export { useStatusesFilter } from "hooks/useStatusesFilter";
 export { useTabs } from "hooks/useTabs";
 export {
   useTableInputFilter,
-  useTableTreeSelectFilter,
+  useTableCheckboxFilter,
 } from "hooks/useTableFilters";
 
 export const usePrevious = <T>(state: T): T | undefined => {

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,18 +1,23 @@
-import { useDefaultPath } from "hooks/useDefaultPath";
-import { useDisableTableSortersIfLoading } from "hooks/useDisableTableSortersIfLoading";
 import { useEffect, useRef } from "react";
-import { useFilterInputChangeHandler } from "hooks/useFilterInputChangeHandler";
-import { useGetUserPatchesPageTitleAndLink } from "hooks/useGetUserPatchesPageTitleAndLink";
-import { useNotificationModal } from "hooks/useNotificationModal";
-import { useOnClickOutside } from "hooks/useOnClickOutside";
-import { usePatchStatusSelect } from "hooks/usePatchStatusSelect";
-import { usePollQuery } from "hooks/usePollQuery";
-import { useSetColumnDefaultSortOrder } from "hooks/useSetColumnDefaultSortOrder";
-import { useLegacyUIURL } from "hooks/useLegacyUIURL";
-import { usePageTitle } from "hooks/usePageTitle";
-import { useNetworkStatus } from "hooks/useNetworkStatus";
-import { useStatusesFilter } from "hooks/useStatusesFilter";
-import { useTabs } from "hooks/useTabs";
+
+export { useDefaultPath } from "hooks/useDefaultPath";
+export { useDisableTableSortersIfLoading } from "hooks/useDisableTableSortersIfLoading";
+export { useFilterInputChangeHandler } from "hooks/useFilterInputChangeHandler";
+export { useGetUserPatchesPageTitleAndLink } from "hooks/useGetUserPatchesPageTitleAndLink";
+export { useNotificationModal } from "hooks/useNotificationModal";
+export { useOnClickOutside } from "hooks/useOnClickOutside";
+export { usePatchStatusSelect } from "hooks/usePatchStatusSelect";
+export { usePollQuery } from "hooks/usePollQuery";
+export { useSetColumnDefaultSortOrder } from "hooks/useSetColumnDefaultSortOrder";
+export { useLegacyUIURL } from "hooks/useLegacyUIURL";
+export { usePageTitle } from "hooks/usePageTitle";
+export { useNetworkStatus } from "hooks/useNetworkStatus";
+export { useStatusesFilter } from "hooks/useStatusesFilter";
+export { useTabs } from "hooks/useTabs";
+export {
+  useTableInputFilter,
+  useTableTreeSelectFilter,
+} from "hooks/useTableFilters";
 
 export const usePrevious = <T>(state: T): T | undefined => {
   const ref = useRef<T>();
@@ -20,21 +25,4 @@ export const usePrevious = <T>(state: T): T | undefined => {
     ref.current = state;
   }, [state]);
   return ref.current;
-};
-
-export {
-  useDefaultPath,
-  useDisableTableSortersIfLoading,
-  useFilterInputChangeHandler,
-  useGetUserPatchesPageTitleAndLink,
-  useLegacyUIURL,
-  useNotificationModal,
-  useOnClickOutside,
-  usePageTitle,
-  usePatchStatusSelect,
-  usePollQuery,
-  useSetColumnDefaultSortOrder,
-  useNetworkStatus,
-  useStatusesFilter,
-  useTabs,
 };

--- a/src/hooks/tests/useTableFilters/TestComponent.tsx
+++ b/src/hooks/tests/useTableFilters/TestComponent.tsx
@@ -20,7 +20,6 @@ export const InputFilterTestComponent = () => {
       <div>host id from url: {queryParams[hostIdUrlParam] ?? "N/A"}</div>
       <InputFilter
         {...{
-          dataCy: "",
           placeholder: "Search ID",
           value,
           onChange,
@@ -58,7 +57,6 @@ export const CheckboxFilterTestComponent = () => {
       <div>statuses from url: {urlValue}</div>
       <CheckboxFilter
         {...{
-          dataCy: "",
           statuses,
           value,
           onChange,

--- a/src/hooks/tests/useTableFilters/TestComponent.tsx
+++ b/src/hooks/tests/useTableFilters/TestComponent.tsx
@@ -58,7 +58,7 @@ export const CheckboxFilterTestComponent = () => {
       <div>statuses from url: {urlValue}</div>
       <CheckboxFilter
         {...{
-          dataCy: "tree-select-filter",
+          dataCy: "",
           statuses,
           value,
           onChange,

--- a/src/hooks/tests/useTableFilters/TestComponent.tsx
+++ b/src/hooks/tests/useTableFilters/TestComponent.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useTableInputFilter, useTableTreeSelectFilter } from "hooks";
+import { useTableInputFilter, useTableCheckboxFilter } from "hooks";
 import { useLocation } from "react-router";
 import { parseQueryString } from "utils";
 import { CheckboxFilter, InputFilter } from "components/Table/Filters";
@@ -40,7 +40,7 @@ export const CheckboxFilterTestComponent = () => {
     onChange,
     updateUrlParam,
     resetUrlParam,
-  ] = useTableTreeSelectFilter({
+  ] = useTableCheckboxFilter({
     urlSearchParam: statusesUrlParam,
     sendAnalyticsEvent: () => undefined,
   });

--- a/src/hooks/tests/useTableFilters/TestComponent.tsx
+++ b/src/hooks/tests/useTableFilters/TestComponent.tsx
@@ -1,0 +1,84 @@
+import React from "react";
+import { useTableInputFilter, useTableTreeSelectFilter } from "hooks";
+import { useLocation } from "react-router";
+import { parseQueryString } from "utils";
+import { CheckboxFilter, InputFilter } from "components/Table/Filters";
+
+const hostIdUrlParam = "hostId";
+
+export const InputFilterTestComponent = () => {
+  const [value, onChange, updateUrlParam, resetUrlParam] = useTableInputFilter({
+    urlSearchParam: hostIdUrlParam,
+    sendAnalyticsEvent: () => undefined,
+  });
+
+  const { search } = useLocation();
+  const queryParams = parseQueryString(search);
+
+  return (
+    <>
+      <div>host id from url: {queryParams[hostIdUrlParam] ?? "N/A"}</div>
+      <InputFilter
+        {...{
+          dataCy: "",
+          placeholder: "Search ID",
+          value,
+          onChange,
+          updateUrlParam,
+          resetUrlParam,
+        }}
+      />
+    </>
+  );
+};
+
+const statusesUrlParam = "statuses";
+
+export const CheckboxFilterTestComponent = () => {
+  const [
+    value,
+    onChange,
+    updateUrlParam,
+    resetUrlParam,
+  ] = useTableTreeSelectFilter({
+    urlSearchParam: statusesUrlParam,
+    sendAnalyticsEvent: () => undefined,
+  });
+
+  const { search } = useLocation();
+  const queryParams = parseQueryString(search);
+  const statusesFromUrl = queryParams[statusesUrlParam];
+
+  const urlValue = Array.isArray(statusesFromUrl)
+    ? statusesFromUrl.join()
+    : statusesFromUrl ?? "none";
+
+  return (
+    <>
+      <div>statuses from url: {urlValue}</div>
+      <CheckboxFilter
+        {...{
+          dataCy: "tree-select-filter",
+          statuses,
+          value,
+          onChange,
+          updateUrlParam,
+          resetUrlParam,
+        }}
+      />
+    </>
+  );
+};
+
+export const statuses = [
+  {
+    title: "Running",
+    value: "running",
+    key: "running",
+  },
+  {
+    title: "Terminated",
+    value: "terminated",
+    key: "terminated",
+  },
+];

--- a/src/hooks/tests/useTableFilters/useTableFilters.test.tsx
+++ b/src/hooks/tests/useTableFilters/useTableFilters.test.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+import { MemoryRouter, Route } from "react-router-dom";
+import { render, fireEvent } from "@testing-library/react";
+import {
+  InputFilterTestComponent,
+  CheckboxFilterTestComponent,
+} from "./TestComponent";
+
+test("useTableInputFilter", async () => {
+  const { getByText, getByPlaceholderText } = render(
+    <MemoryRouter initialEntries={[`/hosts?hostId=123`]}>
+      <Route path="/hosts">
+        <InputFilterTestComponent />
+      </Route>
+    </MemoryRouter>
+  );
+
+  const input = getByPlaceholderText("Search ID") as HTMLInputElement;
+  const searchButton = getByText("Search");
+  const resetButton = getByText("Reset");
+
+  // starts with initial url params as value
+  expect(input.value).toBe("123");
+
+  fireEvent.change(input, { target: { value: "" } });
+  fireEvent.change(input, { target: { value: "abc" } });
+  fireEvent.click(searchButton);
+
+  // returns updates value when component changes
+  expect(input.value).toBe("abc");
+
+  // updates url query params when update fn is called
+  getByText("host id from url: abc");
+
+  fireEvent.click(resetButton);
+
+  // resets url query params when reset fn is called
+  expect(input.value).toBe("");
+  getByText("host id from url: N/A");
+});
+
+test("useTableTreeSelectFilter", async () => {
+  const { getByText, getByLabelText } = render(
+    <MemoryRouter initialEntries={[`/hosts?statuses=running,terminated`]}>
+      <Route path="/hosts">
+        <CheckboxFilterTestComponent />
+      </Route>
+    </MemoryRouter>
+  );
+
+  const runningCheckbox = getByLabelText("Running") as HTMLInputElement;
+  const termindatedCheckbox = getByLabelText("Terminated") as HTMLInputElement;
+  const searchButton = getByText("Filter");
+  const resetButton = getByText("Reset");
+
+  // starts with initial url params as value
+  expect(runningCheckbox.checked).toBe(true);
+  expect(termindatedCheckbox.checked).toBe(true);
+
+  // returns updates value when component changes
+  fireEvent.click(runningCheckbox);
+  fireEvent.click(searchButton);
+
+  // updates url query params when update fn is called
+  expect(runningCheckbox.checked).toBe(false);
+  expect(termindatedCheckbox.checked).toBe(true);
+
+  getByText("statuses from url: terminated");
+
+  // resets url query params when reset fn is called
+  fireEvent.click(resetButton);
+
+  expect(runningCheckbox.checked).toBe(false);
+  expect(termindatedCheckbox.checked).toBe(false);
+
+  getByText("statuses from url: none");
+});

--- a/src/hooks/tests/useTableFilters/useTableFilters.test.tsx
+++ b/src/hooks/tests/useTableFilters/useTableFilters.test.tsx
@@ -39,7 +39,7 @@ test("useTableInputFilter", async () => {
   getByText("host id from url: N/A");
 });
 
-test("useTableTreeSelectFilter", async () => {
+test("useTableCheckboxFilter", async () => {
   const { getByText, getByLabelText } = render(
     <MemoryRouter initialEntries={[`/hosts?statuses=running,terminated`]}>
       <Route path="/hosts">

--- a/src/hooks/useFilterInputChangeHandler.ts
+++ b/src/hooks/useFilterInputChangeHandler.ts
@@ -2,32 +2,11 @@ import { useState } from "react";
 import debounce from "lodash.debounce";
 import queryString from "query-string";
 import { useLocation, useHistory } from "react-router-dom";
+import { updateUrlQueryParam } from "utils/url";
 
 const arrayFormat = "comma";
 
-const updateQueryParam = debounce(
-  (
-    urlSearchParam: string,
-    inputValue: string,
-    search: string,
-    replace: (path: string) => void,
-    pathname: string,
-    sendAnalyticsEvent: (filterBy: string) => void,
-    resetPage?: boolean
-  ) => {
-    const nextQueryParams = queryString.stringify(
-      {
-        ...queryString.parse(search, { arrayFormat }),
-        [urlSearchParam]: inputValue === "" ? undefined : inputValue,
-        ...(resetPage && { page: 0 }),
-      },
-      { arrayFormat }
-    );
-    replace(`${pathname}?${nextQueryParams}`);
-    sendAnalyticsEvent(urlSearchParam);
-  },
-  250
-);
+const updateQueryParamWithDebounce = debounce(updateUrlQueryParam, 250);
 
 type InputEvent = React.ChangeEvent<HTMLInputElement>;
 
@@ -57,7 +36,7 @@ export const useFilterInputChangeHandler = (
 
   const onChange = (e: InputEvent): void => {
     setValue(e.target.value);
-    updateQueryParam(
+    updateQueryParamWithDebounce(
       urlSearchParam,
       e.target.value,
       search,
@@ -67,5 +46,6 @@ export const useFilterInputChangeHandler = (
       resetPage
     );
   };
+
   return [value, onChange];
 };

--- a/src/hooks/useFilterInputChangeHandler.ts
+++ b/src/hooks/useFilterInputChangeHandler.ts
@@ -36,6 +36,9 @@ export const useFilterInputChangeHandler = (
 
   const onChange = (e: InputEvent): void => {
     setValue(e.target.value);
+
+    sendAnalyticsEvent(urlSearchParam);
+
     updateQueryParamWithDebounce(
       urlSearchParam,
       e.target.value,

--- a/src/hooks/useTableFilters.ts
+++ b/src/hooks/useTableFilters.ts
@@ -66,17 +66,17 @@ export const useTableInputFilter = <SearchParam extends string>({
   return [value, onChange, updateParams, resetQueryParam];
 };
 
-type UseTreeSelectFilterReturn = [
+type UseCheckboxFilterReturn = [
   string[], // url param value
   (e: InputEvent, key: string) => void, // onChange handler
   () => void, // update url param
   () => void // reset url param
 ];
 
-export const useTableTreeSelectFilter = <SearchParam extends string>({
+export const useTableCheckboxFilter = <SearchParam extends string>({
   urlSearchParam,
   sendAnalyticsEvent = () => undefined,
-}: Params<SearchParam>): UseTreeSelectFilterReturn => {
+}: Params<SearchParam>): UseCheckboxFilterReturn => {
   const { pathname, search } = useLocation();
   const { replace } = useHistory();
 

--- a/src/hooks/useTableFilters.ts
+++ b/src/hooks/useTableFilters.ts
@@ -43,7 +43,7 @@ export const useTableInputFilter = <SearchParam extends string>({
       replace,
       pathname,
       sendAnalyticsEvent,
-      true // when does this need to be false?
+      true
     );
 
     sendAnalyticsEvent(urlSearchParam);
@@ -59,7 +59,7 @@ export const useTableInputFilter = <SearchParam extends string>({
       replace,
       pathname,
       sendAnalyticsEvent,
-      true // when does this need to be false?
+      true
     );
   };
 
@@ -105,7 +105,7 @@ export const useTableTreeSelectFilter = <SearchParam extends string>({
       replace,
       pathname,
       sendAnalyticsEvent,
-      true // when does this need to be false?
+      true
     );
 
     sendAnalyticsEvent(urlSearchParam);
@@ -121,7 +121,7 @@ export const useTableTreeSelectFilter = <SearchParam extends string>({
       replace,
       pathname,
       sendAnalyticsEvent,
-      true // when does this need to be false?
+      true
     );
   };
 

--- a/src/hooks/useTableFilters.ts
+++ b/src/hooks/useTableFilters.ts
@@ -1,0 +1,129 @@
+import { useState } from "react";
+import { useLocation, useHistory } from "react-router-dom";
+import { parseQueryString } from "utils";
+import { updateUrlQueryParam } from "utils/url";
+
+type InputEvent = React.ChangeEvent<HTMLInputElement>;
+
+interface Params<SearchParam> {
+  urlSearchParam: SearchParam; // the name of url param
+  sendAnalyticsEvent: (filterBy: string) => void; // callback function to send analytics event
+}
+
+type UseInputFilterReturn = [
+  string, // url param value
+  (e: InputEvent) => void, // onChange handler
+  () => void, // update url param
+  () => void // reset url param
+];
+
+// USE FOR FILTERS BUILT INTO TABLE COLUMN HEADERS
+export const useTableInputFilter = <SearchParam extends string>({
+  urlSearchParam,
+  sendAnalyticsEvent = () => undefined,
+}: Params<SearchParam>): UseInputFilterReturn => {
+  const { pathname, search } = useLocation();
+  const { replace } = useHistory();
+
+  const urlParams = parseQueryString(search);
+
+  const inputValueFromUrl = (urlParams[urlSearchParam] || "").toString();
+
+  const [value, setValue] = useState(inputValueFromUrl);
+
+  const onChange = (e: InputEvent): void => {
+    setValue(e.target.value);
+  };
+
+  const updateParams = () => {
+    updateUrlQueryParam(
+      urlSearchParam,
+      value,
+      search,
+      replace,
+      pathname,
+      sendAnalyticsEvent,
+      true // when does this need to be false?
+    );
+
+    sendAnalyticsEvent(urlSearchParam);
+  };
+
+  const resetQueryParam = () => {
+    setValue("");
+
+    updateUrlQueryParam(
+      urlSearchParam,
+      null,
+      search,
+      replace,
+      pathname,
+      sendAnalyticsEvent,
+      true // when does this need to be false?
+    );
+  };
+
+  return [value, onChange, updateParams, resetQueryParam];
+};
+
+type UseTreeSelectFilterReturn = [
+  string[], // url param value
+  (e: InputEvent, key: string) => void, // onChange handler
+  () => void, // update url param
+  () => void // reset url param
+];
+
+export const useTableTreeSelectFilter = <SearchParam extends string>({
+  urlSearchParam,
+  sendAnalyticsEvent = () => undefined,
+}: Params<SearchParam>): UseTreeSelectFilterReturn => {
+  const { pathname, search } = useLocation();
+  const { replace } = useHistory();
+
+  const { [urlSearchParam]: rawStatuses } = parseQueryString(search);
+
+  const valueFromUrl = Array.isArray(rawStatuses)
+    ? rawStatuses
+    : [rawStatuses].filter((v) => v);
+
+  const [value, setValue] = useState<string[]>(valueFromUrl);
+
+  const onChange = (e: InputEvent, key: string): void => {
+    if (e.target.checked) {
+      setValue([...value, key]);
+    } else {
+      const index = value.findIndex((v) => v === key);
+      setValue([...value.slice(0, index), ...value.slice(index + 1)]);
+    }
+  };
+
+  const updateParams = () => {
+    updateUrlQueryParam(
+      urlSearchParam,
+      value,
+      search,
+      replace,
+      pathname,
+      sendAnalyticsEvent,
+      true // when does this need to be false?
+    );
+
+    sendAnalyticsEvent(urlSearchParam);
+  };
+
+  const resetQueryParam = () => {
+    setValue([]);
+
+    updateUrlQueryParam(
+      urlSearchParam,
+      null,
+      search,
+      replace,
+      pathname,
+      sendAnalyticsEvent,
+      true // when does this need to be false?
+    );
+  };
+
+  return [value, onChange, updateParams, resetQueryParam];
+};

--- a/src/utils/url/index.ts
+++ b/src/utils/url/index.ts
@@ -18,3 +18,5 @@ export const getLimitFromSearch = (search: string): number => {
     ? limit
     : getDefaultPageSize();
 };
+
+export { updateUrlQueryParam } from "./updateUrlQueryParam";

--- a/src/utils/url/updateUrlQueryParam.ts
+++ b/src/utils/url/updateUrlQueryParam.ts
@@ -1,0 +1,28 @@
+import { parseQueryString, stringifyQuery } from "utils";
+
+export const updateUrlQueryParam = (
+  urlSearchParam: string,
+  inputValue: string | string[] | null,
+  search: string,
+  replace: (path: string) => void,
+  pathname: string,
+  sendAnalyticsEvent: (filterBy: string) => void,
+  resetPage?: boolean
+) => {
+  const urlParams = parseQueryString(search);
+
+  if (!inputValue) {
+    delete urlParams[urlSearchParam];
+  } else {
+    urlParams[urlSearchParam] = inputValue;
+  }
+
+  const nextQueryParams = stringifyQuery({
+    ...urlParams,
+    ...(resetPage && { page: 0 }),
+  });
+
+  replace(`${pathname}?${nextQueryParams}`);
+
+  sendAnalyticsEvent(urlSearchParam);
+};

--- a/src/utils/url/updateUrlQueryParam.ts
+++ b/src/utils/url/updateUrlQueryParam.ts
@@ -23,6 +23,4 @@ export const updateUrlQueryParam = (
   });
 
   replace(`${pathname}?${nextQueryParams}`);
-
-  sendAnalyticsEvent(urlSearchParam);
 };


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-12527

### The reusable table filters that will be used for filtering tables on hosts page & all other pages with a table that can be filtered

![table-filters](https://user-images.githubusercontent.com/15262143/88818701-fbe5f600-d18c-11ea-897f-1acda7337369.gif)

### This PR includes
- CheckboxGroup component used for filtering statuses
- The table filter dropdown UI for selecting filters, update button and reset button
- Hooks used to store filter state and update url query params
- Jest integration tests that test the UI and the table filter hooks together

### Up Next
Adding the UI and hooks introduced in this PR to the hosts table