### PR TITLE
EVG-13320 Use volume limit for spawn volume page + misc improvements

### DIFF
--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -27,6 +27,7 @@ export type Query = {
   userSettings?: Maybe<UserSettings>;
   spruceConfig?: Maybe<SpruceConfig>;
   awsRegions?: Maybe<Array<Scalars["String"]>>;
+  subnetAvailabilityZones: Array<Scalars["String"]>;
   userConfig?: Maybe<UserConfig>;
   clientConfig?: Maybe<ClientConfig>;
   host?: Maybe<Host>;
@@ -327,6 +328,7 @@ export enum TaskSortCategory {
 }
 
 export enum TestSortCategory {
+  BaseStatus = "BASE_STATUS",
   Status = "STATUS",
   Duration = "DURATION",
   TestName = "TEST_NAME",
@@ -434,7 +436,7 @@ export type SpawnHostInput = {
   homeVolumeSize?: Maybe<Scalars["Int"]>;
   volumeId?: Maybe<Scalars["String"]>;
   taskId?: Maybe<Scalars["String"]>;
-  useProjectSetupScript: Scalars["Boolean"];
+  useProjectSetupScript?: Maybe<Scalars["Boolean"]>;
   spawnHostsStartedByTask?: Maybe<Scalars["Boolean"]>;
 };
 
@@ -710,6 +712,7 @@ export type TaskTestResult = {
 export type TestResult = {
   id: Scalars["String"];
   status: Scalars["String"];
+  baseStatus?: Maybe<Scalars["String"]>;
   testFile: Scalars["String"];
   logs: TestLog;
   exitCode?: Maybe<Scalars["Int"]>;
@@ -953,6 +956,7 @@ export type SpruceConfig = {
   jira?: Maybe<JiraConfig>;
   banner?: Maybe<Scalars["String"]>;
   bannerTheme?: Maybe<Scalars["String"]>;
+  providers?: Maybe<CloudProviderConfig>;
 };
 
 export type JiraConfig = {
@@ -961,6 +965,14 @@ export type JiraConfig = {
 
 export type UiConfig = {
   userVoice?: Maybe<Scalars["String"]>;
+};
+
+export type CloudProviderConfig = {
+  aws?: Maybe<AwsConfig>;
+};
+
+export type AwsConfig = {
+  maxVolumeSizePerUser?: Maybe<Scalars["Int"]>;
 };
 
 export type HostEvents = {
@@ -1600,15 +1612,6 @@ export type GetMyPublicKeysQuery = {
   myPublicKeys: Array<{ name: string; key: string }>;
 };
 
-export type GetSpawnHostTaskQueryVariables = {
-  taskId: Scalars["String"];
-  distroId: Scalars["String"];
-};
-
-export type GetSpawnHostTaskQuery = {
-  task?: Maybe<{ buildVariant: string; displayName: string }>;
-};
-
 export type GetSpruceConfigQueryVariables = {};
 
 export type GetSpruceConfigQuery = {
@@ -1617,6 +1620,9 @@ export type GetSpruceConfigQuery = {
     banner?: Maybe<string>;
     ui?: Maybe<{ userVoice?: Maybe<string> }>;
     jira?: Maybe<{ host?: Maybe<string> }>;
+    providers?: Maybe<{
+      aws?: Maybe<{ maxVolumeSizePerUser?: Maybe<number> }>;
+    }>;
   }>;
 };
 

--- a/src/gql/queries/get-spruce-config.ts
+++ b/src/gql/queries/get-spruce-config.ts
@@ -11,6 +11,11 @@ export const GET_SPRUCE_CONFIG = gql`
       jira {
         host
       }
+      providers {
+        aws {
+          maxVolumeSizePerUser
+        }
+      }
     }
   }
 `;

--- a/src/pages/spawn/spawnHost/SpawnHostModal.tsx
+++ b/src/pages/spawn/spawnHost/SpawnHostModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { useQuery, useMutation } from "@apollo/client";
 import styled from "@emotion/styled";
 import Button, { Variant } from "@leafygreen-ui/button";
@@ -96,18 +96,36 @@ export const SpawnHostModal: React.FC<SpawnHostModalProps> = ({
     refetchQueries: ["MyHosts"],
   });
 
+  const [distroInput, setDistroInput] = useState("");
   const { reducer } = useSpawnHostModalState();
   const [spawnHostModalState, dispatch] = reducer;
 
   const { distroId, region, publicKey } = spawnHostModalState;
 
-  const distros = distrosData?.distros;
+  const fetchedDistros = distrosData?.distros;
   const publicKeys = publicKeysData?.myPublicKeys;
   const awsRegions = awsData?.awsRegions;
   const volumes = volumesData?.myVolumes;
 
   useEffect(() => {
     dispatch({ type: "reset" });
+    if (awsRegions) {
+      dispatch({ type: "editAWSRegion", region: awsRegions[0] });
+    }
+    if (publicKeys) {
+      dispatch({
+        type: "editPublicKey",
+        publicKey: publicKeys[0],
+        savePublicKey: false,
+      });
+    }
+    const futureDate = new Date();
+    futureDate.setDate(futureDate.getDate() + 7);
+    dispatch({
+      type: "editExpiration",
+      expiration: futureDate,
+      noExpiration: false,
+    });
   }, [visible]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Need to initialize these here so they can be used in the useEffect hook
@@ -118,6 +136,7 @@ export const SpawnHostModal: React.FC<SpawnHostModalProps> = ({
     return null;
   }
 
+  const distros = fetchedDistros.filter((d) => d.name.includes(distroInput));
   virtualWorkstationDistros = distros.filter((d) => d.isVirtualWorkStation);
   notVirtualWorkstationDistros = distros.filter((d) => !d.isVirtualWorkStation);
 
@@ -194,6 +213,7 @@ export const SpawnHostModal: React.FC<SpawnHostModalProps> = ({
               placeholder="Search for Distro"
               suffix={<Icon glyph="MagnifyingGlass" />}
               data-cy="distro-input"
+              onChange={(e) => setDistroInput(e.target.value)}
             />
           </AutoComplete>
         </Section>

--- a/src/pages/spawn/spawnHost/SpawnHostTable.tsx
+++ b/src/pages/spawn/spawnHost/SpawnHostTable.tsx
@@ -96,5 +96,5 @@ const HostIdSpan = styled.div`
   white-space: nowrap;
   word-break: break-all;
   overflow: scroll;
-  width: 150px;
+  width: 160px;
 `;

--- a/src/pages/spawn/spawnVolume/SpawnVolumeButton.tsx
+++ b/src/pages/spawn/spawnVolume/SpawnVolumeButton.tsx
@@ -1,18 +1,23 @@
 import React, { useState } from "react";
+import { useQuery } from "@apollo/client";
 import styled from "@emotion/styled";
 import { uiColors } from "@leafygreen-ui/palette";
 import { Disclaimer } from "@leafygreen-ui/typography";
 import { PlusButton } from "components/Spawn";
+import { GetSpruceConfigQuery } from "gql/generated/types";
+import { GET_SPRUCE_CONFIG } from "gql/queries";
 import { SpawnVolumeModal } from "./spawnVolumeButton/SpawnVolumeModal";
 
 export const SpawnVolumeButton: React.FC = () => {
   const [openModal, setOpenModal] = useState(false);
+  const { data } = useQuery<GetSpruceConfigQuery>(GET_SPRUCE_CONFIG);
+  const volumeLimit = data?.spruceConfig?.providers?.aws?.maxVolumeSizePerUser;
   return (
     <PaddedContainer>
       <PlusButton data-cy="spawn-volume-btn" onClick={() => setOpenModal(true)}>
         Spawn a Volume
       </PlusButton>
-      <Info>Limit 1500 GiB per User</Info>
+      <Info>Limit {volumeLimit} GiB per User</Info>
       <SpawnVolumeModal
         visible={openModal}
         onCancel={() => setOpenModal(false)}


### PR DESCRIPTION
This pr makes spruce use a queried value for the spawn volume limit.
and has some general improvements mainly for the spawn host modal. 
Some fields are now auto populated such as awsregions and public keys. The distros dropdown now filters the distro's based on the input.

dependent on https://github.com/evergreen-ci/evergreen/pull/4111