### PR TITLE
EVG-12918 adjust time format for execution dropdown

### DIFF
--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -1400,6 +1400,7 @@ export type GetTaskAllExecutionsQuery = {
     execution?: Maybe<number>;
     status: string;
     ingestTime?: Maybe<Date>;
+    activatedTime?: Maybe<Date>;
   }>;
 };
 

--- a/src/gql/queries/get-task-all-executions.ts
+++ b/src/gql/queries/get-task-all-executions.ts
@@ -6,6 +6,7 @@ export const GET_TASK_ALL_EXECUTIONS = gql`
       execution
       status
       ingestTime
+      activatedTime
     }
   }
 `;

--- a/src/pages/task/executionDropdown/ExecutionSelector.tsx
+++ b/src/pages/task/executionDropdown/ExecutionSelector.tsx
@@ -60,7 +60,9 @@ export const ExecutionSelect: React.FC<ExecutionSelectProps> = ({
           <StyledP1>
             {" "}
             Execution {ExecutionAsDisplay(singleExecution.execution)} -{" "}
-            {shortDate(singleExecution.ingestTime)}
+            {shortDate(
+              singleExecution.activatedTime ?? singleExecution.ingestTime
+            )}
           </StyledP1>
         </Option>
       ))}
@@ -79,5 +81,6 @@ const StyledSquare = styled(Square)`
   margin-right: 3px;
 `;
 const StyledP1 = styled(P1)`
+  font-size: 14px;
   float: left;
 `;

--- a/src/utils/string/index.ts
+++ b/src/utils/string/index.ts
@@ -122,7 +122,7 @@ export const getDateCopy = (time: Date, tz?: string) => {
   return "";
 };
 
-const SHORT_DATE_FORMAT = "M/d/yy h:m aa";
+const SHORT_DATE_FORMAT = "M/d/yy h:mm aa";
 export const shortDate = (d: Date): string =>
   d ? format(new Date(d), SHORT_DATE_FORMAT) : "";
 


### PR DESCRIPTION
The problem was that the ingest (creation) time is always set to when the task was first created (ie. patch was scheduled). The activated time will be when it was restarted, though it can change if it gets unscheduled/rescheduled I think. Also made some improvements to the date formatting