### PR TITLE
EVG-14694 Auto select required tasks in configure patch page

### DIFF
--- a/cypress/integration/patch/configure_patch.ts
+++ b/cypress/integration/patch/configure_patch.ts
@@ -34,13 +34,17 @@ describe("Configure Patch Page", () => {
         .first()
         .should("have.attr", "data-selected", "true");
     });
-    describe("visiting a configure page with display tasks", () => {
+    describe("Visiting a configure page with display tasks", () => {
       before(() => {
         cy.visit(`patch/${patchWithDisplayTasks}/configure/tasks`);
       });
       it("should show display tasks if there are any", () => {
         cy.contains("display_task");
       });
+    });
+    it("Required tasks should be auto selected", () => {
+      cy.visit(`patch/${patchWithDisplayTasks}/configure/tasks`);
+      getInputByLabel("test-graphql").should("be.checked");
     });
   });
 


### PR DESCRIPTION
[EVG-14694](https://jira.mongodb.org/browse/EVG-14694)

### Description 
This auto selects required tasks on the configure patch page. This used to work but was removed in a past change.
It depended on the [variantsTasks patch field](https://github.com/evergreen-ci/evergreen/blob/4071b3c5984744e3a71589c95445d89f6db446be/graphql/schema.graphql#L490) which only returned required tasks.
It was replaced  by the [Patch.Project.variants](https://github.com/evergreen-ci/evergreen/blob/4071b3c5984744e3a71589c95445d89f6db446be/graphql/schema.graphql#L532) field which returns all the tasks for a patch. 
There was the assumption that these fields were the same and only one was needed but they aren't and they both are.
### Testing 
Local testing and added cypress tests

### Evergreen PR 
Related to/ Dependent on https://github.com/evergreen-ci/evergreen/pull/4734
