### PR TITLE
EVG-14782: Fix Jest config on Evergreen

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -183,6 +183,7 @@ functions:
     params:
       files:
         - "./spruce/bin/cypress/*.xml"
+        - "./spruce/bin/jest/*.xml"
 
   attach-cypress-screenshots:
     command: s3.put

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -1,28 +1,27 @@
-'use strict';
-
 // Do this as the first thing so that any code reading it knows the right env.
-process.env.BABEL_ENV = 'test';
-process.env.NODE_ENV = 'test';
-process.env.PUBLIC_URL = '';
+process.env.BABEL_ENV = "test";
+process.env.NODE_ENV = "test";
+process.env.PUBLIC_URL = "";
 
 // Makes the script crash on unhandled rejections instead of silently
 // ignoring them. In the future, promise rejections that are not handled will
 // terminate the Node.js process with a non-zero exit code.
-process.on('unhandledRejection', err => {
+process.on("unhandledRejection", (err) => {
   throw err;
 });
 
 // Ensure environment variables are read.
-require('../config/env');
+require("../config/env");
 
+const jest = require("jest");
+const { execSync } = require("child_process");
+const path = require("path");
 
-const jest = require('jest');
-const execSync = require('child_process').execSync;
-let argv = process.argv.slice(2);
+const argv = process.argv.slice(2);
 
 function isInGitRepository() {
   try {
-    execSync('git rev-parse --is-inside-work-tree', { stdio: 'ignore' });
+    execSync("git rev-parse --is-inside-work-tree", { stdio: "ignore" });
     return true;
   } catch (e) {
     return false;
@@ -31,7 +30,7 @@ function isInGitRepository() {
 
 function isInMercurialRepository() {
   try {
-    execSync('hg --cwd . root', { stdio: 'ignore' });
+    execSync("hg --cwd . root", { stdio: "ignore" });
     return true;
   } catch (e) {
     return false;
@@ -41,13 +40,16 @@ function isInMercurialRepository() {
 // Watch unless on CI or explicitly running all tests
 if (
   !process.env.CI &&
-  argv.indexOf('--watchAll') === -1 &&
-  argv.indexOf('--watchAll=false') === -1
+  argv.indexOf("--watchAll") === -1 &&
+  argv.indexOf("--watchAll=false") === -1
 ) {
   // https://github.com/facebook/create-react-app/issues/5210
   const hasSourceControl = isInGitRepository() || isInMercurialRepository();
-  argv.push(hasSourceControl ? '--watch' : '--watchAll');
+  argv.push(hasSourceControl ? "--watch" : "--watchAll");
 }
 
+if (argv.indexOf("--reporters=jest-junit") !== -1) {
+  process.env.JEST_JUNIT_OUTPUT_DIR = path.join(process.cwd(), "/bin/jest");
+}
 
 jest.run(argv);


### PR DESCRIPTION
EVG-14782

### Description 
- Ensure test results are visible in Evergreen: write jest-junit output to `bin/jest/` and upload this asset
- Apply formatting & ESLint recommendations to `scripts/test.js` caught by the precommit hook
- E2E tests appear to be failing unrelatedly -- perhaps due to https://github.com/evergreen-ci/evergreen/pull/4673 and the earlier revert?

### Screenshots
"Tests" tab no longer reports 0 tests:
<img width="1552" alt="image" src="https://user-images.githubusercontent.com/9298431/122983006-84ebba00-d369-11eb-89ef-10c2a2b4c7fd.png">