### PR TITLE
EVG-14094 Load date picker and time picker css manually

### DIFF
--- a/src/components/DatePicker.tsx
+++ b/src/components/DatePicker.tsx
@@ -1,6 +1,8 @@
 import generatePicker from "antd/lib/date-picker/generatePicker";
 import dateFnsGenerateConfig from "rc-picker/lib/generate/dateFns";
 
+import "antd/es/date-picker/style/css";
+
 const DatePicker = generatePicker<Date>(dateFnsGenerateConfig);
 
 export default DatePicker;

--- a/src/components/DatePicker.tsx
+++ b/src/components/DatePicker.tsx
@@ -1,7 +1,7 @@
 import generatePicker from "antd/lib/date-picker/generatePicker";
 import dateFnsGenerateConfig from "rc-picker/lib/generate/dateFns";
 
-import "antd/es/date-picker/style/css";
+import "antd/lib/date-picker/style/css";
 
 const DatePicker = generatePicker<Date>(dateFnsGenerateConfig);
 

--- a/src/components/TimePicker.tsx
+++ b/src/components/TimePicker.tsx
@@ -3,6 +3,8 @@ import { Omit } from "antd/es/_util/type";
 import { PickerTimeProps } from "antd/es/date-picker/generatePicker";
 import DatePicker from "./DatePicker";
 
+import "antd/es/time-picker/style/css";
+
 export interface TimePickerProps
   extends Omit<PickerTimeProps<Date>, "picker"> {}
 

--- a/src/components/TimePicker.tsx
+++ b/src/components/TimePicker.tsx
@@ -3,7 +3,7 @@ import { Omit } from "antd/es/_util/type";
 import { PickerTimeProps } from "antd/es/date-picker/generatePicker";
 import DatePicker from "./DatePicker";
 
-import "antd/es/time-picker/style/css";
+import "antd/lib/time-picker/style/css";
 
 export interface TimePickerProps
   extends Omit<PickerTimeProps<Date>, "picker"> {}


### PR DESCRIPTION
The babel plugin that automatically loads the styles for antd components doesn't catch the date picker and time picker components. Most likely since we use a utility function to build our own custom versions of these components. This imports the styles manually. 