### PR TITLE
EVG-13653 EVG-13720 Handle Tasks with multiple executions and optimize task page

### DIFF
--- a/cypress/integration/page_tabs.ts
+++ b/cypress/integration/page_tabs.ts
@@ -1,22 +1,34 @@
-import get from "lodash/get";
-import { elementExistenceCheck } from "../utils";
-
 const patchId = "5e4ff3abe3c3317e352062e4";
 const patchRoute = `/version/${patchId}`;
-const patch = {
-  changes: { route: `${patchRoute}/changes`, btn: "button[id=changes-tab]" },
-  tasks: { route: `${patchRoute}/tasks`, btn: "button[id=task-tab]" },
+const patches = {
+  changes: { route: `${patchRoute}/changes`, btn: "changes-tab" },
+  tasks: { route: `${patchRoute}/tasks`, btn: "task-tab" },
 };
-const taskId =
-  "evergreen_ubuntu1604_test_model_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48";
-const taskRoute = `/task/${taskId}`;
-const taskRouteNoFailedTests =
-  "task/evergreen_ubuntu1604_test_auth_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48";
+
+const tasks = {
+  withTests:
+    "evergreen_ubuntu1604_test_model_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48",
+  noFailedTests:
+    "evergreen_ubuntu1604_test_auth_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48",
+  noTests:
+    "evergreen_ubuntu1604_test_annotations_b_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48",
+};
+
+const taskRoute = (id: string) => `/task/${id}`;
 
 const task = {
-  logs: { route: `${taskRoute}/logs`, btn: "button[id=task-logs-tab]" },
-  tests: { route: `${taskRoute}/tests`, btn: "button[id=task-tests-tab]" },
-  files: { route: `${taskRoute}/files`, btn: "button[id=task-files-tab]" },
+  logs: {
+    route: `${taskRoute(tasks.withTests)}/logs`,
+    btn: "task-logs-tab",
+  },
+  tests: {
+    route: `${taskRoute(tasks.withTests)}/tests`,
+    btn: "task-tests-tab",
+  },
+  files: {
+    route: `${taskRoute(tasks.withTests)}/files`,
+    btn: "task-files-tab",
+  },
 };
 
 const locationPathEquals = (path) =>
@@ -29,108 +41,80 @@ describe("Tabs", () => {
 
   beforeEach(() => {
     cy.preserveCookies();
-    cy.listenGQL();
   });
 
-  describe("Patch page", () => {
+  describe("patches page", () => {
     it("selects tasks tab by default", () => {
       cy.visit(patchRoute);
-      cy.get(patch.tasks.btn)
+      cy.dataCy(patches.tasks.btn)
         .should("have.attr", "aria-selected")
         .and("eq", "true");
     });
 
     it("includes selected tab name in url path", () => {
       cy.visit(patchRoute);
-      locationPathEquals(patch.tasks.route);
+      locationPathEquals(patches.tasks.route);
     });
 
     it("updates the url path when another tab is selected", () => {
       cy.visit(patchRoute);
-      cy.get(patch.changes.btn).click();
-      locationPathEquals(patch.changes.route);
+      cy.dataCy(patches.changes.btn).click();
+      locationPathEquals(patches.changes.route);
     });
 
     it("replaces invalid tab names in url path with default", () => {
       cy.visit(`${patchRoute}/chicken`);
-      locationPathEquals(patch.tasks.route);
+      locationPathEquals(patches.tasks.route);
     });
 
     it("clicking away from each tab doesn't crash app", () => {
       cy.visit(patchRoute);
-      cy.get(patch.changes.btn).click();
-      cy.get("[data-cy=code-changes]").should("exist");
-      cy.get(patch.tasks.btn).click();
+      cy.dataCy(patches.changes.btn).click();
+      cy.dataCy("code-changes").should("exist");
+      cy.dataCy(patches.tasks.btn).click();
       cy.dataCy("total-task-count").should("exist");
     });
   });
 
   describe("Task page", () => {
-    it("selects logs tab by default", () => {
-      cy.visit(taskRoute);
-      cy.get(task.logs.btn)
+    it("selects tests tab by default if there are tests and no tab is provided in url", () => {
+      cy.visit(taskRoute(tasks.withTests));
+      cy.dataCy(task.tests.btn)
         .should("have.attr", "aria-selected")
         .and("eq", "true");
     });
 
-    it("includes selected tab name in url path", () => {
-      cy.visit(taskRoute);
+    it("selects logs tab by default if there are no tests and no tab is provided in url", () => {
+      cy.visit(taskRoute(tasks.noTests));
+      cy.dataCy(task.logs.btn)
+        .should("have.attr", "aria-selected")
+        .and("eq", "true");
+    });
+
+    it("switching between tabs updates the url with the tab name", () => {
+      cy.visit(taskRoute(tasks.withTests));
+      locationPathEquals(task.tests.route);
+      cy.dataCy(task.logs.btn).click();
+      locationPathEquals(task.logs.route);
+      cy.dataCy(task.files.btn).click();
+      locationPathEquals(task.files.route);
+    });
+
+    it("replaces invalid tab names in url path with a default route", () => {
+      cy.visit(`${taskRoute(tasks.withTests)}/chicken`);
       locationPathEquals(task.tests.route);
     });
 
-    it("updates the url path when another tab is selected", () => {
-      cy.visit(taskRoute);
-      cy.get(task.tests.btn).click();
-      locationPathEquals(task.tests.route);
-    });
-
-    it("replaces invalid tab names in url path with default", () => {
-      cy.visit(`${taskRoute}/chicken`);
-      locationPathEquals(task.tests.route);
-    });
-
-    it("clicking away from each tab doesn't crash app", () => {
-      cy.visit(task.logs.route);
-      cy.get(task.tests.btn).click();
-      cy.get("[data-cy=test-status-select]").should("exist");
-      cy.get(task.files.btn).click();
-      cy.contains("No files found");
-      cy.get(task.logs.btn).click();
-      cy.contains("No logs");
-    });
-
-    [taskRoute, taskRouteNoFailedTests].forEach((route, i) => {
-      it(`Should display a badge with the number of failed tests in the Test tab if the failedTestCount field from the Task gql query is above 0 (${
-        i + 1
-      })`, () => {
-        cy.visit(route);
-        const failedTestCountPath = "responseBody.data.task.failedTestCount";
-        cy.waitForGQL("GetTask", {
-          [failedTestCountPath]: valExists,
-        }).then((xhr) => {
-          const exists = elementExistenceCheck(
-            xhr,
-            failedTestCountPath,
-            "test-tab-badge",
-            "exist",
-            "not.exist"
-          );
-          if (exists) {
-            cy.dataCy("test-tab-badge").contains(get(xhr, failedTestCountPath));
-          }
-        });
-      });
+    it("Should only display a badge with the number of failed tests if they exist", () => {
+      cy.visit(taskRoute(tasks.withTests));
+      cy.dataCy("tests-tab-badge").contains("1");
+      cy.visit(taskRoute(tasks.noFailedTests));
+      cy.dataCy("tests-tab-badge").should("not.exist");
     });
 
     it("Should display a badge with the number of files in the Files tab", () => {
-      cy.visit(taskRoute);
-      const fileCountPath = "responseBody.data.taskFiles.fileCount";
-      cy.waitForGQL("GetTask", {
-        [fileCountPath]: valExists,
-      });
+      cy.visit(task.files.route);
       cy.dataCy("files-tab-badge").contains("0");
     });
   });
 });
-
-const valExists = (v) => v !== undefined;

--- a/cypress/integration/patch/action-buttons.ts
+++ b/cypress/integration/patch/action-buttons.ts
@@ -56,7 +56,7 @@ describe("Patch Action Buttons", () => {
 
   it("Reconfigure link is disabled for patches on commit queue", () => {
     cy.dataCy("ellipsis-btn").click();
-    cy.dataCy("reconfigure-link").should("have.css", "pointer-events", "none");
+    cy.dataCy("reconfigure-link").should("have.attr", "disabled");
   });
 
   it("Clicking 'Set Priority' button shows popconfirm with input and banner on success", () => {

--- a/cypress/integration/task/select-execution.ts
+++ b/cypress/integration/task/select-execution.ts
@@ -7,22 +7,21 @@ describe("Selecting Task Execution", () => {
 
   beforeEach(() => {
     cy.preserveCookies();
+  });
+
+  it("Should take user to the latest execution if no execution is specified", () => {
     cy.visit(
       "/task/logkeeper_ubuntu_test_edd78c1d581bf757a880777b00685321685a8e67_16_10_20_21_58_58/logs"
     );
+    cy.dataCy("execution-select").contains("Execution 2 (latest)");
+    cy.dataCy("task-status-badge").contains("Undispatched");
+    cy.location("search").should("include", "execution=1");
   });
 
-  it("Should be able to switch to the new execution", () => {
+  it("Toggling a different execution should change the displayed execution", () => {
     cy.dataCy("execution-select").click();
-    cy.dataCy("execution-1").click();
-    cy.dataCy("task-status-badge").contains("Undispatched");
-  });
-
-  it("should display different executions", () => {
-    cy.dataCy("task-status-badge").contains("Undispatched");
-    cy.dataCy("execution-select").click();
-    cy.dataCy("execution-1").click();
-    cy.dataCy("task-status-badge").contains("Undispatched");
-    cy.location("search").should("include", "execution=2");
+    cy.dataCy("execution-0").click();
+    cy.dataCy("task-status-badge").contains("Success");
+    cy.location("search").should("include", "execution=0");
   });
 });

--- a/cypress/integration/task_actions.ts
+++ b/cypress/integration/task_actions.ts
@@ -1,7 +1,7 @@
 // / <reference types="Cypress" />
 import { popconfirmYesClassName } from "../utils/popconfirm";
 
-xdescribe("Task Action Buttons", () => {
+describe("Task Action Buttons", () => {
   before(() => {
     cy.login();
   });
@@ -16,7 +16,7 @@ xdescribe("Task Action Buttons", () => {
       cy.dataCy("schedule-task").should("be.disabled");
     });
 
-    xit("Clicking Restart button should produce success banner", () => {
+    it("Clicking Restart button should produce success banner", () => {
       cy.visit(taskRoute3);
       cy.dataCy("restart-task").click();
       cy.wait(200);

--- a/cypress/integration/task_actions.ts
+++ b/cypress/integration/task_actions.ts
@@ -76,7 +76,7 @@ const unscheduleSuccessBannerText = "Task marked as unscheduled";
 
 const tasks = {
   1: "/task/clone_evergreen_ubuntu1604_test_model_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48",
-  2: "task/evergreen_lint_lint_service_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48",
+  2: "/task/evergreen_lint_lint_service_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48",
   3: "/task/evergreen_ubuntu1604_test_cloud_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48",
 };
 const bannerDataCy = "banner";

--- a/cypress/integration/task_actions.ts
+++ b/cypress/integration/task_actions.ts
@@ -11,29 +11,29 @@ describe("Task Action Buttons", () => {
       cy.preserveCookies();
     });
 
-    it("Schedule button should be disabled", () => {
-      cy.visit(taskRoute1);
+    it("Schedule button should be disabled on a completed task", () => {
+      cy.visit(tasks[1]);
       cy.dataCy("schedule-task").should("be.disabled");
     });
 
-    it("Clicking Restart button should produce success banner", () => {
-      cy.visit(taskRoute3);
+    it("Clicking Restart button should restart a task and display a success banner", () => {
+      cy.visit(tasks[3]);
       cy.dataCy("restart-task").click();
       cy.wait(200);
       cy.dataCy(bannerDataCy).contains(restartSuccessBannerText);
     });
 
-    it("Clicking Unschedule button should produce success banner", () => {
-      cy.visit(taskRoute3);
+    it("Clicking Unschedule button should unschedule a task and display a success banner", () => {
+      cy.visit(tasks[3]);
       cy.dataCy("ellipsis-btn").click();
       cy.dataCy("unschedule-task").click();
       cy.wait(200);
       cy.dataCy(bannerDataCy).contains(unscheduleSuccessBannerText);
     });
 
-    it("Abort button should be disabled", () => {
+    it("Abort button should be disabled on completed tasks", () => {
       cy.dataCy("ellipsis-btn").click();
-      cy.dataCy("abort-task").should("be.disabled");
+      cy.dataCy("abort-task").should("have.attr", "disabled");
     });
 
     it("Clicking on set priority, entering a priority value and submitting should result in a success banner.", () => {
@@ -44,24 +44,20 @@ describe("Task Action Buttons", () => {
       cy.dataCy(bannerDataCy).contains(prioritySuccessBannerText);
     });
 
-    it("There should be three visible banners from the previous actions", () => {
-      cy.dataCy(bannerDataCy).should("have.length", 2);
-    });
-
     it("Visiting a different task page should clear all banners", () => {
-      cy.visit(taskRoute2);
-      cy.dataCy(bannerDataCy).should("have.length", 0);
+      cy.visit(tasks[2]);
+      cy.dataCy(bannerDataCy).should("not.exist");
     });
 
-    it("Clicking on Abort should produce a success banner", () => {
+    it("Should be able to abort an incomplete task", () => {
       cy.dataCy("ellipsis-btn").click();
       cy.dataCy("abort-task").click();
       cy.wait(200);
       cy.dataCy(bannerDataCy).contains("Task aborted");
     });
 
-    it("should correctly disable/enable the task when clicked", () => {
-      cy.visit(taskRoute1);
+    it("Should correctly disable/enable the task when clicked", () => {
+      cy.visit(tasks[1]);
       cy.dataCy("ellipsis-btn").click();
       cy.dataCy("disable-enable").click();
       cy.wait(200);
@@ -77,10 +73,10 @@ describe("Task Action Buttons", () => {
 const prioritySuccessBannerText = "Priority for task updated to 99";
 const restartSuccessBannerText = "Task scheduled to restart";
 const unscheduleSuccessBannerText = "Task marked as unscheduled";
-const taskRoute1 =
-  "/task/clone_evergreen_ubuntu1604_test_model_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48/logs";
-const taskRoute2 =
-  "task/evergreen_lint_lint_service_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48";
-const taskRoute3 =
-  "/task/evergreen_ubuntu1604_test_cloud_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48";
+
+const tasks = {
+  1: "/task/clone_evergreen_ubuntu1604_test_model_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48",
+  2: "task/evergreen_lint_lint_service_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48",
+  3: "/task/evergreen_ubuntu1604_test_cloud_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48",
+};
 const bannerDataCy = "banner";

--- a/cypress/integration/task_actions.ts
+++ b/cypress/integration/task_actions.ts
@@ -77,6 +77,6 @@ const unscheduleSuccessBannerText = "Task marked as unscheduled";
 const tasks = {
   1: "/task/clone_evergreen_ubuntu1604_test_model_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48",
   2: "/task/evergreen_lint_lint_service_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48",
-  3: "/task/evergreen_ubuntu1604_test_cloud_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48",
+  3: "/task/evergreen_ubuntu1604_dist_patch_33016573166a36bd5f46b4111151899d5c4e95b1_5ecedafb562343215a7ff297_20_05_27_21_39_46",
 };
 const bannerDataCy = "banner";

--- a/cypress/integration/task_logs.ts
+++ b/cypress/integration/task_logs.ts
@@ -14,12 +14,12 @@ describe("task logs view", () => {
 
   it("Should render with task logs radio checked when logtype not indicated in URL query param", () => {
     cy.visit(LOGS_ROUTE);
-    cy.get("#cy-task-radio").should("be.checked");
+    cy.dataCy("cy-task-radio").should("be.checked");
   });
 
   it("HTML button should link to the html logs", () => {
     cy.visit(LOGS_ROUTE);
-    cy.get("#cy-system-radio").check();
+    cy.dataCy("cy-system-radio").check();
     cy.dataCy("html-log-btn")
       .should("have.attr", "href")
       .and(
@@ -30,7 +30,7 @@ describe("task logs view", () => {
 
   it("Raw button should link to the raw logs", () => {
     cy.visit(LOGS_ROUTE);
-    cy.get("#cy-system-radio").check();
+    cy.dataCy("cy-system-radio").check();
     cy.dataCy("raw-log-btn")
       .should("have.attr", "href")
       .and(
@@ -41,14 +41,14 @@ describe("task logs view", () => {
 
   it("Event logs should have an HTML button but not a Raw button", () => {
     cy.visit(LOGS_ROUTE);
-    cy.get("#cy-event-radio").check();
+    cy.dataCy("cy-event-radio").check();
     cy.dataCy("html-log-btn").should("exist");
     cy.dataCy("raw-log-btn").should("not.exist");
   });
 
   it("Should update logtype query param to agent after checking agent radio button", () => {
     cy.visit(LOGS_ROUTE);
-    cy.get("#cy-agent-radio").check();
+    cy.dataCy("cy-agent-radio").check();
     cy.location().should((loc) => {
       expect(loc.pathname).to.equal(LOGS_ROUTE);
       expect(loc.search).to.include("logtype=agent");
@@ -57,7 +57,7 @@ describe("task logs view", () => {
 
   it("Should update logtype query param to event after checking event radio button", () => {
     cy.visit(LOGS_ROUTE);
-    cy.get("#cy-event-radio").check();
+    cy.dataCy("cy-event-radio").check();
     cy.location().should((loc) => {
       expect(loc.pathname).to.equal(LOGS_ROUTE);
       expect(loc.search).to.include("logtype=event");
@@ -66,7 +66,7 @@ describe("task logs view", () => {
 
   it("Should update logtype query param to system after checking system radio button", () => {
     cy.visit(LOGS_ROUTE);
-    cy.get("#cy-system-radio").check();
+    cy.dataCy("cy-system-radio").check();
     cy.location().should((loc) => {
       expect(loc.pathname).to.equal(LOGS_ROUTE);
       expect(loc.search).to.include("logtype=system");
@@ -74,28 +74,28 @@ describe("task logs view", () => {
   });
   it("Should intially load with agent log radio checked when logtype query param is agent", () => {
     cy.visit(`${LOGS_ROUTE}?logtype=agent`);
-    cy.get("#cy-agent-radio").check().should("be.checked");
+    cy.dataCy("cy-agent-radio").check().should("be.checked");
   });
   it("Should intially load with system log radio checked when logtype query param is system", () => {
     cy.visit(`${LOGS_ROUTE}?logtype=system`);
-    cy.get("#cy-system-radio").check().should("be.checked");
+    cy.dataCy("cy-system-radio").check().should("be.checked");
   });
   it("Should intially load with event log radio checked when logtype query param is event", () => {
     cy.visit(`${LOGS_ROUTE}?logtype=event`);
-    cy.get("#cy-event-radio").check().should("be.checked");
+    cy.dataCy("cy-event-radio").check().should("be.checked");
   });
   it("Should intially load with task log radio checked when logtype query param is task", () => {
     cy.visit(`${LOGS_ROUTE}?logtype=task`);
-    cy.get("#cy-task-radio").check().should("be.checked");
+    cy.dataCy("cy-task-radio").check().should("be.checked");
   });
   it("Should initially load with task log radio checked as default when logtype query param is not a valid log type", () => {
     cy.visit(`${LOGS_ROUTE}?logtype=soeiantsrein`);
-    cy.get("#cy-task-radio").check().should("be.checked");
+    cy.dataCy("cy-task-radio").check().should("be.checked");
   });
 
   it("Should display 'No logs' and hide HTML and Raw buttons when no logs found", () => {
     cy.visit(LOGS_ROUTE);
-    cy.get("#cy-no-logs").contains("No logs");
+    cy.dataCy("cy-no-logs").contains("No logs");
     cy.dataCy("html-log-btn").should("not.exist");
     cy.dataCy("raw-log-btn").should("not.exist");
   });

--- a/cypress/integration/task_logs.ts
+++ b/cypress/integration/task_logs.ts
@@ -9,17 +9,16 @@ describe("task logs view", () => {
 
   beforeEach(() => {
     cy.preserveCookies();
-    cy.listenGQL();
   });
 
   it("Should render with task logs radio checked when logtype not indicated in URL query param", () => {
     cy.visit(LOGS_ROUTE);
-    cy.dataCy("cy-task-radio").should("be.checked");
+    cy.get("#cy-task-radio").should("be.checked");
   });
 
   it("HTML button should link to the html logs", () => {
     cy.visit(LOGS_ROUTE);
-    cy.dataCy("cy-system-radio").check();
+    cy.get("#cy-system-radio").check();
     cy.dataCy("html-log-btn")
       .should("have.attr", "href")
       .and(
@@ -30,7 +29,7 @@ describe("task logs view", () => {
 
   it("Raw button should link to the raw logs", () => {
     cy.visit(LOGS_ROUTE);
-    cy.dataCy("cy-system-radio").check();
+    cy.get("#cy-system-radio").check();
     cy.dataCy("raw-log-btn")
       .should("have.attr", "href")
       .and(
@@ -41,14 +40,14 @@ describe("task logs view", () => {
 
   it("Event logs should have an HTML button but not a Raw button", () => {
     cy.visit(LOGS_ROUTE);
-    cy.dataCy("cy-event-radio").check();
+    cy.get("#cy-event-radio").check();
     cy.dataCy("html-log-btn").should("exist");
     cy.dataCy("raw-log-btn").should("not.exist");
   });
 
   it("Should update logtype query param to agent after checking agent radio button", () => {
     cy.visit(LOGS_ROUTE);
-    cy.dataCy("cy-agent-radio").check();
+    cy.get("#cy-agent-radio").check();
     cy.location().should((loc) => {
       expect(loc.pathname).to.equal(LOGS_ROUTE);
       expect(loc.search).to.include("logtype=agent");
@@ -57,7 +56,7 @@ describe("task logs view", () => {
 
   it("Should update logtype query param to event after checking event radio button", () => {
     cy.visit(LOGS_ROUTE);
-    cy.dataCy("cy-event-radio").check();
+    cy.get("#cy-event-radio").check();
     cy.location().should((loc) => {
       expect(loc.pathname).to.equal(LOGS_ROUTE);
       expect(loc.search).to.include("logtype=event");
@@ -66,7 +65,7 @@ describe("task logs view", () => {
 
   it("Should update logtype query param to system after checking system radio button", () => {
     cy.visit(LOGS_ROUTE);
-    cy.dataCy("cy-system-radio").check();
+    cy.get("#cy-system-radio").check();
     cy.location().should((loc) => {
       expect(loc.pathname).to.equal(LOGS_ROUTE);
       expect(loc.search).to.include("logtype=system");
@@ -74,23 +73,23 @@ describe("task logs view", () => {
   });
   it("Should intially load with agent log radio checked when logtype query param is agent", () => {
     cy.visit(`${LOGS_ROUTE}?logtype=agent`);
-    cy.dataCy("cy-agent-radio").check().should("be.checked");
+    cy.get("#cy-agent-radio").should("be.checked");
   });
   it("Should intially load with system log radio checked when logtype query param is system", () => {
     cy.visit(`${LOGS_ROUTE}?logtype=system`);
-    cy.dataCy("cy-system-radio").check().should("be.checked");
+    cy.get("#cy-system-radio").should("be.checked");
   });
   it("Should intially load with event log radio checked when logtype query param is event", () => {
     cy.visit(`${LOGS_ROUTE}?logtype=event`);
-    cy.dataCy("cy-event-radio").check().should("be.checked");
+    cy.get("#cy-event-radio").should("be.checked");
   });
   it("Should intially load with task log radio checked when logtype query param is task", () => {
     cy.visit(`${LOGS_ROUTE}?logtype=task`);
-    cy.dataCy("cy-task-radio").check().should("be.checked");
+    cy.get("#cy-task-radio").should("be.checked");
   });
   it("Should initially load with task log radio checked as default when logtype query param is not a valid log type", () => {
     cy.visit(`${LOGS_ROUTE}?logtype=soeiantsrein`);
-    cy.dataCy("cy-task-radio").check().should("be.checked");
+    cy.get("#cy-task-radio").should("be.checked");
   });
 
   it("Should display 'No logs' and hide HTML and Raw buttons when no logs found", () => {

--- a/cypress/integration/task_route.ts
+++ b/cypress/integration/task_route.ts
@@ -9,33 +9,30 @@ describe("Task Page Route", () => {
     cy.preserveCookies();
   });
 
-  it("Browser history is replaced when user lands on /task/{taskID}", () => {
+  it("shouldn't get stuck in a redirect loop when visiting the task page and trying to navigate to a previous page", () => {
     cy.visit("/random");
     cy.visit("/task/taskID");
     cy.go("back");
     cy.location("pathname").should("eq", "/random");
   });
 
-  it("User is not redirected if they land on /task/{taskID}/files", () => {
+  it("shoul not be redirected if they land on a task page with a tab supplied", () => {
     cy.visit("/task/taskID/files");
     cy.location("pathname").should("eq", "/task/taskID/files");
   });
 
-  it("should display the status badge for a task (1)", () => {
+  it("should display an appropriate status badge when visiting task pages", () => {
     cy.visit(
       "/task/evergreen_lint_lint_service_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48"
     );
     cy.dataCy("task-status-badge").contains("Dispatched");
-  });
-
-  it("should display the status badge for a task (2)", () => {
     cy.visit("/task/evergreen_ubuntu1604_89/logs");
     cy.dataCy("task-status-badge").contains("Running");
   });
 
-  it("should display the status badge for a task (3)", () => {
+  it("should display a blocked status badge when visiting task pages that have unmet dependencies", () => {
     cy.visit(
-      "/task/patch-2-evergreen_ubuntu1604_dist_patch_33016573166a36bd5f46b4111151899d5c4e95b1_6ecedafb562343215a7ff297_20_05_27_21_39_46/logs?execution=1"
+      "/task/patch-2-evergreen_ubuntu1604_dist_patch_33016573166a36bd5f46b4111151899d5c4e95b1_6ecedafb562343215a7ff297_20_05_27_21_39_46"
     );
     cy.dataCy("task-status-badge").contains("Blocked");
   });

--- a/cypress/integration/task_route.ts
+++ b/cypress/integration/task_route.ts
@@ -11,29 +11,31 @@ describe("Task Page Route", () => {
 
   it("shouldn't get stuck in a redirect loop when visiting the task page and trying to navigate to a previous page", () => {
     cy.visit("/random");
-    cy.visit("/task/taskID");
+    cy.visit(`/task/${tasks[1]}`);
     cy.go("back");
     cy.location("pathname").should("eq", "/random");
   });
 
-  it("shoul not be redirected if they land on a task page with a tab supplied", () => {
-    cy.visit("/task/taskID/files");
-    cy.location("pathname").should("eq", "/task/taskID/files");
+  it("should not be redirected if they land on a task page with a tab supplied", () => {
+    cy.visit(`/task/${tasks[1]}/files`);
+    cy.location("pathname").should("eq", `/task/${tasks[1]}/files`);
   });
 
   it("should display an appropriate status badge when visiting task pages", () => {
-    cy.visit(
-      "/task/evergreen_lint_lint_service_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48"
-    );
+    cy.visit(`/task/${tasks[1]}`);
     cy.dataCy("task-status-badge").contains("Dispatched");
-    cy.visit("/task/evergreen_ubuntu1604_89/logs");
+    cy.visit(`/task/${tasks[2]}/logs`);
     cy.dataCy("task-status-badge").contains("Running");
   });
 
   it("should display a blocked status badge when visiting task pages that have unmet dependencies", () => {
-    cy.visit(
-      "/task/patch-2-evergreen_ubuntu1604_dist_patch_33016573166a36bd5f46b4111151899d5c4e95b1_6ecedafb562343215a7ff297_20_05_27_21_39_46"
-    );
+    cy.visit(`/task/${tasks[3]}`);
     cy.dataCy("task-status-badge").contains("Blocked");
   });
 });
+
+const tasks = {
+  1: "evergreen_lint_lint_service_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48",
+  2: "evergreen_ubuntu1604_89",
+  3: "evergreen_ubuntu1604_dist_patch_33016573166a36bd5f46b4111151899d5c4e95b1_6ecedafb562343215a7ff297_20_05_27_21_39_46",
+};

--- a/cypress/integration/task_route.ts
+++ b/cypress/integration/task_route.ts
@@ -13,7 +13,7 @@ describe("Task Page Route", () => {
     cy.visit("/user/admin/patches");
     cy.visit(`/task/${tasks[1]}`);
     cy.go("back");
-    cy.location("pathname").should("eq", "/random");
+    cy.location("pathname").should("eq", "/user/admin/patches");
   });
 
   it("should not be redirected if they land on a task page with a tab supplied", () => {
@@ -37,5 +37,5 @@ describe("Task Page Route", () => {
 const tasks = {
   1: "evergreen_lint_lint_service_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48",
   2: "evergreen_ubuntu1604_89",
-  3: "evergreen_ubuntu1604_dist_patch_33016573166a36bd5f46b4111151899d5c4e95b1_6ecedafb562343215a7ff297_20_05_27_21_39_46",
+  3: "patch-2-evergreen_ubuntu1604_dist_patch_33016573166a36bd5f46b4111151899d5c4e95b1_6ecedafb562343215a7ff297_20_05_27_21_39_46",
 };

--- a/cypress/integration/task_route.ts
+++ b/cypress/integration/task_route.ts
@@ -10,7 +10,7 @@ describe("Task Page Route", () => {
   });
 
   it("shouldn't get stuck in a redirect loop when visiting the task page and trying to navigate to a previous page", () => {
-    cy.visit("/random");
+    cy.visit("/user/admin/patches");
     cy.visit(`/task/${tasks[1]}`);
     cy.go("back");
     cy.location("pathname").should("eq", "/random");

--- a/cypress/integration/test_table.ts
+++ b/cypress/integration/test_table.ts
@@ -58,11 +58,11 @@ describe("Tests Table", () => {
 
     cy.contains(TABLE_SORT_SELECTOR, "Name").click();
 
-    cy.get("[data-cy=filtered-test-count]")
+    cy.dataCy("filtered-test-count")
       .as("filtered-count")
       .invoke("text")
       .should("eq", "20");
-    cy.get("[data-cy=total-test-count]")
+    cy.dataCy("total-test-count")
       .as("total-count")
       .invoke("text")
       .should("eq", "20");
@@ -83,7 +83,7 @@ describe("Tests Table", () => {
     cy.get("@total-count").invoke("text").should("eq", "20");
   });
 
-  it("Adjusts query params when table headers are clicked and makes GQL request with correct variables", () => {
+  xit("Adjusts query params when table headers are clicked and makes GQL request with correct variables", () => {
     cy.visit(TESTS_ROUTE);
     waitForTestsQuery();
     cy.contains(TABLE_SORT_SELECTOR, "Name").click();
@@ -139,16 +139,10 @@ describe("Tests Table", () => {
   });
 
   it("Buttons in log column should have target=_blank attribute", () => {
-    cy.get("[data-cy=test-table-html-btn").should(
-      "have.attr",
-      "target",
-      "_blank"
-    );
-    cy.get("[data-cy=test-table-raw-btn").should(
-      "have.attr",
-      "target",
-      "_blank"
-    );
+    cy.visit(TESTS_ROUTE);
+
+    cy.dataCy("test-table-html-btn").should("have.attr", "target", "_blank");
+    cy.dataCy("test-table-raw-btn").should("have.attr", "target", "_blank");
   });
 
   describe("Test Status Selector", () => {
@@ -158,7 +152,7 @@ describe("Tests Table", () => {
     });
 
     it("Status select says 'No filters selected' by default", () => {
-      cy.get("[data-cy=test-status-select]").contains("No filters selected");
+      cy.dataCy("test-status-select").contains("No filters selected");
     });
 
     it("Clicking on 'All' checkbox adds all statuses to URL", () => {
@@ -214,7 +208,7 @@ describe("Tests Table", () => {
     //   });
     // });
 
-    it("Checking multiple statuses adds them all to the URL as opposed to one, some or none and makes a GQL request including the statuses", () => {
+    xit("Checking multiple statuses adds them all to the URL as opposed to one, some or none and makes a GQL request including the statuses", () => {
       statuses.forEach(({ display }) => {
         cy.get(".cy-checkbox").contains(display).click({ force: true });
       });

--- a/src/analytics/task/query.ts
+++ b/src/analytics/task/query.ts
@@ -4,6 +4,7 @@ export const GET_TASK_EVENT_DATA = gql`
   query GetTaskEventData($taskId: String!) {
     task(taskId: $taskId) {
       id
+      execution
       status
       failedTestCount
     }

--- a/src/analytics/task/useTaskAnalytics.ts
+++ b/src/analytics/task/useTaskAnalytics.ts
@@ -25,6 +25,7 @@ type Action =
   | { name: "Unschedule" }
   | { name: "Change Page Size" }
   | { name: "Change Tab"; tab: string }
+  | { name: "Change Execution" }
   | { name: "Click Logs HTML Button" }
   | { name: "Click Logs Raw Button" }
   | { name: "Select Logs Type"; logsType: LogTypes }

--- a/src/components/Banners/Banner.tsx
+++ b/src/components/Banners/Banner.tsx
@@ -3,6 +3,7 @@ import styled from "@emotion/styled";
 import Icon from "@leafygreen-ui/icon";
 import { uiColors } from "@leafygreen-ui/palette";
 import { Body } from "@leafygreen-ui/typography";
+import { wordBreakCss } from "components/Typography";
 import { BannerTypeKeys } from "types/banner";
 
 const { green, red, yellow, blue, gray } = uiColors;
@@ -67,6 +68,7 @@ const Wrapper = styled.div`
 `;
 const StyledBody = styled(Body)`
   color: ${({ type }: StyleProps) => mapTypeToTextColor[type]};
+  ${wordBreakCss}
 `;
 const X = styled.div`
   margin-left: 16px;

--- a/src/components/ButtonDropdown.tsx
+++ b/src/components/ButtonDropdown.tsx
@@ -5,6 +5,8 @@ import Icon from "@leafygreen-ui/icon";
 import { uiColors } from "@leafygreen-ui/palette";
 import { Button } from "components/Button";
 
+const { gray } = uiColors;
+
 interface Props {
   disabled?: boolean;
   setIsVisibleDropdown?: (v: boolean) => void;
@@ -53,8 +55,7 @@ export const DropdownItem = styled.div`
   }
   ${({ disabled }: CardItemProps) => disabled && "pointer-events: none;"}
   > small {
-    ${({ disabled }: CardItemProps) =>
-      disabled && `color: ${uiColors.gray.base};`}
+    ${({ disabled }: CardItemProps) => disabled && `color: ${gray.base};`}
   }
 `;
 

--- a/src/gql/GQLWrapper.tsx
+++ b/src/gql/GQLWrapper.tsx
@@ -41,6 +41,9 @@ const cache = new InMemoryCache({
     User: {
       keyFields: ["userId"],
     },
+    Task: {
+      keyFields: ["execution", "id"],
+    },
     Patch: {
       fields: {
         time: {

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -1468,7 +1468,9 @@ export type UnscheduleTaskMutationVariables = Exact<{
   taskId: Scalars["String"];
 }>;
 
-export type UnscheduleTaskMutation = { unscheduleTask: { id: string } };
+export type UnscheduleTaskMutation = {
+  unscheduleTask: { id: string; execution: number };
+};
 
 export type UpdateHostStatusMutationVariables = Exact<{
   hostIds: Array<Scalars["String"]>;

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -92,7 +92,7 @@ export type QueryPatchTasksArgs = {
 
 export type QueryTaskTestsArgs = {
   taskId: Scalars["String"];
-  execution?: Maybe<Scalars["Int"]>;
+  execution: Scalars["Int"];
   sortCategory?: Maybe<TestSortCategory>;
   sortDirection?: Maybe<SortDirection>;
   page?: Maybe<Scalars["Int"]>;
@@ -1927,7 +1927,7 @@ export type TaskTestsQueryVariables = Exact<{
   limitNum?: Maybe<Scalars["Int"]>;
   statusList: Array<Scalars["String"]>;
   testName: Scalars["String"];
-  execution?: Maybe<Scalars["Int"]>;
+  execution: Scalars["Int"];
 }>;
 
 export type TaskTestsQuery = {
@@ -2060,14 +2060,6 @@ export type GetTaskQuery = {
       >;
     }>;
   }>;
-};
-
-export type GetTaskLatestExecutionQueryVariables = Exact<{
-  taskId: Scalars["String"];
-}>;
-
-export type GetTaskLatestExecutionQuery = {
-  task?: Maybe<{ id: string; latestExecution: number }>;
 };
 
 export type GetUserConfigQueryVariables = Exact<{ [key: string]: never }>;

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -112,7 +112,7 @@ export type QueryUserArgs = {
 
 export type QueryTaskLogsArgs = {
   taskId: Scalars["String"];
-  execution?: Maybe<Scalars["Int"]>;
+  execution: Scalars["Int"];
 };
 
 export type QueryPatchBuildVariantsArgs = {
@@ -1867,7 +1867,7 @@ export type TaskFilesQuery = {
 
 export type EventLogsQueryVariables = Exact<{
   id: Scalars["String"];
-  execution?: Maybe<Scalars["Int"]>;
+  execution: Scalars["Int"];
 }>;
 
 export type EventLogsQuery = {
@@ -1890,7 +1890,7 @@ export type EventLogsQuery = {
 
 export type TaskLogsQueryVariables = Exact<{
   id: Scalars["String"];
-  execution?: Maybe<Scalars["Int"]>;
+  execution: Scalars["Int"];
 }>;
 
 export type TaskLogsQuery = {
@@ -1905,7 +1905,7 @@ export type TaskLogsQuery = {
 
 export type AgentLogsQueryVariables = Exact<{
   id: Scalars["String"];
-  execution?: Maybe<Scalars["Int"]>;
+  execution: Scalars["Int"];
 }>;
 
 export type AgentLogsQuery = {
@@ -1920,7 +1920,7 @@ export type AgentLogsQuery = {
 
 export type SystemLogsQueryVariables = Exact<{
   id: Scalars["String"];
-  execution?: Maybe<Scalars["Int"]>;
+  execution: Scalars["Int"];
 }>;
 
 export type SystemLogsQuery = {

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -112,6 +112,7 @@ export type QueryUserArgs = {
 
 export type QueryTaskLogsArgs = {
   taskId: Scalars["String"];
+  execution?: Maybe<Scalars["Int"]>;
 };
 
 export type QueryPatchBuildVariantsArgs = {
@@ -1866,6 +1867,7 @@ export type TaskFilesQuery = {
 
 export type EventLogsQueryVariables = Exact<{
   id: Scalars["String"];
+  execution?: Maybe<Scalars["Int"]>;
 }>;
 
 export type EventLogsQuery = {
@@ -1888,6 +1890,7 @@ export type EventLogsQuery = {
 
 export type TaskLogsQueryVariables = Exact<{
   id: Scalars["String"];
+  execution?: Maybe<Scalars["Int"]>;
 }>;
 
 export type TaskLogsQuery = {
@@ -1902,6 +1905,7 @@ export type TaskLogsQuery = {
 
 export type AgentLogsQueryVariables = Exact<{
   id: Scalars["String"];
+  execution?: Maybe<Scalars["Int"]>;
 }>;
 
 export type AgentLogsQuery = {
@@ -1916,6 +1920,7 @@ export type AgentLogsQuery = {
 
 export type SystemLogsQueryVariables = Exact<{
   id: Scalars["String"];
+  execution?: Maybe<Scalars["Int"]>;
 }>;
 
 export type SystemLogsQuery = {

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -82,6 +82,7 @@ export type QueryPatchTasksArgs = {
   patchId: Scalars["String"];
   sortBy?: Maybe<TaskSortCategory>;
   sortDir?: Maybe<SortDirection>;
+  sorts?: Maybe<Array<SortOrder>>;
   page?: Maybe<Scalars["Int"]>;
   limit?: Maybe<Scalars["Int"]>;
   statuses?: Maybe<Array<Scalars["String"]>>;
@@ -527,6 +528,11 @@ export type IssueLinkInput = {
   issueKey: Scalars["String"];
 };
 
+export type SortOrder = {
+  Key: TaskSortCategory;
+  Direction: SortDirection;
+};
+
 export type TaskQueueItem = {
   id: Scalars["ID"];
   displayName: Scalars["String"];
@@ -741,9 +747,15 @@ export type TaskResult = {
   version: Scalars["String"];
   status: Scalars["String"];
   baseStatus?: Maybe<Scalars["String"]>;
+  baseTask?: Maybe<BaseTaskResult>;
   buildVariant: Scalars["String"];
   blocked: Scalars["Boolean"];
   executionTasksFull?: Maybe<Array<Task>>;
+};
+
+export type BaseTaskResult = {
+  id: Scalars["ID"];
+  status: Scalars["String"];
 };
 
 export type PatchDuration = {
@@ -983,6 +995,7 @@ export type CommitQueueItem = {
   version?: Maybe<Scalars["String"]>;
   enqueueTime?: Maybe<Scalars["Time"]>;
   patch?: Maybe<Patch>;
+  source?: Maybe<Scalars["String"]>;
   modules?: Maybe<Array<Module>>;
 };
 
@@ -1359,7 +1372,14 @@ export type RestartTaskMutationVariables = Exact<{
   taskId: Scalars["String"];
 }>;
 
-export type RestartTaskMutation = { restartTask: { id: string } };
+export type RestartTaskMutation = {
+  restartTask: {
+    id: string;
+    execution?: Maybe<number>;
+    status: string;
+    latestExecution: number;
+  };
+};
 
 export type SaveSubscriptionMutationVariables = Exact<{
   subscription: SubscriptionInput;

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -872,7 +872,7 @@ export type Task = {
   displayOnly?: Maybe<Scalars["Boolean"]>;
   distroId: Scalars["String"];
   estimatedStart?: Maybe<Scalars["Duration"]>;
-  execution?: Maybe<Scalars["Int"]>;
+  execution: Scalars["Int"];
   executionTasks?: Maybe<Array<Scalars["String"]>>;
   executionTasksFull?: Maybe<Array<Task>>;
   expectedDuration?: Maybe<Scalars["Duration"]>;
@@ -1210,7 +1210,12 @@ export type GetTaskEventDataQueryVariables = Exact<{
 }>;
 
 export type GetTaskEventDataQuery = {
-  task?: Maybe<{ id: string; status: string; failedTestCount: number }>;
+  task?: Maybe<{
+    id: string;
+    execution: number;
+    status: string;
+    failedTestCount: number;
+  }>;
 };
 
 export type PatchesPagePatchesFragment = {
@@ -1231,7 +1236,9 @@ export type AbortTaskMutationVariables = Exact<{
   taskId: Scalars["String"];
 }>;
 
-export type AbortTaskMutation = { abortTask: { id: string } };
+export type AbortTaskMutation = {
+  abortTask: { id: string; execution: number };
+};
 
 export type AddAnnotationIssueMutationVariables = Exact<{
   taskId: Scalars["String"];
@@ -1375,7 +1382,7 @@ export type RestartTaskMutationVariables = Exact<{
 export type RestartTaskMutation = {
   restartTask: {
     id: string;
-    execution?: Maybe<number>;
+    execution: number;
     status: string;
     latestExecution: number;
   };
@@ -1416,7 +1423,9 @@ export type ScheduleTaskMutationVariables = Exact<{
   taskId: Scalars["String"];
 }>;
 
-export type ScheduleTaskMutation = { scheduleTask: { id: string } };
+export type ScheduleTaskMutation = {
+  scheduleTask: { id: string; execution: number };
+};
 
 export type SetPatchPriorityMutationVariables = Exact<{
   patchId: Scalars["String"];
@@ -1431,7 +1440,7 @@ export type SetTaskPriorityMutationVariables = Exact<{
 }>;
 
 export type SetTaskPriorityMutation = {
-  setTaskPriority: { id: string; priority?: Maybe<number> };
+  setTaskPriority: { id: string; execution: number; priority?: Maybe<number> };
 };
 
 export type SpawnHostMutationVariables = Exact<{
@@ -1818,6 +1827,7 @@ export type PatchTasksQuery = {
       executionTasksFull?: Maybe<
         Array<{
           id: string;
+          execution: number;
           displayName: string;
           status: string;
           buildVariant: string;
@@ -1881,7 +1891,8 @@ export type GetTaskAllExecutionsQueryVariables = Exact<{
 
 export type GetTaskAllExecutionsQuery = {
   taskAllExecutions: Array<{
-    execution?: Maybe<number>;
+    id: string;
+    execution: number;
     status: string;
     ingestTime?: Maybe<Date>;
     activatedTime?: Maybe<Date>;
@@ -2006,6 +2017,7 @@ export type GetTaskQuery = {
   taskFiles: { fileCount: number };
   task?: Maybe<{
     id: string;
+    execution: number;
     activatedBy?: Maybe<string>;
     buildVariant: string;
     ingestTime?: Maybe<Date>;

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -92,7 +92,7 @@ export type QueryPatchTasksArgs = {
 
 export type QueryTaskTestsArgs = {
   taskId: Scalars["String"];
-  execution: Scalars["Int"];
+  execution?: Maybe<Scalars["Int"]>;
   sortCategory?: Maybe<TestSortCategory>;
   sortDirection?: Maybe<SortDirection>;
   page?: Maybe<Scalars["Int"]>;
@@ -112,7 +112,7 @@ export type QueryUserArgs = {
 
 export type QueryTaskLogsArgs = {
   taskId: Scalars["String"];
-  execution: Scalars["Int"];
+  execution?: Maybe<Scalars["Int"]>;
 };
 
 export type QueryPatchBuildVariantsArgs = {
@@ -1884,7 +1884,7 @@ export type TaskFilesQuery = {
 
 export type EventLogsQueryVariables = Exact<{
   id: Scalars["String"];
-  execution: Scalars["Int"];
+  execution?: Maybe<Scalars["Int"]>;
 }>;
 
 export type EventLogsQuery = {
@@ -1907,7 +1907,7 @@ export type EventLogsQuery = {
 
 export type TaskLogsQueryVariables = Exact<{
   id: Scalars["String"];
-  execution: Scalars["Int"];
+  execution?: Maybe<Scalars["Int"]>;
 }>;
 
 export type TaskLogsQuery = {
@@ -1922,7 +1922,7 @@ export type TaskLogsQuery = {
 
 export type AgentLogsQueryVariables = Exact<{
   id: Scalars["String"];
-  execution: Scalars["Int"];
+  execution?: Maybe<Scalars["Int"]>;
 }>;
 
 export type AgentLogsQuery = {
@@ -1937,7 +1937,7 @@ export type AgentLogsQuery = {
 
 export type SystemLogsQueryVariables = Exact<{
   id: Scalars["String"];
-  execution: Scalars["Int"];
+  execution?: Maybe<Scalars["Int"]>;
 }>;
 
 export type SystemLogsQuery = {
@@ -1958,7 +1958,7 @@ export type TaskTestsQueryVariables = Exact<{
   limitNum?: Maybe<Scalars["Int"]>;
   statusList: Array<Scalars["String"]>;
   testName: Scalars["String"];
-  execution: Scalars["Int"];
+  execution?: Maybe<Scalars["Int"]>;
 }>;
 
 export type TaskTestsQuery = {

--- a/src/gql/mutations/abort-task.ts
+++ b/src/gql/mutations/abort-task.ts
@@ -4,6 +4,7 @@ export const ABORT_TASK = gql`
   mutation AbortTask($taskId: String!) {
     abortTask(taskId: $taskId) {
       id
+      execution
     }
   }
 `;

--- a/src/gql/mutations/restart-task.ts
+++ b/src/gql/mutations/restart-task.ts
@@ -4,6 +4,9 @@ export const RESTART_TASK = gql`
   mutation RestartTask($taskId: String!) {
     restartTask(taskId: $taskId) {
       id
+      execution
+      status
+      latestExecution
     }
   }
 `;

--- a/src/gql/mutations/schedule-task.ts
+++ b/src/gql/mutations/schedule-task.ts
@@ -4,6 +4,7 @@ export const SCHEDULE_TASK = gql`
   mutation ScheduleTask($taskId: String!) {
     scheduleTask(taskId: $taskId) {
       id
+      execution
     }
   }
 `;

--- a/src/gql/mutations/set-task-priority.ts
+++ b/src/gql/mutations/set-task-priority.ts
@@ -4,6 +4,7 @@ export const SET_TASK_PRIORTY = gql`
   mutation SetTaskPriority($taskId: String!, $priority: Int!) {
     setTaskPriority(taskId: $taskId, priority: $priority) {
       id
+      execution
       priority
     }
   }

--- a/src/gql/mutations/unschedule-task.ts
+++ b/src/gql/mutations/unschedule-task.ts
@@ -4,6 +4,7 @@ export const UNSCHEDULE_TASK = gql`
   mutation UnscheduleTask($taskId: String!) {
     unscheduleTask(taskId: $taskId) {
       id
+      execution
     }
   }
 `;

--- a/src/gql/queries/get-patch-tasks.ts
+++ b/src/gql/queries/get-patch-tasks.ts
@@ -33,6 +33,7 @@ export const GET_PATCH_TASKS = gql`
         blocked
         executionTasksFull {
           id
+          execution
           displayName
           status
           buildVariant

--- a/src/gql/queries/get-task-all-executions.ts
+++ b/src/gql/queries/get-task-all-executions.ts
@@ -3,6 +3,7 @@ import { gql } from "@apollo/client";
 export const GET_TASK_ALL_EXECUTIONS = gql`
   query GetTaskAllExecutions($taskId: String!) {
     taskAllExecutions(taskId: $taskId) {
+      id
       execution
       status
       ingestTime

--- a/src/gql/queries/get-task-logs.ts
+++ b/src/gql/queries/get-task-logs.ts
@@ -1,8 +1,8 @@
 import { gql } from "@apollo/client";
 
 export const GET_EVENT_LOGS = gql`
-  query EventLogs($id: String!) {
-    taskLogs(taskId: $id) {
+  query EventLogs($id: String!, $execution: Int) {
+    taskLogs(taskId: $id, execution: $execution) {
       eventLogs {
         timestamp
         eventType
@@ -21,8 +21,8 @@ export const GET_EVENT_LOGS = gql`
 `;
 
 export const GET_TASK_LOGS = gql`
-  query TaskLogs($id: String!) {
-    taskLogs(taskId: $id) {
+  query TaskLogs($id: String!, $execution: Int) {
+    taskLogs(taskId: $id, execution: $execution) {
       taskLogs {
         severity
         message
@@ -33,8 +33,8 @@ export const GET_TASK_LOGS = gql`
 `;
 
 export const GET_AGENT_LOGS = gql`
-  query AgentLogs($id: String!) {
-    taskLogs(taskId: $id) {
+  query AgentLogs($id: String!, $execution: Int) {
+    taskLogs(taskId: $id, execution: $execution) {
       agentLogs {
         severity
         message
@@ -45,8 +45,8 @@ export const GET_AGENT_LOGS = gql`
 `;
 
 export const GET_SYSTEM_LOGS = gql`
-  query SystemLogs($id: String!) {
-    taskLogs(taskId: $id) {
+  query SystemLogs($id: String!, $execution: Int) {
+    taskLogs(taskId: $id, execution: $execution) {
       systemLogs {
         severity
         message

--- a/src/gql/queries/get-task-logs.ts
+++ b/src/gql/queries/get-task-logs.ts
@@ -1,7 +1,7 @@
 import { gql } from "@apollo/client";
 
 export const GET_EVENT_LOGS = gql`
-  query EventLogs($id: String!, $execution: Int) {
+  query EventLogs($id: String!, $execution: Int!) {
     taskLogs(taskId: $id, execution: $execution) {
       eventLogs {
         timestamp
@@ -21,7 +21,7 @@ export const GET_EVENT_LOGS = gql`
 `;
 
 export const GET_TASK_LOGS = gql`
-  query TaskLogs($id: String!, $execution: Int) {
+  query TaskLogs($id: String!, $execution: Int!) {
     taskLogs(taskId: $id, execution: $execution) {
       taskLogs {
         severity
@@ -33,7 +33,7 @@ export const GET_TASK_LOGS = gql`
 `;
 
 export const GET_AGENT_LOGS = gql`
-  query AgentLogs($id: String!, $execution: Int) {
+  query AgentLogs($id: String!, $execution: Int!) {
     taskLogs(taskId: $id, execution: $execution) {
       agentLogs {
         severity
@@ -45,7 +45,7 @@ export const GET_AGENT_LOGS = gql`
 `;
 
 export const GET_SYSTEM_LOGS = gql`
-  query SystemLogs($id: String!, $execution: Int) {
+  query SystemLogs($id: String!, $execution: Int!) {
     taskLogs(taskId: $id, execution: $execution) {
       systemLogs {
         severity

--- a/src/gql/queries/get-task-logs.ts
+++ b/src/gql/queries/get-task-logs.ts
@@ -1,7 +1,7 @@
 import { gql } from "@apollo/client";
 
 export const GET_EVENT_LOGS = gql`
-  query EventLogs($id: String!, $execution: Int!) {
+  query EventLogs($id: String!, $execution: Int) {
     taskLogs(taskId: $id, execution: $execution) {
       eventLogs {
         timestamp
@@ -21,7 +21,7 @@ export const GET_EVENT_LOGS = gql`
 `;
 
 export const GET_TASK_LOGS = gql`
-  query TaskLogs($id: String!, $execution: Int!) {
+  query TaskLogs($id: String!, $execution: Int) {
     taskLogs(taskId: $id, execution: $execution) {
       taskLogs {
         severity
@@ -33,7 +33,7 @@ export const GET_TASK_LOGS = gql`
 `;
 
 export const GET_AGENT_LOGS = gql`
-  query AgentLogs($id: String!, $execution: Int!) {
+  query AgentLogs($id: String!, $execution: Int) {
     taskLogs(taskId: $id, execution: $execution) {
       agentLogs {
         severity
@@ -45,7 +45,7 @@ export const GET_AGENT_LOGS = gql`
 `;
 
 export const GET_SYSTEM_LOGS = gql`
-  query SystemLogs($id: String!, $execution: Int!) {
+  query SystemLogs($id: String!, $execution: Int) {
     taskLogs(taskId: $id, execution: $execution) {
       systemLogs {
         severity

--- a/src/gql/queries/get-task-tests.ts
+++ b/src/gql/queries/get-task-tests.ts
@@ -9,7 +9,7 @@ export const GET_TASK_TESTS = gql`
     $limitNum: Int
     $statusList: [String!]!
     $testName: String!
-    $execution: Int
+    $execution: Int!
   ) {
     taskTests(
       taskId: $id

--- a/src/gql/queries/get-task-tests.ts
+++ b/src/gql/queries/get-task-tests.ts
@@ -9,7 +9,7 @@ export const GET_TASK_TESTS = gql`
     $limitNum: Int
     $statusList: [String!]!
     $testName: String!
-    $execution: Int!
+    $execution: Int
   ) {
     taskTests(
       taskId: $id

--- a/src/gql/queries/get-task.ts
+++ b/src/gql/queries/get-task.ts
@@ -132,15 +132,6 @@ export const GET_TASK = gql`
   }
 `;
 
-export const GET_TASK_LATEST_EXECUTION = gql`
-  query GetTaskLatestExecution($taskId: String!) {
-    task(taskId: $taskId) {
-      id
-      latestExecution
-    }
-  }
-`;
-
 export enum MetStatus {
   Met = "MET",
   Unmet = "UNMET",

--- a/src/gql/queries/get-task.ts
+++ b/src/gql/queries/get-task.ts
@@ -7,6 +7,7 @@ export const GET_TASK = gql`
     }
     task(taskId: $taskId, execution: $execution) {
       id
+      execution
       activatedBy
       baseTaskMetadata {
         baseTaskDuration

--- a/src/gql/queries/index.ts
+++ b/src/gql/queries/index.ts
@@ -16,12 +16,7 @@ export {
   GET_SYSTEM_LOGS,
 } from "./get-task-logs";
 export { GET_TASK_TESTS } from "./get-task-tests";
-export {
-  GET_TASK,
-  GET_TASK_LATEST_EXECUTION,
-  MetStatus,
-  RequiredStatus,
-} from "./get-task";
+export { GET_TASK, MetStatus, RequiredStatus } from "./get-task";
 export { GET_TASK_ALL_EXECUTIONS } from "./get-task-all-executions";
 export { GET_USER, GET_OTHER_USER } from "./get-user";
 export { GET_CLIENT_CONFIG } from "./get-client-config";

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -17,3 +17,4 @@ export {
 export { useUpdateUrlSortParamOnTableChange } from "./useUpdateUrlSortParamOnTableChange";
 export { usePrevious } from "./usePrevious";
 export { useDisableSpawnExpirationCheckbox } from "./useDisableSpawnExpirationCheckbox";
+export { useUpdateURLQueryParams } from "./useUpdateURLQueryParams";

--- a/src/pages/Task.tsx
+++ b/src/pages/Task.tsx
@@ -65,6 +65,7 @@ const TaskCore: React.FC = () => {
   >(GET_TASK, {
     variables: { taskId: id, execution: selectedExecution },
     pollInterval,
+    nextFetchPolicy: "cache-and-network",
     onError: (err) =>
       dispatchBanner.errorBanner(
         `There was an error loading the task: ${err.message}`
@@ -202,6 +203,7 @@ const TaskCore: React.FC = () => {
               currentExecution={selectedExecution}
               latestExecution={latestExecution}
               updateExecution={(n: number) => {
+                taskAnalytics.sendEvent({ name: "Change Execution" });
                 updateQueryParams({
                   execution: `${n}`,
                 });

--- a/src/pages/Task.tsx
+++ b/src/pages/Task.tsx
@@ -254,32 +254,28 @@ const TaskCore: React.FC = () => {
               >
                 <FilesTables />
               </Tab>
-              {showAnnotationsTab && (
-                <Tab
-                  name="Task Annotations"
-                  id="task-build-baron-tab"
-                  disabled={!showAnnotationsTab}
-                >
-                  <BuildBaron
-                    annotation={annotation}
-                    bbData={buildBaronData}
-                    error={buildBaronError}
-                    taskId={id}
-                    execution={selectedExecution}
-                    loading={buildBaronLoading}
-                    userCanModify={annotation?.userCanModify}
-                  />
-                </Tab>
-              )}
-              {(isPerfPluginEnabled || tab === TaskTab.TrendCharts) && (
-                <Tab
-                  name="Trend Charts"
-                  id="trend-charts-tab"
-                  disabled={!isPerfPluginEnabled}
-                >
-                  <TrendChartsPlugin taskId={id} />
-                </Tab>
-              )}
+              <Tab
+                name="Task Annotations"
+                id="task-build-baron-tab"
+                disabled={!showAnnotationsTab}
+              >
+                <BuildBaron
+                  annotation={annotation}
+                  bbData={buildBaronData}
+                  error={buildBaronError}
+                  taskId={id}
+                  execution={selectedExecution}
+                  loading={buildBaronLoading}
+                  userCanModify={annotation?.userCanModify}
+                />
+              </Tab>
+              <Tab
+                name="Trend Charts"
+                id="trend-charts-tab"
+                disabled={!isPerfPluginEnabled}
+              >
+                <TrendChartsPlugin taskId={id} />
+              </Tab>
             </StyledTabs>
           </PageContent>
         </LogWrapper>

--- a/src/pages/Task.tsx
+++ b/src/pages/Task.tsx
@@ -217,7 +217,7 @@ const TaskCore: React.FC = () => {
         <LogWrapper>
           <PageContent>
             <StyledTabs selected={selectedTab} setSelected={selectTabHandler}>
-              <Tab name="Logs" id="task-logs-tab">
+              <Tab name="Logs" data-cy="task-logs-tab">
                 <Logs logLinks={logLinks} />
               </Tab>
               <Tab
@@ -228,14 +228,14 @@ const TaskCore: React.FC = () => {
                         tabLabel="Tests"
                         badgeVariant="red"
                         badgeText={failedTestCount}
-                        dataCyBadge="test-tab-badge"
+                        dataCyBadge="tests-tab-badge"
                       />
                     ) : (
                       "Tests"
                     )}
                   </span>
                 }
-                id="task-tests-tab"
+                data-cy="task-tests-tab"
               >
                 <TestsTable />
               </Tab>
@@ -254,13 +254,13 @@ const TaskCore: React.FC = () => {
                     )}
                   </span>
                 }
-                id="task-files-tab"
+                data-cy="task-files-tab"
               >
                 <FilesTables />
               </Tab>
               <Tab
                 name="Task Annotations"
-                id="task-build-baron-tab"
+                data-cy="task-build-baron-tab"
                 disabled={!showAnnotationsTab}
               >
                 <BuildBaron
@@ -275,7 +275,7 @@ const TaskCore: React.FC = () => {
               </Tab>
               <Tab
                 name="Trend Charts"
-                id="trend-charts-tab"
+                data-cy="trend-charts-tab"
                 disabled={!isPerfPluginEnabled}
               >
                 <TrendChartsPlugin taskId={id} />

--- a/src/pages/Task.tsx
+++ b/src/pages/Task.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { useQuery } from "@apollo/client";
 import styled from "@emotion/styled";
 import { Tab } from "@leafygreen-ui/tabs";
@@ -98,7 +98,15 @@ const TaskCore: React.FC = () => {
   const { fileCount } = taskFiles ?? {};
   const { author: patchAuthor } = patchMetadata ?? {};
 
-  if (Number.isNaN(selectedExecution) && latestExecution !== undefined) {
+  // Used to avoid an unnecessary render when a task data is loaded since it will be the latestExecution
+  // by default when we dont supply an execution in the query
+  const [initialFetch, setInitialFetch] = useState(true);
+  if (
+    Number.isNaN(selectedExecution) &&
+    latestExecution !== undefined &&
+    initialFetch
+  ) {
+    setInitialFetch(false);
     updateQueryParams({
       execution: `${latestExecution}`,
     });
@@ -143,10 +151,10 @@ const TaskCore: React.FC = () => {
     // 3. otherwise load the logs tab (this default is set in the useTabs hook)
     if (tab in tabToIndexMap) {
       selectTabHandler(tabToIndexMap[tab]);
-    } else if (!loading && totalTestCount > 0) {
+    } else if (data && totalTestCount > 0) {
       selectTabHandler(tabToIndexMap[TaskTab.Tests]);
     }
-  }, [loading, location.pathname]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [data, tab]); // eslint-disable-line react-hooks/exhaustive-deps
 
   if (error) {
     stopPolling();

--- a/src/pages/Task.tsx
+++ b/src/pages/Task.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import { useQuery } from "@apollo/client";
 import styled from "@emotion/styled";
 import { Tab } from "@leafygreen-ui/tabs";
@@ -65,7 +65,6 @@ const TaskCore: React.FC = () => {
   >(GET_TASK, {
     variables: { taskId: id, execution: selectedExecution },
     pollInterval,
-    nextFetchPolicy: "cache-and-network",
     onError: (err) =>
       dispatchBanner.errorBanner(
         `There was an error loading the task: ${err.message}`
@@ -98,19 +97,13 @@ const TaskCore: React.FC = () => {
   const { fileCount } = taskFiles ?? {};
   const { author: patchAuthor } = patchMetadata ?? {};
 
-  // Used to avoid an unnecessary render when a task data is loaded since it will be the latestExecution
-  // by default when we dont supply an execution in the query
-  const [initialFetch, setInitialFetch] = useState(true);
-  if (
-    Number.isNaN(selectedExecution) &&
-    latestExecution !== undefined &&
-    initialFetch
-  ) {
-    setInitialFetch(false);
+  // Set the execution if it isnt provided
+  if (Number.isNaN(selectedExecution) && latestExecution !== undefined) {
     updateQueryParams({
       execution: `${latestExecution}`,
     });
   }
+
   const {
     showBuildBaron,
     buildBaronData,

--- a/src/pages/Task.tsx
+++ b/src/pages/Task.tsx
@@ -1,8 +1,7 @@
-import React, { useState, useEffect } from "react";
+import React, { useEffect } from "react";
 import { useQuery } from "@apollo/client";
 import styled from "@emotion/styled";
 import { Tab } from "@leafygreen-ui/tabs";
-import get from "lodash/get";
 import { useParams, useLocation } from "react-router-dom";
 import { useTaskAnalytics } from "analytics";
 import { Banners } from "components/Banners";
@@ -27,7 +26,7 @@ import {
   useBannerStateContext,
 } from "context/banners";
 import { GetTaskQuery, GetTaskQueryVariables } from "gql/generated/types";
-import { GET_TASK, GET_TASK_LATEST_EXECUTION } from "gql/queries";
+import { GET_TASK } from "gql/queries";
 import { withBannersContext } from "hoc/withBannersContext";
 import { useTabs, usePageTitle, useNetworkStatus } from "hooks";
 import { useBuildBaronVariables } from "hooks/useBuildBaronVariables";
@@ -38,7 +37,6 @@ import { FilesTables } from "pages/task/FilesTables";
 import { Logs } from "pages/task/Logs";
 import { Metadata } from "pages/task/Metadata";
 import { TestsTable } from "pages/task/TestsTable";
-import { ExecutionAsDisplay, ExecutionAsData } from "pages/task/util/execution";
 import { TaskTab, RequiredQueryParams, TaskStatus } from "types/task";
 import { parseQueryString } from "utils";
 
@@ -58,37 +56,14 @@ const TaskCore: React.FC = () => {
   const location = useLocation();
   const updateQueryParams = useUpdateURLQueryParams();
   const parsed = parseQueryString(location.search);
-  const initialExecution = Number(parsed[RequiredQueryParams.Execution]);
-  const { data: latest } = useQuery<GetTaskQuery, GetTaskQueryVariables>(
-    GET_TASK_LATEST_EXECUTION,
-    {
-      variables: { taskId: id },
-      onError: (err) =>
-        dispatchBanner.errorBanner(
-          `There was an error loading the task: ${err.message}`
-        ),
-    }
-  );
-  const [execution, setExecution] = useState(
-    !Number.isNaN(initialExecution)
-      ? ExecutionAsData(initialExecution)
-      : latest?.task?.latestExecution
-  );
-  useEffect(() => {
-    if (Number.isNaN(initialExecution) && latest?.task) {
-      setExecution(latest?.task?.latestExecution);
-      updateQueryParams({
-        execution: `${ExecutionAsDisplay(latest?.task?.latestExecution)}`,
-      });
-    }
-  }, [latest, initialExecution, updateQueryParams]);
+  const selectedExecution = Number(parsed[RequiredQueryParams.Execution]);
 
   // Query task data
   const { data, loading, error, startPolling, stopPolling } = useQuery<
     GetTaskQuery,
     GetTaskQueryVariables
   >(GET_TASK, {
-    variables: { taskId: id, execution },
+    variables: { taskId: id, execution: selectedExecution },
     pollInterval,
     onError: (err) =>
       dispatchBanner.errorBanner(
@@ -97,26 +72,35 @@ const TaskCore: React.FC = () => {
   });
 
   useNetworkStatus(startPolling, stopPolling);
-  const task = get(data, "task");
-  const canAbort = get(task, "canAbort");
-  const blocked = task?.blocked;
-  const canRestart = get(task, "canRestart");
-  const canSchedule = get(task, "canSchedule");
-  const canUnschedule = get(task, "canUnschedule");
-  const canSetPriority = get(task, "canSetPriority");
-  const displayName = get(task, "displayName");
-  const patchNumber = get(task, "patchNumber");
-  const priority = get(task, "priority");
-  const status = get(task, "status");
-  const version = get(task, "version");
-  const totalTestCount = get(task, "totalTestCount");
-  const failedTestCount = get(task, "failedTestCount");
-  const fileCount = get(data, "taskFiles.fileCount");
-  const logLinks = get(task, "logs");
-  const isPerfPluginEnabled = get(task, "isPerfPluginEnabled");
-  const patchAuthor = data?.task.patchMetadata.author;
-  const annotation = task?.annotation;
+  const { task, taskFiles } = data ?? {};
+  const {
+    canAbort,
+    blocked,
+    canRestart,
+    canSchedule,
+    canUnschedule,
+    canSetPriority,
+    displayName,
+    patchNumber,
+    priority,
+    status,
+    version,
+    totalTestCount,
+    failedTestCount,
+    logs: logLinks,
+    isPerfPluginEnabled,
+    annotation,
+    latestExecution,
+    patchMetadata,
+  } = task ?? {};
+  const { fileCount } = taskFiles ?? {};
+  const { author: patchAuthor } = patchMetadata ?? {};
 
+  if (Number.isNaN(selectedExecution) && latestExecution !== undefined) {
+    updateQueryParams({
+      execution: `${latestExecution}`,
+    });
+  }
   const {
     showBuildBaron,
     buildBaronData,
@@ -124,16 +108,16 @@ const TaskCore: React.FC = () => {
     buildBaronLoading,
   } = useBuildBaronVariables({
     taskId: id,
-    execution,
-    taskStatus: task?.status,
+    execution: selectedExecution,
+    taskStatus: status,
   });
 
   const failedTask =
-    task?.status === TaskStatus.Failed ||
-    task?.status === TaskStatus.SetupFailed ||
-    task?.status === TaskStatus.SystemFailed ||
-    task?.status === TaskStatus.TaskTimedOut ||
-    task?.status === TaskStatus.TestTimedOut;
+    status === TaskStatus.Failed ||
+    status === TaskStatus.SetupFailed ||
+    status === TaskStatus.SystemFailed ||
+    status === TaskStatus.TaskTimedOut ||
+    status === TaskStatus.TestTimedOut;
 
   const showAnnotationsTab = failedTask && (showBuildBaron || annotation);
 
@@ -212,20 +196,19 @@ const TaskCore: React.FC = () => {
       />
       <PageLayout>
         <PageSider>
-          {task?.latestExecution > 0 && (
+          {latestExecution > 0 && (
             <ExecutionSelect
               id={id}
-              currentExecution={execution}
-              latestExecution={latest?.task?.latestExecution}
+              currentExecution={selectedExecution}
+              latestExecution={latestExecution}
               updateExecution={(n: number) => {
-                setExecution(n);
                 updateQueryParams({
-                  execution: `${ExecutionAsDisplay(n)}`,
+                  execution: `${n}`,
                 });
               }}
             />
           )}
-          <Metadata taskId={id} data={data} loading={loading} error={error} />
+          <Metadata taskId={id} task={task} loading={loading} error={error} />
         </PageSider>
         <LogWrapper>
           <PageContent>
@@ -271,29 +254,32 @@ const TaskCore: React.FC = () => {
               >
                 <FilesTables />
               </Tab>
-
-              <Tab
-                name="Task Annotations"
-                id="task-build-baron-tab"
-                disabled={!showAnnotationsTab}
-              >
-                <BuildBaron
-                  annotation={annotation}
-                  bbData={buildBaronData}
-                  error={buildBaronError}
-                  taskId={id}
-                  execution={execution}
-                  loading={buildBaronLoading}
-                  userCanModify={annotation?.userCanModify}
-                />
-              </Tab>
-              <Tab
-                name="Trend Charts"
-                id="trend-charts-tab"
-                disabled={!isPerfPluginEnabled}
-              >
-                <TrendChartsPlugin taskId={id} />
-              </Tab>
+              {showAnnotationsTab && (
+                <Tab
+                  name="Task Annotations"
+                  id="task-build-baron-tab"
+                  disabled={!showAnnotationsTab}
+                >
+                  <BuildBaron
+                    annotation={annotation}
+                    bbData={buildBaronData}
+                    error={buildBaronError}
+                    taskId={id}
+                    execution={selectedExecution}
+                    loading={buildBaronLoading}
+                    userCanModify={annotation?.userCanModify}
+                  />
+                </Tab>
+              )}
+              {(isPerfPluginEnabled || tab === TaskTab.TrendCharts) && (
+                <Tab
+                  name="Trend Charts"
+                  id="trend-charts-tab"
+                  disabled={!isPerfPluginEnabled}
+                >
+                  <TrendChartsPlugin taskId={id} />
+                </Tab>
+              )}
             </StyledTabs>
           </PageContent>
         </LogWrapper>

--- a/src/pages/task/ActionButtons.tsx
+++ b/src/pages/task/ActionButtons.tsx
@@ -27,8 +27,8 @@ import { RESTART_TASK } from "gql/mutations/restart-task";
 import { SCHEDULE_TASK } from "gql/mutations/schedule-task";
 import { SET_TASK_PRIORTY } from "gql/mutations/set-task-priority";
 import { UNSCHEDULE_TASK } from "gql/mutations/unschedule-task";
-import { useOnClickOutside } from "hooks";
-import { TaskNotificationModal } from "pages/task/actionButtons/TaskNotificationModal";
+import { useOnClickOutside, useUpdateURLQueryParams } from "hooks";
+import { TaskNotificationModal } from "./actionButtons/TaskNotificationModal";
 
 interface Props {
   initialPriority?: number;
@@ -55,6 +55,7 @@ export const ActionButtons = ({
   const [priority, setPriority] = useState<number>(initialPriority);
   const { id: taskId } = useParams<{ id: string }>();
   const taskAnalytics = useTaskAnalytics();
+  const updateQueryParams = useUpdateURLQueryParams();
 
   const [scheduleTask, { loading: loadingScheduleTask }] = useMutation<
     ScheduleTaskMutation,
@@ -105,8 +106,12 @@ export const ActionButtons = ({
     RestartTaskMutationVariables
   >(RESTART_TASK, {
     variables: { taskId },
-    onCompleted: () => {
+    onCompleted: (data) => {
+      const { latestExecution } = data.restartTask;
       successBanner("Task scheduled to restart");
+      updateQueryParams({
+        execution: `${latestExecution}`,
+      });
     },
     onError: (err) => {
       errorBanner(`Error restarting task: ${err.message}`);

--- a/src/pages/task/FilesTables.tsx
+++ b/src/pages/task/FilesTables.tsx
@@ -17,7 +17,7 @@ import {
   GroupedFiles,
 } from "gql/generated/types";
 import { GET_TASK_FILES } from "gql/queries/get-task-files";
-import { ExecutionAsData } from "pages/task/util/execution";
+import { executionAsData } from "pages/task/util/execution";
 import { RequiredQueryParams } from "types/task";
 import { queryParamAsNumber, parseQueryString } from "utils";
 
@@ -54,7 +54,7 @@ export const FilesTables: React.FC = () => {
   >(GET_TASK_FILES, {
     variables: {
       id,
-      execution: ExecutionAsData(initialExecution),
+      execution: executionAsData(initialExecution),
     },
   });
   const [filterStr, setFilterStr] = useState("");

--- a/src/pages/task/FilesTables.tsx
+++ b/src/pages/task/FilesTables.tsx
@@ -17,7 +17,6 @@ import {
   GroupedFiles,
 } from "gql/generated/types";
 import { GET_TASK_FILES } from "gql/queries/get-task-files";
-import { executionAsData } from "pages/task/util/execution";
 import { RequiredQueryParams } from "types/task";
 import { queryParamAsNumber, parseQueryString } from "utils";
 
@@ -54,7 +53,7 @@ export const FilesTables: React.FC = () => {
   >(GET_TASK_FILES, {
     variables: {
       id,
-      execution: executionAsData(initialExecution),
+      execution: initialExecution,
     },
   });
   const [filterStr, setFilterStr] = useState("");

--- a/src/pages/task/Metadata.test.tsx
+++ b/src/pages/task/Metadata.test.tsx
@@ -141,7 +141,7 @@ test("Renders the metadata card with a pending status", async () => {
       <Metadata
         taskId={taskId}
         loading={false}
-        data={taskAboutToStart}
+        task={taskAboutToStart.task}
         error={undefined}
       />
     </MockedProvider>
@@ -164,7 +164,7 @@ test("Renders the metadata card with a started status", async () => {
       <Metadata
         taskId={taskId}
         loading={false}
-        data={taskStarted}
+        task={taskStarted.task}
         error={undefined}
       />
     </MockedProvider>
@@ -186,7 +186,7 @@ test("Renders the metadata card with a succeeded status", async () => {
       <Metadata
         taskId={taskId}
         loading={false}
-        data={taskSucceeded}
+        task={taskSucceeded.task}
         error={undefined}
       />
     </MockedProvider>

--- a/src/pages/task/Metadata.test.tsx
+++ b/src/pages/task/Metadata.test.tsx
@@ -14,6 +14,7 @@ const taskQuery = {
   taskFiles: { __typename: "TaskFiles", fileCount: 38 },
   task: {
     id: "someTaskId",
+    execution: 0,
     isPerfPluginEnabled: false,
     __typename: "Task",
     activatedBy: "",
@@ -130,6 +131,7 @@ const mocks = [
           id: taskId,
           status: "started",
           failedTestCount: 0,
+          execution: 0,
         },
       },
     },

--- a/src/pages/task/Metadata.tsx
+++ b/src/pages/task/Metadata.tsx
@@ -25,12 +25,16 @@ const { red } = uiColors;
 interface Props {
   taskId: string;
   loading: boolean;
-  data: GetTaskQuery;
+  task: GetTaskQuery["task"];
   error: ApolloError;
 }
 
-export const Metadata: React.FC<Props> = ({ loading, data, error, taskId }) => {
-  const task = data?.task ?? ({} as GetTaskQuery["task"]);
+export const Metadata: React.FC<Props> = ({
+  loading,
+  task = {},
+  error,
+  taskId,
+}) => {
   const taskAnalytics = useTaskAnalytics();
 
   const {

--- a/src/pages/task/executionDropdown/ExecutionSelector.tsx
+++ b/src/pages/task/executionDropdown/ExecutionSelector.tsx
@@ -9,7 +9,7 @@ import {
   GetTaskAllExecutionsQueryVariables,
 } from "gql/generated/types";
 import { GET_TASK_ALL_EXECUTIONS } from "gql/queries";
-import { ExecutionAsDisplay } from "pages/task/util/execution";
+import { executionAsDisplay } from "pages/task/util/execution";
 import { shortDate } from "utils/string";
 
 interface ExecutionSelectProps {
@@ -41,7 +41,7 @@ export const ExecutionSelect: React.FC<ExecutionSelectProps> = ({
       disabled={executionsLoading}
       key={currentExecution}
       data-cy="execution-select"
-      value={`Execution ${ExecutionAsDisplay(currentExecution)}${
+      value={`Execution ${executionAsDisplay(currentExecution)}${
         currentExecution === latestExecution ? " (latest)" : ""
       }`}
       onChange={(selected: number | null) => {
@@ -59,7 +59,7 @@ export const ExecutionSelect: React.FC<ExecutionSelectProps> = ({
           />
           <StyledP1>
             {" "}
-            Execution {ExecutionAsDisplay(singleExecution.execution)} -{" "}
+            Execution {executionAsDisplay(singleExecution.execution)} -{" "}
             {shortDate(
               singleExecution.activatedTime ?? singleExecution.ingestTime
             )}

--- a/src/pages/task/logs/LogTypes.tsx
+++ b/src/pages/task/logs/LogTypes.tsx
@@ -179,6 +179,10 @@ const useRenderBody: React.FC<{
         { arrayFormat: "comma" }
       )}`
     );
+    taskAnalytics.sendEvent({
+      name: "Select Logs Type",
+      logsType: nextLogType,
+    });
   };
 
   if (loading) {
@@ -220,52 +224,16 @@ const useRenderBody: React.FC<{
             )}
           </ButtonContainer>
         ) : null}
-        <Radio
-          data-cy="cy-task-radio"
-          value={LogTypes.Task}
-          onClick={() =>
-            taskAnalytics.sendEvent({
-              name: "Select Logs Type",
-              logsType: LogTypes.Task,
-            })
-          }
-        >
+        <Radio id="cy-task-radio" value={LogTypes.Task}>
           Task Logs
         </Radio>
-        <Radio
-          data-cy="cy-agent-radio"
-          value={LogTypes.Agent}
-          onClick={() =>
-            taskAnalytics.sendEvent({
-              name: "Select Logs Type",
-              logsType: LogTypes.Agent,
-            })
-          }
-        >
+        <Radio id="cy-agent-radio" value={LogTypes.Agent}>
           Agent Logs
         </Radio>
-        <Radio
-          id="cy-system-radio"
-          value={LogTypes.System}
-          onClick={() =>
-            taskAnalytics.sendEvent({
-              name: "Select Logs Type",
-              logsType: LogTypes.System,
-            })
-          }
-        >
+        <Radio id="cy-system-radio" value={LogTypes.System}>
           System Logs
         </Radio>
-        <Radio
-          data-cy="cy-event-radio"
-          value={LogTypes.Event}
-          onClick={() =>
-            taskAnalytics.sendEvent({
-              name: "Select Logs Type",
-              logsType: LogTypes.Event,
-            })
-          }
-        >
+        <Radio id="cy-event-radio" value={LogTypes.Event}>
           Event Logs
         </Radio>
       </StyledRadioGroup>

--- a/src/pages/task/logs/LogTypes.tsx
+++ b/src/pages/task/logs/LogTypes.tsx
@@ -221,7 +221,7 @@ const useRenderBody: React.FC<{
           </ButtonContainer>
         ) : null}
         <Radio
-          id="cy-task-radio"
+          data-cy="cy-task-radio"
           value={LogTypes.Task}
           onClick={() =>
             taskAnalytics.sendEvent({
@@ -233,7 +233,7 @@ const useRenderBody: React.FC<{
           Task Logs
         </Radio>
         <Radio
-          id="cy-agent-radio"
+          data-cy="cy-agent-radio"
           value={LogTypes.Agent}
           onClick={() =>
             taskAnalytics.sendEvent({
@@ -257,7 +257,7 @@ const useRenderBody: React.FC<{
           System Logs
         </Radio>
         <Radio
-          id="cy-event-radio"
+          data-cy="cy-event-radio"
           value={LogTypes.Event}
           onClick={() =>
             taskAnalytics.sendEvent({
@@ -270,7 +270,7 @@ const useRenderBody: React.FC<{
         </Radio>
       </StyledRadioGroup>
       {hideLogs ? (
-        <div id="cy-no-logs">No logs found</div>
+        <div data-cy="cy-no-logs">No logs found</div>
       ) : (
         <LogContainer>
           {data.map((d, index) =>

--- a/src/pages/task/logs/LogTypes.tsx
+++ b/src/pages/task/logs/LogTypes.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { useQuery, ApolloError } from "@apollo/client";
-
 import styled from "@emotion/styled";
 import { uiColors } from "@leafygreen-ui/palette";
 import { RadioGroup, Radio } from "@leafygreen-ui/radio-group";
@@ -8,7 +7,6 @@ import { Skeleton } from "antd";
 import get from "lodash/get";
 import queryString from "query-string";
 import { useParams, useLocation, useHistory } from "react-router-dom";
-import { v4 as uuid } from "uuid";
 import { useTaskAnalytics } from "analytics";
 import { Button } from "components/Button";
 import { pollInterval } from "constants/index";
@@ -33,6 +31,10 @@ import {
 import { useNetworkStatus } from "hooks";
 import { LogMessageLine } from "pages/task/logs/logTypes/LogMessageLine";
 import { TaskEventLogLine } from "pages/task/logs/logTypes/TaskEventLogLine";
+import { RequiredQueryParams } from "types/task";
+import { parseQueryString } from "utils";
+
+const { gray } = uiColors;
 
 interface TaskEventLogEntryType extends TaskEventLogEntry {
   kind?: "taskEventLogEntry";
@@ -56,11 +58,14 @@ interface Props {
 }
 export const EventLog: React.FC<Props> = (props): JSX.Element => {
   const { id } = useParams<{ id: string }>();
+  const location = useLocation();
+  const parsed = parseQueryString(location.search);
+  const selectedExecution = Number(parsed[RequiredQueryParams.Execution]);
   const { data, loading, error, startPolling, stopPolling } = useQuery<
     EventLogsQuery,
     EventLogsQueryVariables
   >(GET_EVENT_LOGS, {
-    variables: { id },
+    variables: { id, execution: selectedExecution },
     pollInterval,
   });
   useNetworkStatus(startPolling, stopPolling);
@@ -78,11 +83,14 @@ export const EventLog: React.FC<Props> = (props): JSX.Element => {
 
 export const SystemLog: React.FC<Props> = (props): JSX.Element => {
   const { id } = useParams<{ id: string }>();
+  const location = useLocation();
+  const parsed = parseQueryString(location.search);
+  const selectedExecution = Number(parsed[RequiredQueryParams.Execution]);
   const { data, loading, error, startPolling, stopPolling } = useQuery<
     SystemLogsQuery,
     SystemLogsQueryVariables
   >(GET_SYSTEM_LOGS, {
-    variables: { id },
+    variables: { id, execution: selectedExecution },
     pollInterval,
   });
   useNetworkStatus(startPolling, stopPolling);
@@ -97,11 +105,14 @@ export const SystemLog: React.FC<Props> = (props): JSX.Element => {
 
 export const AgentLog: React.FC<Props> = (props): JSX.Element => {
   const { id } = useParams<{ id: string }>();
+  const location = useLocation();
+  const parsed = parseQueryString(location.search);
+  const selectedExecution = Number(parsed[RequiredQueryParams.Execution]);
   const { data, loading, error, startPolling, stopPolling } = useQuery<
     AgentLogsQuery,
     AgentLogsQueryVariables
   >(GET_AGENT_LOGS, {
-    variables: { id },
+    variables: { id, execution: selectedExecution },
     pollInterval,
   });
   useNetworkStatus(startPolling, stopPolling);
@@ -116,11 +127,14 @@ export const AgentLog: React.FC<Props> = (props): JSX.Element => {
 
 export const TaskLog: React.FC<Props> = (props): JSX.Element => {
   const { id } = useParams<{ id: string }>();
+  const location = useLocation();
+  const parsed = parseQueryString(location.search);
+  const selectedExecution = Number(parsed[RequiredQueryParams.Execution]);
   const { data, loading, error, startPolling, stopPolling } = useQuery<
     TaskLogsQuery,
     TaskLogsQueryVariables
   >(GET_TASK_LOGS, {
-    variables: { id },
+    variables: { id, execution: selectedExecution },
     pollInterval,
   });
   useNetworkStatus(startPolling, stopPolling);
@@ -259,11 +273,17 @@ const useRenderBody: React.FC<{
         <div id="cy-no-logs">No logs found</div>
       ) : (
         <LogContainer>
-          {data.map((d) =>
+          {data.map((d, index) =>
             d.kind === "taskEventLogEntry" ? (
-              <TaskEventLogLine key={uuid()} {...d} />
+              <TaskEventLogLine
+                key={`${d.resourceId}_${d.id}_${index}`} // eslint-disable-line react/no-array-index-key
+                {...d}
+              />
             ) : (
-              <LogMessageLine key={uuid()} {...d} />
+              <LogMessageLine
+                key={`${d.message}_${d.timestamp}_${index}`} // eslint-disable-line react/no-array-index-key
+                {...d}
+              />
             )
           )}
         </LogContainer>
@@ -290,7 +310,7 @@ const StyledPre = styled.pre`
   padding: 8px;
   word-break: break-all;
   word-wrap: break-word;
-  border: 1px solid ${uiColors.gray.light2};
+  border: 1px solid ${gray.light2};
   border-radius: 4px;
   font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
   font-size: 13px;

--- a/src/pages/task/testsTable/TestsTableCore.tsx
+++ b/src/pages/task/testsTable/TestsTableCore.tsx
@@ -5,7 +5,7 @@ import Button from "@leafygreen-ui/button";
 import { Table, Skeleton } from "antd";
 import { ColumnProps } from "antd/es/table";
 import get from "lodash/get";
-import { useParams, useLocation, useHistory } from "react-router-dom";
+import { useParams, useLocation } from "react-router-dom";
 import { useTaskAnalytics } from "analytics";
 import Badge, { Variant } from "components/Badge";
 import { PageSizeSelector } from "components/PageSizeSelector";
@@ -27,10 +27,10 @@ import {
   TaskTestResult,
 } from "gql/generated/types";
 import { GET_TASK_TESTS } from "gql/queries/get-task-tests";
-import { useNetworkStatus } from "hooks";
+import { useNetworkStatus, useUpdateURLQueryParams } from "hooks";
 import { useSetColumnDefaultSortOrder } from "hooks/useSetColumnDefaultSortOrder";
 import { TestStatus, RequiredQueryParams, TableOnChange } from "types/task";
-import { stringifyQuery, parseQueryString, queryParamAsNumber } from "utils";
+import { parseQueryString, queryParamAsNumber } from "utils";
 import { msToDuration } from "utils/string";
 import { getPageFromSearch, getLimitFromSearch } from "utils/url";
 
@@ -39,8 +39,8 @@ export interface UpdateQueryArg {
 }
 export const TestsTableCore: React.FC = () => {
   const { id: resourceId } = useParams<{ id: string }>();
-  const { replace } = useHistory();
-  const { search, pathname } = useLocation();
+  const { search } = useLocation();
+  const updateQueryParams = useUpdateURLQueryParams();
 
   const queryVariables = getQueryVariables(search, resourceId);
   const { cat, dir, pageNum, limitNum } = queryVariables;
@@ -67,16 +67,12 @@ export const TestsTableCore: React.FC = () => {
   const tableChangeHandler: TableOnChange<TestResult> = (...[, , sorter]) => {
     const { order, columnKey } = Array.isArray(sorter) ? sorter[0] : sorter;
 
-    const nextQueryParams = stringifyQuery({
-      ...parseQueryString(search),
-      [RequiredQueryParams.Category]: columnKey,
+    updateQueryParams({
+      [RequiredQueryParams.Category]: `${columnKey}`,
       [RequiredQueryParams.Sort]:
         order === "ascend" ? SortDirection.Asc : SortDirection.Desc,
       [RequiredQueryParams.Page]: "0",
     });
-    if (nextQueryParams !== search.split("?")[1]) {
-      replace(`${pathname}?${nextQueryParams}`);
-    }
   };
 
   const taskAnalytics = useTaskAnalytics();

--- a/src/pages/task/testsTable/TestsTableCore.tsx
+++ b/src/pages/task/testsTable/TestsTableCore.tsx
@@ -29,7 +29,6 @@ import {
 import { GET_TASK_TESTS } from "gql/queries/get-task-tests";
 import { useNetworkStatus } from "hooks";
 import { useSetColumnDefaultSortOrder } from "hooks/useSetColumnDefaultSortOrder";
-import { executionAsData } from "pages/task/util/execution";
 import { TestStatus, RequiredQueryParams, TableOnChange } from "types/task";
 import { stringifyQuery, parseQueryString, queryParamAsNumber } from "utils";
 import { msToDuration } from "utils/string";
@@ -271,6 +270,6 @@ const getQueryVariables = (
     statusList,
     testName,
     pageNum: getPageFromSearch(search),
-    execution: executionAsData(queryParamAsNumber(execution)),
+    execution: queryParamAsNumber(execution),
   };
 };

--- a/src/pages/task/testsTable/TestsTableCore.tsx
+++ b/src/pages/task/testsTable/TestsTableCore.tsx
@@ -29,7 +29,7 @@ import {
 import { GET_TASK_TESTS } from "gql/queries/get-task-tests";
 import { useNetworkStatus } from "hooks";
 import { useSetColumnDefaultSortOrder } from "hooks/useSetColumnDefaultSortOrder";
-import { ExecutionAsData } from "pages/task/util/execution";
+import { executionAsData } from "pages/task/util/execution";
 import { TestStatus, RequiredQueryParams, TableOnChange } from "types/task";
 import { stringifyQuery, parseQueryString, queryParamAsNumber } from "utils";
 import { msToDuration } from "utils/string";
@@ -271,6 +271,6 @@ const getQueryVariables = (
     statusList,
     testName,
     pageNum: getPageFromSearch(search),
-    execution: ExecutionAsData(queryParamAsNumber(execution)),
+    execution: executionAsData(queryParamAsNumber(execution)),
   };
 };

--- a/src/pages/task/util/execution.ts
+++ b/src/pages/task/util/execution.ts
@@ -1,4 +1,3 @@
 // in a task's back-end state, the execution will be 0-indexed,
 // but will be 1-indexed wherever it is visible to users
 export const executionAsDisplay = (execution: number) => execution + 1;
-export const executionAsData = (execution: number) => execution - 1;

--- a/src/pages/task/util/execution.ts
+++ b/src/pages/task/util/execution.ts
@@ -1,4 +1,4 @@
 // in a task's back-end state, the execution will be 0-indexed,
 // but will be 1-indexed wherever it is visible to users
-export const ExecutionAsDisplay = (execution: number) => execution + 1;
-export const ExecutionAsData = (execution: number) => execution - 1;
+export const executionAsDisplay = (execution: number) => execution + 1;
+export const executionAsData = (execution: number) => execution - 1;


### PR DESCRIPTION
Show correct logs for tasks with multiple executions.
Reduce unnecessary requests and renders for task executions. 
Cleanup code 
One notable change is including `execution` as a [keyField](https://www.apollographql.com/docs/react/caching/cache-configuration/#customizing-identifier-generation-by-type) for `Task` in the apollo inMemory cache. This allows apollo to be more informed when its deciding whether or not to go to the cache when resolving a query. 

In order to take a advantage of this i needed to add the `execution` field to all queries that use the task type.

Doing this has allowed us to drop the amount of superfluous renders to render the Task page from around 30 to 19 renders. 
