### PR TITLE
EVG-14799 Correctly visit configure page when no tab indicated

### DIFF
--- a/cypress/integration/patch/configure_patch.ts
+++ b/cypress/integration/patch/configure_patch.ts
@@ -34,6 +34,17 @@ describe("Configure Patch Page", () => {
         .first()
         .should("have.attr", "data-selected", "true");
     });
+    describe("Visiting configure page from a redirect", () => {
+      it("should default to the tasks tab when there isn't one in the url", () => {
+        cy.visit(`/patch/${unactivatedPatchId}/configure`);
+        cy.get('button[data-cy="tasks-tab"]').should(
+          "have.attr",
+          "aria-selected",
+          "true"
+        );
+        cy.dataCy("tasks-tab").should("be.visible");
+      });
+    });
     describe("Visiting a configure page with display tasks", () => {
       before(() => {
         cy.visit(`patch/${patchWithDisplayTasks}/configure/tasks`);

--- a/src/pages/configurePatch/ConfigurePatchCore.tsx
+++ b/src/pages/configurePatch/ConfigurePatchCore.tsx
@@ -124,7 +124,7 @@ export const ConfigurePatchCore: React.FC<Props> = ({ patch }) => {
   const [state, dispatch] = useReducer(
     reducer,
     initialState({
-      selectedTab: indexToTabMap.indexOf(tab || PatchTab.Configure),
+      selectedTab: tabToIndexMap[tab || PatchTab.Configure],
     })
   );
 


### PR DESCRIPTION
[EVG-14799](https://jira.mongodb.org/browse/EVG-14799)

### Description 
This correctly selects the tab on the initial render when there isn't one in the url. 

### Testing 
added a cypress test to validate. Unfortunately i was unable to easily create a test that tests out the redirect from legacy evergreen ui that was described in the ticket because of cypress' single domain limit. But the test i created tests the url that is returned in the redirect


