### PR TITLE
EVG-12889: Simplify GQLWrapper and decrease the number of renders

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
 import { Global, css } from "@emotion/core";
-import { BrowserRouter as Router } from "react-router-dom";
+import { BrowserRouter as Router, Route } from "react-router-dom";
 import { Content } from "components/Content";
 import { ErrorBoundary } from "components/ErrorBoundary";
+import { routes } from "constants/routes";
 import { ContextProviders } from "context/Providers";
 import GQLWrapper from "gql/GQLWrapper";
 
@@ -26,11 +27,13 @@ import "antd/es/table/style/css";
 import "antd/es/collapse/style/css";
 import "antd/es/date-picker/style/css";
 import "antd/es/time-picker/style/css";
+import { Login } from "pages/Login";
 
 const App: React.FC = () => (
   <ErrorBoundary>
     <ContextProviders>
       <Router>
+        <Route path={routes.login} component={Login} />
         <GQLWrapper>
           <Global
             styles={css`

--- a/src/components/Content/index.tsx
+++ b/src/components/Content/index.tsx
@@ -24,7 +24,6 @@ import { CommitQueue } from "pages/CommitQueue";
 import { ConfigurePatch } from "pages/ConfigurePatch";
 import { Host } from "pages/Host";
 import { Hosts } from "pages/Hosts";
-import { Login } from "pages/Login";
 import { MyPatches } from "pages/MyPatches";
 import { Patch } from "pages/Patch";
 import { PatchRedirect } from "pages/PatchRedirect";
@@ -82,7 +81,6 @@ export const Content: React.FC = () => {
         <PrivateRoute exact path="/">
           <Redirect to={routes.myPatches} />
         </PrivateRoute>
-        <Route path={routes.login} component={Login} />
         <Route component={PageDoesNotExist} />
       </Switch>
       {!hasUsedSpruceBefore && <WelcomeModal />}

--- a/src/gql/GQLWrapper.tsx
+++ b/src/gql/GQLWrapper.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import {
   ApolloClient,
   ApolloProvider,
@@ -13,26 +13,18 @@ import { reportError } from "utils/errorReporting";
 import { getGQLUrl } from "utils/getEnvironmentVariables";
 
 const GQLWrapper: React.FC = ({ children }) => {
-  const [client, setClient] = useState(null);
   const { logout, dispatch } = useAuthDispatchContext();
-
-  useEffect(() => {
-    async function getAndSetClient(): Promise<void> {
-      const gqlClient = await getGQLClient({
+  return (
+    <ApolloProvider
+      client={getGQLClient({
         credentials: "include",
         gqlURL: getGQLUrl(),
         logout,
         dispatch,
-      });
-      setClient(gqlClient);
-    }
-    getAndSetClient();
-  }, [logout, dispatch]);
-
-  return client ? (
-    <ApolloProvider client={client}>{children}</ApolloProvider>
-  ) : (
-    <></>
+      })}
+    >
+      {children}
+    </ApolloProvider>
   );
 };
 
@@ -97,7 +89,7 @@ const retryLink = new RetryLink({
   },
 });
 
-export const getGQLClient = ({
+const getGQLClient = ({
   credentials,
   gqlURL,
   logout,

--- a/src/pages/userPatches/PatchCard.tsx
+++ b/src/pages/userPatches/PatchCard.tsx
@@ -4,7 +4,7 @@ import { uiColors } from "@leafygreen-ui/palette";
 import { format } from "date-fns";
 import { useUserPatchesAnalytics } from "analytics";
 import { PatchStatusBadge } from "components/PatchStatusBadge";
-import { StyledLink } from "components/styles";
+import { StyledRouterLink } from "components/styles";
 import { paths, getBuildStatusIconLink } from "constants/routes";
 import { Maybe } from "gql/generated/types";
 import { BuildStatusIcon } from "pages/userPatches/patchCard/BuildStatusIcon";
@@ -45,7 +45,7 @@ export const PatchCard: React.FC<Props> = ({
       <Left>
         <DescriptionLink
           data-cy="patch-card-patch-link"
-          href={`${paths.patch}/${id}`}
+          to={`${paths.patch}/${id}`}
           onClick={() =>
             userPatchesAnalytics.sendEvent({ name: "Click Patch Link" })
           }
@@ -121,7 +121,7 @@ const Right = styled.div`
   justify-content: flex-end;
 `;
 
-const DescriptionLink = styled(StyledLink)`
+const DescriptionLink = styled(StyledRouterLink)`
   font-size: 18px;
   font-weight: 500;
   padding-bottom: 8px;


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-12889
these code changes remove unnecessary async syntax, decrease the number of GQLWrapper renders from 3 to 2 and replace an `a` tag with a react router link