### PR TITLE
EVG-8181 preserve query part of url on task page

### DIFF
--- a/cypress/integration/task_route.ts
+++ b/cypress/integration/task_route.ts
@@ -9,11 +9,6 @@ describe("Task Page Route", () => {
     cy.preserveCookies();
   });
 
-  it("User is redirected to logs if they land on /task/{taskID}", () => {
-    cy.visit("/task/taskID");
-    cy.location("pathname").should("include", "/task/taskID/logs");
-  });
-
   it("Browser history is replaced when user lands on /task/{taskID}", () => {
     cy.visit("/random");
     cy.visit("/task/taskID");

--- a/src/pages/Task.tsx
+++ b/src/pages/Task.tsx
@@ -133,9 +133,7 @@ const TaskCore: React.FC = () => {
     tabToIndexMap,
     defaultTab: TaskTab.Logs,
     path: `${paths.task}/${id}`,
-    query: new URLSearchParams(
-      `${RequiredQueryParams.Execution}=${ExecutionAsDisplay(execution)}`
-    ),
+    query: new URLSearchParams(location.search),
     sendAnalyticsEvent: (newTab: string) =>
       taskAnalytics.sendEvent({ name: "Change Tab", tab: newTab }),
   });


### PR DESCRIPTION
The previous commit on this ticket exposed an existing bug where we would replace the URL search on the task page. Also removed a test that is no longer relevant now that the default tab is dynamic

This should fix the e2e tests