### PR TITLE
EVG-13171 Reconfigure the file ticket button on the UI

### DIFF
--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -358,6 +358,7 @@ export type MutationEditSpawnHostArgs = {
 
 export type MutationBbCreateTicketArgs = {
   taskId: Scalars["String"];
+  execution?: Maybe<Scalars["Int"]>;
 };
 
 export enum SpawnHostStatusActions {
@@ -1368,6 +1369,7 @@ export type EnqueuePatchMutation = { enqueuePatch: { id: string } };
 
 export type BbCreateTicketMutationVariables = Exact<{
   taskId: Scalars["String"];
+  execution?: Maybe<Scalars["Int"]>;
 }>;
 
 export type BbCreateTicketMutation = { bbCreateTicket: boolean };

--- a/src/gql/mutations/file-jira-ticket.ts
+++ b/src/gql/mutations/file-jira-ticket.ts
@@ -1,7 +1,7 @@
 import { gql } from "@apollo/client";
 
 export const FILE_JIRA_TICKET = gql`
-  mutation bbCreateTicket($taskId: String!) {
-    bbCreateTicket(taskId: $taskId)
+  mutation bbCreateTicket($taskId: String!, $execution: Int) {
+    bbCreateTicket(taskId: $taskId, execution: $execution)
   }
 `;

--- a/src/pages/task/taskTabs/buildBaronAndAnnotations/BBCreatedTickets.tsx
+++ b/src/pages/task/taskTabs/buildBaronAndAnnotations/BBCreatedTickets.tsx
@@ -14,6 +14,7 @@ import { BuildBaronTable } from "./BuildBaronTable";
 
 interface Props {
   taskId: string;
+  execution: number;
   setCreatedTicketsCount: React.Dispatch<React.SetStateAction<number>>;
   createdTicketsCount: number;
   buildBaronConfigured: boolean;
@@ -21,6 +22,7 @@ interface Props {
 
 export const CreatedTickets: React.FC<Props> = ({
   taskId,
+  execution,
   setCreatedTicketsCount,
   createdTicketsCount,
   buildBaronConfigured,
@@ -64,11 +66,10 @@ export const CreatedTickets: React.FC<Props> = ({
       )}
       {buildBaronConfigured && (
         <TitleAndButtons>
-          {length === 0 && (
-            <TicketsTitle>Create a New Ticket in Jira</TicketsTitle>
-          )}
+          {length === 0 && <TicketsTitle>Create a New Ticket</TicketsTitle>}
           <BBFileTicket
             taskId={taskId}
+            execution={execution}
             setCreatedTicketsCount={setCreatedTicketsCount}
             createdTicketsCount={createdTicketsCount}
           />

--- a/src/pages/task/taskTabs/buildBaronAndAnnotations/BBFIleTicket.tsx
+++ b/src/pages/task/taskTabs/buildBaronAndAnnotations/BBFIleTicket.tsx
@@ -13,18 +13,21 @@ import { ButtonWrapper } from "./BBComponents";
 
 interface BBFileTicketProps {
   taskId: string;
+  execution: number;
   setCreatedTicketsCount: React.Dispatch<React.SetStateAction<number>>;
   createdTicketsCount: number;
 }
 
 export const BBFileTicket: React.FC<BBFileTicketProps> = ({
   taskId,
+  execution,
   setCreatedTicketsCount,
   createdTicketsCount,
 }) => (
   <>
     <FileTicket
       taskId={taskId}
+      execution={execution}
       setCreatedTicketsCount={setCreatedTicketsCount}
       createdTicketsCount={createdTicketsCount}
     />
@@ -33,12 +36,14 @@ export const BBFileTicket: React.FC<BBFileTicketProps> = ({
 
 interface FileTicketProps {
   taskId: string;
+  execution: number;
   setCreatedTicketsCount;
   createdTicketsCount: number;
 }
 
 export const FileTicket: React.FC<FileTicketProps> = ({
   taskId,
+  execution,
   setCreatedTicketsCount,
   createdTicketsCount,
 }) => {
@@ -65,7 +70,7 @@ export const FileTicket: React.FC<FileTicketProps> = ({
   const annotationAnalytics = useAnnotationAnalytics();
   const onClickFile = () => {
     annotationAnalytics.sendEvent({ name: "Build Baron File Ticket" });
-    fileJiraTicket({ variables: { taskId } });
+    fileJiraTicket({ variables: { taskId, execution } });
   };
 
   return (

--- a/src/pages/task/taskTabs/buildBaronAndAnnotations/BuildBaron.test.tsx
+++ b/src/pages/task/taskTabs/buildBaronAndAnnotations/BuildBaron.test.tsx
@@ -93,7 +93,10 @@ const mocks = [
   {
     request: {
       query: FILE_JIRA_TICKET,
-      variables: { taskId },
+      variables: {
+        taskId,
+        execution,
+      },
     },
     result: {
       data: {

--- a/src/pages/task/taskTabs/buildBaronAndAnnotations/BuildBaronContent.tsx
+++ b/src/pages/task/taskTabs/buildBaronAndAnnotations/BuildBaronContent.tsx
@@ -71,6 +71,7 @@ const BuildBaronCore: React.FC<BuildBaronCoreProps> = ({
 
           <CreatedTickets
             taskId={taskId}
+            execution={execution}
             setCreatedTicketsCount={setCreatedTicketsCount}
             createdTicketsCount={createdTicketsCount}
             buildBaronConfigured={bbData.buildBaronConfigured}


### PR DESCRIPTION
I ended up using the same backend function for both methods, so there was not much reconfiguration needed on the UI. 

Depends on [4357](https://github.com/evergreen-ci/evergreen/pull/4357) (Merged)