### PR TITLE
EVG-12541 Add total code changes and fix tabs padding

### DIFF
--- a/src/components/styles/StyledTabs.tsx
+++ b/src/components/styles/StyledTabs.tsx
@@ -1,8 +1,21 @@
+import React from "react";
 import styled from "@emotion/styled/macro";
-import { Tabs } from "@leafygreen-ui/tabs";
+import { Tabs, Tab } from "@leafygreen-ui/tabs";
 
-export const StyledTabs = styled(Tabs)`
-  & > div:nth-of-type(3) {
-    margin-top: 12px;
-  }
+type StyledTabsProps = React.ComponentProps<typeof Tabs>;
+export const StyledTabs: React.FC<StyledTabsProps> = ({
+  children,
+  ...rest
+}) => (
+  <Tabs {...rest}>
+    {children.map((c) => (
+      <Tab {...c.props}>
+        <PaddedContainer>{c.props.children}</PaddedContainer>
+      </Tab>
+    ))}
+  </Tabs>
+);
+
+const PaddedContainer = styled.div`
+  margin-top: 12px;
 `;

--- a/src/pages/patch/patchTabs/CodeChanges.tsx
+++ b/src/pages/patch/patchTabs/CodeChanges.tsx
@@ -27,36 +27,34 @@ export const CodeChanges: React.FC = () => {
   if (error) {
     return <div id="patch-error">{error.message}</div>;
   }
-  if (!data.patch.moduleCodeChanges.length) {
+  const { moduleCodeChanges } = data.patch;
+  if (!moduleCodeChanges.length) {
     return <Title className="cy-no-code-changes">No code changes</Title>;
   }
   return (
     <div data-cy="code-changes">
-      {data.patch.moduleCodeChanges.map((modCodeChange) => {
-        const sortedFileDiffs = [...modCodeChange.fileDiffs].sort((a, b) =>
+      {moduleCodeChanges.map((modCodeChange) => {
+        const { fileDiffs, branchName, htmlLink, rawLink } = modCodeChange;
+
+        const sortedFileDiffs = [...fileDiffs].sort((a, b) =>
           a.fileName.localeCompare(b.fileName)
         );
-        const { fileDiffs } = modCodeChange;
-        const TotalFileDiff = {
-          additions: 0,
-          deletions: 0,
-        };
-        TotalFileDiff.additions = fileDiffs.reduce(
+        const additions = fileDiffs.reduce(
           (total, diff) => total + diff.additions,
           0
         );
-        TotalFileDiff.deletions = fileDiffs.reduce(
+        const deletions = fileDiffs.reduce(
           (total, diff) => total + diff.deletions,
           0
         );
         return (
-          <div key={modCodeChange.branchName}>
-            <Title>Changes on {modCodeChange.branchName}: </Title>
+          <div key={branchName}>
+            <Title>Changes on {branchName}: </Title>
             <StyledButton
               className="cy-html-diff-btn"
               size="small"
               title="Open diff as html file"
-              href={modCodeChange.htmlLink}
+              href={htmlLink}
               target="_blank"
             >
               HTML
@@ -65,14 +63,14 @@ export const CodeChanges: React.FC = () => {
               className="cy-raw-diff-btn"
               size="small"
               title="Open diff as raw file"
-              href={modCodeChange.rawLink}
+              href={rawLink}
               target="_blank"
             >
               Raw
             </StyledButton>
             <StyledBadge>
-              <FileDiffText type="+" value={TotalFileDiff.additions} />
-              <FileDiffText type="-" value={TotalFileDiff.deletions} />
+              <FileDiffText type="+" value={additions} />
+              <FileDiffText type="-" value={deletions} />
             </StyledBadge>
             <CodeChangesTable fileDiffs={sortedFileDiffs} />
           </div>

--- a/src/pages/patch/patchTabs/CodeChanges.tsx
+++ b/src/pages/patch/patchTabs/CodeChanges.tsx
@@ -1,10 +1,11 @@
 import React from "react";
 import { useQuery } from "@apollo/client";
 import styled from "@emotion/styled";
+import Badge from "@leafygreen-ui/badge";
 import Button from "@leafygreen-ui/button";
 import { Skeleton } from "antd";
 import { useParams } from "react-router-dom";
-import { CodeChangesTable } from "components/CodeChangesTable";
+import { CodeChangesTable, FileDiffText } from "components/CodeChangesTable";
 import { H2 } from "components/Typography";
 import {
   CodeChangesQuery,
@@ -35,6 +36,19 @@ export const CodeChanges: React.FC = () => {
         const sortedFileDiffs = [...modCodeChange.fileDiffs].sort((a, b) =>
           a.fileName.localeCompare(b.fileName)
         );
+        const { fileDiffs } = modCodeChange;
+        const TotalFileDiff = {
+          additions: 0,
+          deletions: 0,
+        };
+        TotalFileDiff.additions = fileDiffs.reduce(
+          (total, diff) => total + diff.additions,
+          0
+        );
+        TotalFileDiff.deletions = fileDiffs.reduce(
+          (total, diff) => total + diff.deletions,
+          0
+        );
         return (
           <div key={modCodeChange.branchName}>
             <Title>Changes on {modCodeChange.branchName}: </Title>
@@ -56,6 +70,10 @@ export const CodeChanges: React.FC = () => {
             >
               Raw
             </StyledButton>
+            <StyledBadge>
+              <FileDiffText type="+" value={TotalFileDiff.additions} />
+              <FileDiffText type="-" value={TotalFileDiff.deletions} />
+            </StyledBadge>
             <CodeChangesTable fileDiffs={sortedFileDiffs} />
           </div>
         );
@@ -70,4 +88,8 @@ const StyledButton = styled(Button)`
 
 const Title = styled(H2)`
   font-weight: normal;
+`;
+
+const StyledBadge = styled(Badge)`
+  margin-left: 16px;
 `;


### PR DESCRIPTION
This PR adds the total code changes to the changes tab.
It also fixes the padding on the leafygreen tabs that was broken when we update @leafygreen-ui/tabs 

![image](https://user-images.githubusercontent.com/4605522/99578352-b606a500-29aa-11eb-8e7f-13229b87ee5f.png)
