### PR TITLE
EVG-12697: useTableFilters - call update fn when enter key is pressed & trim whitespace

### DIFF
--- a/cypress/integration/hosts/hosts-filtering.ts
+++ b/cypress/integration/hosts/hosts-filtering.ts
@@ -2,7 +2,6 @@ const hostsRoute = "/hosts";
 
 const tableRow = "tr.ant-table-row";
 
-// FILTERS
 const idParam = "hostId";
 const distroParam = "distroId";
 const statusesParam = "statuses";
@@ -16,6 +15,8 @@ const currentTaskIdFilter =
   "mongodb_mongo_v3.6_debian92_sharding_auth_bc405c72dce4714da604810cdc90c132bd5fbaa1_20_07_20_17_39_20";
 const ownerFilter = "mci";
 
+const distroFilterIconDataCy = "distro-id-filter";
+
 const filterTests = [
   {
     param: idParam,
@@ -26,7 +27,7 @@ const filterTests = [
   },
   {
     param: distroParam,
-    filterIconDataCy: "distro-id-filter",
+    filterIconDataCy: distroFilterIconDataCy,
     filterValue: distroFilter,
     filterUrlParam: `${distroParam}=${distroFilter}`,
     expectedIds: [
@@ -155,6 +156,54 @@ describe("Hosts page filtering from table filters", () => {
     cy.preserveCookies();
     cy.listenGQL();
     cy.visit(hostsRoute);
+  });
+
+  it("Filters hosts with input value when Enter key is pressed", () => {
+    cy.visit(`${hostsRoute}?limit=100&page=0`);
+
+    cy.dataCy(distroFilterIconDataCy).click();
+
+    cy.dataCy(`${distroFilterIconDataCy}-wrapper`).within(() => {
+      cy.dataCy("input-filter").type("centos6-perf{enter}");
+    });
+
+    cy.waitForGQL("Hosts");
+
+    cy.get(tableRow).each(($el, index) =>
+      cy
+        .wrap($el)
+        .contains(
+          [
+            "build10.ny.cbi.10gen",
+            "build10.ny.cbi.10gen.c",
+            "build10.ny.cbi.10gen.cc",
+          ][index]
+        )
+    );
+  });
+
+  it("Trims the whitespace from filter input values", () => {
+    cy.visit(`${hostsRoute}?limit=100&page=0`);
+
+    cy.dataCy(distroFilterIconDataCy).click();
+
+    cy.dataCy(`${distroFilterIconDataCy}-wrapper`).within(() => {
+      cy.dataCy("input-filter").type("      centos6-perf     {enter}");
+    });
+
+    cy.waitForGQL("Hosts");
+
+    cy.get(tableRow).each(($el, index) =>
+      cy
+        .wrap($el)
+        .contains(
+          [
+            "build10.ny.cbi.10gen",
+            "build10.ny.cbi.10gen.c",
+            "build10.ny.cbi.10gen.cc",
+          ][index]
+        )
+    );
   });
 
   filterTests.forEach(({ param, filterIconDataCy, filterValue }) => {

--- a/src/components/Table/Filters.tsx
+++ b/src/components/Table/Filters.tsx
@@ -29,6 +29,7 @@ export const InputFilter: React.FC<InputFilterProps> = ({
       placeholder={placeholder}
       value={value}
       onChange={onChange}
+      onPressEnter={updateUrlParam}
     />
     <ButtonsWrapper>
       <ButtonWrapper>

--- a/src/hooks/tests/useTableFilters/useTableFilters.test.tsx
+++ b/src/hooks/tests/useTableFilters/useTableFilters.test.tsx
@@ -39,6 +39,24 @@ test("useTableInputFilter", async () => {
   getByText("host id from url: N/A");
 });
 
+test("useTableInputFilter - trims whitespace from input value", async () => {
+  const { getByText, getByPlaceholderText } = render(
+    <MemoryRouter initialEntries={[`/hosts?hostId=123`]}>
+      <Route path="/hosts">
+        <InputFilterTestComponent />
+      </Route>
+    </MemoryRouter>
+  );
+
+  const input = getByPlaceholderText("Search ID") as HTMLInputElement;
+  const searchButton = getByText("Search");
+
+  fireEvent.change(input, { target: { value: "     abc  " } });
+  fireEvent.click(searchButton);
+
+  getByText("host id from url: abc");
+});
+
 test("useTableCheckboxFilter", async () => {
   const { getByText, getByLabelText } = render(
     <MemoryRouter initialEntries={[`/hosts?statuses=running,terminated`]}>

--- a/src/hooks/useTableFilters.ts
+++ b/src/hooks/useTableFilters.ts
@@ -38,7 +38,7 @@ export const useTableInputFilter = <SearchParam extends string>({
   const updateParams = () => {
     updateUrlQueryParam(
       urlSearchParam,
-      value,
+      value.trim(),
       search,
       replace,
       pathname,


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-12697
https://jira.mongodb.org/browse/EVG-12699

- Table dropdown input filters call `update` function when Enter key is pressed
- Trim whitespace from input filter values when calling `update` function so that values like `   centos6-perf       ` are still valid