### PR TITLE
EVG-14418 restore ability to remove patch from commit queue cards

### DIFF
--- a/cypress/integration/commit_queue.ts
+++ b/cypress/integration/commit_queue.ts
@@ -35,7 +35,7 @@ describe("commit queue page", () => {
       cy.dataCy("code-changes-table").should("be.visible");
     });
 
-    it.skip("Clicking on remove a patch from the commit queue should work", () => {
+    it("Clicking on remove a patch from the commit queue should work", () => {
       cy.dataCy("commit-queue-card").should("exist");
       cy.dataCy("commit-queue-patch-button").should("exist");
       cy.dataCy("commit-queue-patch-button").click();
@@ -98,7 +98,7 @@ describe("commit queue page", () => {
     });
   });
 
-  describe.skip(COMMIT_QUEUE_ROUTE_PR, () => {
+  describe(COMMIT_QUEUE_ROUTE_PR, () => {
     before(() => {
       cy.visit(COMMIT_QUEUE_ROUTE_PR);
     });

--- a/src/pages/commitqueue/CommitQueueCard.tsx
+++ b/src/pages/commitqueue/CommitQueueCard.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useMutation } from "@apollo/client";
 import styled from "@emotion/styled";
 import { uiColors } from "@leafygreen-ui/palette";
 import { Subtitle, Body } from "@leafygreen-ui/typography";
@@ -6,8 +7,15 @@ import { format } from "date-fns";
 import { StyledLink, StyledRouterLink } from "components/styles/StyledLink";
 import { getGithubPullRequestUrl } from "constants/externalResources";
 import { getVersionRoute } from "constants/routes";
-import { ModuleCodeChangeFragment } from "gql/generated/types";
+import { useToastContext } from "context/toast";
+import {
+  ModuleCodeChangeFragment,
+  RemoveItemFromCommitQueueMutation,
+  RemoveItemFromCommitQueueMutationVariables,
+} from "gql/generated/types";
+import { REMOVE_ITEM_FROM_COMMIT_QUEUE } from "gql/mutations";
 import { CodeChangeModule } from "pages/commitqueue/codeChangesModule/CodeChangesModule";
+import { ConfirmPatchButton } from "./ConfirmPatchButton";
 
 const FORMAT_STR = "MM/dd/yy' at 'hh:mm:ss' 'aa";
 
@@ -37,50 +45,79 @@ export const CommitQueueCard: React.FC<Props> = ({
   owner,
   repo,
   moduleCodeChanges,
-}) => (
-  <Card data-cy="commit-queue-card">
-    <Subtitle>{index}.</Subtitle>
-    <CommitQueueCardGrid>
-      {patchId ? (
-        <CommitInfo>
-          {versionId !== "" || issue === "" || Number.isNaN(Number(issue)) ? (
-            <CardTitle
-              data-cy="commit-queue-card-title"
-              to={getVersionRoute(patchId)}
-            >
-              {title}
-            </CardTitle>
-          ) : (
-            <PRCardTitle
-              data-cy="commit-queue-card-title"
-              href={getGithubPullRequestUrl(owner, repo, issue)}
-            >
-              {title}
+  commitQueueId,
+}) => {
+  const dispatchToast = useToastContext();
+
+  const [removeItemFromCommitQueue, { loading }] = useMutation<
+    RemoveItemFromCommitQueueMutation,
+    RemoveItemFromCommitQueueMutationVariables
+  >(REMOVE_ITEM_FROM_COMMIT_QUEUE, {
+    onCompleted: () => {
+      dispatchToast.success("Successfully removed item from commit queue");
+    },
+    onError: (err) => {
+      dispatchToast.error(`Error removing item from commit queue ${err}`);
+    },
+  });
+  const handleEnroll = () => {
+    removeItemFromCommitQueue({
+      variables: { issue, commitQueueId },
+      refetchQueries: ["CommitQueue"],
+    });
+  };
+  return (
+    <Card data-cy="commit-queue-card">
+      <Subtitle>{index}.</Subtitle>
+      <CommitQueueCardGrid>
+        {patchId ? (
+          <CommitInfo>
+            {versionId !== "" || issue === "" || Number.isNaN(Number(issue)) ? (
+              <CardTitle
+                data-cy="commit-queue-card-title"
+                to={getVersionRoute(patchId)}
+              >
+                {title}
+              </CardTitle>
+            ) : (
+              <PRCardTitle
+                data-cy="commit-queue-card-title"
+                href={getGithubPullRequestUrl(owner, repo, issue)}
+              >
+                {title}
+              </PRCardTitle>
+            )}
+            <CardMetaData>
+              By <b>{author}</b> on {format(new Date(commitTime), FORMAT_STR)}
+            </CardMetaData>
+            <Container>
+              {moduleCodeChanges?.map((moduleCodeChange) => (
+                <CodeChangeModule
+                  key={moduleCodeChange.rawLink}
+                  moduleCodeChange={moduleCodeChange}
+                />
+              ))}
+            </Container>
+          </CommitInfo>
+        ) : (
+          // should only get here for pull requests not processed yet (ie. added in the past minute)
+          <CommitInfo>
+            <PRCardTitle href={getGithubPullRequestUrl(owner, repo, issue)}>
+              Pull Request #{issue}
             </PRCardTitle>
-          )}
-          <CardMetaData>
-            By <b>{author}</b> on {format(new Date(commitTime), FORMAT_STR)}
-          </CardMetaData>
-          <Container>
-            {moduleCodeChanges?.map((moduleCodeChange) => (
-              <CodeChangeModule
-                key={moduleCodeChange.rawLink}
-                moduleCodeChange={moduleCodeChange}
-              />
-            ))}
-          </Container>
-        </CommitInfo>
-      ) : (
-        // should only get here for pull requests not processed yet (ie. added in the past minute)
-        <CommitInfo>
-          <PRCardTitle href={getGithubPullRequestUrl(owner, repo, issue)}>
-            Pull Request #{issue}
-          </PRCardTitle>
-        </CommitInfo>
-      )}
-    </CommitQueueCardGrid>
-  </Card>
-);
+          </CommitInfo>
+        )}
+        <CommitQueueCardActions>
+          <ConfirmPatchButton
+            disabled={loading}
+            onConfirm={handleEnroll}
+            commitTitle={title}
+          />
+        </CommitQueueCardActions>
+      </CommitQueueCardGrid>
+    </Card>
+  );
+};
 
 const Card = styled.div`
   display: flex;
@@ -121,6 +158,10 @@ const CommitQueueCardGrid = styled.div`
   grid-column-gap: 0px;
   grid-row-gap: 0px;
   width: 100%;
+`;
+
+const CommitQueueCardActions = styled.div`
+  grid-area: 1 / 3 / 2 / 4;
 `;
 
 const Container = styled.div`


### PR DESCRIPTION
Reverting the change to remove the commit queue remove patch button, since non-existent PRs on the commit queue should no longer exist.