### PR TITLE
EVG-13179 Update build variant design and allow for filtering by variant on status

### DIFF
--- a/src/hooks/useFilterInputChangeHandler.ts
+++ b/src/hooks/useFilterInputChangeHandler.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import debounce from "lodash.debounce";
 import queryString from "query-string";
 import { useLocation, useHistory } from "react-router-dom";
@@ -32,7 +32,12 @@ export const useFilterInputChangeHandler = (
 
   const parsed = queryString.parse(search, { arrayFormat });
   const inputValue = (parsed[urlSearchParam] || "").toString();
+
   const [value, setValue] = useState(inputValue);
+
+  useEffect(() => {
+    setValue(inputValue);
+  }, [inputValue]);
 
   const onChange = (e: InputEvent): void => {
     setValue(e.target.value);

--- a/src/hooks/useFilterInputChangeHandler.ts
+++ b/src/hooks/useFilterInputChangeHandler.ts
@@ -1,10 +1,8 @@
 import { useState, useEffect } from "react";
 import debounce from "lodash.debounce";
-import queryString from "query-string";
 import { useLocation, useHistory } from "react-router-dom";
+import { parseQueryString } from "utils/queryString/parseQueryString";
 import { updateUrlQueryParam } from "utils/url";
-
-const arrayFormat = "comma";
 
 const updateQueryParamWithDebounce = debounce(updateUrlQueryParam, 250);
 
@@ -30,7 +28,7 @@ export const useFilterInputChangeHandler = (
   const { pathname, search } = useLocation();
   const { replace } = useHistory();
 
-  const parsed = queryString.parse(search, { arrayFormat });
+  const parsed = parseQueryString(search);
   const inputValue = (parsed[urlSearchParam] || "").toString();
 
   const [value, setValue] = useState(inputValue);

--- a/src/hooks/useTabs.ts
+++ b/src/hooks/useTabs.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useParams, useHistory } from "react-router-dom";
 import { TabToIndexMap } from "hooks/types";
 
@@ -51,5 +51,8 @@ export const useTabs = ({
     history.replace(`${path}/${currentTab}?${query ? query.toString() : ""}`);
     sendAnalyticsEvent(currentTab);
   };
+  useEffect(() => {
+    setSelectedTab(getIndexFromTab(tab));
+  }, [tab]); // eslint-disable-line react-hooks/exhaustive-deps
   return [selectedTab, selectTabHandler];
 };

--- a/src/pages/patch/BuildVariants.tsx
+++ b/src/pages/patch/BuildVariants.tsx
@@ -84,6 +84,7 @@ const VariantTaskGroup: React.FC<VariantTaskGroupProps> = ({
           count={groupedTasks[color].count}
           color={color}
           textColor={groupedTasks[color].textColor}
+          variant={variant}
         />
       ))}
     </VariantTasks>

--- a/src/pages/patch/buildVariants/GroupedTaskSquare.tsx
+++ b/src/pages/patch/buildVariants/GroupedTaskSquare.tsx
@@ -68,7 +68,7 @@ const TaskSquare = styled.div<TaskSquareProps>`
     `};
   margin: 0 3px;
   border-radius: 3px;
-  width: 35px;
+  width: 40px;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/pages/patch/buildVariants/GroupedTaskSquare.tsx
+++ b/src/pages/patch/buildVariants/GroupedTaskSquare.tsx
@@ -12,6 +12,7 @@ interface Props {
   statuses: string[];
   color: string;
   textColor: string;
+  variant: string;
 }
 
 export const GroupedTaskSquare: React.FC<Props> = ({
@@ -19,6 +20,7 @@ export const GroupedTaskSquare: React.FC<Props> = ({
   count,
   color,
   textColor,
+  variant,
 }) => {
   const patchAnalytics = usePatchAnalytics();
   const { id } = useParams<{ id: string }>();
@@ -26,6 +28,7 @@ export const GroupedTaskSquare: React.FC<Props> = ({
   const nextQueryParams = queryString.stringify(
     {
       statuses,
+      variant,
       page: 0,
     },
     { arrayFormat }
@@ -65,8 +68,7 @@ const TaskSquare = styled.div<TaskSquareProps>`
     `};
   margin: 0 3px;
   border-radius: 3px;
-  width: 40px;
-  height: 40px;
+  width: 35px;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -80,6 +82,7 @@ const StyledText = styled.span<StyledTextProps>`
     color: ${textColor};
     `};
   font-weight: bold;
+  font-size: 12px;
 `;
 
 const arrayFormat = "comma";

--- a/src/pages/patch/patchTabs/Tasks.tsx
+++ b/src/pages/patch/patchTabs/Tasks.tsx
@@ -1,11 +1,13 @@
 import React from "react";
 import { useQuery } from "@apollo/client";
+import styled from "@emotion/styled";
+import Button from "@leafygreen-ui/button";
 import { Skeleton } from "antd";
 import { ColumnProps } from "antd/lib/table";
 import every from "lodash.every";
 import get from "lodash.get";
 import queryString from "query-string";
-import { useParams, useLocation } from "react-router-dom";
+import { useParams, useLocation, Link } from "react-router-dom";
 import { usePatchAnalytics } from "analytics";
 import { ErrorBoundary } from "components/ErrorBoundary";
 import { PageSizeSelector } from "components/PageSizeSelector";
@@ -19,6 +21,7 @@ import {
 } from "components/styles";
 import { TaskStatusBadge } from "components/TaskStatusBadge";
 import { pollInterval } from "constants/index";
+import { getVersionRoute } from "constants/routes";
 import {
   PatchTasksQuery,
   PatchTasksQueryVariables,
@@ -75,13 +78,18 @@ export const Tasks: React.FC<Props> = ({ taskCount }) => {
     <ErrorBoundary>
       <TaskFilters />
       <TableControlOuterRow>
-        <ResultCountLabel
-          dataCyNumerator="current-task-count"
-          dataCyDenominator="total-task-count"
-          label="tasks"
-          numerator={get(data, "patchTasks.count", "-")}
-          denominator={taskCount}
-        />
+        <FlexContainer>
+          <ResultCountLabel
+            dataCyNumerator="current-task-count"
+            dataCyDenominator="total-task-count"
+            label="tasks"
+            numerator={get(data, "patchTasks.count", "-")}
+            denominator={taskCount}
+          />
+          <PaddedButton href={getVersionRoute(resourceId)} as={Link}>
+            Clear All Filters
+          </PaddedButton>
+        </FlexContainer>
         <TableControlInnerRow>
           <Pagination
             dataTestId="tasks-table-pagination"
@@ -243,3 +251,12 @@ const columnsTemplate: Array<ColumnProps<TaskResult>> = [
     className: "cy-task-table-col-VARIANT",
   },
 ];
+
+const FlexContainer = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+const PaddedButton = styled(Button)`
+  margin-left: 15px;
+`;


### PR DESCRIPTION
Further changes on the build variant grid. The squares are now rectangular and smaller. 
And clicking on a status filters for that specific variant 
![image](https://user-images.githubusercontent.com/4605522/95897762-10816580-0d5c-11eb-8e7c-f27fe6448d40.png)
