### PR TITLE
EVG-13325: Fix Create Volume Modal jest test flake

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,6 @@
 module.exports = {
   moduleDirectories: ["node_modules", "utils", __dirname],
+  setupFiles: [
+    "<rootDir>/src/components/app/App.test.tsx"
+  ],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,3 @@
 module.exports = {
   moduleDirectories: ["node_modules", "utils", __dirname],
-  setupFiles: [
-    "<rootDir>/src/components/app/App.test.tsx"
-  ],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -22382,6 +22382,12 @@
       "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
       "integrity": "sha1-sGJ44h/Gw3+lMTcysEEry2rhX1E="
     },
+    "mutation-observer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/mutation-observer/-/mutation-observer-1.0.3.tgz",
+      "integrity": "sha512-M/O/4rF2h776hV7qGMZUH3utZLO/jK7p8rnNgGkjKUw8zCGjRQPxB8z6+5l8+VjRUQ3dNYu4vjqXYLr+U8ZVNA==",
+      "dev": true
+    },
     "mute-stream": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",

--- a/package.json
+++ b/package.json
@@ -157,6 +157,7 @@
     "jest-junit": "10.0.0",
     "jest-localstorage-mock": "2.4.3",
     "lint-staged": "10.2.11",
+    "mutation-observer": "1.0.3",
     "path": "0.12.7",
     "prettier": "1.19.1",
     "prompt": "^1.0.0",

--- a/src/pages/spawn/spawnVolume/spawnVolumeButton/SpawnVolumeModal.test.tsx
+++ b/src/pages/spawn/spawnVolume/spawnVolumeButton/SpawnVolumeModal.test.tsx
@@ -170,18 +170,16 @@ test("Form contains default volumes on initial render.", async () => {
   );
 });
 
-const mockSuccessBanner = jest.fn();
-
-jest.mock("context/banners", () => ({
-  useBannerDispatchContext: () => ({
-    successBanner: mockSuccessBanner,
-    errorBanner: (e) => {
-      console.log(e);
-    },
-  }),
-}));
-
 test("Form submission succeeds with default values", async () => {
+  const mockSuccessBanner = jest.fn();
+  jest.mock("context/banners", () => ({
+    useBannerDispatchContext: () => ({
+      successBanner: mockSuccessBanner,
+      errorBanner: (e) => {
+        console.log(e);
+      },
+    }),
+  }));
   const mocks = [
     ...baseMocks,
     {
@@ -212,6 +210,15 @@ test("Form submission succeeds with default values", async () => {
 });
 
 test("Form submission succeeds after adjusting inputs", async () => {
+  const mockSuccessBanner = jest.fn();
+  jest.mock("context/banners", () => ({
+    useBannerDispatchContext: () => ({
+      successBanner: mockSuccessBanner,
+      errorBanner: (e) => {
+        console.log(e);
+      },
+    }),
+  }));
   const mocks = [
     ...baseMocks,
     {
@@ -246,5 +253,5 @@ test("Form submission succeeds after adjusting inputs", async () => {
   await new Promise((resolve) => setTimeout(resolve, 0));
   act(() => fireEvent.click(queryByText("Spawn")));
   await new Promise((resolve) => setTimeout(resolve, 0));
-  expect(mockSuccessBanner).toBeCalledTimes(2);
+  expect(mockSuccessBanner).toBeCalledTimes(1);
 });

--- a/src/pages/spawn/spawnVolume/spawnVolumeButton/SpawnVolumeModal.test.tsx
+++ b/src/pages/spawn/spawnVolume/spawnVolumeButton/SpawnVolumeModal.test.tsx
@@ -1,7 +1,11 @@
 import React from "react";
 import { MockedProvider } from "@apollo/client/testing";
 import { SPAWN_VOLUME } from "gql/mutations/spawn-volume";
-import { GET_MY_HOSTS, GET_SUBNET_AVAILABILITY_ZONES } from "gql/queries";
+import {
+  GET_MY_HOSTS,
+  GET_SUBNET_AVAILABILITY_ZONES,
+  GET_USER,
+} from "gql/queries";
 import {
   act,
   customRenderWithRouterMatch as render,
@@ -10,6 +14,20 @@ import {
 import { SpawnVolumeModal } from "./SpawnVolumeModal";
 
 const baseMocks = [
+  {
+    request: {
+      query: GET_USER,
+      variables: {},
+    },
+    result: {
+      data: {
+        user: {
+          userId: "a",
+          displayName: "A",
+        },
+      },
+    },
+  },
   {
     request: {
       query: GET_SUBNET_AVAILABILITY_ZONES,
@@ -130,6 +148,20 @@ const baseMocks = [
   },
 ];
 
+const mockSuccessBanner = jest.fn();
+jest.mock("context/banners", () => ({
+  useBannerDispatchContext: () => ({
+    successBanner: mockSuccessBanner,
+    errorBanner: (e) => {
+      console.log(e);
+    },
+  }),
+}));
+
+beforeEach(() => {
+  mockSuccessBanner.mockClear();
+});
+
 test("Renders the Spawn Volume Modal when the visible prop is true", async () => {
   const { queryByDataCy } = render(() => (
     <MockedProvider mocks={baseMocks}>
@@ -171,15 +203,6 @@ test("Form contains default volumes on initial render.", async () => {
 });
 
 test("Form submission succeeds with default values", async () => {
-  const mockSuccessBanner = jest.fn();
-  jest.mock("context/banners", () => ({
-    useBannerDispatchContext: () => ({
-      successBanner: mockSuccessBanner,
-      errorBanner: (e) => {
-        console.log(e);
-      },
-    }),
-  }));
   const mocks = [
     ...baseMocks,
     {
@@ -210,15 +233,6 @@ test("Form submission succeeds with default values", async () => {
 });
 
 test("Form submission succeeds after adjusting inputs", async () => {
-  const mockSuccessBanner = jest.fn();
-  jest.mock("context/banners", () => ({
-    useBannerDispatchContext: () => ({
-      successBanner: mockSuccessBanner,
-      errorBanner: (e) => {
-        console.log(e);
-      },
-    }),
-  }));
   const mocks = [
     ...baseMocks,
     {

--- a/src/pages/spawn/spawnVolume/spawnVolumeButton/SpawnVolumeModal.test.tsx
+++ b/src/pages/spawn/spawnVolume/spawnVolumeButton/SpawnVolumeModal.test.tsx
@@ -10,6 +10,7 @@ import {
   act,
   customRenderWithRouterMatch as render,
   fireEvent,
+  waitFor,
 } from "test_utils/test-utils";
 import { SpawnVolumeModal } from "./SpawnVolumeModal";
 
@@ -229,7 +230,7 @@ test("Form submission succeeds with default values", async () => {
   await new Promise((resolve) => setTimeout(resolve, 0));
   fireEvent.click(queryByText("Spawn"));
   await new Promise((resolve) => setTimeout(resolve, 0));
-  expect(mockSuccessBanner).toBeCalledTimes(1);
+  waitFor(() => expect(mockSuccessBanner).toBeCalledTimes(1));
 });
 
 test("Form submission succeeds after adjusting inputs", async () => {
@@ -267,5 +268,5 @@ test("Form submission succeeds after adjusting inputs", async () => {
   await new Promise((resolve) => setTimeout(resolve, 0));
   act(() => fireEvent.click(queryByText("Spawn")));
   await new Promise((resolve) => setTimeout(resolve, 0));
-  expect(mockSuccessBanner).toBeCalledTimes(1);
+  waitFor(() => expect(mockSuccessBanner).toBeCalledTimes(1));
 });

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -3,3 +3,7 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import "@testing-library/jest-dom/extend-expect";
+import MutationObserver from 'mutation-observer'
+
+// @ts-ignore
+global.MutationObserver = MutationObserver

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -3,7 +3,7 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import "@testing-library/jest-dom/extend-expect";
-import MutationObserver from 'mutation-observer'
+import MutationObserver from "mutation-observer";
 
 // @ts-ignore
-global.MutationObserver = MutationObserver
+global.MutationObserver = MutationObserver;


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-13325
This PR fixes the jest test flake by using the `waitFor` fn exported by `test-utils`. `waitFor` depends on the `MutationObserver` constructor which is unavailable with our current installed version of jsdom so I polyfilled it. The latest version of jsdom, which provides the polyfill, is available from react-scripts v4 however when I attempted to update react-scripts, there were non-trivial dependency issues so I found installing the polyfill directly the cleanest solution. We currently have a version of Jest and eslint installed in our package.json devDependencies. We should carefully remove these dependencies and rely on the installation react-scripts provides when we are ready to upgrade to react-scripts v4 (unless we decide to do something different altogether). 
The first 4 patches on [this page](https://spruce.mongodb.com/user/arjun.patel/patches?limit=10&page=0&patchName=test%20flake) should confirm that the test no longer flakes. 