### PR TITLE
EVG-12525: show hosts selection data when hosts are selected

### DIFF
--- a/cypress/integration/hosts/select-hosts.ts
+++ b/cypress/integration/hosts/select-hosts.ts
@@ -15,19 +15,23 @@ describe("Select hosts in hosts page table", () => {
 
     cy.waitForGQL("Hosts");
 
-    cy.dataCy("hosts-selection-badge").should("not.exist");
+    cy.dataCy("restart-jasper-button")
+      .should("have.attr", "aria-disabled")
+      .and("eq", "true");
+    cy.dataCy("update-status-button")
+      .should("have.attr", "aria-disabled")
+      .and("eq", "true");
 
     cy.get(".ant-table-header-column").within(() => {
       cy.get(".ant-checkbox-input").check({ force: true });
     });
 
-    cy.dataCy("hosts-selection-badge").should("exist");
-
-    cy.get(".ant-table-header-column").within(() => {
-      cy.get(".ant-checkbox-input").uncheck({ force: true });
-    });
-
-    cy.dataCy("hosts-selection-badge").should("not.exist");
+    cy.dataCy("restart-jasper-button")
+      .should("have.attr", "aria-disabled")
+      .and("eq", "false");
+    cy.dataCy("update-status-button")
+      .should("have.attr", "aria-disabled")
+      .and("eq", "false");
   });
 
   it("Can restart jasper for selected hosts", () => {

--- a/cypress/integration/hosts/select-hosts.ts
+++ b/cypress/integration/hosts/select-hosts.ts
@@ -1,0 +1,48 @@
+const hostsRoute = "/hosts";
+
+describe("Select hosts in hosts page table", () => {
+  before(() => {
+    cy.login();
+  });
+
+  beforeEach(() => {
+    cy.preserveCookies();
+    cy.listenGQL();
+  });
+
+  it("Selecting hosts shows hosts selection data", () => {
+    cy.visit(`${hostsRoute}?limit=100&page=0`);
+
+    cy.waitForGQL("Hosts");
+
+    cy.dataCy("hosts-selection-badge").should("not.exist");
+
+    cy.get(".ant-table-header-column").within(() => {
+      cy.get(".ant-checkbox-input").check({ force: true });
+    });
+
+    cy.dataCy("hosts-selection-badge").should("exist");
+
+    cy.get(".ant-table-header-column").within(() => {
+      cy.get(".ant-checkbox-input").uncheck({ force: true });
+    });
+
+    cy.dataCy("hosts-selection-badge").should("not.exist");
+  });
+
+  it("Can restart jasper for selected hosts", () => {
+    cy.visit(`${hostsRoute}?limit=100&page=0`);
+
+    cy.waitForGQL("Hosts");
+
+    cy.get(".ant-table-header-column").within(() => {
+      cy.get(".ant-checkbox-input").check({ force: true });
+    });
+
+    cy.dataCy("restart-jasper-button").click();
+
+    cy.get(".ant-btn.ant-btn-primary.ant-btn-sm").click();
+
+    cy.dataCy("banner").should("exist");
+  });
+});

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -222,8 +222,12 @@ export type Mutation = {
   saveSubscription: Scalars["Boolean"];
   removePatchFromCommitQueue?: Maybe<Scalars["String"]>;
   updateUserSettings: Scalars["Boolean"];
+  restartJasper: Scalars["Int"];
+  updateHostStatus: Scalars["Int"];
   createPublicKey: Array<PublicKey>;
+  spawnHost: Host;
   removePublicKey: Array<PublicKey>;
+  updatePublicKey: Array<PublicKey>;
 };
 
 export type MutationAddFavoriteProjectArgs = {
@@ -297,12 +301,31 @@ export type MutationUpdateUserSettingsArgs = {
   userSettings?: Maybe<UserSettingsInput>;
 };
 
+export type MutationRestartJasperArgs = {
+  hostIds: Array<Scalars["String"]>;
+};
+
+export type MutationUpdateHostStatusArgs = {
+  hostIds: Array<Scalars["String"]>;
+  status: Scalars["String"];
+  notes?: Maybe<Scalars["String"]>;
+};
+
 export type MutationCreatePublicKeyArgs = {
   publicKeyInput: PublicKeyInput;
 };
 
+export type MutationSpawnHostArgs = {
+  spawnHostInput?: Maybe<SpawnHostInput>;
+};
+
 export type MutationRemovePublicKeyArgs = {
   keyName: Scalars["String"];
+};
+
+export type MutationUpdatePublicKeyArgs = {
+  targetKeyName: Scalars["String"];
+  updateInfo: PublicKeyInput;
 };
 
 export type Notifications = {
@@ -559,6 +582,19 @@ export enum SortDirection {
   Desc = "DESC",
 }
 
+export type SpawnHostInput = {
+  distroId: Scalars["String"];
+  region: Scalars["String"];
+  savePublicKey: Scalars["Boolean"];
+  publicKey: PublicKeyInput;
+  userDataScript?: Maybe<Scalars["String"]>;
+  expiration?: Maybe<Scalars["Time"]>;
+  noExpiration: Scalars["Boolean"];
+  setUpScript?: Maybe<Scalars["String"]>;
+  isVirtualWorkStation: Scalars["Boolean"];
+  homeVolumeSize?: Maybe<Scalars["Int"]>;
+};
+
 export type SubscriberInput = {
   type: Scalars["String"];
   target: Scalars["String"];
@@ -799,6 +835,12 @@ export type RemovePatchFromCommitQueueMutationVariables = {
 export type RemovePatchFromCommitQueueMutation = {
   removePatchFromCommitQueue?: Maybe<string>;
 };
+
+export type RestartJasperMutationVariables = {
+  hostIds: Array<Scalars["String"]>;
+};
+
+export type RestartJasperMutation = { restartJasper: number };
 
 export type RestartPatchMutationVariables = {
   patchId: Scalars["String"];

--- a/src/gql/mutations/index.ts
+++ b/src/gql/mutations/index.ts
@@ -10,3 +10,4 @@ export { SET_TASK_PRIORTY } from "./set-task-priority";
 export { UNSCHEDULE_PATCH_TASKS } from "./unschedule-patch-tasks";
 export { UNSCHEDULE_TASK } from "./unschedule-task";
 export { UPDATE_USER_SETTINGS } from "./update-user-settings";
+export { RESTART_JASPER } from "./restart-jasper";

--- a/src/gql/mutations/restart-jasper.ts
+++ b/src/gql/mutations/restart-jasper.ts
@@ -1,0 +1,7 @@
+import gql from "graphql-tag";
+
+export const RESTART_JASPER = gql`
+  mutation RestartJasper($hostIds: [String!]!) {
+    restartJasper(hostIds: $hostIds)
+  }
+`;

--- a/src/pages/Hosts.tsx
+++ b/src/pages/Hosts.tsx
@@ -126,34 +126,40 @@ const Hosts: React.FC = () => {
                 hasFilters ? filteredHostCount : totalHostsCount
               } of ${totalHostsCount}`}
             </Disclaimer>
-            {selectedHostIds.length > 0 && (
-              <HostsSelectionWrapper>
-                <Badge variant={Variant.Blue} data-cy="hosts-selection-badge">
-                  {selectedHostIds.length} Selected
-                </Badge>
-                <ButtonWrapper>
-                  <Button dataCy="update-status-button">Update Status</Button>
-                </ButtonWrapper>
-                <ButtonWrapper>
-                  <Popconfirm
-                    title={`Restart Jasper for ${selectedHostIds.length} host${
-                      selectedHostIds.length > 1 ? "s" : ""
-                    }?`}
-                    onConfirm={onClickRestartJasperConfirm}
-                    icon={null}
-                    placement="bottom"
-                    okText="Yes"
-                    okButtonProps={{ loading: loadingRestartJasper }}
-                    cancelText="No"
-                    cancelButtonProps={{ disabled: loadingRestartJasper }}
+            <HostsSelectionWrapper>
+              <Badge variant={Variant.Blue} data-cy="hosts-selection-badge">
+                {selectedHostIds.length} Selected
+              </Badge>
+              <ButtonWrapper>
+                <Button
+                  dataCy="update-status-button"
+                  disabled={selectedHostIds.length === 0}
+                >
+                  Update Status
+                </Button>
+              </ButtonWrapper>
+              <ButtonWrapper>
+                <Popconfirm
+                  title={`Restart Jasper for ${selectedHostIds.length} host${
+                    selectedHostIds.length > 1 ? "s" : ""
+                  }?`}
+                  onConfirm={onClickRestartJasperConfirm}
+                  icon={null}
+                  placement="bottom"
+                  okText="Yes"
+                  okButtonProps={{ loading: loadingRestartJasper }}
+                  cancelText="No"
+                  cancelButtonProps={{ disabled: loadingRestartJasper }}
+                >
+                  <Button
+                    dataCy="restart-jasper-button"
+                    disabled={selectedHostIds.length === 0}
                   >
-                    <Button dataCy="restart-jasper-button">
-                      Restart Jasper
-                    </Button>
-                  </Popconfirm>
-                </ButtonWrapper>
-              </HostsSelectionWrapper>
-            )}
+                    Restart Jasper
+                  </Button>
+                </Popconfirm>
+              </ButtonWrapper>
+            </HostsSelectionWrapper>
           </SubtitleDataWrapper>
           <TableControlInnerRow>
             <Pagination

--- a/src/pages/hosts/HostsTable.tsx
+++ b/src/pages/hosts/HostsTable.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { ColumnProps } from "antd/es/table";
+import { ColumnProps, TableRowSelection } from "antd/es/table";
 import { Table } from "antd";
 import {
   Host,
@@ -25,7 +25,8 @@ interface Props {
   hosts: Host[];
   sortBy: HostsQueryVariables["sortBy"];
   sortDir: HostsQueryVariables["sortDir"];
-  setSelectedHosts: React.Dispatch<React.SetStateAction<Host[]>>;
+  selectedHostIds: string[];
+  setSelectedHostIds: React.Dispatch<React.SetStateAction<string[]>>;
 }
 
 type HostsUrlParam = keyof HostsQueryVariables;
@@ -34,7 +35,8 @@ export const HostsTable: React.FC<Props> = ({
   hosts,
   sortBy,
   sortDir,
-  setSelectedHosts,
+  selectedHostIds,
+  setSelectedHostIds,
 }) => {
   const tableChangeHandler = useUpdateUrlSortParamOnTableChange<Host>();
 
@@ -232,16 +234,9 @@ export const HostsTable: React.FC<Props> = ({
     },
   ];
 
-  const rowSelection = {
-    onChange: (selectedRowKeys, selectedRows) => {
-      console.log(
-        `selectedRowKeys: ${selectedRowKeys}`,
-        "selectedRows: ",
-        selectedRows
-      );
-      setSelectedHosts(selectedRows);
-    },
-  };
+  const onSelectChange: TableRowSelection<Host>["onChange"] = (
+    selectedRowKeys
+  ) => setSelectedHostIds(selectedRowKeys as string[]);
 
   return (
     <Table
@@ -252,7 +247,8 @@ export const HostsTable: React.FC<Props> = ({
       dataSource={hosts}
       rowSelection={{
         type: "checkbox",
-        ...rowSelection,
+        onChange: onSelectChange,
+        selectedRowKeys: selectedHostIds,
       }}
       onChange={tableChangeHandler}
     />

--- a/src/pages/hosts/HostsTable.tsx
+++ b/src/pages/hosts/HostsTable.tsx
@@ -25,11 +25,17 @@ interface Props {
   hosts: Host[];
   sortBy: HostsQueryVariables["sortBy"];
   sortDir: HostsQueryVariables["sortDir"];
+  setSelectedHosts: React.Dispatch<React.SetStateAction<Host[]>>;
 }
 
 type HostsUrlParam = keyof HostsQueryVariables;
 
-export const HostsTable: React.FC<Props> = ({ hosts, sortBy, sortDir }) => {
+export const HostsTable: React.FC<Props> = ({
+  hosts,
+  sortBy,
+  sortDir,
+  setSelectedHosts,
+}) => {
   const tableChangeHandler = useUpdateUrlSortParamOnTableChange<Host>();
 
   const getDefaultSortOrder = (
@@ -226,6 +232,17 @@ export const HostsTable: React.FC<Props> = ({ hosts, sortBy, sortDir }) => {
     },
   ];
 
+  const rowSelection = {
+    onChange: (selectedRowKeys, selectedRows) => {
+      console.log(
+        `selectedRowKeys: ${selectedRowKeys}`,
+        "selectedRows: ",
+        selectedRows
+      );
+      setSelectedHosts(selectedRows);
+    },
+  };
+
   return (
     <Table
       data-test-id="hosts-table"
@@ -233,6 +250,10 @@ export const HostsTable: React.FC<Props> = ({ hosts, sortBy, sortDir }) => {
       pagination={false}
       columns={columnsTemplate}
       dataSource={hosts}
+      rowSelection={{
+        type: "checkbox",
+        ...rowSelection,
+      }}
       onChange={tableChangeHandler}
     />
   );


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-12525
https://jira.mongodb.org/browse/EVG-12523
https://jira.mongodb.org/browse/EVG-12524

![Aug-07-2020 12-46-58](https://user-images.githubusercontent.com/15262143/89668687-33028880-d8ac-11ea-9108-815722c19a82.gif)

### Summary
- able to select host table rows
- selecting rows displays hosts selection data & action button
- can restart jasper for selected hosts
- update status coming in future PR (requires modal)

The checkboxes in the table are not the Leafygreen checkboxes. Rendering a custom checkbox requires upgrading to ANTD v4, which i believe there is a ticket for but i cannot find it in the backlog. I have designer approval on this.