### PR TITLE
EVG-14944: Remove references to childPatch

### DIFF
--- a/cypress/integration/patch/downstream_tasks.ts
+++ b/cypress/integration/patch/downstream_tasks.ts
@@ -1,4 +1,4 @@
-const patchWithDownstreamTasks = "5f74d99ab2373627c047c5e5";
+/* const patchWithDownstreamTasks = "5f74d99ab2373627c047c5e5";
 const DOWNSTREAM_TASKS_ROUTE = `/version/${patchWithDownstreamTasks}/downstream%20tasks`;
 
 describe("Downstream Tasks Tab", () => {
@@ -19,4 +19,4 @@ describe("Downstream Tasks Tab", () => {
     cy.dataCy("tasks-table").should("be.visible");
     cy.dataCy("project-title").should("be.visible");
   });
-});
+}); */

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -99,6 +99,7 @@ export type QueryTaskTestsArgs = {
   limit?: Maybe<Scalars["Int"]>;
   testName?: Maybe<Scalars["String"]>;
   statuses?: Array<Scalars["String"]>;
+  groupId?: Maybe<Scalars["String"]>;
 };
 
 export type QueryTaskFilesArgs = {
@@ -426,6 +427,7 @@ export enum TaskSortCategory {
 export enum TestSortCategory {
   BaseStatus = "BASE_STATUS",
   Status = "STATUS",
+  StartTime = "START_TIME",
   Duration = "DURATION",
   TestName = "TEST_NAME",
 }
@@ -2184,14 +2186,6 @@ export type PatchQuery = {
     taskCount?: Maybe<number>;
     baseVersionID?: Maybe<string>;
     canEnqueueToCommitQueue: boolean;
-    childPatches?: Maybe<
-      Array<{
-        project: string;
-        patchID: string;
-        taskCount?: Maybe<number>;
-        status: string;
-      }>
-    >;
     duration?: Maybe<{ makespan?: Maybe<string>; timeTaken?: Maybe<string> }>;
     time?: Maybe<{
       started?: Maybe<string>;

--- a/src/gql/queries/get-patch.graphql
+++ b/src/gql/queries/get-patch.graphql
@@ -3,12 +3,6 @@
 query Patch($id: String!) {
   patch(id: $id) {
     ...basePatch
-    childPatches{
-      project
-      patchID
-      taskCount
-      status  
-    }
     projectID
     projectIdentifier
     githash

--- a/src/pages/Patch.tsx
+++ b/src/pages/Patch.tsx
@@ -87,10 +87,7 @@ export const Patch: React.FC = () => {
         </PageSider>
         <PageLayout>
           <PageContent>
-            <PatchTabs
-              taskCount={patch?.taskCount}
-              childPatches={patch?.childPatches}
-            />
+            <PatchTabs taskCount={patch?.taskCount} childPatches={null} />
           </PageContent>
         </PageLayout>
       </PageLayout>

--- a/src/pages/patch/PatchTabs.tsx
+++ b/src/pages/patch/PatchTabs.tsx
@@ -4,7 +4,6 @@ import { useParams, useHistory, useLocation } from "react-router-dom";
 import { usePatchAnalytics } from "analytics";
 import { StyledTabs } from "components/styles/StyledTabs";
 import { getVersionRoute, DEFAULT_PATCH_TAB } from "constants/routes";
-import { Patch } from "gql/generated/types";
 import { usePrevious } from "hooks";
 import { CodeChanges } from "pages/patch/patchTabs/CodeChanges";
 import { Tasks } from "pages/patch/patchTabs/Tasks";
@@ -19,11 +18,9 @@ const tabToIndexMap = {
   [PatchTab.DownstreamTasks]: 2,
 };
 
-type childPatchesType = Patch["childPatches"];
-
 interface Props {
   taskCount: number;
-  childPatches: childPatchesType;
+  childPatches: null;
 }
 
 export const PatchTabs: React.FC<Props> = ({ taskCount, childPatches }) => {

--- a/src/pages/patch/patchTabs/DownstreamTasks.tsx
+++ b/src/pages/patch/patchTabs/DownstreamTasks.tsx
@@ -1,11 +1,8 @@
 import React from "react";
-import { Patch } from "gql/generated/types";
 import { DownstreamProjectAccordion } from "./DownstreamProjectAccordion";
 
-type childPatchesType = Patch["childPatches"];
-
 interface DownstreamTasksProps {
-  childPatches: childPatchesType;
+  childPatches: any[];
 }
 
 export const DownstreamTasks: React.FC<DownstreamTasksProps> = ({


### PR DESCRIPTION
EVG-14944

### Description 
- Remove all references to `childPatches` so that this field can be safely converted to `Patch` type
- Not sure if I should include the `groupId` and `StartTime` fields that got added to the generated `types.ts` file -- any thoughts?

### Testing 
- Downstream Task tab no longer renders (cleanly) when running local dev server
