### PR TITLE
EVG-14898: Add announcement toast interface

### DIFF
--- a/src/components/Content/index.tsx
+++ b/src/components/Content/index.tsx
@@ -18,6 +18,7 @@ import { routes } from "constants/routes";
 import { useAuthStateContext } from "context/auth";
 import { GetUserQuery, GetUserSettingsQuery } from "gql/generated/types";
 import { GET_USER, GET_USER_SETTINGS } from "gql/queries";
+import { useAnnouncementToast } from "hooks/useAnnouncementToast";
 import { PageDoesNotExist } from "pages/404";
 import { CommitQueue } from "pages/CommitQueue";
 import { Commits } from "pages/Commits";
@@ -52,6 +53,8 @@ export const Content: React.FC = () => {
   localStorage.setItem("userId", get(data, "user.userId", ""));
 
   useAnalyticsAttributes();
+
+  useAnnouncementToast();
 
   if (!isAuthenticated) {
     return <FullPageLoad />;

--- a/src/constants/announcementToast.ts
+++ b/src/constants/announcementToast.ts
@@ -1,11 +1,11 @@
-import { Variant } from "@leafygreen-ui/toast";
+import { ToastTypeKeys } from "context/toast";
 
 interface AnnouncementToast {
   closable: boolean;
   expires?: number;
   message: string;
   title?: string;
-  variant: Variant;
+  variant: ToastTypeKeys;
 }
 
 export const toastData: AnnouncementToast | null = null;

--- a/src/constants/announcementToast.ts
+++ b/src/constants/announcementToast.ts
@@ -8,9 +8,4 @@ interface AnnouncementToast {
   variant: Variant;
 }
 
-export const toastData: AnnouncementToast | null = {
-  closable: true,
-  message: "Placeholder navigation copy text.",
-  title: "Navigation Update",
-  variant: "note",
-};
+export const toastData: AnnouncementToast | null = null;

--- a/src/constants/announcementToast.ts
+++ b/src/constants/announcementToast.ts
@@ -1,0 +1,16 @@
+import { Variant } from "@leafygreen-ui/toast";
+
+interface AnnouncementToast {
+  closable: boolean;
+  expires?: number;
+  message: string;
+  title?: string;
+  variant: Variant;
+}
+
+export const toastData: AnnouncementToast | null = {
+  closable: true,
+  message: "Placeholder navigation copy text.",
+  title: "Navigation Update",
+  variant: "note",
+};

--- a/src/context/toast.tsx
+++ b/src/context/toast.tsx
@@ -3,7 +3,7 @@ import Toast, { Variant } from "@leafygreen-ui/toast";
 import { WordBreak } from "components/Typography";
 import { TOAST_TIMEOUT } from "constants/index";
 
-export type ToastType = {
+export type ToastProps = {
   variant: Variant;
   message: string;
   closable: boolean;
@@ -12,6 +12,21 @@ export type ToastType = {
 };
 
 type AddToast = (message: string, closable?: boolean) => void;
+
+interface ToastType {
+  success: string;
+  warning: string;
+  error: string;
+  info: string;
+}
+export type ToastTypeKeys = keyof ToastType;
+
+const mapToastToLeafyGreenVariant: { [key in ToastTypeKeys]: Variant } = {
+  success: Variant.Success,
+  warning: Variant.Important,
+  error: Variant.Warning,
+  info: Variant.Note,
+};
 
 interface DispatchToast {
   success: AddToast;
@@ -31,7 +46,7 @@ const variantToTitleMap = {
 export const ToastDispatchContext = React.createContext<any | null>(null);
 
 const ToastProvider: React.FC = ({ children }) => {
-  const [visibleToast, setVisibleToast] = useState<ToastType>({
+  const [visibleToast, setVisibleToast] = useState<ToastProps>({
     variant: Variant.Note,
     message: "",
     closable: true,
@@ -41,7 +56,7 @@ const ToastProvider: React.FC = ({ children }) => {
   const [toastOpen, setToastOpen] = useState(false);
 
   const addToast = useCallback(
-    (toast: ToastType) => {
+    (toast: ToastProps) => {
       setVisibleToast(toast);
       setToastOpen(true);
     },
@@ -59,7 +74,13 @@ const ToastProvider: React.FC = ({ children }) => {
       onClose: () => void = () => {},
       title?: string
     ) =>
-      addToast({ variant: Variant.Success, message, closable, onClose, title }),
+      addToast({
+        variant: mapToastToLeafyGreenVariant.success,
+        message,
+        closable,
+        onClose,
+        title,
+      }),
     warning: (
       message: string,
       closable: boolean = true,
@@ -67,7 +88,7 @@ const ToastProvider: React.FC = ({ children }) => {
       title?: string
     ) =>
       addToast({
-        variant: Variant.Important,
+        variant: mapToastToLeafyGreenVariant.warning,
         message,
         closable,
         onClose,
@@ -79,13 +100,26 @@ const ToastProvider: React.FC = ({ children }) => {
       onClose: () => void = () => {},
       title?: string
     ) =>
-      addToast({ variant: Variant.Warning, message, closable, onClose, title }),
-    note: (
+      addToast({
+        variant: mapToastToLeafyGreenVariant.error,
+        message,
+        closable,
+        onClose,
+        title,
+      }),
+    info: (
       message: string,
       closable: boolean = true,
       onClose: () => void = () => {},
       title?: string
-    ) => addToast({ variant: Variant.Note, message, closable, onClose, title }),
+    ) =>
+      addToast({
+        variant: mapToastToLeafyGreenVariant.info,
+        message,
+        closable,
+        onClose,
+        title,
+      }),
     hide: hideToast,
   };
 

--- a/src/context/toast.tsx
+++ b/src/context/toast.tsx
@@ -3,7 +3,13 @@ import Toast, { Variant } from "@leafygreen-ui/toast";
 import { WordBreak } from "components/Typography";
 import { TOAST_TIMEOUT } from "constants/index";
 
-type ToastType = { variant: Variant; message: string; closable: boolean };
+export type ToastType = {
+  variant: Variant;
+  message: string;
+  closable: boolean;
+  onClose: () => void;
+  title?: string;
+};
 
 type AddToast = (message: string, closable?: boolean) => void;
 
@@ -11,7 +17,7 @@ interface DispatchToast {
   success: AddToast;
   warning: AddToast;
   error: AddToast;
-  info: AddToast;
+  note: AddToast;
   hide: () => void;
 }
 
@@ -29,6 +35,8 @@ const ToastProvider: React.FC = ({ children }) => {
     variant: Variant.Note,
     message: "",
     closable: true,
+    onClose: () => {},
+    title: null,
   });
   const [toastOpen, setToastOpen] = useState(false);
 
@@ -45,14 +53,39 @@ const ToastProvider: React.FC = ({ children }) => {
   }, [setToastOpen]);
 
   const toastContext = {
-    success: (message: string, closable: boolean = true) =>
-      addToast({ variant: Variant.Success, message, closable }),
-    warning: (message: string, closable: boolean = true) =>
-      addToast({ variant: Variant.Important, message, closable }),
-    error: (message: string, closable: boolean = true) =>
-      addToast({ variant: Variant.Warning, message, closable }),
-    info: (message: string, closable: boolean = true) =>
-      addToast({ variant: Variant.Note, message, closable }),
+    success: (
+      message: string,
+      closable: boolean = true,
+      onClose: () => void = () => {},
+      title?: string
+    ) =>
+      addToast({ variant: Variant.Success, message, closable, onClose, title }),
+    warning: (
+      message: string,
+      closable: boolean = true,
+      onClose: () => void = () => {},
+      title?: string
+    ) =>
+      addToast({
+        variant: Variant.Important,
+        message,
+        closable,
+        onClose,
+        title,
+      }),
+    error: (
+      message: string,
+      closable: boolean = true,
+      onClose: () => void = () => {},
+      title?: string
+    ) =>
+      addToast({ variant: Variant.Warning, message, closable, onClose, title }),
+    note: (
+      message: string,
+      closable: boolean = true,
+      onClose: () => void = () => {},
+      title?: string
+    ) => addToast({ variant: Variant.Note, message, closable, onClose, title }),
     hide: hideToast,
   };
 
@@ -68,10 +101,16 @@ const ToastProvider: React.FC = ({ children }) => {
       {children}
       <Toast
         variant={visibleToast.variant}
-        title={variantToTitleMap[visibleToast?.variant]}
+        title={visibleToast?.title || variantToTitleMap[visibleToast?.variant]}
         body={<WordBreak>{visibleToast.message}</WordBreak>}
         open={toastOpen}
-        close={visibleToast.closable && (() => setToastOpen(false))}
+        close={
+          visibleToast.closable &&
+          (() => {
+            visibleToast.onClose();
+            setToastOpen(false);
+          })
+        }
         data-cy="toast"
       />
     </ToastDispatchContext.Provider>

--- a/src/hooks/useAnnouncementToast.ts
+++ b/src/hooks/useAnnouncementToast.ts
@@ -1,0 +1,28 @@
+import { useEffect } from "react";
+import Cookies from "js-cookie";
+import { toastData } from "constants/announcementToast";
+import { useToastContext } from "context/toast";
+
+const setClosedCookie = (message: string, expires: number = 7) => {
+  Cookies.set(message, "closed", { expires });
+};
+
+export const useAnnouncementToast = () => {
+  const dispatchToast = useToastContext();
+
+  useEffect(() => {
+    if (!toastData) {
+      return;
+    }
+
+    const { closable, expires, message, title, variant } = toastData;
+    if (message !== "" && Cookies.get(message) === undefined) {
+      dispatchToast[variant](
+        message,
+        closable,
+        () => setClosedCookie(message, expires),
+        title
+      );
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+};


### PR DESCRIPTION
EVG-14898 cc @mvankeulen94 

### Description 
- Add hook for setting an announcement toast. The hook utilizes a cookie to check if the user has already dismissed the toast and hides it if so.
- Extend toasts to set custom titles and call an `onClose` function
- Announcement toast content is set in `constants/announcementToast.ts`. The toast is removed by setting this variable to `null` — this approach feels slightly haphazard so let me know if you have any other ideas!
- Will update #777 to set the appropriate toast once this is merged in.

### Screenshots
![image](https://user-images.githubusercontent.com/9298431/123661823-dcbf7080-d802-11eb-9560-c071e6db2ecc.png)

### Testing 
- To test locally, set `toastData` in `constants/announcementToast.ts` to something like this:
  ```js
  export const toastData: AnnouncementToast | null = {
    closable: true,
    message: "Placeholder navigation copy text.",
    title: "Navigation Update Toast",
    variant: "note",
  };
  ```
