### PR TITLE
EVG-13365 fix gql field used for base status

### DIFF
--- a/src/pages/patch/patchTabs/Tasks.tsx
+++ b/src/pages/patch/patchTabs/Tasks.tsx
@@ -232,7 +232,7 @@ const getColumnDefs = (sortOrder: SortOrder[]): ColumnProps<TaskResult>[] => {
     },
     {
       title: "Base Status",
-      dataIndex: "baseStatus",
+      dataIndex: ["baseTask", "status"],
       key: TaskSortCategory.BaseStatus,
       sorter: {
         multiple: 4,


### PR DESCRIPTION
I had done a slight refactor of the query to return the base status as part of a base task object, but forgot to switch the data field the column was looking for