### PR TITLE
EVG-14943: Render base commit link for downstream tasks

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -19,6 +19,11 @@
     -->
   <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
   <!--
+      Load LeafyGreen's monospace font dependency via Google Fonts' CDN
+    -->
+  <link rel="preconnect" href="https://fonts.gstatic.com" />
+  <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:ital,wght@0,400;0,600;1,400&display=swap" rel="stylesheet" />
+  <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.
       Only files inside the `public` folder can be referenced from the HTML.

--- a/src/components/Accordion/index.tsx
+++ b/src/components/Accordion/index.tsx
@@ -39,7 +39,7 @@ export const Accordion: React.FC<AccordionProps> = ({
       </AccordionToggle>
       {!toggleFromBottom && (
         <AnimatedAccordion hide={!isAccordionDisplayed}>
-          {contents}
+          <ContentsContainer indent={showCaret}>{contents}</ContentsContainer>
         </AnimatedAccordion>
       )}
     </>
@@ -60,4 +60,8 @@ const AnimatedAccordion = styled.div`
   max-height: ${(props: { hide: boolean }): string => !props.hide && "1500px"};
   overflow-y: hidden;
   transition: max-height 0.3s ease-in-out;
+`;
+const ContentsContainer = styled.div`
+  margin-left: ${(props: { indent: boolean }): string =>
+    props.indent && "16px"};
 `;

--- a/src/context/Providers.tsx
+++ b/src/context/Providers.tsx
@@ -5,7 +5,7 @@ import { ToastProvider } from "context/toast";
 
 export const ContextProviders: React.FC = ({ children }) => (
   <AuthProvider>
-    <LeafyGreenProvider baseFontSize={16}>
+    <LeafyGreenProvider baseFontSize={14}>
       <ToastProvider>{children}</ToastProvider>
     </LeafyGreenProvider>
   </AuthProvider>

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -99,6 +99,7 @@ export type QueryTaskTestsArgs = {
   limit?: Maybe<Scalars["Int"]>;
   testName?: Maybe<Scalars["String"]>;
   statuses?: Array<Scalars["String"]>;
+  groupId?: Maybe<Scalars["String"]>;
 };
 
 export type QueryTaskFilesArgs = {
@@ -728,6 +729,7 @@ export type Patch = {
   variants: Array<Scalars["String"]>;
   tasks: Array<Scalars["String"]>;
   childPatches?: Maybe<Array<ChildPatch>>;
+  childPatchesTemp?: Maybe<Array<Patch>>;
   variantsTasks: Array<Maybe<VariantTask>>;
   activated: Scalars["Boolean"];
   alias?: Maybe<Scalars["String"]>;
@@ -2188,6 +2190,16 @@ export type PatchQuery = {
       Array<{
         project: string;
         patchID: string;
+        taskCount?: Maybe<number>;
+        status: string;
+      }>
+    >;
+    childPatchesTemp?: Maybe<
+      Array<{
+        baseVersionID?: Maybe<string>;
+        githash: string;
+        id: string;
+        projectID: string;
         taskCount?: Maybe<number>;
         status: string;
       }>

--- a/src/gql/queries/get-patch.graphql
+++ b/src/gql/queries/get-patch.graphql
@@ -9,6 +9,14 @@ query Patch($id: String!) {
       taskCount
       status  
     }
+    childPatchesTemp{
+      baseVersionID
+      githash
+      id
+      projectID
+      taskCount
+      status
+    }
     projectID
     projectIdentifier
     githash

--- a/src/pages/Patch.tsx
+++ b/src/pages/Patch.tsx
@@ -89,7 +89,7 @@ export const Patch: React.FC = () => {
           <PageContent>
             <PatchTabs
               taskCount={patch?.taskCount}
-              childPatches={patch?.childPatches}
+              childPatches={patch?.childPatchesTemp}
             />
           </PageContent>
         </PageLayout>

--- a/src/pages/patch/PatchTabs.tsx
+++ b/src/pages/patch/PatchTabs.tsx
@@ -4,11 +4,10 @@ import { useParams, useHistory, useLocation } from "react-router-dom";
 import { usePatchAnalytics } from "analytics";
 import { StyledTabs } from "components/styles/StyledTabs";
 import { getVersionRoute, DEFAULT_PATCH_TAB } from "constants/routes";
-import { Patch } from "gql/generated/types";
 import { usePrevious } from "hooks";
 import { CodeChanges } from "pages/patch/patchTabs/CodeChanges";
 import { Tasks } from "pages/patch/patchTabs/Tasks";
-import { PatchTab } from "types/patch";
+import { ChildPatch, PatchTab } from "types/patch";
 import { queryString } from "utils";
 import { DownstreamTasks } from "./patchTabs/DownstreamTasks";
 
@@ -19,11 +18,9 @@ const tabToIndexMap = {
   [PatchTab.DownstreamTasks]: 2,
 };
 
-type childPatchesType = Patch["childPatches"];
-
 interface Props {
   taskCount: number;
-  childPatches: childPatchesType;
+  childPatches?: ChildPatch[];
 }
 
 export const PatchTabs: React.FC<Props> = ({ taskCount, childPatches }) => {

--- a/src/pages/patch/PatchTabs.tsx
+++ b/src/pages/patch/PatchTabs.tsx
@@ -21,7 +21,7 @@ const tabToIndexMap = {
 
 interface Props {
   taskCount: number;
-  childPatches?: Partial<Patch>[];
+  childPatches: Partial<Patch>[];
 }
 
 export const PatchTabs: React.FC<Props> = ({ taskCount, childPatches }) => {

--- a/src/pages/patch/PatchTabs.tsx
+++ b/src/pages/patch/PatchTabs.tsx
@@ -1,13 +1,14 @@
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import { Tab } from "@leafygreen-ui/tabs";
 import { useParams, useHistory, useLocation } from "react-router-dom";
 import { usePatchAnalytics } from "analytics";
 import { StyledTabs } from "components/styles/StyledTabs";
 import { getVersionRoute, DEFAULT_PATCH_TAB } from "constants/routes";
+import { Patch } from "gql/generated/types";
 import { usePrevious } from "hooks";
 import { CodeChanges } from "pages/patch/patchTabs/CodeChanges";
 import { Tasks } from "pages/patch/patchTabs/Tasks";
-import { ChildPatch, PatchTab } from "types/patch";
+import { PatchTab } from "types/patch";
 import { queryString } from "utils";
 import { DownstreamTasks } from "./patchTabs/DownstreamTasks";
 
@@ -20,7 +21,7 @@ const tabToIndexMap = {
 
 interface Props {
   taskCount: number;
-  childPatches?: ChildPatch[];
+  childPatches?: Partial<Patch>[];
 }
 
 export const PatchTabs: React.FC<Props> = ({ taskCount, childPatches }) => {

--- a/src/pages/patch/patchTabs/DownstreamProjectAccordion.tsx
+++ b/src/pages/patch/patchTabs/DownstreamProjectAccordion.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useQuery } from "@apollo/client";
 import styled from "@emotion/styled";
+import { InlineCode } from "@leafygreen-ui/typography";
 import { Skeleton } from "antd";
 import { Accordion } from "components/Accordion";
 import { PatchStatusBadge } from "components/PatchStatusBadge";
@@ -9,14 +10,21 @@ import { useToastContext } from "context/toast";
 import { PatchTasksQuery, PatchTasksQueryVariables } from "gql/generated/types";
 import { GET_PATCH_TASKS } from "gql/queries";
 import { useNetworkStatus } from "hooks";
+import { environmentalVariables } from "utils";
+
+const { getUiUrl } = environmentalVariables;
 
 interface DownstreamProjectAccordionProps {
+  baseVersionID: string;
+  githash: string;
   projectName: string;
   status: string;
   taskCount: number;
   childPatchId: string;
 }
 export const DownstreamProjectAccordion: React.FC<DownstreamProjectAccordionProps> = ({
+  baseVersionID,
+  githash,
   projectName,
   childPatchId,
   status,
@@ -52,14 +60,20 @@ export const DownstreamProjectAccordion: React.FC<DownstreamProjectAccordionProp
       <Accordion
         title={variantTitle}
         contents={
-          <TableWrapper>
-            {/* todo: add pagination and filtering  */}
-            {showSkeleton ? (
-              <Skeleton active title={false} paragraph={{ rows: 8 }} />
-            ) : (
-              <TasksTable tasks={patchTasks?.tasks} />
-            )}
-          </TableWrapper>
+          <AccordionContents>
+            Base commit:{" "}
+            <InlineCode href={`${getUiUrl()}/version/${baseVersionID}`}>
+              {githash.slice(0, 10)}
+            </InlineCode>
+            <TableWrapper>
+              {/* todo: add pagination and filtering  */}
+              {showSkeleton ? (
+                <Skeleton active title={false} paragraph={{ rows: 8 }} />
+              ) : (
+                <TasksTable tasks={patchTasks?.tasks} />
+              )}
+            </TableWrapper>
+          </AccordionContents>
         }
       />
     </AccordionWrapper>
@@ -79,4 +93,8 @@ const ProjectTitleWrapper = styled.div`
 const TableWrapper = styled.div`
   padding-bottom: 15px;
   padding-top: 15px;
+`;
+
+const AccordionContents = styled.div`
+  margin: 16px 0;
 `;

--- a/src/pages/patch/patchTabs/DownstreamTasks.tsx
+++ b/src/pages/patch/patchTabs/DownstreamTasks.tsx
@@ -1,8 +1,8 @@
-import React from "react";
+import { Patch } from "gql/generated/types";
 import { DownstreamProjectAccordion } from "./DownstreamProjectAccordion";
 
 interface DownstreamTasksProps {
-  childPatches: any[];
+  childPatches: Partial<Patch>[];
 }
 
 export const DownstreamTasks: React.FC<DownstreamTasksProps> = ({

--- a/src/pages/patch/patchTabs/DownstreamTasks.tsx
+++ b/src/pages/patch/patchTabs/DownstreamTasks.tsx
@@ -1,25 +1,27 @@
 import React from "react";
-import { Patch } from "gql/generated/types";
+import { ChildPatch } from "types/patch";
 import { DownstreamProjectAccordion } from "./DownstreamProjectAccordion";
 
-type childPatchesType = Patch["childPatches"];
-
 interface DownstreamTasksProps {
-  childPatches: childPatchesType;
+  childPatches: ChildPatch[];
 }
 
 export const DownstreamTasks: React.FC<DownstreamTasksProps> = ({
   childPatches,
 }) => (
   <>
-    {childPatches.map(({ project, status, patchID, taskCount }) => (
-      <DownstreamProjectAccordion
-        key={`downstream_project_${patchID}`}
-        projectName={project}
-        status={status}
-        childPatchId={patchID}
-        taskCount={taskCount}
-      />
-    ))}
+    {childPatches.map(
+      ({ baseVersionID, githash, id, projectID, status, taskCount }) => (
+        <DownstreamProjectAccordion
+          key={`downstream_project_${id}`}
+          projectName={projectID}
+          status={status}
+          childPatchId={id}
+          taskCount={taskCount}
+          githash={githash}
+          baseVersionID={baseVersionID}
+        />
+      )
+    )}
   </>
 );

--- a/src/types/patch.ts
+++ b/src/types/patch.ts
@@ -23,12 +23,3 @@ export enum PatchTab {
 }
 
 export const ALL_PATCH_STATUS = "all";
-
-export interface ChildPatch {
-  baseVersionID?: string;
-  githash: string;
-  id: string;
-  projectID: string;
-  taskCount?: number;
-  status: string;
-}

--- a/src/types/patch.ts
+++ b/src/types/patch.ts
@@ -23,3 +23,12 @@ export enum PatchTab {
 }
 
 export const ALL_PATCH_STATUS = "all";
+
+export interface ChildPatch {
+  baseVersionID?: string;
+  githash: string;
+  id: string;
+  projectID: string;
+  taskCount?: number;
+  status: string;
+}


### PR DESCRIPTION
EVG-14943

### Description
- Add link to base commit for each downstream task
- Use LeafyGreen's `InlineCode` component for rendering link
  - Load font dependency via Google Fonts' CDN ([LG's recommended approach](https://github.com/mongodb/leafygreen-ui/blob/main/packages/code/README.md#source-code-pro-font))
  - Lemme know if we'd rather stick to our current monospace styling!

### Screenshots
<img width="1098" alt="image" src="https://user-images.githubusercontent.com/9298431/125647086-fa0d3750-3c74-4dfa-81fe-a8f29b9742f2.png">

### Evergreen PR 
https://github.com/evergreen-ci/evergreen/pull/4810 
