### PR TITLE
EVG-14478 Create button to restart failing base patch tasks

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,4 +1,4 @@
 module.exports = {
-  "*.{js,ts,tsx,.graphql,.gql}": ["yarn eslint-staged", "yarn prettier"],
+  "*.{js,ts,tsx,graphql,gql}": ["yarn eslint-staged", "yarn prettier"],
   "*.{ts,tsx}": () => "tsc -p tsconfig.json --noEmit",
 };

--- a/src/components/PatchActionButtons/DisablePatch.tsx
+++ b/src/components/PatchActionButtons/DisablePatch.tsx
@@ -1,0 +1,41 @@
+import { useMutation } from "@apollo/client";
+import { DropdownItem } from "components/ButtonDropdown";
+import { useToastContext } from "context/toast";
+import {
+  SetPatchPriorityMutation,
+  SetPatchPriorityMutationVariables,
+} from "gql/generated/types";
+import { SET_PATCH_PRIORITY } from "gql/mutations";
+
+interface Props {
+  patchId: string;
+  refetchQueries: string[];
+}
+export const DisablePatch: React.FC<Props> = ({ patchId, refetchQueries }) => {
+  const dispatchToast = useToastContext();
+  const [disablePatch] = useMutation<
+    SetPatchPriorityMutation,
+    SetPatchPriorityMutationVariables
+  >(SET_PATCH_PRIORITY, {
+    onCompleted: () => {
+      dispatchToast.success(`Tasks in this patch were disabled`);
+    },
+    onError: (err) => {
+      dispatchToast.error(`Unable to disable patch tasks: ${err.message}`);
+    },
+    refetchQueries,
+  });
+  return (
+    <DropdownItem
+      data-cy="disable"
+      disabled={false}
+      onClick={() => {
+        disablePatch({
+          variables: { patchId, priority: -1 },
+        });
+      }}
+    >
+      Disable all tasks
+    </DropdownItem>
+  );
+};

--- a/src/components/PatchActionButtons/index.tsx
+++ b/src/components/PatchActionButtons/index.tsx
@@ -4,3 +4,4 @@ export { RestartPatch } from "./RestartPatch";
 export { SetPatchPriority } from "./SetPatchPriority";
 export { EnqueuePatch } from "./EnqueuePatch";
 export { AddNotification } from "./AddNotification";
+export { DisablePatch } from "./DisablePatch";

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -174,6 +174,7 @@ export type Mutation = {
   schedulePatchTasks?: Maybe<Scalars["String"]>;
   unschedulePatchTasks?: Maybe<Scalars["String"]>;
   restartPatch?: Maybe<Scalars["String"]>;
+  scheduleFailingBasePatchTasks?: Maybe<Array<Task>>;
   enqueuePatch: Patch;
   setPatchPriority?: Maybe<Scalars["String"]>;
   scheduleTask: Task;
@@ -231,6 +232,10 @@ export type MutationRestartPatchArgs = {
   patchId: Scalars["String"];
   abort: Scalars["Boolean"];
   taskIds: Array<Scalars["String"]>;
+};
+
+export type MutationScheduleFailingBasePatchTasksArgs = {
+  patchId: Scalars["String"];
 };
 
 export type MutationEnqueuePatchArgs = {
@@ -748,6 +753,8 @@ export type Patch = {
 export type ChildPatch = {
   project: Scalars["String"];
   patchID: Scalars["String"];
+  status: Scalars["String"];
+  taskCount?: Maybe<Scalars["Int"]>;
 };
 
 export type Build = {
@@ -1596,6 +1603,16 @@ export type SaveSubscriptionMutationVariables = Exact<{
 }>;
 
 export type SaveSubscriptionMutation = { saveSubscription: boolean };
+
+export type ScheduleFailingBasePatchTasksMutationVariables = Exact<{
+  patchId: Scalars["String"];
+}>;
+
+export type ScheduleFailingBasePatchTasksMutation = {
+  scheduleFailingBasePatchTasks?: Maybe<
+    Array<{ id: string; execution: number; status: string }>
+  >;
+};
 
 export type SchedulePatchTasksMutationVariables = Exact<{
   patchId: Scalars["String"];

--- a/src/gql/mutations/index.ts
+++ b/src/gql/mutations/index.ts
@@ -19,6 +19,7 @@ import RESTART_JASPER from "./restart-jasper.graphql";
 import RESTART_PATCH from "./restart-patch.graphql";
 import RESTART_TASK from "./restart-task.graphql";
 import SAVE_SUBSCRIPTION from "./save-subscription.graphql";
+import SCHEDULE_FAILING_BASE_PATCH_TASKS from "./schedule-failing-base-patch-tasks.graphql";
 import SCHEDULE_PATCH_TASKS from "./schedule-patch-tasks.graphql";
 import SCHEDULE_PATCH from "./schedule-patch.graphql";
 import SCHEDULE_TASK from "./schedule-task.graphql";
@@ -49,6 +50,7 @@ export {
   RESTART_JASPER,
   RESTART_PATCH,
   RESTART_TASK,
+  SCHEDULE_FAILING_BASE_PATCH_TASKS,
   SCHEDULE_PATCH_TASKS,
   SCHEDULE_PATCH,
   SCHEDULE_TASK,

--- a/src/gql/mutations/schedule-failing-base-patch-tasks.graphql
+++ b/src/gql/mutations/schedule-failing-base-patch-tasks.graphql
@@ -1,0 +1,8 @@
+
+  mutation ScheduleFailingBasePatchTasks($patchId: String!) {
+    scheduleFailingBasePatchTasks(patchId: $patchId){
+      id
+      execution
+      status
+    }
+  }

--- a/src/gql/mutations/schedule-failing-base-patch-tasks.graphql
+++ b/src/gql/mutations/schedule-failing-base-patch-tasks.graphql
@@ -1,8 +1,7 @@
-
-  mutation ScheduleFailingBasePatchTasks($patchId: String!) {
-    scheduleFailingBasePatchTasks(patchId: $patchId){
-      id
-      execution
-      status
-    }
+mutation ScheduleFailingBasePatchTasks($patchId: String!) {
+  scheduleFailingBasePatchTasks(patchId: $patchId){
+    id
+    execution
+    status
   }
+}

--- a/src/pages/patch/ActionButtons.tsx
+++ b/src/pages/patch/ActionButtons.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { useMutation } from "@apollo/client";
 import { ButtonDropdown, DropdownItem } from "components/ButtonDropdown";
 import { LinkToReconfigurePage } from "components/LinkToReconfigurePage";
 import {
@@ -9,14 +8,9 @@ import {
   SetPatchPriority,
   EnqueuePatch,
   AddNotification,
+  DisablePatch,
 } from "components/PatchActionButtons";
 import { PageButtonRow } from "components/styles";
-import { useToastContext } from "context/toast";
-import {
-  SetPatchPriorityMutation,
-  SetPatchPriorityMutationVariables,
-} from "gql/generated/types";
-import { SET_PATCH_PRIORITY } from "gql/mutations";
 
 interface ActionButtonProps {
   canEnqueueToCommitQueue: boolean;
@@ -31,20 +25,6 @@ export const ActionButtons: React.FC<ActionButtonProps> = ({
   patchDescription,
   patchId,
 }) => {
-  const dispatchToast = useToastContext();
-  const [disablePatch] = useMutation<
-    SetPatchPriorityMutation,
-    SetPatchPriorityMutationVariables
-  >(SET_PATCH_PRIORITY, {
-    onCompleted: () => {
-      dispatchToast.success(`Tasks in this patch were disabled`);
-    },
-    onError: (err) => {
-      dispatchToast.error(`Unable to disable patch tasks: ${err.message}`);
-    },
-    refetchQueries: ["Patch"],
-  });
-
   const dropdownItems = [
     <LinkToReconfigurePage
       key="reconfigure"
@@ -56,17 +36,13 @@ export const ActionButtons: React.FC<ActionButtonProps> = ({
       refetchQueries={["Patch"]}
       key="unschedule"
     />,
-    <DropdownItem
-      key="disable-button"
-      data-cy="disable"
-      disabled={false}
-      onClick={() => {
-        disablePatch({
-          variables: { patchId, priority: -1 },
-        });
-      }}
-    >
-      Disable all tasks
+    <DisablePatch
+      key="disable-patch"
+      patchId={patchId}
+      refetchQueries={["Patch"]}
+    />,
+    <DropdownItem key="reschedule-failing">
+      Schedule failing base tasks
     </DropdownItem>,
     <SetPatchPriority
       patchId={patchId}

--- a/src/pages/patch/ActionButtons.tsx
+++ b/src/pages/patch/ActionButtons.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { ButtonDropdown, DropdownItem } from "components/ButtonDropdown";
+import { ButtonDropdown } from "components/ButtonDropdown";
 import { LinkToReconfigurePage } from "components/LinkToReconfigurePage";
 import {
   SchedulePatchTasks,
@@ -11,6 +11,7 @@ import {
   DisablePatch,
 } from "components/PatchActionButtons";
 import { PageButtonRow } from "components/styles";
+import { ScheduleFailingBaseTasks } from "./ScheduleFailingBaseTasks";
 
 interface ActionButtonProps {
   canEnqueueToCommitQueue: boolean;
@@ -41,9 +42,10 @@ export const ActionButtons: React.FC<ActionButtonProps> = ({
       patchId={patchId}
       refetchQueries={["Patch"]}
     />,
-    <DropdownItem key="reschedule-failing">
-      Schedule failing base tasks
-    </DropdownItem>,
+    <ScheduleFailingBaseTasks
+      key="schedule-failing-base-tasks"
+      patchId={patchId}
+    />,
     <SetPatchPriority
       patchId={patchId}
       key="priority"

--- a/src/pages/patch/ScheduleFailingBaseTasks.tsx
+++ b/src/pages/patch/ScheduleFailingBaseTasks.tsx
@@ -1,0 +1,52 @@
+import { useMutation } from "@apollo/client";
+import { Body } from "@leafygreen-ui/typography";
+import { Popconfirm } from "antd";
+import { DropdownItem } from "components/ButtonDropdown";
+import { useToastContext } from "context/toast";
+import {
+  ScheduleFailingBasePatchTasksMutation,
+  ScheduleFailingBasePatchTasksMutationVariables,
+} from "gql/generated/types";
+import { SCHEDULE_FAILING_BASE_PATCH_TASKS } from "gql/mutations";
+
+interface Props {
+  patchId: string;
+}
+export const ScheduleFailingBaseTasks: React.FC<Props> = ({ patchId }) => {
+  const dispatchToast = useToastContext();
+  const [scheduleBasePatchTasks] = useMutation<
+    ScheduleFailingBasePatchTasksMutation,
+    ScheduleFailingBasePatchTasksMutationVariables
+  >(SCHEDULE_FAILING_BASE_PATCH_TASKS, {
+    onCompleted({ scheduleFailingBasePatchTasks }) {
+      const successMessage = `Successfully scheduled ${scheduleFailingBasePatchTasks.length} tasks`;
+      dispatchToast.success(successMessage);
+    },
+    onError({ message }) {
+      dispatchToast.error(message);
+    },
+  });
+  return (
+    <Popconfirm
+      icon={null}
+      placement="left"
+      title={
+        <>
+          <Body>
+            Are you sure you want to schedule all the undispatched base tasks
+            for this patches failing tasks?
+          </Body>
+        </>
+      }
+      onConfirm={() => {
+        scheduleBasePatchTasks({ variables: { patchId } });
+      }}
+      okText="Yes"
+      cancelText="Cancel"
+    >
+      <DropdownItem key="reschedule-failing">
+        Schedule failing base tasks
+      </DropdownItem>
+    </Popconfirm>
+  );
+};


### PR DESCRIPTION
[EVG-14478](https://jira.mongodb.org/browse/EVG-14478)

### Description 
This button allows a user to restart a patch tasks base tasks if it is undispatched and the current task is failing.
open to suggestions on copy
### Screenshots
![image](https://user-images.githubusercontent.com/4605522/123807302-bc082100-d8bd-11eb-9f16-597e127ffd66.png)
### Testing 
  Tested in staging. Difficult to test in e2e tests because we are unable to schedule tasks in e2e tests

### Evergreen PR 
Dependent on https://github.com/evergreen-ci/evergreen/pull/4785