### PR TITLE
EVG-12443 add dropdown option to disable task

### DIFF
--- a/cypress/integration/task_actions.ts
+++ b/cypress/integration/task_actions.ts
@@ -1,12 +1,12 @@
 // / <reference types="Cypress" />
 import { popconfirmYesClassName } from "../utils/popconfirm";
 
-xdescribe("Task Action Buttons", () => {
+describe("Task Action Buttons", () => {
   before(() => {
     cy.login();
   });
 
-  xdescribe("Based on the state of the task, some buttons should be disabled and others should be clickable. Clicking on buttons produces banners messaging if the action succeeded or failed.", () => {
+  describe("Based on the state of the task, some buttons should be disabled and others should be clickable. Clicking on buttons produces banners messaging if the action succeeded or failed.", () => {
     beforeEach(() => {
       cy.preserveCookies();
     });
@@ -24,6 +24,7 @@ xdescribe("Task Action Buttons", () => {
     });
 
     it("Clicking Unschedule button should produce success banner", () => {
+      cy.visit(taskRoute3);
       cy.dataCy("ellipsis-btn").click();
       cy.dataCy("unschedule-task").click();
       cy.wait(200);
@@ -48,7 +49,7 @@ xdescribe("Task Action Buttons", () => {
     });
 
     it("There should be three visible banners from the previous actions", () => {
-      cy.dataCy(bannerDataCy).should("have.length", 3);
+      cy.dataCy(bannerDataCy).should("have.length", 2);
     });
 
     it("Visiting a different task page should clear all banners", () => {
@@ -62,6 +63,18 @@ xdescribe("Task Action Buttons", () => {
       cy.wait(200);
       cy.dataCy(bannerDataCy).contains("Task aborted");
     });
+
+    it("should correctly disable/enable the task when clicked", () => {
+      cy.visit(taskRoute1);
+      cy.dataCy("ellipsis-btn").click();
+      cy.dataCy("disable-enable").click();
+      cy.wait(200);
+      cy.dataCy(bannerDataCy).contains("Priority for task updated to -1");
+      cy.dataCy("ellipsis-btn").click();
+      cy.dataCy("disable-enable").click();
+      cy.wait(200);
+      cy.dataCy(bannerDataCy).contains("Priority for task updated to 0");
+    });
   });
 });
 
@@ -70,8 +83,8 @@ const restartSuccessBannerText = "Task scheduled to restart";
 const unscheduleSuccessBannerText = "Task marked as unscheduled";
 const taskRoute1 =
   "/task/clone_evergreen_ubuntu1604_test_model_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48/logs";
-const taskRoute3 =
-  "/task/evergreen_ubuntu1604_test_service_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48";
 const taskRoute2 =
   "task/evergreen_lint_lint_service_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48";
+const taskRoute3 =
+  "/task/evergreen_ubuntu1604_test_cloud_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48";
 const bannerDataCy = "banner";

--- a/src/components/LinkToReconfigurePage.tsx
+++ b/src/components/LinkToReconfigurePage.tsx
@@ -24,7 +24,7 @@ export const LinkToReconfigurePage: React.FC<{
         }
       }}
     >
-      <Disclaimer>Reconfigure Tasks/Variants</Disclaimer>
+      <Disclaimer>Reconfigure tasks/variants</Disclaimer>
     </DropdownItem>
   );
 };

--- a/src/components/PatchActionButtons/UnschedulePatchTasks.tsx
+++ b/src/components/PatchActionButtons/UnschedulePatchTasks.tsx
@@ -90,7 +90,7 @@ export const UnschedulePatchTasks = forwardRef<HTMLDivElement, UnscheduleProps>(
           ref={ref}
           disabled={loadingUnschedulePatchTasks || disabled}
         >
-          <Disclaimer>Unschedule All Tasks</Disclaimer>
+          <Disclaimer>Unschedule all tasks</Disclaimer>
         </DropdownItem>
       </Popconfirm>
     );

--- a/src/pages/patch/ActionButtons.tsx
+++ b/src/pages/patch/ActionButtons.tsx
@@ -34,18 +34,17 @@ export const ActionButtons: React.FC<ActionButtonProps> = ({
   const { id: patchId } = useParams<{ id: string }>();
   const [isActionLoading, setIsActionLoading] = useState(false);
   const { successBanner, errorBanner } = useBannerDispatchContext();
-  const refetchQueries = ["Patch"];
-  const [setPatchPriority] = useMutation<
+  const [disablePatch] = useMutation<
     SetPatchPriorityMutation,
     SetPatchPriorityMutationVariables
   >(SET_PATCH_PRIORITY, {
     onCompleted: () => {
-      successBanner(`Priority for all tasks was updated`);
+      successBanner(`Tasks in this patch were disabled`);
     },
     onError: (err) => {
-      errorBanner(`Error setting priority: ${err.message}`);
+      errorBanner(`Unable to disable patch tasks: ${err.message}`);
     },
-    refetchQueries,
+    refetchQueries: ["Patch"],
   });
 
   const hideMenu = () => setIsVisible(false);
@@ -66,7 +65,7 @@ export const ActionButtons: React.FC<ActionButtonProps> = ({
       {...{
         patchId,
         hideMenu,
-        refetchQueries,
+        refetchQueries: ["Patch"],
         key: "unschedule",
         setParentLoading: setIsActionLoading,
         disabled: isActionLoading,
@@ -76,7 +75,7 @@ export const ActionButtons: React.FC<ActionButtonProps> = ({
       data-cy="disable"
       disabled={false}
       onClick={() => {
-        setPatchPriority({
+        disablePatch({
           variables: { patchId, priority: -1 },
         });
       }}
@@ -89,7 +88,7 @@ export const ActionButtons: React.FC<ActionButtonProps> = ({
         hideMenu,
         key: "priority",
         disabled: isActionLoading,
-        refetchQueries,
+        refetchQueries: ["Patch"],
         setParentLoading: setIsActionLoading,
       }}
     />,
@@ -99,7 +98,7 @@ export const ActionButtons: React.FC<ActionButtonProps> = ({
         hideMenu,
         key: "enqueue",
         disabled: isActionLoading || !canEnqueueToCommitQueue,
-        refetchQueries,
+        refetchQueries: ["Patch"],
         setParentLoading: setIsActionLoading,
       }}
     />,
@@ -115,7 +114,7 @@ export const ActionButtons: React.FC<ActionButtonProps> = ({
             isButton: true,
             disabled: isActionLoading,
             setParentLoading: setIsActionLoading,
-            refetchQueries,
+            refetchQueries: ["Patch"],
           }}
         />
         <RestartPatch
@@ -124,14 +123,14 @@ export const ActionButtons: React.FC<ActionButtonProps> = ({
             hideMenu,
             isButton: true,
             disabled: isActionLoading,
-            refetchQueries,
+            refetchQueries: ["Patch"],
           }}
         />
         <AddNotification
           {...{
             patchId,
             hideMenu,
-            refetchQueries,
+            refetchQueries: ["Patch"],
             key: "notification",
             setParentLoading: setIsActionLoading,
             disabled: isActionLoading,

--- a/src/pages/patch/ActionButtons.tsx
+++ b/src/pages/patch/ActionButtons.tsx
@@ -1,4 +1,6 @@
 import React, { useRef, useState, useEffect } from "react";
+import { useMutation } from "@apollo/client";
+import { Disclaimer } from "@leafygreen-ui/typography";
 import { useParams } from "react-router-dom";
 import { ButtonDropdown, DropdownItem } from "components/ButtonDropdown";
 import { LinkToReconfigurePage } from "components/LinkToReconfigurePage";
@@ -11,14 +13,12 @@ import {
   AddNotification,
 } from "components/PatchActionButtons";
 import { PageButtonRow } from "components/styles";
-import { useMutation } from "@apollo/client";
+import { useBannerDispatchContext } from "context/banners";
 import {
   SetPatchPriorityMutation,
   SetPatchPriorityMutationVariables,
 } from "gql/generated/types";
 import { SET_PATCH_PRIORITY } from "gql/mutations";
-import { Disclaimer } from "@leafygreen-ui/typography";
-import { useBannerDispatchContext } from "context/banners";
 
 interface ActionButtonProps {
   canEnqueueToCommitQueue: boolean;
@@ -40,7 +40,7 @@ export const ActionButtons: React.FC<ActionButtonProps> = ({
     SetPatchPriorityMutationVariables
   >(SET_PATCH_PRIORITY, {
     onCompleted: () => {
-      successBanner(`Priority for all tasks was update`);
+      successBanner(`Priority for all tasks was updated`);
     },
     onError: (err) => {
       errorBanner(`Error setting priority: ${err.message}`);

--- a/src/pages/task/ActionButtons.tsx
+++ b/src/pages/task/ActionButtons.tsx
@@ -120,7 +120,9 @@ export const ActionButtons = ({
   >(SET_TASK_PRIORTY, {
     onCompleted: (data) => {
       successBanner(
-        `Priority for task updated to ${data.setTaskPriority.priority}`
+        data.setTaskPriority.priority >= 0
+          ? `Priority for task updated to ${data.setTaskPriority.priority}`
+          : `Task was successfully disabled`
       );
     },
     onError: (err) => {

--- a/src/pages/task/ActionButtons.tsx
+++ b/src/pages/task/ActionButtons.tsx
@@ -173,6 +173,17 @@ export const ActionButtons = ({
     >
       <Disclaimer>Abort</Disclaimer>
     </DropdownItem>,
+    <DropdownItem
+      data-cy="disable-enable"
+      disabled={disabled}
+      onClick={() => {
+        setTaskPriority({
+          variables: { taskId, priority: initialPriority < 0 ? 0 : -1 },
+        });
+      }}
+    >
+      <Disclaimer>{initialPriority < 0 ? "Enable" : "Disable"}</Disclaimer>
+    </DropdownItem>,
     <Popconfirm
       key="priority"
       icon={null}


### PR DESCRIPTION
![Untitled](https://user-images.githubusercontent.com/29384396/98036078-655a4e00-1de7-11eb-9a6d-d11862c45ea2.gif)

- Add a patch/task dropdown option to disable the patch/task
- Make the patch dropdown options Sentence case to be consistent
- Enable + fix the task action tests. I'm not sure why they were disabled

Note that displaying the disabled status is a separate ticket: https://jira.mongodb.org/browse/EVG-13096