### PR TITLE
EVG-13020 Create poc for Trend charts plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3795,6 +3795,15 @@
         "@leafygreen-ui/palette": "^2.0.0"
       }
     },
+    "@mohamed.khelif-mongo/perf-plugin": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@mohamed.khelif-mongo/perf-plugin/-/perf-plugin-0.2.1.tgz",
+      "integrity": "sha512-p9XgQ6KXeJfv3fX9MlflAqNbc1FHwf0WR9aM0iEeQCLJc1tO7oul3a6NWntoMY3QSXOZQHM5kCug/VppX21/bQ==",
+      "requires": {
+        "@apollo/client": "3.1.3",
+        "graphql": "^15.3.0"
+      }
+    },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@leafygreen-ui/text-input": "1.1.1",
     "@leafygreen-ui/toggle": "3.0.1",
     "@leafygreen-ui/typography": "1.0.1",
+    "@mohamed.khelif-mongo/perf-plugin": "^0.2.1",
     "ansi_up": "4.0.4",
     "antd": "4.5.4",
     "antd-table-infinity": "1.1.6",

--- a/src/pages/Task.tsx
+++ b/src/pages/Task.tsx
@@ -2,12 +2,13 @@ import React, { useState, useEffect } from "react";
 import { useQuery } from "@apollo/client";
 import styled from "@emotion/styled";
 import { Tab } from "@leafygreen-ui/tabs";
+import { TrendCharts, QueryModule } from "@mohamed.khelif-mongo/perf-plugin";
 import get from "lodash/get";
 import { useParams, useLocation } from "react-router-dom";
 import { useTaskAnalytics } from "analytics";
 import { Banners } from "components/Banners";
 import { BreadCrumb } from "components/Breadcrumb";
-import BuildBaron from "components/Buildbaron/BuildBaron";
+// import BuildBaron from "components/Buildbaron/BuildBaron";
 import { ErrorBoundary } from "components/ErrorBoundary";
 import { PageTitle } from "components/PageTitle";
 import {
@@ -53,7 +54,7 @@ const tabToIndexMap = {
   [TaskTab.Logs]: 0,
   [TaskTab.Tests]: 1,
   [TaskTab.Files]: 2,
-  [TaskTab.BuildBaron]: 3,
+  [TaskTab.TrendCharts]: 3,
 };
 const DEFAULT_TAB = TaskTab.Logs;
 
@@ -140,7 +141,7 @@ const TaskCore: React.FC = () => {
   });
 
   // Query build baron data
-  const { data: buildBaronData, error: buildBaronError } = useQuery<
+  const { data: buildBaronData } = useQuery<
     BuildBaronQuery,
     BuildBaronQueryVariables
   >(GET_BUILD_BARON, {
@@ -270,12 +271,19 @@ const TaskCore: React.FC = () => {
                 >
                   <FilesTables />
                 </Tab>
-
+                {/* 
+                Disabled this piece of code to get around a limitation with conditionally rendering leafygreen tabs
                 {showBuildBaronTab ? (
                   <Tab name="Build Baron" id="task-build-baron-tab">
                     <BuildBaron data={buildBaronData} error={buildBaronError} />
                   </Tab>
-                ) : null}
+                ) : null} */}
+
+                <Tab name="Trend Charts" id="Trend Charts">
+                  some value
+                  <TrendCharts someProp="test" />
+                  <QueryModule />
+                </Tab>
               </StyledTabs>
             )}
           </PageContent>
@@ -290,3 +298,10 @@ export const Task = withBannersContext(TaskCore);
 const LogWrapper = styled(PageLayout)`
   width: 100%;
 `;
+
+// interface TrendChartsProps {
+//   someProp: string;
+// }
+// export const TrendCharts: React.FC<TrendChartsProps> = ({ someProp }) => (
+//   <div>Some trend chart heres your prop {someProp}</div>
+// );

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -36,6 +36,7 @@ export enum TaskTab {
   Tests = "tests",
   Files = "files",
   BuildBaron = "build-baron",
+  TrendCharts = "trend-charts",
 }
 
 export enum LogTypes {


### PR DESCRIPTION
This pr is a poc for creating a plugin system for spruce. In which other teams can easily build out npm packages independently of the spruce tam and easily integrate them into spruce.

In this poc i created an [npm package](https://www.npmjs.com/package/@mohamed.khelif-mongo/perf-plugin) and [repo](https://github.com/khelif96/spruce-perf-plugin)  which exported two components `TrendCharts` (Which is a simple component with some hooks state logic and passing in props)  and `QueryModule` (Which is a component that makes a graphql request and renders it).

I added the package as a dependency for spruce and imported and  implemented the components in the task page on spruce.
Resulting in minimal modifications to the spruce code base.

Creating the perf-plugin npm package did take a bit of effort to get started. Most of which was around setting up a build pipeline using [rollup](https://rollupjs.org/guide/en/),  That converts the typescript es6 code written into a compiled module that can be imported easily. (This is a one time process) 

In order to build a `dist/` a user only has to run the command `yarn build` or the npm equivalent; this triggers `rollup` to compile and generate a `dist/` folder with the compiled code.

I was able to develop these components from within spruce by utilizing a linker such as [yarn link](https://classic.yarnpkg.com/en/docs/cli/link/) or [npm link](https://docs.npmjs.com/cli/link) using the following process
```
yarn link // Create a link from within the perf-plugin folder
yarn link "@mohamed.khelif-mongo/perf-plugin" // Link to the plugin from within the spruce folder
```
This process creates a symbolic link from the generated `dist/` folder in the perf-plugin folder to the perf-plugin module spruce imports.

Since this was a symbolic link i was able to set up a hot reloader using rollup that monitored for any changes within the perf-plugin folder. When ever there was a change it would reflect on spruce. 

### Access to spruce resources
Since these components will be embedded within spruce they have access to any providers we have available wrapping the page, including the apollo provider so they can easily make any queries to our graphql backend.

I was able to set up code generation in the perf-plugin process using the same process as spruce. So queries will be able to be easily typed 

Devs should also have access to react router from within the plugin.
We don't have much custom styles in spruce since most of our components come from antd and leafygreen. the perf-plugin repo could utilize both of these libraries to have a similar look and feel to spruce. 

### Testing
There is an expectation that the team building out the perf-plugin tests their components and writes appropriate unit tests and integration tests. 
We can also write some cypress e2e tests for the perf plugin but these would probably be relatively minimal given the assumption that it was tested on its own.

### Publishing  and updating within spruce
After changes have been made  to the perf plugin and a new version of the perf plugin is ready to be released. 
Developers can easily version the plugin and release a new version to the npm registry and update the package within spruce.

```
// From within perf-plugin repo
npm version <major|minor|patch>
npm publish 

// from within spruce repo
npm install @mohamed.khelif-mongo/perf-plugin@versionNumber
```

### Takeaways: 
Created an external npm package, and implemented that in spruce.
Was able to enable hot reloading and linking the dependencies so devs can easily make changes and see them reflected in spruce.
Updates to the component will have minimal effect on the spruce codebase since most changes can be made by just upgrading the dependency version. 
Both teams can behave semi autonomously  since there will be less dependence on each other. Spruce team can continue to work on spruce features. When the plugin is ready to be updated the perf-plugin team can release a new version and we can easily just use it from within spruce.
Both teams can set up the testing infra however they see fit. 

This can be accomplished in both a monorepo as well as a completely separate repo. That decision is up to the team. It might be easier to setup a distinction of who owns what code if they are in a seperate repo however.

### Todo
In order to implement this We would need to clean up the repo and get it ready for professional development. 