### PR TITLE
EVG-13230: Clean up useEditSpawnHostState reducer types and make HostExpirationFields a shared component

### DIFF
--- a/src/components/Spawn/ExpirationField.tsx
+++ b/src/components/Spawn/ExpirationField.tsx
@@ -11,11 +11,12 @@ export interface ExpirationDateType {
   noExpiration?: boolean;
 }
 
-interface HostExpirationFieldProps {
+interface ExpirationFieldProps {
   data: ExpirationDateType;
   onChange: React.Dispatch<React.SetStateAction<any>>;
 }
-export const HostExpirationField: React.FC<HostExpirationFieldProps> = ({
+
+export const ExpirationField: React.FC<ExpirationFieldProps> = ({
   onChange,
   data,
 }) => {

--- a/src/components/Spawn/ExpirationField.tsx
+++ b/src/components/Spawn/ExpirationField.tsx
@@ -13,7 +13,7 @@ export interface ExpirationDateType {
 
 interface ExpirationFieldProps {
   data: ExpirationDateType;
-  onChange: React.Dispatch<React.SetStateAction<any>>;
+  onChange: (data: ExpirationDateType) => void;
 }
 
 export const ExpirationField: React.FC<ExpirationFieldProps> = ({
@@ -27,7 +27,7 @@ export const ExpirationField: React.FC<ExpirationFieldProps> = ({
     const month = d.getMonth();
     const date = d.getDate();
     const updatedTime = set(expiration || new Date(), { year, month, date });
-    onChange({ ...data, expiration: updatedTime });
+    onChange({ expiration: updatedTime });
   };
 
   const updateTime = (d: Date) => {
@@ -39,7 +39,7 @@ export const ExpirationField: React.FC<ExpirationFieldProps> = ({
       minutes,
       seconds,
     });
-    onChange({ ...data, expiration: updatedTime });
+    onChange({ expiration: updatedTime });
   };
 
   const disabledDate = (current) => current < Date.now();
@@ -71,7 +71,7 @@ export const ExpirationField: React.FC<ExpirationFieldProps> = ({
       <PaddedCheckbox
         label="Never"
         checked={noExpiration}
-        onChange={(e) => onChange({ ...data, noExpiration: e.target.checked })}
+        onChange={(e) => onChange({ noExpiration: e.target.checked })}
       />{" "}
     </>
   );

--- a/src/components/Spawn/Layout.tsx
+++ b/src/components/Spawn/Layout.tsx
@@ -37,6 +37,13 @@ const TableContainer = styled.div`
 
 export const SpawnTable = (props: React.ComponentProps<typeof Table>) => (
   <TableContainer>
+    <style>
+      {`
+        tr.ant-table-expanded-row > td, tr.ant-table-expanded-row:hover > td {
+          background: white;
+        }
+      `}
+    </style>
     <Table
       {...{
         ...props,

--- a/src/components/Spawn/Layout.tsx
+++ b/src/components/Spawn/Layout.tsx
@@ -37,13 +37,6 @@ const TableContainer = styled.div`
 
 export const SpawnTable = (props: React.ComponentProps<typeof Table>) => (
   <TableContainer>
-    <style>
-      {`
-        tr.ant-table-expanded-row > td, tr.ant-table-expanded-row:hover > td {
-          background: white;
-        }
-      `}
-    </style>
     <Table
       {...{
         ...props,

--- a/src/components/Spawn/index.tsx
+++ b/src/components/Spawn/index.tsx
@@ -1,2 +1,3 @@
 export * from "./Layout";
 export { RegionSelector } from "./RegionSelector";
+export { ExpirationField } from "./ExpirationField";

--- a/src/pages/spawn/spawnHost/EditSpawnHostModal.tsx
+++ b/src/pages/spawn/spawnHost/EditSpawnHostModal.tsx
@@ -23,7 +23,12 @@ import {
 import { GET_INSTANCE_TYPES, GET_MY_VOLUMES } from "gql/queries";
 import { VolumesField, UserTagsField } from "pages/spawn/spawnHost/fields";
 import { MyHost } from "types/spawn";
-import { useEditSpawnHostModalState } from "./editSpawnHostModal/useEditSpawnHostModalState";
+import {
+  editExpirationData,
+  editInstanceTagsData,
+  editVolumesData,
+  useEditSpawnHostModalState,
+} from "./editSpawnHostModal/useEditSpawnHostModalState";
 
 const { Option } = Select;
 
@@ -107,7 +112,9 @@ export const EditSpawnHostModal: React.FC<EditSpawnHostModalProps> = ({
           <SectionLabel weight="medium">Expiration</SectionLabel>
           <HostExpirationField
             data={editSpawnHostState}
-            onChange={(data) => dispatch({ type: "editExpiration", ...data })}
+            onChange={(data: editExpirationData) =>
+              dispatch({ type: "editExpiration", ...data })
+            }
           />
         </SectionContainer>
         <SectionContainer>
@@ -144,14 +151,18 @@ export const EditSpawnHostModal: React.FC<EditSpawnHostModalProps> = ({
           <SectionLabel weight="medium">Add Volume</SectionLabel>
           <VolumesField
             data={editSpawnHostState}
-            onChange={(data) => dispatch({ type: "editVolumes", ...data })}
+            onChange={(data: editVolumesData) =>
+              dispatch({ type: "editVolumes", ...data })
+            }
             volumes={volumes}
           />
         </SectionContainer>
         <SectionContainer>
           <SectionLabel weight="medium">User Tags</SectionLabel>
           <UserTagsField
-            onChange={(data) => dispatch({ type: "editInstanceTags", ...data })}
+            onChange={(data: editInstanceTagsData) =>
+              dispatch({ type: "editInstanceTags", ...data })
+            }
             instanceTags={host?.instanceTags}
             visible={visible}
           />

--- a/src/pages/spawn/spawnHost/EditSpawnHostModal.tsx
+++ b/src/pages/spawn/spawnHost/EditSpawnHostModal.tsx
@@ -11,6 +11,7 @@ import {
   SectionContainer,
   SectionLabel,
   WideButton,
+  ExpirationField as HostExpirationField,
 } from "components/Spawn";
 import { InputLabel } from "components/styles";
 import {
@@ -20,11 +21,7 @@ import {
   MyVolumesQueryVariables,
 } from "gql/generated/types";
 import { GET_INSTANCE_TYPES, GET_MY_VOLUMES } from "gql/queries";
-import {
-  HostExpirationField,
-  VolumesField,
-  UserTagsField,
-} from "pages/spawn/spawnHost/fields";
+import { VolumesField, UserTagsField } from "pages/spawn/spawnHost/fields";
 import { MyHost } from "types/spawn";
 import { useEditSpawnHostModalState } from "./editSpawnHostModal/useEditSpawnHostModalState";
 

--- a/src/pages/spawn/spawnHost/editSpawnHostModal/useEditSpawnHostModalState.ts
+++ b/src/pages/spawn/spawnHost/editSpawnHostModal/useEditSpawnHostModalState.ts
@@ -73,7 +73,7 @@ type editVolumes = { type: "editVolumes" };
 
 export type editVolumesData = {
   volumeId?: string;
-  homeVolumeSize?: number; // home volume size is only useful for the Spawn Host Modal & mutation
+  homeVolumeSize?: number; // homeVolumeSize is only useful for creating a new host but the consuming component is used for both modals (create & edit)
 };
 
 type Action =

--- a/src/pages/spawn/spawnHost/editSpawnHostModal/useEditSpawnHostModalState.ts
+++ b/src/pages/spawn/spawnHost/editSpawnHostModal/useEditSpawnHostModalState.ts
@@ -36,8 +36,14 @@ const reducer = (state: editSpawnHostState, action: Action) => {
     case "editExpiration":
       return {
         ...state,
-        expiration: action.expiration,
-        noExpiration: action.noExpiration,
+        expiration:
+          action.expiration !== undefined
+            ? action.expiration
+            : state.expiration,
+        noExpiration:
+          action.noExpiration !== undefined
+            ? action.noExpiration
+            : state.noExpiration,
       };
     case "editInstanceType":
       return { ...state, instanceType: action.instanceType };
@@ -54,14 +60,26 @@ const reducer = (state: editSpawnHostState, action: Action) => {
   }
 };
 
+type editExpiration = { type: "editExpiration" };
+export type editExpirationData = { expiration?: Date; noExpiration?: boolean };
+
+type editInstanceTags = { type: "editInstanceTags" };
+export type editInstanceTagsData = {
+  deletedInstanceTags: InstanceTag[];
+  addedInstanceTags: InstanceTag[];
+};
+
+type editVolumes = { type: "editVolumes" };
+
+export type editVolumesData = {
+  volumeId?: string;
+  homeVolumeSize?: number; // home volume size is only useful for the Spawn Host Modal & mutation
+};
+
 type Action =
-  | { type: "reset"; host: MyHost }
-  | { type: "editHostName"; displayName: string }
-  | { type: "editExpiration"; expiration: Date; noExpiration: boolean }
   | { type: "editInstanceType"; instanceType: string }
-  | {
-      type: "editInstanceTags";
-      deletedInstanceTags: InstanceTag[];
-      addedInstanceTags: InstanceTag[];
-    }
-  | { type: "editVolumes"; volumeId: string };
+  | { type: "editHostName"; displayName: string }
+  | { type: "reset"; host: MyHost }
+  | (editExpiration & editExpirationData)
+  | (editInstanceTags & editInstanceTagsData)
+  | (editVolumes & editVolumesData);

--- a/src/pages/spawn/spawnHost/fields/5-userTagsField.stories.tsx
+++ b/src/pages/spawn/spawnHost/fields/5-userTagsField.stories.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { InstanceTag } from "gql/generated/types";
-import { UserTagsField, UserTagsFieldStateType } from "./UserTagsField";
+import { editInstanceTagsData } from "pages/spawn/spawnHost/editSpawnHostModal/useEditSpawnHostModalState";
+import { UserTagsField } from "./UserTagsField";
 import "antd/es/select/style/css";
 import "antd/es/carousel/style/css";
 
@@ -23,7 +24,7 @@ const instanceTags: InstanceTag[] = [
   },
 ];
 export const PublicKeyFormView = () => {
-  const [state, setState] = useState<UserTagsFieldStateType>({
+  const [state, setState] = useState<editInstanceTagsData>({
     addedInstanceTags: [],
     deletedInstanceTags: [],
   });

--- a/src/pages/spawn/spawnHost/fields/UserTagsField.test.tsx
+++ b/src/pages/spawn/spawnHost/fields/UserTagsField.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { v4 as uuid } from "uuid";
 import { render, fireEvent } from "test_utils/test-utils";
+import { editInstanceTagsData } from "../editSpawnHostModal/useEditSpawnHostModalState";
 import { UserTagsField } from "./UserTagsField";
 
 // Must mock uuid for this test since getRandomValues() is not supported in CI
@@ -41,7 +42,7 @@ const defaultData = {
 
 test("Renders only editable instance tags", async () => {
   let data = { ...defaultData };
-  const updateData = jest.fn((x) => {
+  const updateData = jest.fn((x: editInstanceTagsData) => {
     data = x;
   });
 
@@ -56,7 +57,7 @@ test("Renders only editable instance tags", async () => {
 
 test("Editing a tag value should add it to addedInstanceTags", async () => {
   let data = { ...defaultData };
-  const updateData = jest.fn((x) => {
+  const updateData = jest.fn((x: editInstanceTagsData) => {
     data = x;
   });
 
@@ -84,7 +85,7 @@ test("Editing a tag value should add it to addedInstanceTags", async () => {
 
 test("Deleting a tag value should add it to deletedInstanceTags", async () => {
   let data = { ...defaultData };
-  const updateData = jest.fn((x) => {
+  const updateData = jest.fn((x: editInstanceTagsData) => {
     data = x;
   });
 
@@ -107,7 +108,7 @@ test("Deleting a tag value should add it to deletedInstanceTags", async () => {
 
 test("Editing a tag key should add the new tag to addedInstanceTags and delete the old tag", async () => {
   let data = { ...defaultData };
-  const updateData = jest.fn((x) => {
+  const updateData = jest.fn((x: editInstanceTagsData) => {
     data = x;
   });
 
@@ -136,7 +137,7 @@ test("Editing a tag key should add the new tag to addedInstanceTags and delete t
 
 test("Should be able to add an new tag with the add tag button", async () => {
   let data = { ...defaultData };
-  const updateData = jest.fn((x) => {
+  const updateData = jest.fn((x: editInstanceTagsData) => {
     data = x;
   });
 

--- a/src/pages/spawn/spawnHost/fields/UserTagsField.tsx
+++ b/src/pages/spawn/spawnHost/fields/UserTagsField.tsx
@@ -2,18 +2,15 @@ import React, { useState, useEffect } from "react";
 import styled from "@emotion/styled";
 import { InstanceTag, InstanceTagInput } from "gql/generated/types";
 import { convertArrayToObject } from "utils/array";
+import { editInstanceTagsData } from "../editSpawnHostModal/useEditSpawnHostModalState";
 import { UserTagRow } from "./userTagsField/UserTagRow";
 
-export interface UserTagsFieldStateType {
-  addedInstanceTags?: InstanceTagInput[];
-  deletedInstanceTags?: InstanceTagInput[];
-}
-
 interface UserTagsFieldProps {
-  onChange: React.Dispatch<React.SetStateAction<any>>;
+  onChange: (data: editInstanceTagsData) => void;
   instanceTags: InstanceTag[];
   visible?: boolean;
 }
+
 export const UserTagsField: React.FC<UserTagsFieldProps> = ({
   onChange,
   instanceTags,

--- a/src/pages/spawn/spawnHost/fields/VolumesField.tsx
+++ b/src/pages/spawn/spawnHost/fields/VolumesField.tsx
@@ -3,10 +3,11 @@ import styled from "@emotion/styled";
 import { Select, Input } from "antd";
 import { InputLabel } from "components/styles";
 import { MyVolume } from "types/spawn";
+import { editVolumesData } from "../editSpawnHostModal/useEditSpawnHostModalState";
 
 const { Option } = Select;
 interface VolumesFieldProps {
-  onChange: React.Dispatch<React.SetStateAction<any>>;
+  onChange: (data: editVolumesData) => void;
   data: {
     volumeId?: string;
     homeVolumeSize?: number;
@@ -33,7 +34,7 @@ export const VolumesField: React.FC<VolumesFieldProps> = ({
           showSearch
           style={{ width: 200 }}
           placeholder="Select volume"
-          onChange={(v) => onChange({ ...data, volumeId: v })}
+          onChange={(v) => onChange({ volumeId: v })}
           value={volumeId}
         >
           {availableVolumes?.map((v) => (
@@ -59,7 +60,10 @@ export const VolumesField: React.FC<VolumesFieldProps> = ({
               value={homeVolumeSize}
               defaultValue={500}
               onChange={(e) =>
-                onChange({ ...data, homeVolumeSize: e.target.value })
+                onChange({
+                  ...data,
+                  homeVolumeSize: parseInt(e.target.value, 10),
+                })
               }
             />
           </FlexColumnContainer>

--- a/src/pages/spawn/spawnHost/fields/VolumesField.tsx
+++ b/src/pages/spawn/spawnHost/fields/VolumesField.tsx
@@ -61,7 +61,6 @@ export const VolumesField: React.FC<VolumesFieldProps> = ({
               defaultValue={500}
               onChange={(e) =>
                 onChange({
-                  ...data,
                   homeVolumeSize: parseInt(e.target.value, 10),
                 })
               }

--- a/src/pages/spawn/spawnHost/fields/index.ts
+++ b/src/pages/spawn/spawnHost/fields/index.ts
@@ -1,3 +1,2 @@
-export { HostExpirationField } from "./HostExpirationField";
 export { VolumesField } from "./VolumesField";
 export { UserTagsField } from "./UserTagsField";

--- a/src/pages/spawn/spawnHost/spawnHostModal/HostDetailsForm.tsx
+++ b/src/pages/spawn/spawnHost/spawnHostModal/HostDetailsForm.tsx
@@ -6,6 +6,10 @@ import { Input } from "antd";
 import { ExpirationField as HostExpirationField } from "components/Spawn";
 import { VolumesField } from "pages/spawn/spawnHost/fields";
 import { MyVolume } from "types/spawn";
+import {
+  editExpirationData,
+  editVolumesData,
+} from "../editSpawnHostModal/useEditSpawnHostModalState";
 
 const { TextArea } = Input;
 
@@ -54,7 +58,12 @@ export const HostDetailsForm: React.FC<HostDetailsFormProps> = ({
       <SectionContainer>
         <SectionLabel weight="medium">Expiration</SectionLabel>
 
-        <HostExpirationField data={data} onChange={onChange} />
+        <HostExpirationField
+          data={data}
+          onChange={(expData: editExpirationData) =>
+            onChange({ ...data, ...expData })
+          }
+        />
       </SectionContainer>
 
       {isVirtualWorkStation && (
@@ -62,7 +71,9 @@ export const HostDetailsForm: React.FC<HostDetailsFormProps> = ({
           <SectionLabel weight="medium">Virtual Workstation</SectionLabel>
           <VolumesField
             data={data}
-            onChange={onChange}
+            onChange={(volData: editVolumesData) =>
+              onChange({ ...data, ...volData })
+            }
             volumes={volumes}
             allowHomeVolume={isSpawnHostModal}
           />

--- a/src/pages/spawn/spawnHost/spawnHostModal/HostDetailsForm.tsx
+++ b/src/pages/spawn/spawnHost/spawnHostModal/HostDetailsForm.tsx
@@ -3,10 +3,8 @@ import styled from "@emotion/styled";
 import Checkbox from "@leafygreen-ui/checkbox";
 import { Subtitle, Body } from "@leafygreen-ui/typography";
 import { Input } from "antd";
-import {
-  HostExpirationField,
-  VolumesField,
-} from "pages/spawn/spawnHost/fields";
+import { ExpirationField as HostExpirationField } from "components/Spawn";
+import { VolumesField } from "pages/spawn/spawnHost/fields";
 import { MyVolume } from "types/spawn";
 
 const { TextArea } = Input;


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-13230
These code changes allow us to be more specific about information processed in our reducer functions. It also enables us to only ever have expand the host state object in our reducer function instead of within our React function components. A possible next step could be to incorporate useReducer for our Spawn Host Modal. 