### PR TITLE
EVG-13365 sort new bugs to the top on patch page

### DIFF
--- a/cypress/integration/patch/task-table.ts
+++ b/cypress/integration/patch/task-table.ts
@@ -33,43 +33,43 @@ describe("Task table", () => {
     cy.visit(pathTasks);
     cy.location("search").should(
       "contain",
-      "sorts=STATUS%3AASC%3BBASE_STATUS%3AASC"
+      "sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC"
     );
 
     cy.get("th.cy-task-table-col-NAME").click();
     cy.location("search").should(
       "contain",
-      "sorts=STATUS%3AASC%3BBASE_STATUS%3AASC%3BNAME%3AASC"
+      "sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC%3BNAME%3AASC"
     );
 
     cy.get("th.cy-task-table-col-NAME").click();
     cy.location("search").should(
       "contain",
-      "sorts=STATUS%3AASC%3BBASE_STATUS%3AASC%3BNAME%3ADESC"
+      "sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC%3BNAME%3ADESC"
     );
 
     cy.get("th.cy-task-table-col-NAME").click();
     cy.location("search").should(
       "contain",
-      "sorts=STATUS%3AASC%3BBASE_STATUS%3AASC"
+      "sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC"
     );
 
     cy.get("th.cy-task-table-col-VARIANT").click();
     cy.location("search").should(
       "contain",
-      "sorts=STATUS%3AASC%3BBASE_STATUS%3AASC%3BVARIANT%3AASC"
+      "sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC%3BVARIANT%3AASC"
     );
 
     cy.get("th.cy-task-table-col-VARIANT").click();
     cy.location("search").should(
       "contain",
-      "sorts=STATUS%3AASC%3BBASE_STATUS%3AASC%3BVARIANT%3ADESC"
+      "sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC%3BVARIANT%3ADESC"
     );
 
     cy.get("th.cy-task-table-col-VARIANT").click();
     cy.location("search").should(
       "contain",
-      "sorts=STATUS%3AASC%3BBASE_STATUS%3AASC"
+      "sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC"
     );
   });
 

--- a/src/pages/patch/patchTabs/Tasks.tsx
+++ b/src/pages/patch/patchTabs/Tasks.tsx
@@ -58,7 +58,7 @@ export const Tasks: React.FC<Props> = ({ taskCount }) => {
 
   if (sorts.length === 0) {
     updateQueryParams({
-      sorts: "STATUS:ASC;BASE_STATUS:ASC",
+      sorts: "STATUS:ASC;BASE_STATUS:DESC",
     });
   }
 


### PR DESCRIPTION
This changes the default for base status from ascending to descending, so that new bugs default to the top