### PR TITLE
EVG-14607: point to evergreen lobster instead of logkeeper lobster in tests table

### DIFF
--- a/src/constants/externalResources.ts
+++ b/src/constants/externalResources.ts
@@ -47,3 +47,5 @@ export const getLobsterTaskLink = (
   execution: number
 ) =>
   `${getLobsterURL()}/lobster/evergreen/task/${taskId}/${execution}/${logType}`;
+
+export const deprecatedLogkeeperLobsterURL = "https://logkeeper.mongodb.org";

--- a/src/pages/task/taskTabs/testsTable/TestsTableCore.tsx
+++ b/src/pages/task/taskTabs/testsTable/TestsTableCore.tsx
@@ -40,6 +40,9 @@ const { getLobsterURL } = environmentalVariables;
 const { msToDuration } = string;
 const { getPageFromSearch, getLimitFromSearch } = url;
 const { parseQueryString, queryParamAsNumber } = queryString;
+
+const DEPRECATED_LOGKEEPER_LOBSTER_URL = "https://logkeeper.mongodb.org";
+
 export interface UpdateQueryArg {
   taskTests: TaskTestResult;
 }
@@ -297,7 +300,7 @@ const getColumnsTemplate = (
                 target="_blank"
                 variant="default"
                 href={htmlDisplayURL.replace(
-                  "https://logkeeper.mongodb.org",
+                  DEPRECATED_LOGKEEPER_LOBSTER_URL,
                   `${getLobsterURL()}/lobster`
                 )}
                 onClick={() =>

--- a/src/pages/task/taskTabs/testsTable/TestsTableCore.tsx
+++ b/src/pages/task/taskTabs/testsTable/TestsTableCore.tsx
@@ -21,6 +21,7 @@ import { WordBreak } from "components/Typography";
 import {
   getLobsterTestLogUrl,
   isLobsterLink,
+  deprecatedLogkeeperLobsterURL,
 } from "constants/externalResources";
 import { pollInterval } from "constants/index";
 import {
@@ -40,8 +41,6 @@ const { getLobsterURL } = environmentalVariables;
 const { msToDuration } = string;
 const { getPageFromSearch, getLimitFromSearch } = url;
 const { parseQueryString, queryParamAsNumber } = queryString;
-
-const DEPRECATED_LOGKEEPER_LOBSTER_URL = "https://logkeeper.mongodb.org";
 
 export interface UpdateQueryArg {
   taskTests: TaskTestResult;
@@ -300,7 +299,7 @@ const getColumnsTemplate = (
                 target="_blank"
                 variant="default"
                 href={htmlDisplayURL.replace(
-                  DEPRECATED_LOGKEEPER_LOBSTER_URL,
+                  deprecatedLogkeeperLobsterURL,
                   `${getLobsterURL()}/lobster`
                 )}
                 onClick={() =>

--- a/src/pages/task/taskTabs/testsTable/TestsTableCore.tsx
+++ b/src/pages/task/taskTabs/testsTable/TestsTableCore.tsx
@@ -34,8 +34,9 @@ import {
 import { GET_TASK_TESTS } from "gql/queries";
 import { useUpdateURLQueryParams, useNetworkStatus } from "hooks";
 import { TestStatus, RequiredQueryParams, TableOnChange } from "types/task";
-import { queryString, url, string } from "utils";
+import { queryString, url, string, environmentalVariables } from "utils";
 
+const { getLobsterURL } = environmentalVariables;
 const { msToDuration } = string;
 const { getPageFromSearch, getLimitFromSearch } = url;
 const { parseQueryString, queryParamAsNumber } = queryString;
@@ -268,7 +269,6 @@ const getColumnsTemplate = (
       const { execution, lineNum, taskId, id } = b || {};
       const { htmlDisplayURL, rawDisplayURL } = b?.logs ?? {};
       const lobsterLink = getLobsterTestLogUrl(taskId, execution, id, lineNum);
-
       return (
         <>
           {htmlDisplayURL && !isLobsterLink(htmlDisplayURL) && lobsterLink && (
@@ -296,7 +296,10 @@ const getColumnsTemplate = (
                 size="small"
                 target="_blank"
                 variant="default"
-                href={htmlDisplayURL}
+                href={htmlDisplayURL.replace(
+                  "https://logkeeper.mongodb.org",
+                  `${getLobsterURL()}/lobster`
+                )}
                 onClick={() =>
                   isLobsterLink(htmlDisplayURL)
                     ? taskAnalytics.sendEvent({


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-14607

htmlDisplayURL comes from TestLog.HTMLDisplayURL in EVG and sometimes resembles a lobster link with the incorrect base