### PR TITLE
EVG-14560: Replace display modal instances

### DIFF
--- a/cypress/integration/patch/patch_route.ts
+++ b/cypress/integration/patch/patch_route.ts
@@ -36,11 +36,11 @@ describe("Patch route", () => {
   });
 
   it("Shows patch parameters if they exist", () => {
-    cy.dataCy("parameters-modal").should("not.be.visible");
+    cy.dataCy("parameters-modal").should("not.exist");
     cy.dataCy("parameters-link").click();
     cy.dataCy("parameters-modal").should("be.visible");
-    cy.get(".ant-modal-close-x").click();
-    cy.dataCy("parameters-modal").should("not.be.visible");
+    cy.get('button[aria-label="Close modal"]').click();
+    cy.dataCy("parameters-modal").should("not.exist");
   });
   it("'Base commit' link in metadata links to version page of legacy UI", () => {
     cy.dataCy("patch-base-commit")

--- a/src/components/DisplayModal.tsx
+++ b/src/components/DisplayModal.tsx
@@ -22,11 +22,9 @@ export const DisplayModal: React.FC<DisplayModalProps> = ({
   title,
 }) => (
   <StyledModal data-cy={dataCy} open={open} setOpen={setOpen} size={size}>
-    <ContentWrapper>
-      {/* @ts-expect-error */}
-      {title && <StyledHeader>{title}</StyledHeader>}
-      {children}
-    </ContentWrapper>
+    {/* @ts-expect-error */}
+    {title && <StyledHeader>{title}</StyledHeader>}
+    {children}
   </StyledModal>
 );
 
@@ -40,5 +38,3 @@ const StyledModal = styled(Modal)`
 const StyledHeader = styled(H3)`
   margin-bottom: 8px;
 `;
-
-const ContentWrapper = styled.div``;

--- a/src/components/DisplayModal.tsx
+++ b/src/components/DisplayModal.tsx
@@ -21,14 +21,20 @@ export const DisplayModal: React.FC<DisplayModalProps> = ({
   size,
   title,
 }) => (
-  <Modal data-cy={dataCy} open={open} setOpen={setOpen} size={size}>
+  <StyledModal data-cy={dataCy} open={open} setOpen={setOpen} size={size}>
     <ContentWrapper>
       {/* @ts-expect-error */}
       {title && <StyledHeader>{title}</StyledHeader>}
       {children}
     </ContentWrapper>
-  </Modal>
+  </StyledModal>
 );
+
+// @ts-expect-error
+const StyledModal = styled(Modal)`
+  /* Ensure modal appears above feedback dialog */
+  z-index: 40;
+`;
 
 // @ts-expect-error
 const StyledHeader = styled(H3)`

--- a/src/components/DisplayModal.tsx
+++ b/src/components/DisplayModal.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import styled from "@emotion/styled";
+import Modal, { ModalSize } from "@leafygreen-ui/modal";
+import { H3 } from "@leafygreen-ui/typography";
+
+interface DisplayModalProps {
+  "data-cy"?: string;
+  open?: boolean;
+  setOpen?: (
+    open: boolean
+  ) => void | React.Dispatch<React.SetStateAction<boolean>>;
+  size?: ModalSize;
+  title?: string;
+}
+
+export const DisplayModal: React.FC<DisplayModalProps> = ({
+  children,
+  "data-cy": dataCy,
+  open,
+  setOpen,
+  size,
+  title,
+}) => (
+  <Modal data-cy={dataCy} open={open} setOpen={setOpen} size={size}>
+    <ContentWrapper>
+      {/* @ts-expect-error */}
+      {title && <StyledHeader>{title}</StyledHeader>}
+      {children}
+    </ContentWrapper>
+  </Modal>
+);
+
+// @ts-expect-error
+const StyledHeader = styled(H3)`
+  margin-bottom: 8px;
+`;
+
+const ContentWrapper = styled.div``;

--- a/src/components/FilterBadges/SeeMoreModal.tsx
+++ b/src/components/FilterBadges/SeeMoreModal.tsx
@@ -1,8 +1,8 @@
 import { useState } from "react";
 import styled from "@emotion/styled";
 import Button, { Variant, Size } from "@leafygreen-ui/button";
-import Modal from "@leafygreen-ui/modal";
-import { Link, H3 } from "@leafygreen-ui/typography";
+import { Link } from "@leafygreen-ui/typography";
+import { DisplayModal } from "components/DisplayModal";
 import { FilterBadge } from "./FilterBadge";
 
 interface SeeMoreModalProps {
@@ -27,31 +27,32 @@ export const SeeMoreModal: React.FC<SeeMoreModalProps> = ({
       <Link onClick={() => setOpen((curr) => !curr)}>
         see {notVisibleCount} more
       </Link>
-      <Modal open={open} setOpen={setOpen} size="large">
-        <ContentWrapper>
-          <H3>Applied Filters</H3>
-          <BadgeContainer>
-            {badges.map((b) => (
-              <FilterBadge
-                key={`filter_badge_${b.key}_${b.value}`}
-                badge={b}
-                onClose={() => onRemoveBadge(b.key, b.value)}
-              />
-            ))}
-          </BadgeContainer>
-          <Button
-            variant={Variant.Default}
-            size={Size.XSmall}
-            onClick={onClearAll}
-          >
-            CLEAR ALL FILTERS
-          </Button>
-        </ContentWrapper>
-      </Modal>
+      <DisplayModal
+        open={open}
+        setOpen={setOpen}
+        size="large"
+        title="Applied Filters"
+      >
+        <BadgeContainer>
+          {badges.map((b) => (
+            <FilterBadge
+              key={`filter_badge_${b.key}_${b.value}`}
+              badge={b}
+              onClose={() => onRemoveBadge(b.key, b.value)}
+            />
+          ))}
+        </BadgeContainer>
+        <Button
+          variant={Variant.Default}
+          size={Size.XSmall}
+          onClick={onClearAll}
+        >
+          CLEAR ALL FILTERS
+        </Button>
+      </DisplayModal>
     </>
   );
 };
-const ContentWrapper = styled.div``;
 
 const BadgeContainer = styled.div`
   padding-top: 8px;

--- a/src/pages/patch/ParametersModal.tsx
+++ b/src/pages/patch/ParametersModal.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import styled from "@emotion/styled";
 import Badge from "@leafygreen-ui/badge";
-import { Modal } from "components/Modal";
+import { DisplayModal } from "components/DisplayModal";
 import { StyledLink } from "components/styles";
 import { P2 } from "components/Typography";
 import { Parameter } from "gql/generated/types";
@@ -25,23 +25,24 @@ export const ParametersModal: React.FC<ParametersProps> = ({ parameters }) => {
         </P2>
       )}
 
-      <Modal
-        visible={showModal}
-        footer={null}
-        onCancel={() => setShowModal(false)}
-        data-cy="parameters-modal"
+      <DisplayModal
+        open={showModal}
+        setOpen={setShowModal}
         title="Patch Parameters"
+        data-cy="parameters-modal"
       >
         {parameters?.map((param) => (
           <StyledBadge key={`param_${param.key}`}>
             {param.key}:{param.value}
           </StyledBadge>
         ))}
-      </Modal>
+      </DisplayModal>
     </>
   );
 };
 
 const StyledBadge = styled(Badge)`
-  margin-left: 16px;
+  :not(:last-of-type) {
+    margin-right: 16px;
+  }
 `;


### PR DESCRIPTION
[EVG-14560](https://jira.mongodb.org/browse/EVG-14560)

### Description 
- Discussed with Mohamed and [EVG-14754](https://jira.mongodb.org/browse/EVG-14754) has been opened to convert Spruce's more advanced modals to LeafyGreen's [Confirmation Modal](https://www.mongodb.design/component/confirmation-modal/example/). This ticket just handles basic display modals with no actions.

### Screenshots
<img width="1552" alt="image" src="https://user-images.githubusercontent.com/9298431/121030996-fa576800-c777-11eb-9d66-1b852543ebd7.png">