### PR TITLE
EVG-12728: fixed width columns and loading

### DIFF
--- a/src/pages/Hosts.tsx
+++ b/src/pages/Hosts.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { Skeleton, Popconfirm } from "antd";
+import { Popconfirm } from "antd";
 import { useQuery, useMutation } from "@apollo/react-hooks";
 import { useLocation } from "react-router-dom";
 import {
@@ -82,6 +82,7 @@ const Hosts: React.FC = () => {
   const filteredHostCount = hosts?.filteredHostsCount ?? 0;
 
   const isLoading = isNetworkRequestInFlight(networkStatus);
+
   useDisableTableSortersIfLoading(networkStatus);
 
   // REFETCH HOSTS QUERY IF SEARCH CHANGES
@@ -174,16 +175,16 @@ const Hosts: React.FC = () => {
             />
           </TableControlInnerRow>
         </TableControlOuterRow>
-        <TableContainer hide={isLoading}>
+        <TableContainer hide={false}>
           <HostsTable
             hosts={hostItems}
             sortBy={sortBy}
             sortDir={sortDir}
             selectedHostIds={selectedHostIds}
             setSelectedHostIds={setSelectedHostIds}
+            loading={isLoading}
           />
         </TableContainer>
-        {isLoading && <Skeleton active title={false} paragraph={{ rows: 8 }} />}
       </ErrorBoundary>
     </PageWrapper>
   );

--- a/src/pages/hosts/HostsTable.tsx
+++ b/src/pages/hosts/HostsTable.tsx
@@ -26,6 +26,7 @@ interface Props {
   sortBy: HostsQueryVariables["sortBy"];
   sortDir: HostsQueryVariables["sortDir"];
   selectedHostIds: string[];
+  loading: boolean;
   setSelectedHostIds: React.Dispatch<React.SetStateAction<string[]>>;
 }
 
@@ -37,6 +38,7 @@ export const HostsTable: React.FC<Props> = ({
   sortDir,
   selectedHostIds,
   setSelectedHostIds,
+  loading,
 }) => {
   const tableChangeHandler = useUpdateUrlSortParamOnTableChange<Host>();
 
@@ -113,6 +115,7 @@ export const HostsTable: React.FC<Props> = ({
       sorter: true,
       className: "cy-hosts-table-col-ID",
       defaultSortOrder: getDefaultSortOrder(HostSortBy.Id),
+      width: "15%",
       render: (_, { id }: Host): JSX.Element => (
         <StyledRouterLink data-cy="host-id-link" to={getHostRoute(id)}>
           {id}
@@ -133,6 +136,7 @@ export const HostsTable: React.FC<Props> = ({
       dataIndex: "distroId",
       key: HostSortBy.Distro,
       sorter: true,
+      width: "15%",
       className: "cy-task-table-col-DISTRO",
       ...getColumnSearchFilterProps({
         placeholder: "Search Distro",
@@ -149,6 +153,7 @@ export const HostsTable: React.FC<Props> = ({
       key: HostSortBy.Status,
       defaultSortOrder: getDefaultSortOrder(HostSortBy.Status),
       sorter: true,
+      width: "15%",
       className: "cy-task-table-col-STATUS",
       ...getColumnCheckboxFilterProps({
         value: statusesValue,
@@ -165,6 +170,7 @@ export const HostsTable: React.FC<Props> = ({
       key: HostSortBy.CurrentTask,
       defaultSortOrder: getDefaultSortOrder(HostSortBy.CurrentTask),
       sorter: true,
+      width: "15%",
       className: "cy-task-table-col-CURRENT-TASK",
       render: (_, { runningTask }: Host) =>
         runningTask?.id !== null ? (
@@ -193,6 +199,7 @@ export const HostsTable: React.FC<Props> = ({
       key: HostSortBy.Elapsed,
       sorter: true,
       className: "cy-task-table-col-ELAPSED",
+      width: "10%",
       render: (_, { elapsed }) =>
         elapsed ? formatDistanceToNow(new Date(elapsed)) : "N/A",
     },
@@ -202,6 +209,7 @@ export const HostsTable: React.FC<Props> = ({
       defaultSortOrder: getDefaultSortOrder(HostSortBy.Uptime),
       key: HostSortBy.Uptime,
       sorter: true,
+      width: "10%",
       className: "cy-task-table-col-UPTIME",
       render: (_, { uptime }) =>
         uptime ? formatDistanceToNow(new Date(uptime)) : "N/A",
@@ -212,6 +220,7 @@ export const HostsTable: React.FC<Props> = ({
       dataIndex: "totalIdleTime",
       key: HostSortBy.IdleTime,
       sorter: true,
+      width: "10%",
       className: "cy-task-table-col-IDLE-TIME",
       render: (_, { totalIdleTime }) =>
         totalIdleTime ? formatDistanceToNow(new Date(totalIdleTime)) : "N/A",
@@ -222,6 +231,7 @@ export const HostsTable: React.FC<Props> = ({
       dataIndex: "startedBy",
       key: HostSortBy.Owner,
       sorter: true,
+      width: "10%",
       className: "cy-task-table-col-OWNER",
       ...getColumnSearchFilterProps({
         placeholder: "Search Owner",
@@ -251,6 +261,7 @@ export const HostsTable: React.FC<Props> = ({
         selectedRowKeys: selectedHostIds,
       }}
       onChange={tableChangeHandler}
+      loading={loading}
     />
   );
 };


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-12728

- Table columns now have a width property, which prevents column width shifting depending on content size
- I removed the skeleton loading indicator for the table and replaced it with the native antd table loader. The skeleton loader would flash briefly on the screen, creating a flashing effect. 

![Aug-11-2020 10-06-46](https://user-images.githubusercontent.com/15262143/89907238-68fc8100-dbba-11ea-9d23-486a5cf3cbee.gif)

