### PR TITLE
EVG-13726 Reenable cypress tests

### DIFF
--- a/cypress/integration/task_route.ts
+++ b/cypress/integration/task_route.ts
@@ -21,7 +21,7 @@ describe("Task Page Route", () => {
     cy.location("pathname").should("eq", `/task/${tasks[1]}/files`);
   });
 
-  it.only("should display an appropriate status badge when visiting task pages", () => {
+  it("should display an appropriate status badge when visiting task pages", () => {
     cy.visit(`/task/${tasks[1]}`);
     cy.dataCy("task-status-badge").contains("Dispatched");
     cy.visit(`/task/${tasks[2]}`);

--- a/cypress/integration/test_table.ts
+++ b/cypress/integration/test_table.ts
@@ -228,7 +228,7 @@ describe("Tests Table", () => {
       cy.dataCy("testname-input").first().focus().type(testNameInputValue);
     });
 
-    it.only("Typing in test name filter updates testname query param", () => {
+    it("Typing in test name filter updates testname query param", () => {
       cy.location().should((loc) => {
         expect(loc.search).to.include(`testname=${testNameInputValue}`);
       });


### PR DESCRIPTION
I accidentally committed this a while back and  muted all the tests locally 