### PR TITLE
EVG-14768 Mainline Commits Query Fetch From UI

### DIFF
--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -722,6 +722,7 @@ export type Patch = {
   githash: Scalars["String"];
   patchNumber: Scalars["Int"];
   author: Scalars["String"];
+  authorDisplayName: Scalars["String"];
   version: Scalars["String"];
   status: Scalars["String"];
   variants: Array<Scalars["String"]>;
@@ -1991,6 +1992,43 @@ export type GetSuspectedIssuesQuery = {
             jiraTicket?: Maybe<JiraTicketFragment>;
           }>
         >
+      >;
+    }>;
+  }>;
+};
+
+export type MainlineCommitsQueryVariables = Exact<{
+  options: MainlineCommitsOptions;
+}>;
+
+export type MainlineCommitsQuery = {
+  mainlineCommits?: Maybe<{
+    nextPageOrderNumber?: Maybe<number>;
+    versions: Array<{
+      version?: Maybe<{
+        id: string;
+        author: string;
+        buildVariants?: Maybe<
+          Array<
+            Maybe<{
+              variant: string;
+              displayName: string;
+              tasks?: Maybe<
+                Array<
+                  Maybe<{
+                    id: string;
+                    execution: number;
+                    displayName: string;
+                    status: string;
+                  }>
+                >
+              >;
+            }>
+          >
+        >;
+      }>;
+      rolledUpVersions?: Maybe<
+        Array<{ id: string; activated?: Maybe<boolean> }>
       >;
     }>;
   }>;

--- a/src/gql/queries/get-mainline-commits.graphql
+++ b/src/gql/queries/get-mainline-commits.graphql
@@ -1,0 +1,28 @@
+query MainlineCommits($options: MainlineCommitsOptions!) {
+    mainlineCommits(options: $options) {
+        versions {
+            version {
+            id
+            author
+            order
+            createTime
+            buildVariants(options: {}) {
+                variant
+                displayName
+                tasks {
+                id
+                execution
+                displayName
+                status
+                }
+            }
+            }
+            rolledUpVersions {
+            id
+            createTime
+            author
+            }
+        }
+        nextPageOrderNumber
+    }
+}

--- a/src/gql/queries/get-mainline-commits.graphql
+++ b/src/gql/queries/get-mainline-commits.graphql
@@ -2,25 +2,25 @@ query MainlineCommits($options: MainlineCommitsOptions!) {
     mainlineCommits(options: $options) {
         versions {
             version {
-            id
-            author
-            order
-            createTime
-            buildVariants(options: {}) {
-                variant
-                displayName
-                tasks {
                 id
-                execution
-                displayName
-                status
+                author
+                order
+                createTime
+                buildVariants(options: {}) {
+                    variant
+                    displayName
+                    tasks {
+                        id
+                        execution
+                        displayName
+                        status
+                    }
                 }
             }
-            }
             rolledUpVersions {
-            id
-            createTime
-            author
+                id
+                createTime
+                author
             }
         }
         nextPageOrderNumber

--- a/src/gql/queries/index.ts
+++ b/src/gql/queries/index.ts
@@ -15,6 +15,7 @@ import GET_INSTANCE_TYPES from "./get-instance-types.graphql";
 import GET_JIRA_CUSTOM_CREATED_ISSUES from "./get-jira-custom-created-issues.graphql";
 import GET_JIRA_ISSUES from "./get-jira-issues.graphql";
 import GET_JIRA_SUSPECTED_ISSUES from "./get-jira-suspected-issues.graphql";
+import GET_MAINLINE_COMMITS from "./get-mainline-commits.graphql";
 import GET_MY_HOSTS from "./get-my-hosts.graphql";
 import GET_MY_VOLUMES from "./get-my-volumes.graphql";
 import GET_OTHER_USER from "./get-other-user.graphql";
@@ -64,6 +65,7 @@ export {
   HOSTS,
   GET_HOST,
   GET_HOST_EVENTS,
+  GET_MAINLINE_COMMITS,
   GET_MY_PUBLIC_KEYS,
   GET_DISTROS,
   GET_MY_VOLUMES,


### PR DESCRIPTION
[EVG-14768(https://jira.mongodb.org/browse/EVG-14768)

### Description 
* Create graphql query called get-mainline-commits
* Use projectId to query mainline commits on the waterfall page

### Testing 
Tried the query on playground
