### PR TITLE
EVG-14632 Fix Failing cypress tests and Refactor Configure patch page

### DIFF
--- a/cypress/integration/host/host_events.ts
+++ b/cypress/integration/host/host_events.ts
@@ -14,8 +14,7 @@ describe("Host events", () => {
     cy.dataCy("host-event-table-page-size-selector").click();
     cy.dataCy("host-event-table-page-size-selector-100").click();
 
-    const dataCyTableRows =
-      "[data-test-id=host-events-table] tr td:first-child";
+    const dataCyTableRows = "[data-cy=host-events-table] tr td:first-child";
     cy.get(dataCyTableRows).should("have.length.of.at.most", 32);
 
     const hostTypes = [

--- a/cypress/integration/hosts/update_status_modal.ts
+++ b/cypress/integration/hosts/update_status_modal.ts
@@ -11,8 +11,9 @@ describe("Update Status Modal", () => {
   });
 
   it("Update status for selected hosts", () => {
-    cy.get(".ant-checkbox-input").should("not.be.disabled");
-    cy.get(".ant-checkbox-input").check({ force: true });
+    cy.get(".ant-checkbox-input").first().should("be.visible");
+    cy.get(".ant-checkbox-input").first().should("not.be.disabled");
+    cy.get(".ant-checkbox-input").first().check({ force: true });
 
     cy.dataCy("update-status-button").click();
 

--- a/cypress/integration/hosts/update_status_modal.ts
+++ b/cypress/integration/hosts/update_status_modal.ts
@@ -3,17 +3,16 @@ const hostsRoute = "/hosts";
 describe("Update Status Modal", () => {
   before(() => {
     cy.login();
+    cy.preserveCookies();
   });
 
   beforeEach(() => {
-    cy.preserveCookies();
     cy.visit(`${hostsRoute}?limit=100&page=0`);
   });
 
   it("Update status for selected hosts", () => {
-    cy.get(".ant-table-selection-column").within(() => {
-      cy.get(".ant-checkbox-input").check({ force: true });
-    });
+    cy.get(".ant-checkbox-input").should("not.be.disabled");
+    cy.get(".ant-checkbox-input").check({ force: true });
 
     cy.dataCy("update-status-button").click();
 
@@ -28,30 +27,6 @@ describe("Update Status Modal", () => {
     cy.dataCy("toast").should("exist");
 
     // MODAL FORM VALUES SHOULD BE CLEARED AFTER MUTATION
-    cy.dataCy("update-status-button").click();
-
-    cy.dataCy("host-status-select").within(() => {
-      cy.get(".ant-select-selection-item").should("not.exist");
-    });
-
-    cy.dataCy("host-status-notes").invoke("val").should("eq", "");
-  });
-
-  it("Clears form values when modal is closed", () => {
-    cy.get(".ant-table-selection-column").within(() => {
-      cy.get(".ant-checkbox-input").check({ force: true });
-    });
-
-    cy.dataCy("update-status-button").click();
-
-    cy.dataCy("host-status-select").click();
-
-    cy.dataCy("decommissioned-option").click();
-
-    cy.dataCy("host-status-notes").type("notes");
-
-    cy.dataCy("modal-cancel-button").click();
-
     cy.dataCy("update-status-button").click();
 
     cy.dataCy("host-status-select").within(() => {

--- a/cypress/integration/myPatches/my_patches.ts
+++ b/cypress/integration/myPatches/my_patches.ts
@@ -204,6 +204,7 @@ const patchOnCommitQueue =
 const firstPageDisplayNames = [
   "main: EVG-7823 add a commit queue message (#4048)",
   "dist",
+  "hello world",
   "test meee",
   "'evergreen-ci/evergreen' pull request #3186 by bsamek: EVG-7425 Don't send ShouldExit to unprovisioned hosts (https://github.com/evergreen-ci/evergreen/pull/3186)",
   "SERVER-12189 test",
@@ -211,9 +212,9 @@ const firstPageDisplayNames = [
   "Empty patch to run a lot of osx tasks",
   "the right version of ssl_fips",
   "no description",
-  "SERVER-11333 test run 4",
 ];
 const secondPageDisplayNames = [
+  "SERVER-11333 test run 4",
   "linux-64",
   "linux-64",
   "all",
@@ -223,9 +224,9 @@ const secondPageDisplayNames = [
   "SERVER-11183 test run 2",
   "SERVER-11183 test run",
   "SERVER-10992 SERVER-11130 test run",
-  "linux-64-duroff,linux-64-debug-duroff",
 ];
 const thirdPageDisplayNames = [
+  "linux-64-duroff,linux-64-debug-duroff",
   "all",
   "linux-64",
   "osx-108-cxx11-debug",

--- a/cypress/integration/myPatches/my_patches.ts
+++ b/cypress/integration/myPatches/my_patches.ts
@@ -204,8 +204,8 @@ const patchOnCommitQueue =
 const firstPageDisplayNames = [
   "main: EVG-7823 add a commit queue message (#4048)",
   "dist",
-  "hello world",
   "test meee",
+  "Patch with display tasks",
   "'evergreen-ci/evergreen' pull request #3186 by bsamek: EVG-7425 Don't send ShouldExit to unprovisioned hosts (https://github.com/evergreen-ci/evergreen/pull/3186)",
   "SERVER-12189 test",
   "testtest",

--- a/cypress/integration/patch/configure_patch.ts
+++ b/cypress/integration/patch/configure_patch.ts
@@ -1,358 +1,21 @@
 // / <reference types="Cypress" />
 // / <reference path="../../support/index.d.ts" />
-
 const unactivatedPatchId = "5e6bb9e23066155a993e0f1a";
 const patchWithDisplayTasks = "5e6bb9e23066155a993e0f1b";
-const patch = {
-  id: "5e6bb9e23066155a993e0f1a",
-  description: "test meee",
-  author: "admin",
-  alias: "",
-  status: "created",
-  activated: false,
-  commitQueuePosition: null,
-  time: { submittedAt: "March 13, 2020, 4:50PM", __typename: "PatchTime" },
-  project: {
-    tasks: [
-      "coverage",
-      "smoke-test-task",
-      "smoke-test-endpoints",
-      "smoke-test-agent-monitor",
-      "generate-lint",
-      "js-test",
-      "dist",
-      "test-thirdparty-docker",
-      "test-auth",
-      "test-rest-route",
-      "test-rest-client",
-      "test-rest-model",
-      "test-command",
-      "test-units",
-      "test-agent",
-      "test-rest-data",
-      "test-operations",
-      "test-db",
-      "test-cloud",
-      "test-scheduler",
-      "test-service",
-      "test-monitor",
-      "test-evergreen",
-      "test-thirdparty",
-      "test-trigger",
-      "test-util",
-      "test-validator",
-      "test-model",
-      "test-model-alertrecord",
-      "test-model-artifact",
-      "test-model-build",
-      "test-model-event",
-      "test-model-host",
-      "test-model-notification",
-      "test-model-patch",
-      "test-model-stats",
-      "test-model-task",
-      "test-model-testresult",
-      "test-model-user",
-      "test-model-distro",
-      "test-model-commitqueue",
-      "test-model-manifest",
-      "test-plugin",
-      "test-migrations",
-      "test-model-grid",
-      "test-graphql",
-      "docker-cleanup",
-      "test-repotracker",
-    ],
-    variants: [
-      {
-        name: "linux-docker",
-        displayName: "ArchLinux (Docker)",
-        tasks: ["docker-cleanup"],
-        __typename: "ProjectBuildVariant",
-      },
-      {
-        name: "coverage",
-        displayName: "Coverage",
-        tasks: ["coverage"],
-        __typename: "ProjectBuildVariant",
-      },
-      {
-        name: "lint",
-        displayName: "Lint",
-        tasks: ["generate-lint"],
-        __typename: "ProjectBuildVariant",
-      },
-      {
-        name: "osx",
-        displayName: "OSX",
-        tasks: [
-          "dist",
-          "test-agent",
-          "test-auth",
-          "test-cloud",
-          "test-command",
-          "test-db",
-          "test-evergreen",
-          "test-graphql",
-          "test-migrations",
-          "test-model",
-          "test-model-alertrecord",
-          "test-model-artifact",
-          "test-model-build",
-          "test-model-commitqueue",
-          "test-model-distro",
-          "test-model-event",
-          "test-model-grid",
-          "test-model-host",
-          "test-model-manifest",
-          "test-model-notification",
-          "test-model-patch",
-          "test-model-stats",
-          "test-model-task",
-          "test-model-testresult",
-          "test-model-user",
-          "test-monitor",
-          "test-operations",
-          "test-plugin",
-          "test-repotracker",
-          "test-rest-client",
-          "test-rest-data",
-          "test-rest-model",
-          "test-rest-route",
-          "test-scheduler",
-          "test-service",
-          "test-thirdparty",
-          "test-thirdparty-docker",
-          "test-trigger",
-          "test-units",
-          "test-util",
-          "test-validator",
-        ],
-        __typename: "ProjectBuildVariant",
-      },
-      {
-        name: "rhel71-power8",
-        displayName: "RHEL 7.1 POWER8",
-        tasks: [
-          "test-agent",
-          "test-command",
-          "test-rest-client",
-          "test-thirdparty",
-          "test-thirdparty-docker",
-          "test-util",
-        ],
-        __typename: "ProjectBuildVariant",
-      },
-      {
-        name: "rhel72-s390x",
-        displayName: "RHEL 7.2 zLinux",
-        tasks: [
-          "test-agent",
-          "test-command",
-          "test-rest-client",
-          "test-thirdparty",
-          "test-thirdparty-docker",
-          "test-util",
-        ],
-        __typename: "ProjectBuildVariant",
-      },
-      {
-        name: "race-detector",
-        displayName: "Race Detector",
-        tasks: [
-          "test-agent",
-          "test-auth",
-          "test-cloud",
-          "test-command",
-          "test-db",
-          "test-evergreen",
-          "test-graphql",
-          "test-migrations",
-          "test-model",
-          "test-model-alertrecord",
-          "test-model-artifact",
-          "test-model-build",
-          "test-model-commitqueue",
-          "test-model-distro",
-          "test-model-event",
-          "test-model-grid",
-          "test-model-host",
-          "test-model-manifest",
-          "test-model-notification",
-          "test-model-patch",
-          "test-model-stats",
-          "test-model-task",
-          "test-model-testresult",
-          "test-model-user",
-          "test-monitor",
-          "test-operations",
-          "test-plugin",
-          "test-repotracker",
-          "test-rest-client",
-          "test-rest-data",
-          "test-rest-model",
-          "test-rest-route",
-          "test-scheduler",
-          "test-service",
-          "test-thirdparty",
-          "test-thirdparty-docker",
-          "test-trigger",
-          "test-units",
-          "test-util",
-          "test-validator",
-        ],
-        __typename: "ProjectBuildVariant",
-      },
-      {
-        name: "ubuntu1604",
-        displayName: "Ubuntu 16.04",
-        tasks: [
-          "dist",
-          "js-test",
-          "smoke-test-agent-monitor",
-          "smoke-test-endpoints",
-          "smoke-test-task",
-          "test-agent",
-          "test-auth",
-          "test-cloud",
-          "test-command",
-          "test-db",
-          "test-evergreen",
-          "test-graphql",
-          "test-migrations",
-          "test-model",
-          "test-model-alertrecord",
-          "test-model-artifact",
-          "test-model-build",
-          "test-model-commitqueue",
-          "test-model-distro",
-          "test-model-event",
-          "test-model-grid",
-          "test-model-host",
-          "test-model-manifest",
-          "test-model-notification",
-          "test-model-patch",
-          "test-model-stats",
-          "test-model-task",
-          "test-model-testresult",
-          "test-model-user",
-          "test-monitor",
-          "test-operations",
-          "test-plugin",
-          "test-repotracker",
-          "test-rest-client",
-          "test-rest-data",
-          "test-rest-model",
-          "test-rest-route",
-          "test-scheduler",
-          "test-service",
-          "test-thirdparty",
-          "test-thirdparty-docker",
-          "test-trigger",
-          "test-units",
-          "test-util",
-          "test-validator",
-        ],
-        __typename: "ProjectBuildVariant",
-      },
-      {
-        name: "ubuntu1604-docker",
-        displayName: "Ubuntu 16.04 (Docker)",
-        tasks: [
-          "dist",
-          "smoke-test-agent-monitor",
-          "smoke-test-endpoints",
-          "smoke-test-task",
-          "test-agent",
-          "test-auth",
-          "test-cloud",
-          "test-command",
-          "test-db",
-          "test-evergreen",
-          "test-graphql",
-          "test-migrations",
-          "test-model",
-          "test-model-alertrecord",
-          "test-model-artifact",
-          "test-model-build",
-          "test-model-commitqueue",
-          "test-model-distro",
-          "test-model-event",
-          "test-model-grid",
-          "test-model-host",
-          "test-model-manifest",
-          "test-model-notification",
-          "test-model-patch",
-          "test-model-stats",
-          "test-model-task",
-          "test-model-testresult",
-          "test-model-user",
-          "test-monitor",
-          "test-operations",
-          "test-plugin",
-          "test-repotracker",
-          "test-rest-client",
-          "test-rest-data",
-          "test-rest-model",
-          "test-rest-route",
-          "test-scheduler",
-          "test-service",
-          "test-thirdparty",
-          "test-thirdparty-docker",
-          "test-trigger",
-          "test-units",
-          "test-util",
-          "test-validator",
-        ],
-        __typename: "ProjectBuildVariant",
-      },
-      {
-        name: "ubuntu1604-arm64",
-        displayName: "Ubuntu 16.04 ARM",
-        tasks: [
-          "test-agent",
-          "test-command",
-          "test-rest-client",
-          "test-thirdparty",
-          "test-thirdparty-docker",
-          "test-util",
-        ],
-        __typename: "ProjectBuildVariant",
-      },
-      {
-        name: "windows",
-        displayName: "Windows",
-        tasks: [
-          "test-agent",
-          "test-command",
-          "test-operations",
-          "test-rest-client",
-          "test-thirdparty",
-          "test-thirdparty-docker",
-          "test-util",
-        ],
-        __typename: "ProjectBuildVariant",
-      },
-    ],
-    __typename: "PatchProject",
-  },
-  variantsTasks: [
-    {
-      name: "ubuntu1604",
-      tasks: ["test-graphql"],
-      __typename: "VariantTask",
-    },
-  ],
-  __typename: "Patch",
-};
 
 describe("Configure Patch Page", () => {
   before(() => {
     cy.login();
-    cy.visit(`/version/${unactivatedPatchId}`);
   });
+  beforeEach(() => {
+    cy.preserveCookies();
+  });
+
   describe("Initial state reflects patch data", () => {
-    it("Configure patch path is present in url", () => {
+    before(() => {
+      cy.visit(`/version/${unactivatedPatchId}`);
+    });
+    it("Should Redirect to configure page for unconfigured patches", () => {
       cy.location().should((loc) =>
         expect(loc.pathname).to.eq(
           `/patch/${unactivatedPatchId}/configure/tasks`
@@ -360,349 +23,407 @@ describe("Configure Patch Page", () => {
       );
     });
     it("Patch name input field value is patch description", () => {
-      cy.dataCy("configurePatch-nameInput")
+      cy.dataCy("patch-name-input")
         .invoke("val")
         .then((text) => {
-          expect(text).to.equal(patch.description);
+          expect(text).to.equal("test meee");
         });
     });
     it("First build variant in list is selected by default", () => {
-      const firstVariantDisplayNameInList =
-        patch.project.variants[0].displayName;
-      cy.get("[data-cy-selected=true]")
-        .invoke("text")
-        .should("eq", firstVariantDisplayNameInList);
+      cy.dataCy("build-variant-list-item")
+        .first()
+        .should("have.attr", "data-selected", "true");
     });
-    it("Patch tasks are selected by default", () => {
-      const { variantsTasks } = patch;
-      variantsTasks.forEach(({ name, tasks }) => {
-        cy.get(`[data-cy-name=${name}`)
-          .click()
-          .then(() => {
-            tasks.forEach((task) => {
-              cy.dataCy(`configurePatch-${task}`).should("be.checked");
-            });
-          });
+    describe("visiting a configure page with display tasks", () => {
+      before(() => {
+        cy.visit(`patch/${patchWithDisplayTasks}/configure/tasks`);
+      });
+      it("should show display tasks if there are any", () => {
+        cy.contains("display_task");
       });
     });
   });
-  describe("Add parameters", () => {
+
+  describe("Switching tabs", () => {
     before(() => {
-      cy.login();
-    });
-    beforeEach(() => {
-      cy.preserveCookies();
-    });
-    it("Navigating to 'Parameters' tab shows the existing parameters", () => {
       cy.visit(`patch/${unactivatedPatchId}/configure/tasks`);
       cy.wait(10);
+    });
+    it("Should be able to switch between tabs", () => {
+      cy.get('button[data-cy="changes-tab"]').click();
+      cy.location("pathname").should(
+        "eq",
+        `/patch/${unactivatedPatchId}/configure/changes`
+      );
       cy.get('button[data-cy="parameters-tab"]').click();
-      cy.dataCy("select-variants-and-task-card-wrapper").should(
+      cy.location("pathname").should(
+        "eq",
+        `/patch/${unactivatedPatchId}/configure/parameters`
+      );
+      cy.get('button[data-cy="tasks-tab"]').click();
+      cy.location("pathname").should(
+        "eq",
+        `/patch/${unactivatedPatchId}/configure/tasks`
+      );
+    });
+    it("Navigating away from the configure tab should disable the build variant selector", () => {
+      cy.get('button[data-cy="changes-tab"]').click();
+      cy.dataCy("build-variant-select-wrapper").should("have.attr", "disabled");
+      cy.dataCy("build-variant-select-wrapper").should(
         "have.css",
         "pointer-events",
         "none"
       );
     });
-    it("Adding a parameter is reflected on the page", () => {
-      cy.visit(`patch/${unactivatedPatchId}/configure/tasks`);
-      cy.wait(10);
-      cy.get('button[data-cy="parameters-tab"]').click();
-      cy.dataCy("add-tag-button").click();
-      cy.dataCy("user-tag-key-field").type("testKey");
-      cy.dataCy("user-tag-value-field").type("testValue");
-      cy.dataCy("user-tag-edit-icon").click();
-      cy.dataCy("user-tag-row").its("length").should("eq", 1);
+  });
+
+  describe("Patch Parameters", () => {
+    describe("Unactivated Patch", () => {
+      before(() => {
+        cy.visit(`patch/${unactivatedPatchId}/configure/tasks`);
+        cy.get('button[data-cy="parameters-tab"]').click();
+      });
+      it("Adding a parameter is reflected on the page", () => {
+        cy.dataCy("add-tag-button").click();
+        cy.dataCy("user-tag-key-field").type("testKey");
+        cy.dataCy("user-tag-value-field").type("testValue");
+        cy.dataCy("user-tag-edit-icon").click();
+        cy.dataCy("user-tag-row").its("length").should("eq", 1);
+      });
     });
-    it("Parameters cannot be added once activated", () => {
-      cy.visit(`patch/5ecedafb562343215a7ff297/configure/tasks`);
-      cy.wait(10);
-      cy.get('button[data-cy="parameters-tab"]').click();
-      cy.dataCy("parameters-disclaimer").should("exist");
-      cy.dataCy("badge-this-is-a-parameter").should("exist");
-      cy.dataCy("badge-my_team").should("exist");
+    describe("Activated Patch", () => {
+      before(() => {
+        cy.visit(`patch/5ecedafb562343215a7ff297/configure/tasks`);
+        cy.get('button[data-cy="parameters-tab"]').click();
+      });
+      it("Parameters cannot be added once activated", () => {
+        cy.dataCy("add-tag-button").should("not.exist");
+        cy.dataCy("parameters-disclaimer").should("exist");
+        cy.dataCy("badge-this-is-a-parameter").should("exist");
+        cy.dataCy("badge-my_team").should("exist");
+      });
     });
   });
 
   describe("Configuring a patch", () => {
     before(() => {
-      cy.login();
-      cy.preserveCookies();
+      cy.visit(`patch/${unactivatedPatchId}/configure/tasks`);
     });
     it("Can update patch description by typing into `Patch Name` input field", () => {
-      cy.visit(`patch/${unactivatedPatchId}/configure/tasks`);
       const val = "michelle obama";
-      cy.dataCy(`configurePatch-nameInput`)
-        .as("patchNameInput")
-        .clear()
-        .type(val);
-      cy.get("@patchNameInput").invoke("val").should("eq", val);
+      cy.dataCy(`patch-name-input`).clear().type(val);
+      cy.dataCy(`patch-name-input`).should("have.value", val);
     });
-    it("Selecting build variant displays tasks of that variant", () => {
-      patch.project.variants.forEach(({ name, tasks }) => {
-        cy.get(`[data-cy-name=${name}`)
-          .click()
-          .then(() => {
-            cy.dataCy(`configurePatch-tasks`)
-              .children()
-              .its("length")
-              .should("eq", tasks.length);
-          });
-      });
-    });
-    it("Clicking on tasks checks them and updates task counts", () => {
-      // select last build variant in list
-      const { variants } = patch.project;
-      const lastVariantInList = variants[variants.length - 1];
-      const firstTask = lastVariantInList.tasks[0];
-      cy.get(`[data-cy-name=${lastVariantInList.name}`).as("variant").click();
+    it("Schedule button should be disabled when no tasks are selected and enabled when they are", () => {
+      cy.dataCy("task-checkbox").should("not.be.checked");
+      cy.dataCy("schedule-patch").should("be.disabled");
+      cy.dataCy("task-checkbox").check({ force: true });
 
-      cy.get("@variant").then(($variant) => {
-        const taskCountBadge = `[data-cy=configurePatch-taskCountBadge-${lastVariantInList.name}]`;
-        if ($variant.find(taskCountBadge).length > 0) {
-          cy.get(taskCountBadge)
-            .as("taskCount")
-            .invoke("text")
-            .then(($taskCount) => {
-              const firstTask1 = lastVariantInList.tasks[0];
-              cy.dataCy(`configurePatch-${firstTask1}`).check({
-                force: true,
-              });
-              cy.get("@taskCount")
-                .invoke("text")
-                .then(($newTaskCount) => {
-                  expect(getTaskCountFromText($newTaskCount)).to.eq(
-                    getTaskCountFromText($taskCount) + 1
-                  );
-                  cy.get("@taskCheckbox").uncheck({
-                    force: true,
-                  });
-                  cy.get(taskCountBadge)
-                    .invoke("text")
-                    .should("eq", $taskCount);
-                });
-            });
-        } else {
-          cy.dataCy(`configurePatch-${firstTask}`).as("taskCheckbox").check({
-            force: true,
-          });
-          cy.get(taskCountBadge)
-            .invoke("text")
-            .then(($newTaskCount) => {
-              expect(getTaskCountFromText($newTaskCount)).to.eq(1);
-              // unselect checkbox
-              cy.get("@taskCheckbox").uncheck({
-                force: true,
-              });
-              cy.get(taskCountBadge).should("not.exist");
-            });
-        }
+      cy.dataCy("schedule-patch").should("not.be.disabled");
+      cy.dataCy("task-checkbox").uncheck({ force: true });
+    });
+    it("Clicking on unchecked tasks checks them and updates task counts", () => {
+      const variantItem = cy.dataCy("build-variant-list-item");
+      variantItem.eq(-1).click();
+
+      variantItem.find('[data-cy="task-count-badge"]').should("not.exist");
+      let count = 0;
+      cy.dataCy("selected-task-disclaimer").contains(
+        `${count} tasks across 0 build variants`
+      );
+      cy.dataCy("task-checkbox").each(($el) => {
+        const checkbox = cy.wrap($el);
+        checkbox.should("not.be.checked");
+        checkbox.check({
+          force: true,
+        });
+        count += 1;
+        checkbox.should("be.checked");
+        cy.dataCy("selected-task-disclaimer").contains(`${count} task`);
+        cy.dataCy("selected-task-disclaimer").contains(`1 build variant`);
+        cy.dataCy("build-variant-list-item")
+          .find('[data-cy="task-count-badge"]')
+          .should("exist");
+        cy.dataCy("build-variant-list-item")
+          .find('[data-cy="task-count-badge"]')
+          .should("have.text", count);
       });
     });
-    describe("Select/Deselect All buttons", () => {
-      const checkboxTaskNames = [
-        "test-agent",
-        "test-command",
-        "test-operations",
-        "test-rest-client",
-        "test-thirdparty",
-        "test-thirdparty-docker",
-        "test-util",
-      ];
-      it("Clicking Select All should check all task checkboxes when all of the task checkboxes unchecked", () => {
-        cy.dataCy("configurePatch-selectAll").click({ force: true });
-        cy.get("[data-checked=task-checkbox-checked]")
-          .its("length")
-          .should("eq", 7);
+    it("Clicking on checked tasks unchecks them and updates task counts", () => {
+      const variantItem = cy.dataCy("build-variant-list-item");
+      variantItem.find('[data-cy="task-count-badge"]').should("exist");
+      let count = 7;
+      cy.dataCy("selected-task-disclaimer").contains(
+        `${count} tasks across 1 build variant`
+      );
+
+      cy.dataCy("task-checkbox").each(($el) => {
+        const checkbox = cy.wrap($el);
+        checkbox.should("be.checked");
+        checkbox.uncheck({
+          force: true,
+        });
+        count -= 1;
+        checkbox.should("not.be.checked");
       });
-      it("Clicking on Select All should uncheck all task checkboxes when all of the task checkboxes are checked", () => {
-        cy.dataCy("configurePatch-selectAll").click({ force: true });
-        cy.get("[data-checked=task-checkbox-unchecked]")
-          .its("length")
-          .should("eq", 7);
+
+      cy.dataCy("build-variant-list-item")
+        .find('[data-cy="task-count-badge"]')
+        .should("not.exist");
+      cy.dataCy("selected-task-disclaimer").contains(
+        `0 tasks across 0 build variants`
+      );
+    });
+
+    describe("Select/Deselect All buttons", () => {
+      it("Checking Select All should check all task checkboxes when all of the task checkboxes unchecked", () => {
+        cy.dataCy("select-all-checkbox").check({
+          force: true,
+        });
+        cy.dataCy("task-checkbox").each(($el) => {
+          cy.wrap($el).should("be.checked");
+        });
+      });
+      it("Unchecking the Select All checkbox should uncheck all task checkboxes when all of the task checkboxes are checked", () => {
+        cy.dataCy("select-all-checkbox").uncheck({
+          force: true,
+        });
+        cy.dataCy("task-checkbox").each(($el) => {
+          cy.wrap($el).should("not.be.checked");
+        });
       });
       it("Checking all task checkboxes should check the Select All checkbox", () => {
-        cy.wrap(checkboxTaskNames).each((taskName) => {
-          cy.dataCy(`configurePatch-${taskName}`).click({ force: true });
+        cy.dataCy("select-all-checkbox").should("not.be.checked");
+        cy.dataCy("task-checkbox").each(($el) => {
+          cy.wrap($el).check({ force: true });
         });
-        cy.get("[data-checked=selectAll-checked]").should("exist");
+        cy.dataCy("select-all-checkbox").should("be.checked");
       });
       it("Unchecking all task checkboxes should uncheck the Select All checkbox", () => {
-        cy.wrap(checkboxTaskNames).each((taskName) => {
-          cy.dataCy(`configurePatch-${taskName}`).click({ force: true });
+        cy.dataCy("select-all-checkbox").should("be.checked");
+        cy.dataCy("task-checkbox").each(($el) => {
+          cy.wrap($el).uncheck({ force: true });
         });
-        cy.get("[data-checked=selectAll-unchecked]").should("exist");
+        cy.dataCy("select-all-checkbox").should("not.be.checked");
       });
-      it("A mixture of checked and unchecked task checkboxes sets the Select All checkbox in an indeterminate state", () => {
-        cy.dataCy("configurePatch-test-agent").click({ force: true });
+      //   TODO: Fix this test after PD-1386
+      it.skip("A mixture of checked and unchecked task checkboxes sets the Select All checkbox in an indeterminate state", () => {
+        cy.dataCy("configurePatch-test-agent").click({
+          force: true,
+        });
         cy.get("[data-checked=selectAll-indeterminate]").should("exist");
       });
     });
 
     describe("Build variant selection", () => {
+      it("Should be able to select and unselect an individual task and have task count be reflected in variant tab badge and task count label", () => {
+        cy.dataCy("build-variant-list-item")
+          .contains("RHEL 7.2 zLinux")
+          .click();
+        getInputByLabel("test-agent").check({
+          force: true,
+        });
+        cy.dataCy("task-count-badge").should("have.length", 1);
+        cy.dataCy("task-count-badge").contains("1");
+
+        cy.dataCy("selected-task-disclaimer").contains(
+          "1 task across 1 build variant"
+        );
+        getInputByLabel("test-agent").uncheck({
+          force: true,
+        });
+        cy.dataCy("task-count-badge").should("not.exist");
+        cy.dataCy("selected-task-disclaimer").contains(
+          "0 tasks across 0 build variants"
+        );
+      });
       it("Selecting multiple build variants should display deduplicated task checkboxes", () => {
-        cy.get("body").type("{meta}", { release: false });
-        cy.get('[data-cy-name="rhel72-s390x"]').click();
-        cy.dataCy("configurePatch-tasks")
-          .children()
-          .its("length")
-          .should("eq", 7);
-        cy.get('[data-cy-name="rhel71-power8"]').click();
-        cy.dataCy("configurePatch-tasks")
-          .children()
-          .its("length")
-          .should("eq", 7);
-        cy.get('[data-cy-name="race-detector"]').click();
-        cy.dataCy("configurePatch-tasks")
-          .children()
-          .its("length")
-          .should("eq", 40);
-        cy.get("body").type("{meta}", { release: true });
+        cy.get("body").type("{meta}", {
+          release: false,
+        });
+        cy.dataCy("build-variant-list-item")
+          .contains("RHEL 7.2 zLinux")
+          .click();
+
+        cy.dataCy("build-variant-list-item")
+          .contains("RHEL 7.1 POWER8")
+          .click();
+
+        cy.dataCy("build-variant-list-item").contains("Race Detector").click();
+        cy.get("body").type("{meta}", {
+          release: true,
+        });
+        getInputByLabel("test-agent").should("have.length", 1);
       });
 
-      it("Deselecting multiple build variants should display deduplicated task checkboxes", () => {
-        cy.get("body").type("{meta}", { release: false });
-        cy.get('[data-cy-name="rhel72-s390x"]').click();
-        cy.dataCy("configurePatch-tasks")
-          .children()
-          .its("length")
-          .should("eq", 40);
-        cy.get('[data-cy-name="rhel71-power8"]').click();
-        cy.dataCy("configurePatch-tasks")
-          .children()
-          .its("length")
-          .should("eq", 40);
-        cy.get('[data-cy-name="race-detector"]').click();
-        cy.dataCy("configurePatch-tasks")
-          .children()
-          .its("length")
-          .should("eq", 7);
+      it("Deselecting multiple build variants should remove the associated tasks ", () => {
+        cy.dataCy("task-checkbox").as("before-tasks");
+        cy.get("body").type("{meta}", {
+          release: false,
+        });
+        cy.dataCy("build-variant-list-item").contains("Race Detector").click();
+        cy.dataCy("build-variant-list-item")
+          .contains("RHEL 7.1 POWER8")
+          .click();
+
+        cy.dataCy("build-variant-list-item")
+          .contains("RHEL 7.2 zLinux")
+          .click();
+        cy.dataCy("task-checkbox").should("have.length", 6);
       });
 
       it("Checking a deduplicated task between multiple build variants updates the task within each selected build variant", () => {
-        cy.get("body").type("{meta}", { release: false });
-        cy.get('[data-cy-name="rhel72-s390x"]').click();
-        cy.get('[data-cy-name="rhel71-power8"]').click();
-        cy.get("body").type("{meta}", { release: true });
-        cy.dataCy("configurePatch-test-agent").click({ force: true });
-        cy.dataCy("configurePatch-test-agent").click({ force: true });
-        cy.get('[data-cy-name="rhel72-s390x"]').click({ force: true });
-        cy.get("[data-checked=task-checkbox-checked]")
-          .its("length")
-          .should("eq", 1);
-        cy.get('[data-cy-name="rhel71-power8"').click({ force: true });
-        cy.get("[data-checked=task-checkbox-checked]")
-          .its("length")
-          .should("eq", 1);
-        cy.get('[data-cy-name="windows"').click({ force: true });
-        cy.get("[data-checked=task-checkbox-checked]")
-          .its("length")
-          .should("eq", 1);
+        cy.get("body").type("{meta}", {
+          release: false,
+        });
+        cy.dataCy("build-variant-list-item")
+          .contains("RHEL 7.2 zLinux")
+          .click();
+        cy.dataCy("build-variant-list-item")
+          .contains("RHEL 7.1 POWER8")
+          .click();
+        cy.get("body").type("{meta}", {
+          release: true,
+        });
+        getInputByLabel("test-agent").should("have.length", 1);
+        getInputByLabel("test-agent").check({
+          force: true,
+        });
+        cy.dataCy("build-variant-list-item").within(($el) => {
+          cy.wrap($el)
+            .find('[data-cy="task-count-badge"]')
+            .should("have.text", 11);
+        });
+
+        cy.dataCy("build-variant-list-item")
+          .contains("RHEL 7.2 zLinux")
+          .click();
+
+        getInputByLabel("test-agent").should("be.checked");
+
+        cy.dataCy("build-variant-list-item")
+          .contains("RHEL 7.1 POWER8")
+          .click();
+        getInputByLabel("test-agent").should("be.checked");
+
+        // Deselect the buttons and reset                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                ;
+        getInputByLabel("test-agent").uncheck({
+          force: true,
+        });
+        cy.dataCy("build-variant-list-item")
+          .contains("RHEL 7.2 zLinux")
+          .click();
+
+        getInputByLabel("test-agent").uncheck({
+          force: true,
+        });
       });
 
-      it("Should be able to select/deselect all for multiple build variants and have the number of selected tasks reflected in the variant tab bade and task count label", () => {
-        cy.get("body").type("{meta}", { release: false });
-        cy.get('[data-cy-name="rhel72-s390x"]').click();
-        cy.get('[data-cy-name="rhel71-power8"]').click();
-        cy.dataCy("configurePatch-selectAll").click({ force: true });
-        cy.get("[data-checked=task-checkbox-checked]")
-          .its("length")
-          .should("eq", 7);
-        cy.contains("20 tasks across 4 build variants");
-        cy.dataCy("configurePatch-taskCountBadge-rhel71-power8").contains("6");
-        cy.dataCy("configurePatch-taskCountBadge-rhel72-s390x").contains("6");
-        cy.dataCy("configurePatch-taskCountBadge-windows").contains("7");
-        cy.dataCy("configurePatch-selectAll").click({ force: true });
-        cy.get("[data-checked=task-checkbox-unchecked]")
-          .its("length")
-          .should("eq", 7);
-        cy.contains("1 task across 1 build variant");
-        cy.dataCy("configurePatch-taskCountBadge-rhel71-power8").should(
-          "not.exist"
-        );
-        cy.dataCy("configurePatch-taskCountBadge-rhel72-s390x").should(
-          "not.exist"
-        );
-        cy.dataCy("configurePatch-taskCountBadge-windows").should("not.exist");
+      describe("Selecting/deselecting all multiple buildvariants", () => {
+        it("Should be able to select all tasks from multiple build variants", () => {
+          cy.dataCy("build-variant-list-item")
+            .contains("RHEL 7.2 zLinux")
+            .click();
+
+          cy.dataCy("task-checkbox").its("length").as("variant1TaskCount");
+
+          cy.dataCy("build-variant-list-item")
+            .contains("RHEL 7.1 POWER8")
+            .click();
+
+          cy.dataCy("task-checkbox").its("length").as("variant2TaskCount");
+
+          cy.get("body").type("{meta}", {
+            release: false,
+          });
+          cy.dataCy("build-variant-list-item")
+            .contains("RHEL 7.2 zLinux")
+            .click();
+
+          cy.dataCy("select-all-checkbox").check({
+            force: true,
+          });
+          cy.dataCy("task-checkbox").each(($el) => {
+            cy.wrap($el).should("be.checked");
+          });
+
+          cy.get("@variant1TaskCount").then((variant1TaskCount) => {
+            cy.get("@variant2TaskCount").then((variant2TaskCount) => {
+              cy.dataCy("selected-task-disclaimer").contains(
+                `${
+                  variant1TaskCount + variant2TaskCount
+                } tasks across 2 build variants`
+              );
+            });
+          });
+          cy.get("body").type("{meta}", {
+            release: true,
+          });
+        });
+
+        it("Should be able to deselect all tasks from multiple build variants", () => {
+          cy.dataCy("build-variant-list-item")
+            .contains("RHEL 7.2 zLinux")
+            .click();
+
+          cy.dataCy("task-checkbox").each(($el) => {
+            cy.wrap($el).should("be.checked");
+          });
+
+          cy.dataCy("build-variant-list-item")
+            .contains("RHEL 7.1 POWER8")
+            .click();
+
+          cy.dataCy("task-checkbox").each(($el) => {
+            cy.wrap($el).should("be.checked");
+          });
+
+          cy.get("body").type("{meta}", {
+            release: false,
+          });
+          cy.dataCy("build-variant-list-item")
+            .contains("RHEL 7.2 zLinux")
+            .click();
+
+          cy.dataCy("select-all-checkbox").uncheck({
+            force: true,
+          });
+
+          cy.dataCy("task-checkbox").each(($el) => {
+            cy.wrap($el).should("not.be.checked");
+          });
+
+          cy.dataCy("selected-task-disclaimer").contains(
+            `0 tasks across 0 build variants`
+          );
+        });
       });
 
-      it("Should be able to select and unselect an individual task and have task count be reflected in variant tab badge and task count label", () => {
-        cy.dataCy("configurePatch-test-agent").click({ force: true });
-        cy.dataCy("configurePatch-taskCountBadge-rhel71-power8").contains("1");
-        cy.dataCy("configurePatch-taskCountBadge-rhel72-s390x").contains("1");
-        cy.dataCy("configurePatch-taskCountBadge-windows").contains("1");
-        cy.contains("4 tasks across 4 build variants");
-      });
       it("Shift+click will select the clicked build variant along with all build variants between the clicked build variant and the first selected build variant in the list", () => {
-        cy.get("body").type("{shift}", { release: false }); // hold shift
-        cy.get('[data-cy-name="windows"]').click();
-        cy.get("[data-cy-selected=true]").its("length").should("eq", 7);
-        const variantsFirstTime = [
-          "RHEL 7.1 POWER81",
-          "RHEL 7.2 zLinux",
-          "Race Detector",
-          "Ubuntu 16.041",
-          "Ubuntu 16.04 (Docker)",
-          "Ubuntu 16.04 ARM",
-          "Windows1",
-        ];
-        cy.get("[data-cy-selected=true]").each((v, i) => {
-          cy.wrap(v).contains(variantsFirstTime[i]);
-        });
-        cy.get("body").type("{shift}", { release: true }); // release shift
-        cy.get("body").type("{meta}", { release: false }); // hold meta
-        cy.get('[data-cy-name="lint"]').click();
-        cy.get("body").type("{meta}", { release: true }); // release meta
-        cy.get("body").type("{shift}", { release: false }); // hold shift
-        cy.get('[data-cy-name="linux-docker"]').click();
-        const variantsSecondTime = [
-          "ArchLinux (Docker)",
-          "Coverage",
-          "Lint",
-        ].concat(variantsFirstTime);
-        cy.get("[data-cy-selected=true]").each((v, i) => {
-          cy.wrap(v).contains(variantsSecondTime[i]);
-        });
-        cy.get("[data-cy-selected=true]").its("length").should("eq", 10);
+        cy.get("body").type("{shift}", {
+          release: false,
+        }); // hold shift
+        cy.dataCy("build-variant-list-item")
+          .contains("RHEL 7.2 zLinux")
+          .click();
+
+        cy.dataCy("build-variant-list-item").contains("Windows").click();
+
+        cy.get("[data-selected=true]").its("length").should("eq", 6);
       });
     });
   });
-  describe("visiting a configure page with display tasks", () => {
-    before(() => {
-      cy.login();
-      cy.preserveCookies();
-    });
-    it("should show display tasks if there are any", () => {
-      cy.visit(`patch/${patchWithDisplayTasks}/configure/tasks`);
-      cy.dataCy("configurePatch-display_task").should("exist");
-    });
-  });
-  describe("Indeterminate task checkbox states", () => {
-    it("Checking a task in 1 build variant but not the other shows the task checkbox as indeterminate when viewing tasks from both variants and puts the Select All checkbox in an indeterminate state", () => {
-      cy.get('[data-cy-name="rhel72-s390x"]').click();
-      cy.dataCy("configurePatch-test-agent").click({ force: true });
-      cy.get("body").type("{meta}", { release: false });
-      cy.get('[data-cy-name="rhel71-power8"]').click();
-      cy.get(
-        "[data-name-checked=task-checkbox-test-agent-indeterminate]"
-      ).should("exist");
-      cy.get("[data-checked=selectAll-indeterminate]").should("exist");
-    });
-  });
+
+  //   Using mocked responses because we are unable to schedule a patch because of a missing github token
   describe("Scheduling a patch", () => {
-    before(() => {
-      cy.login();
-    });
     beforeEach(() => {
-      cy.preserveCookies();
       cy.server();
+      cy.visit(`/patch/${unactivatedPatchId}`);
     });
     it("Clicking `Schedule` button schedules patch and redirects to patch page", () => {
-      cy.visit(`/patch/${unactivatedPatchId}`);
       const val = "hello world";
-      cy.dataCy(`configurePatch-nameInput`)
-        .as("patchNameInput")
-        .clear()
-        .type(val);
+      cy.dataCy(`patch-name-input`).as("patchNameInput").clear().type(val);
+      cy.dataCy("task-checkbox").first().check({ force: true });
       cy.route({
         method: "POST",
         url: "/graphql/query",
@@ -716,12 +437,10 @@ describe("Configure Patch Page", () => {
     });
 
     it("Shows error toast if unsuccessful and keeps data", () => {
-      cy.visit(`/version/${unactivatedPatchId}`);
       const val = "hello world";
-      cy.dataCy(`configurePatch-nameInput`)
-        .as("patchNameInput")
-        .clear()
-        .type(val);
+      cy.dataCy(`patch-name-input`).as("patchNameInput").clear().type(val);
+      cy.dataCy("task-checkbox").first().check({ force: true });
+
       cy.route({
         method: "POST",
         url: "/graphql/query",
@@ -735,44 +454,24 @@ describe("Configure Patch Page", () => {
       cy.dataCy("toast").contains("WAH WAH CHICKEN WAH");
     });
   });
-  describe("Switching tabs", () => {
-    before(() => {
-      cy.login();
-    });
-    beforeEach(() => {
-      cy.preserveCookies();
-    });
-    it("Navigating to 'Changes' tab from 'Configure' disables the 'Select Build Variants and Tasks' card", () => {
-      cy.visit(`patch/${unactivatedPatchId}/configure/tasks`);
-      cy.wait(10);
-      cy.get('button[data-cy="changes-tab"]').click();
-      cy.dataCy("select-variants-and-task-card-wrapper").should(
-        "have.css",
-        "pointer-events",
-        "none"
-      );
-      cy.dataCy("select-variants-and-task-card-wrapper").should(
-        "have.css",
-        "opacity",
-        "0.4"
-      );
-    });
-  });
 });
 
-const getTaskCountFromText = (text) => {
-  if (!text) {
-    return 0;
-  }
-  return parseInt(text, 10);
-};
+const getInputByLabel = (label) =>
+  cy
+    .contains("label", label)
+    .invoke("attr", "for")
+    .then((id) => {
+      cy.get(`#${id}`);
+    });
 
 const mockedErrorConfigureResponse = {
   errors: [
     {
       message: "WAH WAH CHICKEN WAH",
       path: ["schedulePatch"],
-      extensions: { code: "INTERNAL_SERVER_ERROR" },
+      extensions: {
+        code: "INTERNAL_SERVER_ERROR",
+      },
     },
   ],
   data: null,

--- a/cypress/integration/project/patches.ts
+++ b/cypress/integration/project/patches.ts
@@ -8,9 +8,10 @@ describe("Project Patches Page", () => {
     cy.preserveCookies();
   });
 
-  it("Patch card links to project patches page.", () => {
+  it("Should link to project patches page from the user patches page", () => {
     cy.visit("/user/admin/patches");
     cy.dataCy("project-patches-link").first().click();
     cy.location("pathname").should("eq", route);
+    cy.dataCy("patch-card").should("exist");
   });
 });

--- a/cypress/integration/project/patches.ts
+++ b/cypress/integration/project/patches.ts
@@ -5,9 +5,6 @@ const route = "/project/evergreen/patches";
 describe("Project Patches Page", () => {
   before(() => {
     cy.login();
-  });
-
-  beforeEach(() => {
     cy.preserveCookies();
   });
 
@@ -15,21 +12,5 @@ describe("Project Patches Page", () => {
     cy.visit("/user/admin/patches");
     cy.dataCy("project-patches-link").first().click();
     cy.location("pathname").should("eq", route);
-  });
-
-  it("Page title and data rows are displayed.", () => {
-    cy.visit(route);
-    cy.dataCy("patches-page-title").contains("evergreen smoke test Patches");
-    const patchDisplayNames = [
-      "Commit Queue Merge",
-      "commit queue",
-      "dist",
-      "dist",
-      "test meee",
-      "'evergreen-ci/evergreen' pull request #3186 by bsamek: EVG-7425 Don't send ShouldExit to unprovisioned hosts (https://github.com/evergreen-ci/evergreen/pull/3186)",
-    ];
-    cy.dataCy("patch-card").each(($el, index) => {
-      cy.wrap($el).contains(patchDisplayNames[index]);
-    });
   });
 });

--- a/src/pages/configurePatch/ConfigurePatchCore.tsx
+++ b/src/pages/configurePatch/ConfigurePatchCore.tsx
@@ -231,8 +231,7 @@ export const ConfigurePatchCore: React.FC<Props> = ({ patch }) => {
             >
               <Tab data-cy="tasks-tab" name="Configure">
                 <ConfigureTasks
-                  variants={variants}
-                  selectedBuildVariant={selectedBuildVariants}
+                  selectedBuildVariants={selectedBuildVariants}
                   selectedBuildVariantTasks={selectedBuildVariantTasks}
                   setSelectedBuildVariantTasks={(variantTasks) =>
                     dispatch({

--- a/src/pages/configurePatch/ConfigurePatchCore.tsx
+++ b/src/pages/configurePatch/ConfigurePatchCore.tsx
@@ -46,9 +46,16 @@ type Action =
   | { type: "setSelectedBuildVariants"; buildVariants: string[] }
   | { type: "setPatchParams"; params: ParameterInput[] }
   | { type: "setSelectedBuildVariantTasks"; variantTasks: VariantTasksState }
-  | { type: "setSelectedTab"; tabIndex: number };
+  | { type: "setSelectedTab"; tabIndex: number }
+  | {
+      type: "updatePatchData";
+      description: string;
+      buildVariants: string[];
+      params: ParameterInput[];
+      variantTasks: VariantTasksState;
+    };
 
-const initialState = ({ selectedTab = 0 }) => ({
+const initialState = ({ selectedTab = 0 }: { selectedTab: number }) => ({
   description: "",
   selectedBuildVariants: [],
   selectedBuildVariantTasks: {},
@@ -90,6 +97,14 @@ const reducer = (state: configurePatchState, action: Action) => {
           indexToTabMap[action.tabIndex] !== PatchTab.Tasks,
       };
     }
+    case "updatePatchData":
+      return {
+        ...state,
+        description: action.description,
+        selectedBuildVariants: action.buildVariants,
+        patchParams: action.params,
+        selectedBuildVariantTasks: action.variantTasks,
+      };
 
     default:
       throw new Error();
@@ -151,17 +166,11 @@ export const ConfigurePatchCore: React.FC<Props> = ({ patch }) => {
 
   useEffect(() => {
     if (patch) {
-      dispatch({ type: "setDescription", description: patch.description });
       dispatch({
-        type: "setSelectedBuildVariants",
+        type: "updatePatchData",
+        description: patch.description,
         buildVariants: [variants[0]?.name],
-      });
-      dispatch({
-        type: "setPatchParams",
-        params: patch?.parameters,
-      });
-      dispatch({
-        type: "setSelectedBuildVariantTasks",
+        params: patch.parameters,
         variantTasks: convertPatchVariantTasksToStateShape(variants),
       });
     }

--- a/src/pages/configurePatch/configurePatchCore/ConfigureBuildVariants.tsx
+++ b/src/pages/configurePatch/configurePatchCore/ConfigureBuildVariants.tsx
@@ -7,8 +7,8 @@ import { Body } from "@leafygreen-ui/typography";
 import { SiderCard } from "components/styles";
 import { Divider } from "components/styles/Divider";
 import { ProjectBuildVariant } from "gql/generated/types";
-import { VariantTasksState } from "pages/configurePatch/ConfigurePatchCore";
 import { array } from "utils";
+import { VariantTasksState } from "./state";
 
 const { toggleArray } = array;
 const { green } = uiColors;
@@ -161,7 +161,7 @@ interface UserSelectWrapperProps {
   isHotKeyPressed: boolean;
 }
 
-export const cardSidePadding = css`
+const cardSidePadding = css`
   padding-left: 8px;
   padding-right: 8px;
 `;

--- a/src/pages/configurePatch/configurePatchCore/ConfigureBuildVariants.tsx
+++ b/src/pages/configurePatch/configurePatchCore/ConfigureBuildVariants.tsx
@@ -16,15 +16,17 @@ const { green } = uiColors;
 interface Props {
   variants: ProjectBuildVariant[];
   selectedVariantTasks: VariantTasksState;
-  selectedBuildVariant: string[];
-  setSelectedBuildVariant: React.Dispatch<React.SetStateAction<string[]>>;
+  selectedBuildVariants: string[];
+  setSelectedBuildVariants: (bv: string[]) => void;
+  disabled: boolean;
 }
 
 export const ConfigureBuildVariants: React.FC<Props> = ({
   variants,
   selectedVariantTasks,
-  selectedBuildVariant,
-  setSelectedBuildVariant,
+  selectedBuildVariants,
+  setSelectedBuildVariants,
+  disabled,
 }) => {
   const [state, dispatch] = useReducer(reducer, { numButtonsPressed: 0 });
   const keyDownCb = useMemo(
@@ -54,9 +56,9 @@ export const ConfigureBuildVariants: React.FC<Props> = ({
   const getClickVariantHandler = (variantName: string) => (e): void => {
     if (e.ctrlKey || e.metaKey) {
       const updatedBuildVariants = toggleArray(variantName, [
-        ...selectedBuildVariant,
+        ...selectedBuildVariants,
       ]);
-      setSelectedBuildVariant(
+      setSelectedBuildVariants(
         updatedBuildVariants.length > 0 ? updatedBuildVariants : [variantName]
       );
     } else if (e.shiftKey) {
@@ -64,7 +66,7 @@ export const ConfigureBuildVariants: React.FC<Props> = ({
       const clickIndex = variantNames.indexOf(variantName);
       const anchorIndex = variants.reduce(
         (accum, { name }, index) =>
-          accum > -1 || !selectedBuildVariant.includes(name) ? accum : index,
+          accum > -1 || !selectedBuildVariants.includes(name) ? accum : index,
         -1
       );
       if (clickIndex === anchorIndex) {
@@ -75,57 +77,61 @@ export const ConfigureBuildVariants: React.FC<Props> = ({
       const nextSelectedBuildVariants = Array.from(
         new Set([
           ...variantNames.slice(startIndex, endIndex + 1),
-          ...selectedBuildVariant,
+          ...selectedBuildVariants,
         ])
       );
-      setSelectedBuildVariant(nextSelectedBuildVariants);
+      setSelectedBuildVariants(nextSelectedBuildVariants);
     } else {
-      setSelectedBuildVariant([variantName]);
+      setSelectedBuildVariants([variantName]);
     }
   };
   return (
-    <UserSelectWrapper isHotKeyPressed={state.numButtonsPressed !== 0}>
-      {/* @ts-expect-error */}
-      <StyledSiderCard>
-        <Container>
-          <Body weight="medium">Select Build Variants and Tasks</Body>
-          <Divider />
-        </Container>
-        <ScrollableBuildVariantContainer>
-          {variants.map(({ displayName, name }) => {
-            const taskCount = selectedVariantTasks[name]
-              ? Object.values(selectedVariantTasks[name]).filter((v) => v)
-                  .length
-              : null;
-            const isSelected = selectedBuildVariant.includes(name);
-            return (
-              <BuildVariant
-                data-cy="configurePatch-buildVariantListItem"
-                data-cy-name={name}
-                data-cy-selected={isSelected}
-                key={name}
-                isSelected={isSelected}
-                onClick={getClickVariantHandler(name)}
-              >
-                <VariantName>
-                  <Body weight={isSelected ? "medium" : "regular"}>
-                    {displayName}
-                  </Body>
-                </VariantName>
-                {taskCount > 0 && (
-                  <StyledBadge
-                    data-cy={`configurePatch-taskCountBadge-${name}`}
-                    variant={isSelected ? Variant.DarkGray : Variant.LightGray}
-                  >
-                    {taskCount}
-                  </StyledBadge>
-                )}
-              </BuildVariant>
-            );
-          })}
-        </ScrollableBuildVariantContainer>
-      </StyledSiderCard>
-    </UserSelectWrapper>
+    <DisableWrapper data-cy="build-variant-select-wrapper" disabled={disabled}>
+      <UserSelectWrapper isHotKeyPressed={state.numButtonsPressed !== 0}>
+        {/* @ts-expect-error */}
+        <StyledSiderCard>
+          <Container>
+            <Body weight="medium">Select Build Variants and Tasks</Body>
+            <Divider />
+          </Container>
+          <ScrollableBuildVariantContainer>
+            {variants.map(({ displayName, name }) => {
+              const taskCount = selectedVariantTasks[name]
+                ? Object.values(selectedVariantTasks[name]).filter((v) => v)
+                    .length
+                : 0;
+              const isSelected = selectedBuildVariants.includes(name);
+              return (
+                <BuildVariant
+                  data-cy="build-variant-list-item"
+                  data-cy-name={name}
+                  data-cy-selected={isSelected}
+                  key={name}
+                  isSelected={isSelected}
+                  onClick={getClickVariantHandler(name)}
+                >
+                  <VariantName>
+                    <Body weight={isSelected ? "medium" : "regular"}>
+                      {displayName}
+                    </Body>
+                  </VariantName>
+                  {taskCount > 0 && (
+                    <StyledBadge
+                      data-cy="task-count-badge"
+                      variant={
+                        isSelected ? Variant.DarkGray : Variant.LightGray
+                      }
+                    >
+                      {taskCount}
+                    </StyledBadge>
+                  )}
+                </BuildVariant>
+              );
+            })}
+          </ScrollableBuildVariantContainer>
+        </StyledSiderCard>
+      </UserSelectWrapper>
+    </DisableWrapper>
   );
 };
 
@@ -167,6 +173,16 @@ const UserSelectWrapper = styled.span<UserSelectWrapperProps>`
   ${(props: UserSelectWrapperProps): string =>
     props.isHotKeyPressed && "user-select: none;"}
 `;
+
+const DisableWrapper = styled.div`
+  ${(props: { disabled: boolean }) =>
+    props.disabled &&
+    `
+    opacity:0.4;
+    pointer-events:none;
+    `}
+`;
+
 const StyledSiderCard = styled(SiderCard)`
   padding-left: 0px;
   padding-right: 0px;

--- a/src/pages/configurePatch/configurePatchCore/ConfigureBuildVariants.tsx
+++ b/src/pages/configurePatch/configurePatchCore/ConfigureBuildVariants.tsx
@@ -104,8 +104,7 @@ export const ConfigureBuildVariants: React.FC<Props> = ({
               return (
                 <BuildVariant
                   data-cy="build-variant-list-item"
-                  data-cy-name={name}
-                  data-cy-selected={isSelected}
+                  data-selected={isSelected}
                   key={name}
                   isSelected={isSelected}
                   onClick={getClickVariantHandler(name)}

--- a/src/pages/configurePatch/configurePatchCore/ConfigureTasks.tsx
+++ b/src/pages/configurePatch/configurePatchCore/ConfigureTasks.tsx
@@ -88,13 +88,11 @@ export const ConfigureTasks: React.FC<Props> = ({
         </Button>
         <Checkbox
           data-cy="select-all-checkbox"
-          indeterminate={selectAllCheckboxState === CheckboxState.INDETERMINITE}
+          // TODO: Fix indeterminate state handling after PD-1386
+          data-state={selectAllCheckboxState}
           onChange={onClickSelectAll}
           label={selectAllCheckboxCopy}
-          checked={
-            selectAllCheckboxState === CheckboxState.CHECKED ||
-            selectAllCheckboxState === CheckboxState.INDETERMINITE
-          }
+          checked={selectAllCheckboxState === CheckboxState.CHECKED}
         />
       </Actions>
       <StyledDisclaimer data-cy="selected-task-disclaimer">
@@ -104,10 +102,11 @@ export const ConfigureTasks: React.FC<Props> = ({
         {Object.entries(currentTasks).map(([name, status]) => (
           <Checkbox
             data-cy="task-checkbox"
+            data-state={status}
             key={name}
             onChange={onClickCheckbox(name)}
             label={name}
-            indeterminate={status === CheckboxState.INDETERMINITE}
+            // TODO: Fix indeterminate state handling after PD-1386
             checked={status === CheckboxState.CHECKED}
           />
         ))}
@@ -147,16 +146,20 @@ const deduplicateTasks = (
     Object.entries(bv).forEach(([taskName, value]) => {
       switch (visibleTasks[taskName]) {
         case CheckboxState.UNCHECKED:
+          // If a task is UNCHECKED and the next task of the same name is CHECKED it is INDETERMINATE
           visibleTasks[taskName] = value
             ? CheckboxState.INDETERMINITE
             : CheckboxState.UNCHECKED;
           break;
         case CheckboxState.CHECKED:
+          // If a task is CHECKED and the next task of the same name is UNCHECKED it is INDETERMINATE
           visibleTasks[taskName] = value
             ? CheckboxState.CHECKED
             : CheckboxState.INDETERMINITE;
           break;
         case CheckboxState.INDETERMINITE:
+          // If a task is INDETERMINATE because of previous task statuses
+          // it wouldn't change when subsequent statuses are considered
           break;
         default:
           visibleTasks[taskName] = value

--- a/src/pages/configurePatch/configurePatchCore/ConfigureTasks.tsx
+++ b/src/pages/configurePatch/configurePatchCore/ConfigureTasks.tsx
@@ -13,10 +13,8 @@ import { VariantTasksState } from "pages/configurePatch/ConfigurePatchCore";
 interface Props {
   variants: ProjectBuildVariant[];
   selectedBuildVariant: string[];
-  selectedVariantTasks: VariantTasksState;
-  setSelectedVariantTasks: React.Dispatch<
-    React.SetStateAction<VariantTasksState>
-  >;
+  selectedBuildVariantTasks: VariantTasksState;
+  setSelectedBuildVariantTasks: (vt: VariantTasksState) => void;
   loading: boolean;
   onClickSchedule: () => void;
 }
@@ -24,18 +22,18 @@ interface Props {
 export const ConfigureTasks: React.FC<Props> = ({
   variants,
   selectedBuildVariant,
-  selectedVariantTasks,
-  setSelectedVariantTasks,
+  selectedBuildVariantTasks,
+  setSelectedBuildVariantTasks,
   loading,
   onClickSchedule,
 }) => {
-  const buildVariantCount = Object.values(selectedVariantTasks).reduce(
+  const buildVariantCount = Object.values(selectedBuildVariantTasks).reduce(
     (count, taskOb) =>
       count +
       (every(Object.values(taskOb), (isSelected) => !isSelected) ? 0 : 1),
     0
   );
-  const taskCount = Object.values(selectedVariantTasks).reduce(
+  const taskCount = Object.values(selectedBuildVariantTasks).reduce(
     (count, taskObj) => count + Object.values(taskObj).filter((v) => v).length,
     0
   );
@@ -53,11 +51,11 @@ export const ConfigureTasks: React.FC<Props> = ({
       getTaskCheckboxState(
         taskName,
         selectedBuildVariant,
-        selectedVariantTasks,
+        selectedBuildVariantTasks,
         variants
       ) === "unchecked";
 
-    setSelectedVariantTasks(
+    setSelectedBuildVariantTasks(
       selectedBuildVariant.reduce((accum, buildVariantName) => {
         const variantHasTask = taskExistsInVariant(
           taskName,
@@ -73,25 +71,29 @@ export const ConfigureTasks: React.FC<Props> = ({
               },
             }
           : accum;
-      }, selectedVariantTasks)
+      }, selectedBuildVariantTasks)
     );
   };
 
   const selectAllCheckboxState = getSelectAllCheckboxState(
     selectedBuildVariant,
-    selectedVariantTasks,
+    selectedBuildVariantTasks,
     variants
   );
 
   const selectAllCheckboxCopy = `Select all tasks in ${
     selectedBuildVariant.length > 1 ? "these variants" : "this variant"
   }`;
-
+  const selectedTaskDisclaimerCopy = `${taskCount} task${
+    taskCount !== 1 ? "s" : ""
+  } across ${buildVariantCount} build variant${
+    buildVariantCount !== 1 ? "s" : ""
+  }`;
   const onClickSelectAll = () => {
-    setSelectedVariantTasks(
+    setSelectedBuildVariantTasks(
       selectedBuildVariant.reduce(
         getSetAllCb(selectAllCheckboxState !== "checked", variants),
-        selectedVariantTasks
+        selectedBuildVariantTasks
       )
     );
   };
@@ -103,41 +105,34 @@ export const ConfigureTasks: React.FC<Props> = ({
           data-cy="schedule-patch"
           variant="primary"
           onClick={onClickSchedule}
-          disabled={isEmpty(selectedVariantTasks) || loading}
+          disabled={isEmpty(selectedBuildVariantTasks) || loading}
           loading={loading}
         >
           Schedule
         </Button>
         <Checkbox
-          data-cy="configurePatch-selectAll"
-          data-checked={`selectAll-${selectAllCheckboxState}`}
+          data-cy="selectAll-checkbox"
           indeterminate={selectAllCheckboxState === "indeterminate"}
           onChange={onClickSelectAll}
           label={selectAllCheckboxCopy}
           checked={selectAllCheckboxState === "checked"}
         />
       </Actions>
-      <StyledDisclaimer data-cy="x-tasks-across-y-variants">
-        {`${taskCount} task${
-          taskCount !== 1 ? "s" : ""
-        } across ${buildVariantCount} build variant${
-          buildVariantCount !== 1 ? "s" : ""
-        }`}
+      <StyledDisclaimer data-cy="selected-task-disclaimer">
+        {selectedTaskDisclaimerCopy}
       </StyledDisclaimer>
       <Tasks data-cy="configurePatch-tasks">
         {currentTasks.map((task) => {
           const checkboxState = getTaskCheckboxState(
             task,
             selectedBuildVariant,
-            selectedVariantTasks,
+            selectedBuildVariantTasks,
             variants
           );
           const isChecked = checkboxState === "checked";
           return (
             <Checkbox
-              data-cy={`configurePatch-${task}`}
-              data-checked={`task-checkbox-${checkboxState}`}
-              data-name-checked={`task-checkbox-${task}-${checkboxState}`}
+              data-cy="task-checkbox"
               key={task}
               indeterminate={checkboxState === "indeterminate"}
               onChange={() => onChangeCheckbox(task)}

--- a/src/pages/configurePatch/configurePatchCore/ConfigureTasks.tsx
+++ b/src/pages/configurePatch/configurePatchCore/ConfigureTasks.tsx
@@ -88,8 +88,9 @@ export const ConfigureTasks: React.FC<Props> = ({
         </Button>
         <Checkbox
           data-cy="select-all-checkbox"
-          // TODO: Fix indeterminate state handling after PD-1386
           data-state={selectAllCheckboxState}
+          // TODO: Fix indeterminate state handling after PD-1386
+          indeterminate={selectAllCheckboxState === CheckboxState.INDETERMINITE}
           onChange={onClickSelectAll}
           label={selectAllCheckboxCopy}
           checked={selectAllCheckboxState === CheckboxState.CHECKED}
@@ -107,6 +108,7 @@ export const ConfigureTasks: React.FC<Props> = ({
             onChange={onClickCheckbox(name)}
             label={name}
             // TODO: Fix indeterminate state handling after PD-1386
+            indeterminate={status === CheckboxState.INDETERMINITE}
             checked={status === CheckboxState.CHECKED}
           />
         ))}

--- a/src/pages/configurePatch/configurePatchCore/ConfigureTasks.tsx
+++ b/src/pages/configurePatch/configurePatchCore/ConfigureTasks.tsx
@@ -4,7 +4,6 @@ import styled from "@emotion/styled";
 import Checkbox from "@leafygreen-ui/checkbox";
 import { Disclaimer } from "@leafygreen-ui/typography";
 import every from "lodash.every";
-import isEmpty from "lodash/isEmpty";
 import { Button } from "components/Button";
 import { VariantTasksState } from "pages/configurePatch/ConfigurePatchCore";
 
@@ -82,7 +81,7 @@ export const ConfigureTasks: React.FC<Props> = ({
           data-cy="schedule-patch"
           variant="primary"
           onClick={onClickSchedule}
-          disabled={isEmpty(selectedBuildVariantTasks) || loading}
+          disabled={taskCount === 0 || loading}
           loading={loading}
         >
           Schedule

--- a/src/pages/configurePatch/configurePatchCore/ConfigureTasks.tsx
+++ b/src/pages/configurePatch/configurePatchCore/ConfigureTasks.tsx
@@ -119,7 +119,6 @@ export const ConfigureTasks: React.FC<Props> = ({
 const getSelectAllCheckboxState = (buildVariants: {
   [task: string]: CheckboxState;
 }): CheckboxState => {
-  // iterate through selectedBuildVariants and see if all the checked items represent all the takss in variant
   let state;
   const allStatuses = Object.entries(buildVariants).map(
     ([, checked]) => checked

--- a/src/pages/configurePatch/configurePatchCore/ConfigureTasks.tsx
+++ b/src/pages/configurePatch/configurePatchCore/ConfigureTasks.tsx
@@ -5,7 +5,7 @@ import Checkbox from "@leafygreen-ui/checkbox";
 import { Disclaimer } from "@leafygreen-ui/typography";
 import every from "lodash.every";
 import { Button } from "components/Button";
-import { VariantTasksState } from "pages/configurePatch/ConfigurePatchCore";
+import { VariantTasksState } from "./state";
 
 enum CheckboxState {
   CHECKED = "CHECKED",
@@ -197,7 +197,7 @@ const Tasks = styled.div`
 const StyledDisclaimer = styled(Disclaimer)`
   margin-bottom: 8px;
 `;
-export const cardSidePadding = css`
+const cardSidePadding = css`
   padding-left: 8px;
   padding-right: 8px;
 `;

--- a/src/pages/configurePatch/configurePatchCore/ConfigureTasks.tsx
+++ b/src/pages/configurePatch/configurePatchCore/ConfigureTasks.tsx
@@ -135,7 +135,6 @@ const getSelectAllCheckboxState = (buildVariants: {
   } else {
     state = CheckboxState.INDETERMINITE;
   }
-  console.log({ hasSelectedTasks, hasUnselectedTasks, state, allStatuses });
 
   return state;
 };

--- a/src/pages/configurePatch/configurePatchCore/state.ts
+++ b/src/pages/configurePatch/configurePatchCore/state.ts
@@ -1,0 +1,6 @@
+export type TasksState = {
+  [task: string]: boolean;
+};
+export type VariantTasksState = {
+  [variant: string]: TasksState;
+};

--- a/src/pages/host/HostTable.tsx
+++ b/src/pages/host/HostTable.tsx
@@ -73,7 +73,7 @@ export const HostTable: React.FC<{
       </TableTitle>
 
       <Table
-        data-test-id="host-events-table"
+        data-cy="host-events-table"
         dataSource={logEntries}
         rowKey={rowKey}
         columns={columnsTemplate}

--- a/src/pages/patch/patchTabs/ParametersContent.tsx
+++ b/src/pages/patch/patchTabs/ParametersContent.tsx
@@ -8,7 +8,7 @@ import { ParameterInput, SchedulePatchMutation } from "gql/generated/types";
 interface Props {
   patchActivated: boolean;
   patchParameters: SchedulePatchMutation["schedulePatch"]["parameters"];
-  setPatchParams: React.Dispatch<React.SetStateAction<ParameterInput[]>>;
+  setPatchParams: (p: ParameterInput[]) => void;
 }
 
 export const ParametersContent: React.FC<Props> = ({

--- a/src/utils/array/array.test.ts
+++ b/src/utils/array/array.test.ts
@@ -1,4 +1,9 @@
-import { toggleArray, convertArrayToObject, convertObjectToArray } from ".";
+import {
+  toggleArray,
+  convertArrayToObject,
+  convertObjectToArray,
+  mapStringArrayToObject,
+} from ".";
 
 describe("toggleArray", () => {
   test("Should add an element to the array if the array is empty", () => {
@@ -88,5 +93,34 @@ describe("convertArrayToObject", () => {
     expect(
       convertArrayToObject([element1, element2, element3], "keyDNE")
     ).toStrictEqual({});
+  });
+});
+
+describe("mapStringArrayToObject", () => {
+  test("Should convert a string array to an array of key value pairs", () => {
+    const someArray = ["keyA", "keyB", "keyC", "keyD"];
+    expect(mapStringArrayToObject(someArray, "Value")).toStrictEqual({
+      keyA: "Value",
+      keyB: "Value",
+      keyC: "Value",
+      keyD: "Value",
+    });
+    expect(mapStringArrayToObject(someArray, true)).toStrictEqual({
+      keyA: true,
+      keyB: true,
+      keyC: true,
+      keyD: true,
+    });
+  });
+
+  test("Should handle functions for passed in values", () => {
+    const someArray = ["keyA", "keyB", "keyC", "keyD"];
+    const someFunc = (v: string) => v.toUpperCase();
+    expect(mapStringArrayToObject(someArray, someFunc)).toStrictEqual({
+      keyA: "KEYA",
+      keyB: "KEYB",
+      keyC: "KEYC",
+      keyD: "KEYD",
+    });
   });
 });

--- a/src/utils/array/index.ts
+++ b/src/utils/array/index.ts
@@ -50,3 +50,16 @@ export const convertObjectToArray = <T>(object: {
   });
   return result;
 };
+
+// Takes a deduplicated string array and returns an object of key value pairs where the array keys  are the object key mapped to a value
+export const mapStringArrayToObject = <T>(
+  array: string[],
+  v: T
+): { [key: string]: T } =>
+  array.reduce((prev, curr) => {
+    let value = v;
+    if (typeof v === "function") {
+      value = v(curr);
+    }
+    return { ...prev, [curr]: value };
+  }, {});

--- a/src/utils/array/index.ts
+++ b/src/utils/array/index.ts
@@ -37,8 +37,8 @@ export const convertObjectToArray = <T>(object: {
 }): { key: string; value: T }[] => {
   const result = [];
   if (object === undefined) return result;
-  const queryParamsList = Object.keys(object);
-  queryParamsList.forEach((key) => {
+  const objectKeys = Object.keys(object);
+  objectKeys.forEach((key) => {
     const value = object[key];
     if (!Array.isArray(value)) {
       result.push({ key, value });


### PR DESCRIPTION
I tracked down some of the failures to some changes that were made in Johns PR due to some data changing.
Some of the failures were a result of evergreen returning a host query slower then usual which caused an element to not be clickable. I resolved this by asserting the element is clickable.

I also did some refactoring on the configure patch page to make the state management more readable and maintainable. 
I also noticed some broken behavior with the indeterminate state handling for partially selected tasks, caused by the leafygreen checkbox component. I ommited that for now but will be fixing them in a follow up ticket once leafygreen makes the changes they need to. That work is tracked in https://jira.mongodb.org/browse/EVG-14652 and https://jira.mongodb.org/browse/PD-1386 According to the leafygreen folks it should be fixed by next week. 