### PR TITLE
EVG-13701 Add analytics for display task dropdown

### DIFF
--- a/src/analytics/addPageAction.ts
+++ b/src/analytics/addPageAction.ts
@@ -52,9 +52,7 @@ export const addPageAction = <A extends ActionType, P extends Properties>(
 
   if (typeof newrelic !== "object") {
     // These will only print when new relic is not available such as during local development
-    console.log("____ ANALYTICS EVENT ____");
-    console.log({ name });
-    console.log({ attributesToSend });
+    console.log("ANALYTICS EVENT ", { name, attributesToSend });
     return;
   }
 

--- a/src/analytics/addPageAction.ts
+++ b/src/analytics/addPageAction.ts
@@ -51,6 +51,10 @@ export const addPageAction = <A extends ActionType, P extends Properties>(
   };
 
   if (typeof newrelic !== "object") {
+    // These will only print when new relic is not available such as during local development
+    console.log("____ ANALYTICS EVENT ____");
+    console.log({ name });
+    console.log({ attributesToSend });
     return;
   }
 

--- a/src/analytics/patch/usePatchAnalytics.ts
+++ b/src/analytics/patch/usePatchAnalytics.ts
@@ -26,7 +26,8 @@ type Action =
   | {
       name: "Add Notification";
       subscription: SaveSubscriptionMutationVariables["subscription"];
-    };
+    }
+  | { name: "Toggle Display Task Dropdown"; expanded: boolean };
 
 interface P extends Properties {
   patchId: string;

--- a/src/pages/patch/patchTabs/tasks/TasksTable.tsx
+++ b/src/pages/patch/patchTabs/tasks/TasksTable.tsx
@@ -3,6 +3,7 @@ import { Table } from "antd";
 import { ColumnProps } from "antd/es/table";
 import get from "lodash/get";
 import { useHistory, useLocation } from "react-router-dom";
+import { usePatchAnalytics } from "analytics";
 import { TaskResult, SortDirection, PatchTasks } from "gql/generated/types";
 import { PatchTasksQueryParams, TableOnChange } from "types/task";
 import { stringifyQuery, parseQueryString } from "utils/queryString";
@@ -16,6 +17,7 @@ export const TasksTable: React.FC<Props> = ({ data, columns }) => {
   const { replace } = useHistory();
   const { search, pathname } = useLocation();
 
+  const patchAnalytics = usePatchAnalytics();
   const tableChangeHandler: TableOnChange<TaskResult> = (...[, , sorter]) => {
     const { order, columnKey } = Array.isArray(sorter) ? sorter[0] : sorter;
 
@@ -40,6 +42,14 @@ export const TasksTable: React.FC<Props> = ({ data, columns }) => {
       dataSource={get(data, "tasks", []) as TaskResult[]}
       onChange={tableChangeHandler}
       childrenColumnName="executionTasksFull"
+      expandable={{
+        onExpand: (expanded) => {
+          patchAnalytics.sendEvent({
+            name: "Toggle Display Task Dropdown",
+            expanded,
+          });
+        },
+      }}
     />
   );
 };


### PR DESCRIPTION
I added back the console.logs for analytics since they are useful when testing analytics locally. And they wont show up in production. 