### PR TITLE
EVG-13169 Let users move between Issues and Suspect Issues on the UI

### DIFF
--- a/cypress/integration/task/annotations.ts
+++ b/cypress/integration/task/annotations.ts
@@ -5,7 +5,7 @@ const taskWithAnnotations =
 const taskRoute = `/task/${taskWithAnnotations}/annotations`;
 
 describe("Task Annotation Tab", () => {
-  before(() => {
+  beforeEach(() => {
     cy.login();
   });
 

--- a/cypress/integration/task/annotations.ts
+++ b/cypress/integration/task/annotations.ts
@@ -31,4 +31,24 @@ describe("Task Annotation Tab", () => {
     cy.get(dataCyTableRows2).should("have.length", 1);
     cy.get(dataCyTableRows).should("have.length", 3);
   });
+
+  it("annotations can be moved between lists", () => {
+    cy.visit(taskRoute);
+    const dataCyTableRows =
+      "[data-test-id=suspected-issues-table] tr td:first-child";
+
+    const dataCyTableRows2 = "[data-test-id=issues-table] tr td:first-child";
+    cy.get(dataCyTableRows2).should("have.length", 1);
+    cy.get(dataCyTableRows).should("have.length", 3);
+
+    cy.dataCy("move-btn-AnotherOne").first().click();
+    cy.get(popconfirmYesClassName).click();
+    cy.get(dataCyTableRows2).should("have.length", 2);
+    cy.get(dataCyTableRows).should("have.length", 2);
+
+    cy.dataCy("move-btn-AnotherOne").first().click();
+    cy.get(popconfirmYesClassName).click();
+    cy.get(dataCyTableRows2).should("have.length", 1);
+    cy.get(dataCyTableRows).should("have.length", 3);
+  });
 });

--- a/src/components/BuildBaronAndAnnotations/AnnotationTickets.tsx
+++ b/src/components/BuildBaronAndAnnotations/AnnotationTickets.tsx
@@ -9,6 +9,7 @@ import { AnnotationTicketsTable } from "./AnnotationTicketsTable";
 import { TicketsTitle, TitleAndButtons } from "./BBComponents";
 
 interface Props {
+  annotationId: string;
   taskId: string;
   execution: number;
   tickets: IssueLink[];
@@ -17,6 +18,7 @@ interface Props {
 }
 
 export const AnnotationTickets: React.FC<Props> = ({
+  annotationId,
   tickets,
   taskId,
   execution,
@@ -25,12 +27,11 @@ export const AnnotationTickets: React.FC<Props> = ({
 }) => {
   const title = isIssue ? "Issues" : "Suspected Issues";
   const buttonText = isIssue ? "Add Issue" : "Add Suspected Issue";
-
   const [
     isAddAnnotationModalVisible,
     setIsAddAnnotationModalVisible,
   ] = useState<boolean>(false);
-  return tickets?.length ? (
+  return (
     <>
       <TitleAndButtons>
         <TicketsTitle>{title} </TicketsTitle>
@@ -55,11 +56,12 @@ export const AnnotationTickets: React.FC<Props> = ({
       </TitleAndButtons>
       <AnnotationTicketsTable
         jiraIssues={tickets}
+        annotationId={annotationId}
         taskId={taskId}
         execution={execution}
         isIssue={isIssue}
         userCanModify={userCanModify}
-      />{" "}
+      />
       <AddIssueModal
         dataCy="addIssueModal"
         visible={isAddAnnotationModalVisible}
@@ -69,7 +71,7 @@ export const AnnotationTickets: React.FC<Props> = ({
         isIssue={isIssue}
       />
     </>
-  ) : null;
+  );
 };
 
 const StyledButton = styled(PlusButton)`

--- a/src/components/BuildBaronAndAnnotations/BuildBaron.tsx
+++ b/src/components/BuildBaronAndAnnotations/BuildBaron.tsx
@@ -34,6 +34,7 @@ const BuildBaron: React.FC<Props> = ({
     {bbData && (
       <BuildBaronContent
         bbData={bbData.buildBaron}
+        annotationId={annotation?.id}
         taskId={taskId}
         execution={execution}
         loading={loading}

--- a/src/components/BuildBaronAndAnnotations/BuildBaronContent.tsx
+++ b/src/components/BuildBaronAndAnnotations/BuildBaronContent.tsx
@@ -24,6 +24,7 @@ import { BuildBaronTable } from "./BuildBaronTable";
 
 interface BuildBaronCoreProps {
   bbData: BuildBaron;
+  annotationId: string;
   taskId: string;
   execution: number;
   loading: boolean;
@@ -33,6 +34,7 @@ interface BuildBaronCoreProps {
 
 const BuildBaronCore: React.FC<BuildBaronCoreProps> = ({
   bbData,
+  annotationId,
   taskId,
   execution,
   loading,
@@ -83,6 +85,7 @@ const BuildBaronCore: React.FC<BuildBaronCoreProps> = ({
               <AnnotationTickets
                 tickets={annotation?.issues}
                 isIssue
+                annotationId={annotationId}
                 taskId={taskId}
                 execution={execution}
                 userCanModify={userCanModify}
@@ -90,6 +93,7 @@ const BuildBaronCore: React.FC<BuildBaronCoreProps> = ({
               <AnnotationTickets
                 tickets={annotation?.suspectedIssues}
                 isIssue={false}
+                annotationId={annotationId}
                 taskId={taskId}
                 execution={execution}
                 userCanModify={userCanModify}


### PR DESCRIPTION
This change builds on EVG-13170, so I branched off of that branch. When reviewing this PR, please filter commits to only view the ones after the first one. (I will hold off merging, and only merge the new changes after the  EVG-13170 has been merged). 

![move_ann](https://user-images.githubusercontent.com/13104717/104030958-286d5780-519a-11eb-900d-763ff0938132.gif)
