### PR TITLE
EVG-13946 Update types for mainline commits pr

### DIFF
--- a/cypress/integration/patch/configure_patch.ts
+++ b/cypress/integration/patch/configure_patch.ts
@@ -816,24 +816,24 @@ const mockedSuccessfulConfigureResponse = {
               "mci_osx_dist_patch_c12773e028910390ab4fda66e4b1745cfdc9ee65_5ea99425b23736089a09a98f_20_04_29_14_53_16",
             name: "dist",
             status: "success",
-            __typename: "PatchBuildVariantTask",
+            __typename: "Task",
           },
           {
             id:
               "mci_osx_test_auth_patch_c12773e028910390ab4fda66e4b1745cfdc9ee65_5ea99425b23736089a09a98f_20_04_29_14_53_16",
             name: "test-auth",
             status: "success",
-            __typename: "PatchBuildVariantTask",
+            __typename: "Task",
           },
           {
             id:
               "mci_osx_test_graphql_patch_c12773e028910390ab4fda66e4b1745cfdc9ee65_5ea99425b23736089a09a98f_20_04_29_14_53_16",
             name: "test-graphql",
             status: "success",
-            __typename: "PatchBuildVariantTask",
+            __typename: "Task",
           },
         ],
-        __typename: "PatchBuildVariant",
+        __typename: "GroupedBuildVariant",
       },
     ],
     patch: {

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -30,7 +30,7 @@ export type Query = {
   taskFiles: TaskFiles;
   user: User;
   taskLogs: RecentTaskLogs;
-  patchBuildVariants: Array<PatchBuildVariant>;
+  patchBuildVariants: Array<GroupedBuildVariant>;
   commitQueue: CommitQueue;
   userSettings?: Maybe<UserSettings>;
   spruceConfig?: Maybe<SpruceConfig>;
@@ -50,6 +50,7 @@ export type Query = {
   taskQueueDistros: Array<TaskQueueDistro>;
   buildBaron: BuildBaron;
   bbGetCreatedTickets: Array<JiraTicket>;
+  mainlineCommits: Array<MainlineCommit>;
 };
 
 export type QueryUserPatchesArgs = {
@@ -160,6 +161,10 @@ export type QueryBuildBaronArgs = {
 
 export type QueryBbGetCreatedTicketsArgs = {
   taskId: Scalars["String"];
+};
+
+export type QueryMainlineCommitsArgs = {
+  options: MainlineCommitsOptions;
 };
 
 export type Mutation = {
@@ -359,6 +364,40 @@ export type MutationEditSpawnHostArgs = {
 export type MutationBbCreateTicketArgs = {
   taskId: Scalars["String"];
   execution?: Maybe<Scalars["Int"]>;
+};
+
+export type MainlineCommit = {
+  version?: Maybe<Version>;
+  versionMeta?: Maybe<VersionMeta>;
+};
+
+export type VersionMeta = {
+  id: Scalars["String"];
+  createTime: Scalars["Time"];
+  author: Scalars["String"];
+  message: Scalars["String"];
+};
+
+export type Version = {
+  id: Scalars["String"];
+  createTime: Scalars["Time"];
+  startTime: Scalars["Time"];
+  finishTime: Scalars["Time"];
+  revision: Scalars["String"];
+  author: Scalars["String"];
+  message: Scalars["String"];
+  status: Scalars["String"];
+  order: Scalars["Int"];
+  buildVariants?: Maybe<Array<Maybe<GroupedBuildVariant>>>;
+};
+
+export type MainlineCommitsOptions = {
+  projectID: Scalars["String"];
+  variants?: Maybe<Array<Scalars["String"]>>;
+  tasks?: Maybe<Array<Scalars["String"]>>;
+  statuses?: Maybe<Array<Scalars["String"]>>;
+  limit?: Maybe<Scalars["Int"]>;
+  page?: Maybe<Scalars["Int"]>;
 };
 
 export enum SpawnHostStatusActions {
@@ -623,19 +662,10 @@ export type PatchTasks = {
   count: Scalars["Int"];
 };
 
-export type PatchBuildVariant = {
+export type GroupedBuildVariant = {
   variant: Scalars["String"];
   displayName: Scalars["String"];
   tasks?: Maybe<Array<Maybe<Task>>>;
-};
-
-export type PatchBuildVariantTask = {
-  id: Scalars["ID"];
-  execution: Scalars["Int"];
-  displayName: Scalars["String"];
-  name: Scalars["String"];
-  status: Scalars["String"];
-  baseStatus?: Maybe<Scalars["String"]>;
 };
 
 export type TaskFiles = {
@@ -1214,7 +1244,7 @@ export type Note = {
 export type IssueLink = {
   issueKey?: Maybe<Scalars["String"]>;
   url?: Maybe<Scalars["String"]>;
-  source: Source;
+  source?: Maybe<Source>;
   jiraTicket?: Maybe<JiraTicket>;
 };
 
@@ -1238,7 +1268,7 @@ export type AnnotationFragment = {
       Maybe<{
         issueKey?: Maybe<string>;
         url?: Maybe<string>;
-        source: { author: string; time: Date; requester: string };
+        source?: Maybe<{ author: string; time: Date; requester: string }>;
       }>
     >
   >;
@@ -1247,7 +1277,7 @@ export type AnnotationFragment = {
       Maybe<{
         issueKey?: Maybe<string>;
         url?: Maybe<string>;
-        source: { author: string; time: Date; requester: string };
+        source?: Maybe<{ author: string; time: Date; requester: string }>;
       }>
     >
   >;
@@ -1256,7 +1286,7 @@ export type AnnotationFragment = {
       Maybe<{
         issueKey?: Maybe<string>;
         url?: Maybe<string>;
-        source: { author: string; time: Date; requester: string };
+        source?: Maybe<{ author: string; time: Date; requester: string }>;
       }>
     >
   >;

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -50,7 +50,7 @@ export type Query = {
   taskQueueDistros: Array<TaskQueueDistro>;
   buildBaron: BuildBaron;
   bbGetCreatedTickets: Array<JiraTicket>;
-  mainlineCommits: Array<MainlineCommit>;
+  mainlineCommits?: Maybe<MainlineCommits>;
 };
 
 export type QueryUserPatchesArgs = {
@@ -366,38 +366,48 @@ export type MutationBbCreateTicketArgs = {
   execution?: Maybe<Scalars["Int"]>;
 };
 
-export type MainlineCommit = {
-  version?: Maybe<Version>;
-  versionMeta?: Maybe<VersionMeta>;
+export type MainlineCommits = {
+  nextPageOrderNumber?: Maybe<Scalars["Int"]>;
+  versions: Array<MainlineCommitVersion>;
 };
 
-export type VersionMeta = {
-  id: Scalars["String"];
-  createTime: Scalars["Time"];
-  author: Scalars["String"];
-  message: Scalars["String"];
+export type MainlineCommitVersion = {
+  version?: Maybe<Version>;
+  rolledUpVersions?: Maybe<Array<Version>>;
 };
 
 export type Version = {
   id: Scalars["String"];
   createTime: Scalars["Time"];
-  startTime: Scalars["Time"];
-  finishTime: Scalars["Time"];
+  startTime?: Maybe<Scalars["Time"]>;
+  finishTime?: Maybe<Scalars["Time"]>;
+  message: Scalars["String"];
   revision: Scalars["String"];
   author: Scalars["String"];
-  message: Scalars["String"];
   status: Scalars["String"];
   order: Scalars["Int"];
+  repo: Scalars["String"];
+  project: Scalars["String"];
+  branch: Scalars["String"];
+  requester: Scalars["String"];
+  activated?: Maybe<Scalars["Boolean"]>;
   buildVariants?: Maybe<Array<Maybe<GroupedBuildVariant>>>;
+};
+
+export type VersionBuildVariantsArgs = {
+  options?: Maybe<BuildVariantOptions>;
+};
+
+export type BuildVariantOptions = {
+  variants?: Maybe<Array<Scalars["String"]>>;
+  tasks?: Maybe<Array<Scalars["String"]>>;
+  statuses?: Maybe<Array<Scalars["String"]>>;
 };
 
 export type MainlineCommitsOptions = {
   projectID: Scalars["String"];
-  variants?: Maybe<Array<Scalars["String"]>>;
-  tasks?: Maybe<Array<Scalars["String"]>>;
-  statuses?: Maybe<Array<Scalars["String"]>>;
   limit?: Maybe<Scalars["Int"]>;
-  page?: Maybe<Scalars["Int"]>;
+  skipOrderNumber?: Maybe<Scalars["Int"]>;
 };
 
 export enum SpawnHostStatusActions {

--- a/src/hooks/usePatchStatusSelect.ts
+++ b/src/hooks/usePatchStatusSelect.ts
@@ -1,5 +1,5 @@
 import { useEffect, useReducer, useState } from "react";
-import { PatchBuildVariant } from "gql/generated/types";
+import { GroupedBuildVariant } from "gql/generated/types";
 import { usePrevious } from "hooks";
 import { environmentalVariables } from "utils";
 
@@ -54,7 +54,7 @@ type HookResult = [
   }
 ];
 
-type UpdatedPatchBuildVariantType = Omit<PatchBuildVariant, "tasks"> & {
+type UpdatedPatchBuildVariantType = Omit<GroupedBuildVariant, "tasks"> & {
   tasks?: {
     id: string;
     execution: number;


### PR DESCRIPTION
This is the corresponding pr to https://github.com/evergreen-ci/evergreen/pull/4663
This just updates some type names that were changed. 

This doesn't need to be deployed along side the back end pr. All this changes is some types. Which only really affect local development. 