### PR TITLE
EVG-4785: Fix Tests table default sort

### DIFF
--- a/src/pages/task/taskTabs/testsTable/TestsTableCore.tsx
+++ b/src/pages/task/taskTabs/testsTable/TestsTableCore.tsx
@@ -46,23 +46,27 @@ export interface UpdateQueryArg {
 }
 export const TestsTableCore: React.FC = () => {
   const { id: resourceId } = useParams<{ id: string }>();
-  const { search } = useLocation();
+  const { pathname, search } = useLocation();
   const updateQueryParams = useUpdateURLQueryParams();
   const taskAnalytics = useTaskAnalytics();
 
   const queryVariables = getQueryVariables(search, resourceId);
   const { cat, dir, pageNum, limitNum } = queryVariables;
 
-  const appliedDefaultSort = useRef(false);
+  const appliedDefaultSort = useRef(null);
   useEffect(() => {
-    if (cat === undefined && updateQueryParams && !appliedDefaultSort.current) {
-      appliedDefaultSort.current = true;
+    if (
+      cat === undefined &&
+      updateQueryParams &&
+      appliedDefaultSort.current !== pathname
+    ) {
+      appliedDefaultSort.current = pathname;
       updateQueryParams({
         [RequiredQueryParams.Category]: TestSortCategory.Status,
         [RequiredQueryParams.Sort]: SortDirection.Asc,
       });
     }
-  }, [updateQueryParams]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [pathname, updateQueryParams]); // eslint-disable-line react-hooks/exhaustive-deps
   // Apply sorts to columns
   const columns = getColumnsTemplate(taskAnalytics).map((column) => ({
     ...column,


### PR DESCRIPTION
EVG-14785

### Description 
Default sorting of the task details' Tests table was introduced in https://github.com/evergreen-ci/spruce/pull/749. However, these query params were being set once `TestsTableCore` mounted, but before the URL was updated to the `/tests` tab. This meant that the params were immediately overwritten by [this hook](https://github.com/evergreen-ci/spruce/blob/main/src/pages/task/TaskTabs.tsx#L179-L192)'s `history.replace()` call.

Update `TestsTableCore` to watch the page's `pathname` and append query params when the pathname is updated. This results in the hook firing twice (once on the initial url and once on `/tests`), but I think that is preferable to attempting an equality check on the pathname.