### PR TITLE
EVG-14876: Background Grid for Commit Charts

### DIFF
--- a/src/pages/commits/CommitsWrapper.tsx
+++ b/src/pages/commits/CommitsWrapper.tsx
@@ -7,11 +7,17 @@ import { MainlineCommitsQuery } from "gql/generated/types";
 import { Grid } from "pages/commits/commitChart/Grid";
 import { GroupedResult } from "pages/commits/commitChart/utils";
 
-export const CommitsWrapper: React.FC<{
+interface Props {
   versions: MainlineCommitsQuery["mainlineCommits"]["versions"];
   error?: ApolloError;
   isLoading: boolean;
-}> = ({ versions, isLoading, error }) => {
+}
+
+export const CommitsWrapper: React.FC<Props> = ({
+  versions,
+  isLoading,
+  error,
+}) => {
   if (error) {
     return <PageWrapper>ERROR</PageWrapper>;
   }

--- a/src/pages/commits/CommitsWrapper.tsx
+++ b/src/pages/commits/CommitsWrapper.tsx
@@ -1,13 +1,11 @@
 import React from "react";
 import { ApolloError } from "@apollo/client";
 import styled from "@emotion/styled";
-import { uiColors } from "@leafygreen-ui/palette";
 import { Skeleton } from "antd";
 import { PageWrapper } from "components/styles";
 import { MainlineCommitsQuery } from "gql/generated/types";
+import { Grid } from "pages/commits/commitChart/Grid";
 import { GroupedResult } from "pages/commits/commitChart/utils";
-
-const { gray } = uiColors;
 
 export const CommitsWrapper: React.FC<{
   versions: MainlineCommitsQuery["mainlineCommits"]["versions"];
@@ -22,17 +20,10 @@ export const CommitsWrapper: React.FC<{
   }
   if (!isLoading && versions?.length !== 0) {
     return (
-      <Container>
+      <ProjectHealthWrapper>
         <FlexRowContainer />
-        <ColumnContainer>
-          <DashedLine />
-          <DashedLine />
-          <DashedLine />
-          <DashedLine />
-          <DashedLine />
-          <SolidLine />
-        </ColumnContainer>
-      </Container>
+        <Grid />
+      </ProjectHealthWrapper>
     );
   }
   return <NoResults data-cy="no-commits-found">No commits found</NoResults>;
@@ -51,7 +42,7 @@ export const FlexRowContainer = styled.div`
   width: 100%;
 `;
 
-const Container = styled.div`
+const ProjectHealthWrapper = styled.div`
   display: flex;
   flex-direction: row;
   justify-content: flex-start;
@@ -59,25 +50,6 @@ const Container = styled.div`
   height: 222px;
   width: 100%;
   position: relative;
-`;
-
-const ColumnContainer = styled.div`
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  align-items: flex-end;
-`;
-const DashedLine = styled.div`
-  width: 100%;
-  border: 1px dashed ${gray.light2};
-`;
-
-const SolidLine = styled.div`
-  width: 100%;
-  border: 1px solid ${gray.light1};
 `;
 
 const NoResults = styled.div`

--- a/src/pages/commits/CommitsWrapper.tsx
+++ b/src/pages/commits/CommitsWrapper.tsx
@@ -1,10 +1,13 @@
 import React from "react";
 import { ApolloError } from "@apollo/client";
 import styled from "@emotion/styled";
+import { uiColors } from "@leafygreen-ui/palette";
 import { Skeleton } from "antd";
 import { PageWrapper } from "components/styles";
 import { MainlineCommitsQuery } from "gql/generated/types";
 import { GroupedResult } from "pages/commits/commitChart/utils";
+
+const { gray } = uiColors;
 
 export const CommitsWrapper: React.FC<{
   versions: MainlineCommitsQuery["mainlineCommits"]["versions"];
@@ -18,7 +21,19 @@ export const CommitsWrapper: React.FC<{
     return <StyledSkeleton active title={false} paragraph={{ rows: 6 }} />;
   }
   if (!isLoading && versions?.length !== 0) {
-    return <FlexRowContainer />;
+    return (
+      <Container>
+        <FlexRowContainer />
+        <ColumnContainer>
+          <DashedLine />
+          <DashedLine />
+          <DashedLine />
+          <DashedLine />
+          <DashedLine />
+          <SolidLine />
+        </ColumnContainer>
+      </Container>
+    );
   }
   return <NoResults data-cy="no-commits-found">No commits found</NoResults>;
 };
@@ -34,6 +49,35 @@ export const FlexRowContainer = styled.div`
   align-items: flex-end;
   height: 222px;
   width: 100%;
+`;
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  align-items: flex-end;
+  height: 222px;
+  width: 100%;
+  position: relative;
+`;
+
+const ColumnContainer = styled.div`
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: flex-end;
+`;
+const DashedLine = styled.div`
+  width: 100%;
+  border: 1px dashed ${gray.light2};
+`;
+
+const SolidLine = styled.div`
+  width: 100%;
+  border: 1px solid ${gray.light1};
 `;
 
 const NoResults = styled.div`

--- a/src/pages/commits/CommitsWrapper.tsx
+++ b/src/pages/commits/CommitsWrapper.tsx
@@ -22,7 +22,7 @@ export const CommitsWrapper: React.FC<{
     return (
       <ProjectHealthWrapper>
         <FlexRowContainer />
-        <Grid />
+        <Grid numDashedLine={5} />
       </ProjectHealthWrapper>
     );
   }
@@ -42,7 +42,7 @@ export const FlexRowContainer = styled.div`
   width: 100%;
 `;
 
-const ProjectHealthWrapper = styled.div`
+export const ProjectHealthWrapper = styled.div`
   display: flex;
   flex-direction: row;
   justify-content: flex-start;

--- a/src/pages/commits/commitChart/Grid.stories.tsx
+++ b/src/pages/commits/commitChart/Grid.stories.tsx
@@ -1,0 +1,13 @@
+import { Grid } from "pages/commits/commitChart/Grid";
+import { ProjectHealthWrapper } from "pages/commits/CommitsWrapper";
+
+export default {
+  title: "Commit Charts Grid",
+  component: Grid,
+};
+
+export const GridLines = () => (
+  <ProjectHealthWrapper>
+    <Grid numDashedLine={5} />
+  </ProjectHealthWrapper>
+);

--- a/src/pages/commits/commitChart/Grid.tsx
+++ b/src/pages/commits/commitChart/Grid.tsx
@@ -18,11 +18,12 @@ export const Grid: React.FC<{
 const ColumnContainer = styled.div`
   position: absolute;
   width: 100%;
-  height: 100%;
+  height: 224px;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
   align-items: flex-end;
+  margin-bottom: -0.5px;
 `;
 
 const DashedLine = styled.div`
@@ -32,5 +33,5 @@ const DashedLine = styled.div`
 
 const SolidLine = styled.div`
   width: 100%;
-  border: 1px solid ${gray.light1};
+  border: 0.95px solid ${gray.light1};
 `;

--- a/src/pages/commits/commitChart/Grid.tsx
+++ b/src/pages/commits/commitChart/Grid.tsx
@@ -8,8 +8,8 @@ export const Grid: React.FC<{
   numDashedLine: number;
 }> = ({ numDashedLine }) => (
   <ColumnContainer>
-    {[...Array(numDashedLine)].map(() => (
-      <DashedLine />
+    {[...Array(numDashedLine)].map((index) => (
+      <DashedLine key={index.toString()}/>
     ))}
     <SolidLine />
   </ColumnContainer>

--- a/src/pages/commits/commitChart/Grid.tsx
+++ b/src/pages/commits/commitChart/Grid.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import styled from "@emotion/styled";
+import { uiColors } from "@leafygreen-ui/palette";
+
+const { gray } = uiColors;
+
+export const Grid: React.FC = () => (
+  <ColumnContainer>
+    <DashedLine />
+    <DashedLine />
+    <DashedLine />
+    <DashedLine />
+    <DashedLine />
+    <SolidLine />
+  </ColumnContainer>
+);
+
+const ColumnContainer = styled.div`
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: flex-end;
+`;
+const DashedLine = styled.div`
+  width: 100%;
+  border: 1px dashed ${gray.light2};
+`;
+
+const SolidLine = styled.div`
+  width: 100%;
+  border: 1px solid ${gray.light1};
+`;

--- a/src/pages/commits/commitChart/Grid.tsx
+++ b/src/pages/commits/commitChart/Grid.tsx
@@ -23,7 +23,6 @@ const ColumnContainer = styled.div`
   flex-direction: column;
   justify-content: space-between;
   align-items: flex-end;
-  margin-bottom: -0.5px;
 `;
 
 const DashedLine = styled.div`
@@ -34,4 +33,5 @@ const DashedLine = styled.div`
 const SolidLine = styled.div`
   width: 100%;
   border: 0.9px solid ${gray.light1};
+  z-index: 2;
 `;

--- a/src/pages/commits/commitChart/Grid.tsx
+++ b/src/pages/commits/commitChart/Grid.tsx
@@ -4,13 +4,13 @@ import { uiColors } from "@leafygreen-ui/palette";
 
 const { gray } = uiColors;
 
-export const Grid: React.FC = () => (
+export const Grid: React.FC<{
+  numDashedLine: number;
+}> = ({ numDashedLine }) => (
   <ColumnContainer>
-    <DashedLine />
-    <DashedLine />
-    <DashedLine />
-    <DashedLine />
-    <DashedLine />
+    {[...Array(numDashedLine)].map(() => (
+      <DashedLine />
+    ))}
     <SolidLine />
   </ColumnContainer>
 );
@@ -24,6 +24,7 @@ const ColumnContainer = styled.div`
   justify-content: space-between;
   align-items: flex-end;
 `;
+
 const DashedLine = styled.div`
   width: 100%;
   border: 1px dashed ${gray.light2};

--- a/src/pages/commits/commitChart/Grid.tsx
+++ b/src/pages/commits/commitChart/Grid.tsx
@@ -8,8 +8,8 @@ export const Grid: React.FC<{
   numDashedLine: number;
 }> = ({ numDashedLine }) => (
   <ColumnContainer>
-    {[...Array(numDashedLine)].map((index) => (
-      <DashedLine key={index.toString()}/>
+    {Array.from(Array(numDashedLine).keys()).map((number) => (
+      <DashedLine key={number} />
     ))}
     <SolidLine />
   </ColumnContainer>

--- a/src/pages/commits/commitChart/Grid.tsx
+++ b/src/pages/commits/commitChart/Grid.tsx
@@ -33,5 +33,5 @@ const DashedLine = styled.div`
 
 const SolidLine = styled.div`
   width: 100%;
-  border: 0.95px solid ${gray.light1};
+  border: 0.9px solid ${gray.light1};
 `;

--- a/src/pages/commits/commitChart/__snapshots__/CommitChart.stories.storyshot
+++ b/src/pages/commits/commitChart/__snapshots__/CommitChart.stories.storyshot
@@ -2,7 +2,7 @@
 
 exports[`Storyshots Commit Charts Absolute Chart 1`] = `
 <div
-  className="css-fo2guw-FlexRowContainer ech0nhv1"
+  className="css-fo2guw-FlexRowContainer ech0nhv2"
 >
   <div
     className="css-vpeskt-ChartContainer e7hg92c1"
@@ -114,7 +114,7 @@ exports[`Storyshots Commit Charts Absolute Chart 1`] = `
 
 exports[`Storyshots Commit Charts Percent Chart 1`] = `
 <div
-  className="css-fo2guw-FlexRowContainer ech0nhv1"
+  className="css-fo2guw-FlexRowContainer ech0nhv2"
 >
   <div
     className="css-vpeskt-ChartContainer e7hg92c1"

--- a/src/pages/commits/commitChart/__snapshots__/Grid.stories.storyshot
+++ b/src/pages/commits/commitChart/__snapshots__/Grid.stories.storyshot
@@ -1,0 +1,30 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots Commit Charts Grid Grid Lines 1`] = `
+<div
+  className="css-vbs4p3-ProjectHealthWrapper ech0nhv1"
+>
+  <div
+    className="css-185hinz-ColumnContainer e1xuhwwu2"
+  >
+    <div
+      className="css-oxpn1r-DashedLine e1xuhwwu1"
+    />
+    <div
+      className="css-oxpn1r-DashedLine e1xuhwwu1"
+    />
+    <div
+      className="css-oxpn1r-DashedLine e1xuhwwu1"
+    />
+    <div
+      className="css-oxpn1r-DashedLine e1xuhwwu1"
+    />
+    <div
+      className="css-oxpn1r-DashedLine e1xuhwwu1"
+    />
+    <div
+      className="css-1sahvn-SolidLine e1xuhwwu0"
+    />
+  </div>
+</div>
+`;

--- a/src/pages/commits/commitChart/__snapshots__/Grid.stories.storyshot
+++ b/src/pages/commits/commitChart/__snapshots__/Grid.stories.storyshot
@@ -5,7 +5,7 @@ exports[`Storyshots Commit Charts Grid Grid Lines 1`] = `
   className="css-vbs4p3-ProjectHealthWrapper ech0nhv1"
 >
   <div
-    className="css-x6smgz-ColumnContainer e1xuhwwu2"
+    className="css-1hbk7id-ColumnContainer e1xuhwwu2"
   >
     <div
       className="css-oxpn1r-DashedLine e1xuhwwu1"
@@ -23,7 +23,7 @@ exports[`Storyshots Commit Charts Grid Grid Lines 1`] = `
       className="css-oxpn1r-DashedLine e1xuhwwu1"
     />
     <div
-      className="css-y4y5ws-SolidLine e1xuhwwu0"
+      className="css-1bpyomh-SolidLine e1xuhwwu0"
     />
   </div>
 </div>

--- a/src/pages/commits/commitChart/__snapshots__/Grid.stories.storyshot
+++ b/src/pages/commits/commitChart/__snapshots__/Grid.stories.storyshot
@@ -5,7 +5,7 @@ exports[`Storyshots Commit Charts Grid Grid Lines 1`] = `
   className="css-vbs4p3-ProjectHealthWrapper ech0nhv1"
 >
   <div
-    className="css-185hinz-ColumnContainer e1xuhwwu2"
+    className="css-x6smgz-ColumnContainer e1xuhwwu2"
   >
     <div
       className="css-oxpn1r-DashedLine e1xuhwwu1"
@@ -23,7 +23,7 @@ exports[`Storyshots Commit Charts Grid Grid Lines 1`] = `
       className="css-oxpn1r-DashedLine e1xuhwwu1"
     />
     <div
-      className="css-1sahvn-SolidLine e1xuhwwu0"
+      className="css-y4y5ws-SolidLine e1xuhwwu0"
     />
   </div>
 </div>


### PR DESCRIPTION
[EVG-14876](https://jira.mongodb.org/browse/EVG-14876)

### Description 
Added background lines for the commits wrapper

### Screenshots
<img width="1439" alt="Screen Shot 2021-07-06 at 2 38 26 PM" src="https://user-images.githubusercontent.com/55669681/124650565-df0b7580-de67-11eb-9336-648261c92bf4.png">

Design:
<img width="891" alt="Screen Shot 2021-07-06 at 2 26 48 PM" src="https://user-images.githubusercontent.com/55669681/124649289-4c1e0b80-de66-11eb-947f-87311cd48bef.png">

### Description 
Added storybook test
