### PR TITLE
EVG-13316 Track gql errors in bugsnag properly and fix the notify error

### DIFF
--- a/src/gql/GQLWrapper.tsx
+++ b/src/gql/GQLWrapper.tsx
@@ -72,7 +72,11 @@ const authLink = (logout: () => void): ApolloLink =>
 const logErrorsLink = onError(({ graphQLErrors }) => {
   if (Array.isArray(graphQLErrors)) {
     graphQLErrors.forEach((gqlErr) => {
-      reportError(gqlErr).warning();
+      reportError({
+        name: "GraphQL Error",
+        message: gqlErr.message,
+        metadata: gqlErr,
+      }).warning();
     });
   }
   // dont track network errors here because they are


### PR DESCRIPTION
Graphql errors no longer throw a bugsnag error and instead reported as a proper error as well as include some additional metadata
![image](https://user-images.githubusercontent.com/4605522/105224281-f90c0280-5b2a-11eb-8e59-abcb3b08dd93.png)

Instead of throwing a notify error