### PR TITLE
EVG-13378 Dont allow user to edit spawn host if it is not running or started

### DIFF
--- a/src/components/Spawn/MountVolumeSelect.tsx
+++ b/src/components/Spawn/MountVolumeSelect.tsx
@@ -46,12 +46,12 @@ export const MountVolumeSelect = ({
   });
   useNetworkStatus(startPolling, stopPolling);
 
-  // User should not be able to make changes to a host if it isn't in the running or stopped status and the host is not in the wrong availability zone
-  const canUpdateHost = (status: string, availabilityZone: string) =>
-    availabilityZone === targetAvailabilityZone &&
-    (status === HostStatus.Running || status === HostStatus.Stopped);
   // set host dropdown options
   useEffect(() => {
+    // User should not be able to make changes to a host if it isn't in the running or stopped status and the host is not in the wrong availability zone
+    const canUpdateHost = (status: string, availabilityZone: string) =>
+      availabilityZone === targetAvailabilityZone &&
+      (status === HostStatus.Running || status === HostStatus.Stopped);
     if (data?.myHosts) {
       const opts = data.myHosts
         // Filter hosts that do not have the same availability zone as the volume.

--- a/src/components/Spawn/MountVolumeSelect.tsx
+++ b/src/components/Spawn/MountVolumeSelect.tsx
@@ -8,6 +8,7 @@ import { useBannerDispatchContext } from "context/banners";
 import { MyHostsQuery, MyHostsQueryVariables } from "gql/generated/types";
 import { GET_MY_HOSTS } from "gql/queries";
 import { useNetworkStatus } from "hooks/useNetworkStatus";
+import { HostStatus } from "types/host";
 
 const { Option } = Select;
 interface HostOption {
@@ -45,13 +46,17 @@ export const MountVolumeSelect = ({
   });
   useNetworkStatus(startPolling, stopPolling);
 
+  // User should not be able to make changes to a host if it isn't in the running or stopped status and the host is not in the wrong availability zone
+  const canUpdateHost = (status: string, availabilityZone: string) =>
+    availabilityZone === targetAvailabilityZone &&
+    (status === HostStatus.Running || status === HostStatus.Stopped);
   // set host dropdown options
   useEffect(() => {
     if (data?.myHosts) {
       const opts = data.myHosts
         // Filter hosts that do not have the same availability zone as the volume.
-        .filter(
-          ({ availabilityZone }) => availabilityZone === targetAvailabilityZone
+        .filter(({ availabilityZone, status }) =>
+          canUpdateHost(status, availabilityZone)
         )
         // Map host to a displayName and ID for the dropdown <Option />
         .map(({ id, displayName }) => ({

--- a/src/pages/spawn/spawnHost/EditSpawnHostButton.tsx
+++ b/src/pages/spawn/spawnHost/EditSpawnHostButton.tsx
@@ -1,8 +1,11 @@
 import React, { useState } from "react";
 import { Size } from "@leafygreen-ui/button";
+import { Tooltip } from "antd";
 import { useSpawnAnalytics } from "analytics";
+import { ConditionalWrapper } from "components/ConditionalWrapper";
 import { PaddedButton } from "components/Spawn";
 import { EditSpawnHostModal } from "pages/spawn/spawnHost/index";
+import { HostStatus } from "types/host";
 import { MyHost } from "types/spawn";
 
 interface EditSpawnHostButtonProps {
@@ -13,22 +16,37 @@ export const EditSpawnHostButton: React.FC<EditSpawnHostButtonProps> = ({
 }) => {
   const [openModal, setOpenModal] = useState(false);
   const spawnAnalytics = useSpawnAnalytics();
+  const canEditSpawnHost =
+    host.status === HostStatus.Stopped || host.status === HostStatus.Running;
   return (
     <>
-      <PaddedButton
-        size={Size.XSmall}
-        onClick={(e) => {
-          e.stopPropagation();
-          setOpenModal(true);
-          spawnAnalytics.sendEvent({
-            name: "Open the Edit Spawn Host Modal",
-            hostId: host.id,
-            status: host.status,
-          });
-        }}
+      <ConditionalWrapper
+        condition={!canEditSpawnHost}
+        wrapper={(children) => (
+          <Tooltip
+            title={`Can only edit a spawn host when the status is ${HostStatus.Stopped} or ${HostStatus.Running}`}
+          >
+            <span>{children}</span>
+          </Tooltip>
+        )}
       >
-        Edit
-      </PaddedButton>
+        <PaddedButton
+          size={Size.XSmall}
+          disabled={!canEditSpawnHost}
+          onClick={(e) => {
+            e.stopPropagation();
+            setOpenModal(true);
+            spawnAnalytics.sendEvent({
+              name: "Open the Edit Spawn Host Modal",
+              hostId: host.id,
+              status: host.status,
+            });
+          }}
+        >
+          Edit
+        </PaddedButton>
+      </ConditionalWrapper>
+
       <EditSpawnHostModal
         onCancel={() => setOpenModal(false)}
         visible={openModal}


### PR DESCRIPTION
This pr disables the ability to edit a spawn host if it is not in the running or started status. This is to prevent changes to the state of a spawned host while it is being initialized which might cause it to be in an unpredictable state. 