### PR TITLE
EVG-13082: task link in task queue item goes to legacy UI for mainline commits

### DIFF
--- a/cypress/integration/taskQueue/route.ts
+++ b/cypress/integration/taskQueue/route.ts
@@ -63,4 +63,22 @@ describe("Task Queue", () => {
       .contains("13")
       .should("be.visible");
   });
+
+  it("Task links goes to Spruce for patches and legacy UI for mainline commits", () => {
+    cy.visit(
+      "/task-queue/osx-108/evergreen_lint_lint_service_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48"
+    );
+
+    // patch
+    cy.dataCy("current-task-link")
+      .eq(0)
+      .should("have.attr", "href")
+      .and("not.contain", "localhost");
+
+    // mainline commit
+    cy.dataCy("current-task-link")
+      .eq(1)
+      .should("have.attr", "href")
+      .and("contain", "localhost");
+  });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,10 @@
 {
   "name": "spruce",
+<<<<<<< HEAD
   "version": "1.3.2",
+=======
+  "version": "1.0.0",
+>>>>>>> 1.0.0
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,6 @@
 {
   "name": "spruce",
-<<<<<<< HEAD
   "version": "1.3.2",
-=======
-  "version": "1.0.0",
->>>>>>> 1.0.0
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/pages/taskQueue/TaskQueueTable.tsx
+++ b/src/pages/taskQueue/TaskQueueTable.tsx
@@ -72,18 +72,30 @@ export const TaskQueueTable = () => {
       key: "displayName",
       className: "cy-task-queue-col-task",
       width: "30%",
-      render: (_, { displayName, id, project, buildVariant }) => (
+      render: (_, { displayName, id, project, buildVariant, requester }) => (
         <TaskCell>
           <Body>
-            <StyledRouterLink
-              data-cy="current-task-link"
-              to={getTaskRoute(id)}
-              onClick={() =>
-                taskQueueAnalytics.sendEvent({ name: "Click Task Link" })
-              }
-            >
-              {displayName}
-            </StyledRouterLink>
+            {requester === TaskQueueItemType.Patch ? (
+              <StyledRouterLink
+                data-cy="current-task-link"
+                to={getTaskRoute(id)}
+                onClick={() =>
+                  taskQueueAnalytics.sendEvent({ name: "Click Task Link" })
+                }
+              >
+                {displayName}
+              </StyledRouterLink>
+            ) : (
+              <StyledLink
+                data-cy="current-task-link"
+                href={`${getUiUrl()}/task/${id}`}
+                onClick={() =>
+                  taskQueueAnalytics.sendEvent({ name: "Click Version Link" })
+                }
+              >
+                {displayName}
+              </StyledLink>
+            )}
           </Body>
           <Body>{buildVariant}</Body>
           <Disclaimer>{project}</Disclaimer>


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-13082

Currently, the Spruce workflow is only officially supported for patch builds. However, the links to the patch details from the Task Queue page lead to Spruce both for patch builds and for mainline commits.

Task link should go to legacy UI if task type is `commit`