### PR TITLE
EVG-13965 Reenable polling for tests table

### DIFF
--- a/src/pages/task/taskTabs/testsTable/TestsTableCore.tsx
+++ b/src/pages/task/taskTabs/testsTable/TestsTableCore.tsx
@@ -17,6 +17,7 @@ import {
   TableControlInnerRow,
 } from "components/styles";
 import { WordBreak } from "components/Typography";
+import { pollInterval } from "constants/index";
 import {
   TaskTestsQuery,
   TaskTestsQueryVariables,
@@ -26,7 +27,7 @@ import {
   TaskTestResult,
 } from "gql/generated/types";
 import { GET_TASK_TESTS } from "gql/queries/get-task-tests";
-import { useUpdateURLQueryParams } from "hooks";
+import { useUpdateURLQueryParams, useNetworkStatus } from "hooks";
 import { TestStatus, RequiredQueryParams, TableOnChange } from "types/task";
 import { parseQueryString, queryParamAsNumber } from "utils";
 import { msToDuration } from "utils/string";
@@ -54,13 +55,14 @@ export const TestsTableCore: React.FC = () => {
   }));
 
   // initial request for task tests
-  const { data } = useQuery<TaskTestsQuery, TaskTestsQueryVariables>(
-    GET_TASK_TESTS,
-    {
-      variables: queryVariables,
-    }
-  );
-
+  const { data, startPolling, stopPolling } = useQuery<
+    TaskTestsQuery,
+    TaskTestsQueryVariables
+  >(GET_TASK_TESTS, {
+    variables: queryVariables,
+    pollInterval,
+  });
+  useNetworkStatus(startPolling, stopPolling);
   // update url query params when user event triggers change
   const tableChangeHandler: TableOnChange<TestResult> = (...[, , sorter]) => {
     const { order, columnKey } = Array.isArray(sorter) ? sorter[0] : sorter;


### PR DESCRIPTION
DO NOT MERGE until https://github.com/evergreen-ci/evergreen/pull/4405 is deployed. And the testresults query is confirmed fixed.