### PR TITLE
EVG-8030 & EVG-13380: Add a loading state to spawn pages & Show error banner when MyVolumes query fails

### DIFF
--- a/src/pages/spawn/SpawnVolume.tsx
+++ b/src/pages/spawn/SpawnVolume.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { useQuery } from "@apollo/client";
 import { Variant } from "@leafygreen-ui/badge";
 import { Subtitle } from "@leafygreen-ui/typography";
+import { Skeleton } from "antd";
 import {
   Title,
   BadgeWrapper,
@@ -10,15 +11,20 @@ import {
 } from "components/Spawn";
 import { MyVolumesQuery, MyVolumesQueryVariables } from "gql/generated/types";
 import { GET_MY_VOLUMES } from "gql/queries";
+import { useNetworkStatus } from "hooks";
 import { SpawnVolumeTable } from "pages/spawn/spawnVolume/SpawnVolumeTable";
 import { SpawnVolumeButton } from "./spawnVolume/SpawnVolumeButton";
 
 export const SpawnVolume = () => {
-  const { data: volumesData } = useQuery<
+  const { data: volumesData, loading, startPolling, stopPolling } = useQuery<
     MyVolumesQuery,
     MyVolumesQueryVariables
   >(GET_MY_VOLUMES);
+  useNetworkStatus(startPolling, stopPolling);
 
+  if (loading) {
+    return <Skeleton />;
+  }
   const mountedCount =
     volumesData?.myVolumes.filter((v) => v.hostID).length ?? 0;
   const unmountedCount =

--- a/src/pages/spawn/SpawnVolume.tsx
+++ b/src/pages/spawn/SpawnVolume.tsx
@@ -9,6 +9,7 @@ import {
   TitleContainer,
   StyledBadge,
 } from "components/Spawn";
+import { pollInterval } from "constants/index";
 import { MyVolumesQuery, MyVolumesQueryVariables } from "gql/generated/types";
 import { GET_MY_VOLUMES } from "gql/queries";
 import { useNetworkStatus } from "hooks";
@@ -19,7 +20,9 @@ export const SpawnVolume = () => {
   const { data: volumesData, loading, startPolling, stopPolling } = useQuery<
     MyVolumesQuery,
     MyVolumesQueryVariables
-  >(GET_MY_VOLUMES);
+  >(GET_MY_VOLUMES, {
+    pollInterval,
+  });
   useNetworkStatus(startPolling, stopPolling);
 
   if (loading) {

--- a/src/pages/spawn/SpawnVolume.tsx
+++ b/src/pages/spawn/SpawnVolume.tsx
@@ -10,6 +10,7 @@ import {
   StyledBadge,
 } from "components/Spawn";
 import { pollInterval } from "constants/index";
+import { useBannerDispatchContext } from "context/banners";
 import { MyVolumesQuery, MyVolumesQueryVariables } from "gql/generated/types";
 import { GET_MY_VOLUMES } from "gql/queries";
 import { useNetworkStatus } from "hooks";
@@ -17,11 +18,15 @@ import { SpawnVolumeTable } from "pages/spawn/spawnVolume/SpawnVolumeTable";
 import { SpawnVolumeButton } from "./spawnVolume/SpawnVolumeButton";
 
 export const SpawnVolume = () => {
+  const { errorBanner } = useBannerDispatchContext();
   const { data: volumesData, loading, startPolling, stopPolling } = useQuery<
     MyVolumesQuery,
     MyVolumesQueryVariables
   >(GET_MY_VOLUMES, {
     pollInterval,
+    onError: (e) => {
+      errorBanner(`There was an error loading your spawn volume: ${e.message}`);
+    },
   });
   useNetworkStatus(startPolling, stopPolling);
 

--- a/src/pages/spawn/spawnHost/EditSpawnHostModal.tsx
+++ b/src/pages/spawn/spawnHost/EditSpawnHostModal.tsx
@@ -80,6 +80,7 @@ export const EditSpawnHostModal: React.FC<EditSpawnHostModalProps> = ({
   >(EDIT_SPAWN_HOST, {
     onCompleted(mutationResult) {
       const { id } = mutationResult?.editSpawnHost;
+      dispatchBanner.clearAllBanners();
       dispatchBanner.successBanner(`Successfully modified spawned host: ${id}`);
       onCancel();
     },

--- a/src/pages/spawn/spawnHost/SpawnHostActionButton.tsx
+++ b/src/pages/spawn/spawnHost/SpawnHostActionButton.tsx
@@ -55,6 +55,7 @@ export const SpawnHostActionButton: React.FC<{ host: MyHost }> = ({ host }) => {
     UpdateSpawnHostStatusMutationVariables
   >(UPDATE_SPAWN_HOST_STATUS, {
     onCompleted() {
+      dispatchBanner.clearAllBanners();
       dispatchBanner.successBanner(
         `Successfully triggered host status update!`
       );

--- a/src/pages/spawn/spawnHost/SpawnHostModal.tsx
+++ b/src/pages/spawn/spawnHost/SpawnHostModal.tsx
@@ -84,6 +84,7 @@ export const SpawnHostModal: React.FC<SpawnHostModalProps> = ({
     onCompleted(hostMutation) {
       const { id } = hostMutation?.spawnHost;
       onCancel();
+      dispatchBanner.clearAllBanners();
       dispatchBanner.successBanner(`Successfully spawned host: ${id}`);
     },
     onError(err) {

--- a/src/pages/spawn/spawnHost/SpawnHostModal.tsx
+++ b/src/pages/spawn/spawnHost/SpawnHostModal.tsx
@@ -196,7 +196,6 @@ export const SpawnHostModal: React.FC<SpawnHostModalProps> = ({
           onClick={spawnHost}
           variant={Variant.Primary}
           key="spawn_host_button"
-          glyph={loadingSpawnHost && <Icon glyph="Refresh" />}
         >
           {loadingSpawnHost ? "Spawning Host" : "Spawn"}
         </WideButton>,

--- a/src/pages/spawn/spawnHost/SpawnHostModal.tsx
+++ b/src/pages/spawn/spawnHost/SpawnHostModal.tsx
@@ -102,10 +102,10 @@ export const SpawnHostModal: React.FC<SpawnHostModalProps> = ({
 
   const { distroId, region, publicKey } = spawnHostModalState;
 
-  const fetchedDistros = distrosData?.distros;
+  const fetchedDistros = distrosData?.distros ?? [];
   const publicKeys = publicKeysData?.myPublicKeys;
   const awsRegions = awsData?.awsRegions;
-  const volumes = volumesData?.myVolumes;
+  const volumes = volumesData?.myVolumes ?? [];
 
   useEffect(() => {
     dispatch({ type: "reset" });

--- a/src/pages/spawn/spawnVolume/spawnVolumeButton/SpawnVolumeModal.test.tsx
+++ b/src/pages/spawn/spawnVolume/spawnVolumeButton/SpawnVolumeModal.test.tsx
@@ -314,6 +314,7 @@ jest.mock("context/banners", () => ({
     errorBanner: (e) => {
       console.log(e);
     },
+    clearAllBanners: () => {},
   }),
 }));
 

--- a/src/pages/spawn/spawnVolume/spawnVolumeButton/SpawnVolumeModal.tsx
+++ b/src/pages/spawn/spawnVolume/spawnVolumeButton/SpawnVolumeModal.tsx
@@ -53,6 +53,7 @@ export const SpawnVolumeModal: React.FC<SpawnVolumeModalProps> = ({
   >(SPAWN_VOLUME, {
     onCompleted() {
       onCancel();
+      dispatchBanner.clearAllBanners();
       dispatchBanner.successBanner("Successfully spawned volume");
     },
     onError(err) {

--- a/src/pages/spawn/spawnVolume/spawnVolumeTable/spawnVolumeTableActions/DeleteVolumeBtn.tsx
+++ b/src/pages/spawn/spawnVolume/spawnVolumeTable/spawnVolumeTableActions/DeleteVolumeBtn.tsx
@@ -26,6 +26,7 @@ export const DeleteVolumeBtn: React.FC<Props> = ({ volume }) => {
     onError: (err) =>
       dispatchBanner.errorBanner(`Error removing volume: '${err.message}'`),
     onCompleted: () => {
+      dispatchBanner.clearAllBanners();
       dispatchBanner.successBanner("Successfully deleted the volume.");
     },
   });

--- a/src/pages/spawn/spawnVolume/spawnVolumeTable/spawnVolumeTableActions/UnmountBtn.tsx
+++ b/src/pages/spawn/spawnVolume/spawnVolumeTable/spawnVolumeTableActions/UnmountBtn.tsx
@@ -21,6 +21,7 @@ export const UnmountBtn: React.FC<Props> = ({ volume }) => {
       onError: (err) =>
         dispatchBanner.errorBanner(`Error detaching volume: '${err.message}'`),
       onCompleted: () => {
+        dispatchBanner.clearAllBanners();
         dispatchBanner.successBanner("Successfully unmounted the volume.");
       },
       refetchQueries: ["MyVolumes", "MyHosts"],

--- a/src/pages/spawn/spawnVolume/spawnVolumeTable/spawnVolumeTableActions/UnmountBtn.tsx
+++ b/src/pages/spawn/spawnVolume/spawnVolumeTable/spawnVolumeTableActions/UnmountBtn.tsx
@@ -24,23 +24,12 @@ export const UnmountBtn: React.FC<Props> = ({ volume }) => {
   const dispatchBanner = useBannerDispatchContext();
   const spawnAnalytics = useSpawnAnalytics();
 
-  const [detachVolume, { loading: loadingDetachVolume }] = useMutation(
-    DETACH_VOLUME,
-    {
-      onError: (err) =>
-        dispatchBanner.errorBanner(`Error detaching volume: '${err.message}'`),
-      onCompleted: () => {
-        dispatchBanner.clearAllBanners();
-        dispatchBanner.successBanner("Successfully unmounted the volume.");
-      },
-      refetchQueries: ["MyVolumes", "MyHosts"],
-    }
-
   const { data: myHostsData } = useQuery<MyHostsQuery, MyHostsQueryVariables>(
     GET_MY_HOSTS
   );
 
   const myHosts = myHostsData?.myHosts ?? [];
+
   const [detachVolume, { loading: loadingDetachVolume }] = useMutation<
     DetachVolumeFromHostMutation,
     DetachVolumeFromHostMutationVariables

--- a/src/pages/spawn/spawnVolume/spawnVolumeTable/spawnVolumeTableActions/editButton/EditVolumeModal.tsx
+++ b/src/pages/spawn/spawnVolume/spawnVolumeTable/spawnVolumeTableActions/editButton/EditVolumeModal.tsx
@@ -50,6 +50,7 @@ export const EditVolumeModal: React.FC<Props> = ({
     },
     onError(err) {
       onCancel();
+      dispatchBanner.clearAllBanners();
       dispatchBanner.errorBanner(
         `There was an error while updating your volume: ${err.message}`
       );

--- a/src/pages/spawn/spawnVolume/spawnVolumeTable/spawnVolumeTableActions/mountButton/MountVolumeModal.tsx
+++ b/src/pages/spawn/spawnVolume/spawnVolumeTable/spawnVolumeTableActions/mountButton/MountVolumeModal.tsx
@@ -34,6 +34,7 @@ export const MountVolumeModal: React.FC<Props> = ({
     onError: (err) =>
       dispatchBanner.errorBanner(`Error attaching volume: '${err.message}'`),
     onCompleted: () => {
+      dispatchBanner.clearAllBanners();
       dispatchBanner.successBanner("Successfully mounted the volume.");
     },
     refetchQueries: ["MyVolumes", "MyHosts"],


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-8030
These code changes:
1. add a skeleton to the Spawn Volume page
2. add query polling the Spawn Volume page
3. clear error banners after successful mutations
4. shows an error banner of the MyVolumes query fails
5. prevents accessing undefined data fields that could result from the MyVolumes from failing
6. adjusts the confirm button copy in the Edit Host Modal while the mutation is in flight