### PR TITLE
EVG-14901 add ssh key to EditSpawnHostModal

### DIFF
--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -557,6 +557,8 @@ export type EditSpawnHostInput = {
   deletedInstanceTags?: Maybe<Array<InstanceTagInput>>;
   volume?: Maybe<Scalars["String"]>;
   servicePassword?: Maybe<Scalars["String"]>;
+  publicKey?: Maybe<PublicKeyInput>;
+  savePublicKey?: Maybe<Scalars["Boolean"]>;
 };
 
 export type SpawnVolumeInput = {
@@ -1494,6 +1496,8 @@ export type EditSpawnHostMutationVariables = Exact<{
   expiration?: Maybe<Scalars["Time"]>;
   noExpiration?: Maybe<Scalars["Boolean"]>;
   servicePassword?: Maybe<Scalars["String"]>;
+  publicKey?: Maybe<PublicKeyInput>;
+  savePublicKey?: Maybe<Scalars["Boolean"]>;
 }>;
 
 export type EditSpawnHostMutation = { editSpawnHost: BaseSpawnHostFragment };

--- a/src/gql/mutations/edit-spawn-host.graphql
+++ b/src/gql/mutations/edit-spawn-host.graphql
@@ -10,6 +10,8 @@ mutation EditSpawnHost(
   $expiration: Time
   $noExpiration: Boolean
   $servicePassword: String
+  $publicKey: PublicKeyInput
+  $savePublicKey: Boolean
 ) {
   editSpawnHost(
     spawnHost: {
@@ -22,6 +24,8 @@ mutation EditSpawnHost(
       expiration: $expiration
       noExpiration: $noExpiration
       servicePassword: $servicePassword
+      publicKey: $publicKey
+      savePublicKey: $savePublicKey
     }
   ) {
     ...baseSpawnHost

--- a/src/pages/spawn/spawnHost/EditSpawnHostModal.tsx
+++ b/src/pages/spawn/spawnHost/EditSpawnHostModal.tsx
@@ -326,6 +326,9 @@ const computeDiff = (defaultEditSpawnHostState, editSpawnHostState) => {
     editSpawnHostState
   ) as EditSpawnHostMutationVariables;
 
+  if (mutationParams.publicKey) {
+    mutationParams.publicKey = omitTypename(mutationParams.publicKey);
+  }
   // diff returns na object to compare the differences in positions of an array. So we take this object
   // and convert it into an array for these fields
   if (mutationParams.addedInstanceTags) {

--- a/src/pages/spawn/spawnHost/EditSpawnHostModal.tsx
+++ b/src/pages/spawn/spawnHost/EditSpawnHostModal.tsx
@@ -28,9 +28,15 @@ import {
   MyVolumesQueryVariables,
   EditSpawnHostMutation,
   EditSpawnHostMutationVariables,
+  GetMyPublicKeysQuery,
+  GetMyPublicKeysQueryVariables,
 } from "gql/generated/types";
 import { EDIT_SPAWN_HOST } from "gql/mutations";
-import { GET_INSTANCE_TYPES, GET_MY_VOLUMES } from "gql/queries";
+import {
+  GET_INSTANCE_TYPES,
+  GET_MY_PUBLIC_KEYS,
+  GET_MY_VOLUMES,
+} from "gql/queries";
 import {
   VolumesField,
   UserTagsField,
@@ -41,6 +47,10 @@ import { HostStatus } from "types/host";
 import { MyHost } from "types/spawn";
 import { string } from "utils";
 import { useEditSpawnHostModalState } from "./editSpawnHostModal/useEditSpawnHostModalState";
+import {
+  PublicKeyForm,
+  publicKeyStateType,
+} from "./spawnHostModal/PublicKeyForm";
 
 const { Option } = Select;
 const { omitTypename } = string;
@@ -79,6 +89,12 @@ export const EditSpawnHostModal: React.FC<EditSpawnHostModalProps> = ({
     MyVolumesQueryVariables
   >(GET_MY_VOLUMES);
 
+  // QUERY public keys
+  const { data: publicKeysData } = useQuery<
+    GetMyPublicKeysQuery,
+    GetMyPublicKeysQueryVariables
+  >(GET_MY_PUBLIC_KEYS);
+
   // UPDATE HOST STATUS MUTATION
   const [editSpawnHostMutation, { loading: loadingSpawnHost }] = useMutation<
     EditSpawnHostMutation,
@@ -103,6 +119,7 @@ export const EditSpawnHostModal: React.FC<EditSpawnHostModalProps> = ({
   const volumes = volumesData?.myVolumes?.filter(
     (v) => v.availabilityZone === host.availabilityZone
   );
+  const publicKeys = publicKeysData?.myPublicKeys;
 
   const [hasChanges, mutationParams] = computeDiff(
     defaultEditSpawnHostState,
@@ -282,6 +299,16 @@ export const EditSpawnHostModal: React.FC<EditSpawnHostModalProps> = ({
             }
             instanceTags={host?.instanceTags}
             visible={visible}
+          />
+        </SectionContainer>
+        <SectionContainer>
+          <SectionLabel weight="medium">Add SSH Key</SectionLabel>
+          <PublicKeyForm
+            publicKeys={publicKeys}
+            data={editSpawnHostState}
+            onChange={(data: publicKeyStateType) =>
+              dispatch({ type: "editPublicKey", ...data })
+            }
           />
         </SectionContainer>
       </ModalContent>

--- a/src/pages/spawn/spawnHost/editSpawnHostModal/useEditSpawnHostModalState.ts
+++ b/src/pages/spawn/spawnHost/editSpawnHostModal/useEditSpawnHostModalState.ts
@@ -1,10 +1,13 @@
 import { useReducer } from "react";
 import { ExpirationDateType } from "components/Spawn/ExpirationField";
-import { InstanceTagInput } from "gql/generated/types";
+import { InstanceTagInput, PublicKeyInput } from "gql/generated/types";
 import { MyHost } from "types/spawn";
 import { UserTagsData, VolumesData } from "../fields";
+import { publicKeyStateType } from "../spawnHostModal/PublicKeyForm";
 
 export interface editSpawnHostStateType {
+  publicKey: PublicKeyInput;
+  savePublicKey: boolean;
   expiration?: Date;
   noExpiration: boolean;
   displayName?: string;
@@ -29,6 +32,11 @@ const init = (host: MyHost) => ({
   addedInstanceTags: [],
   deletedInstanceTags: [],
   servicePassword: null,
+  publicKey: {
+    name: "",
+    key: "",
+  },
+  savePublicKey: false,
 });
 
 const reducer = (state: editSpawnHostStateType, action: Action) => {
@@ -66,6 +74,12 @@ const reducer = (state: editSpawnHostStateType, action: Action) => {
           ? action.servicePassword
           : null,
       };
+    case "editPublicKey":
+      return {
+        ...state,
+        publicKey: action.publicKey,
+        savePublicKey: action.savePublicKey,
+      };
     default:
       throw new Error();
   }
@@ -78,4 +92,5 @@ type Action =
   | { type: "reset"; host: MyHost }
   | ({ type: "editExpiration" } & ExpirationDateType)
   | ({ type: "editInstanceTags" } & UserTagsData)
-  | ({ type: "editVolumes" } & VolumesData);
+  | ({ type: "editVolumes" } & VolumesData)
+  | ({ type: "editPublicKey" } & publicKeyStateType);


### PR DESCRIPTION
[EVG-14901](https://jira.mongodb.org/browse/EVG-14901)

### Description 
Reuse the PublicKeyForm component within the EditSpawnHost modal so users can add keys to existing hosts.

### Screenshots
 ![Screen Shot 2021-07-08 at 10 02 27 AM](https://user-images.githubusercontent.com/17027265/124935484-b3a59980-dfd3-11eb-8a0f-d9e2918b5d62.png)

### Testing 
  Added a key to a host on staging. Also saved a new key.

### Evergreen PR 
  https://github.com/evergreen-ci/evergreen/pull/4815
