### PR TITLE
EVG-13928 check if bbData is undefined

### DIFF
--- a/src/pages/task/taskTabs/buildBaronAndAnnotations/BuildBaronContent.tsx
+++ b/src/pages/task/taskTabs/buildBaronAndAnnotations/BuildBaronContent.tsx
@@ -60,7 +60,7 @@ export const BuildBaronContent: React.FC<BuildBaronCoreProps> = ({
           execution={execution}
           setCreatedTicketsCount={setCreatedTicketsCount}
           createdTicketsCount={createdTicketsCount}
-          buildBaronConfigured={bbData.buildBaronConfigured}
+          buildBaronConfigured={bbData?.buildBaronConfigured}
         />
       )}
 


### PR DESCRIPTION
It looks like this is the only unsafe reference of bbData we have.