### PR TITLE
EVG-13386: use strict regex when variant link clicked

### DIFF
--- a/src/pages/patch/BuildVariants.tsx
+++ b/src/pages/patch/BuildVariants.tsx
@@ -49,7 +49,10 @@ export const BuildVariants: React.FC = () => {
           >
             <P1>
               <Link
-                to={`${getVersionRoute(id, { page: 0, variant })}`}
+                to={`${getVersionRoute(id, {
+                  page: 0,
+                  variant: `^${variant}$`, // strict regex
+                })}`}
                 onClick={() =>
                   patchAnalytics.sendEvent({
                     name: "Click Build Variant Grid Link",


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-13386

When variant link is clicked in the Build Variants metadata on the patch details page, surround variant with `^$` to match variants strictly by the variant clicked. 

### Example

Variants
- e2e_local
- e2e_local_with_daemon

`e2e_local` variant link is clicked => filter variants strictly by `e2e_local`, do not show variants that include `e2e_local` (i.e. `e2e_local_with_daemon`)