### PR TITLE
EVG-14597  Make child patches restartable from parent's restart modal

### DIFF
--- a/cypress/integration/patch/patch_restart_modal.ts
+++ b/cypress/integration/patch/patch_restart_modal.ts
@@ -1,5 +1,22 @@
 // / <reference types="Cypress" />
 
+describe("Restarting a patch with Downstream Tasks", () => {
+  before(() => {
+    cy.login();
+    cy.viewport(1920, 1600);
+    cy.preserveCookies();
+  });
+
+  it("Clicking on the Select Downstream Tasks should show the downstream projects", () => {
+    cy.visit(pathWithDownstreamTasks);
+    cy.dataCy("restart-patch").click();
+    cy.dataCy("select-downstream").first().click();
+    cy.dataCy("select-downstream").first().contains("evergreen").click();
+  });
+
+  const pathWithDownstreamTasks = `/version/5f74d99ab2373627c047c5e5`;
+});
+
 describe("Restarting a patch", () => {
   before(() => {
     cy.login();

--- a/cypress/integration/patch/patch_restart_modal.ts
+++ b/cypress/integration/patch/patch_restart_modal.ts
@@ -79,7 +79,7 @@ describe("Restarting a patch", () => {
     cy.dataCy("patch-restart-modal").within(() => {
       cy.get(statusFilter).click();
       cy.get(".cy-checkbox")
-        .contains("Failed")
+        .contains("Aborted")
         .as("target")
         .click({ force: true });
       cy.get(statusFilter).click();

--- a/cypress/integration/patch/patch_restart_modal.ts
+++ b/cypress/integration/patch/patch_restart_modal.ts
@@ -43,7 +43,7 @@ describe("Restarting a patch", () => {
     // support cy-data elements currently
     cy.dataCy("patch-restart-modal").should(
       "contain.text",
-      "Are you sure you want to restart the 50 selected tasks?"
+      "Are you sure you want to restart the selected tasks?"
     );
     cy.get(statusFilter).click();
     cy.get(".cy-checkbox").contains("All").as("target").click({ force: true });
@@ -63,7 +63,7 @@ describe("Restarting a patch", () => {
       // support cy-data elements currently
       cy.dataCy("confirmation-message").should(
         "contain.text",
-        "Are you sure you want to restart the 44 selected tasks?"
+        "Are you sure you want to restart the selected tasks?"
       );
       cy.get(baseStatusFilter).click();
 
@@ -79,7 +79,7 @@ describe("Restarting a patch", () => {
     cy.dataCy("patch-restart-modal").within(() => {
       cy.get(statusFilter).click();
       cy.get(".cy-checkbox")
-        .contains("Aborted")
+        .contains("Failed")
         .as("target")
         .click({ force: true });
       cy.get(statusFilter).click();

--- a/src/components/PatchActionButtons/RestartPatch.tsx
+++ b/src/components/PatchActionButtons/RestartPatch.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { Button } from "components/Button";
 import { DropdownItem } from "components/ButtonDropdown";
 import { Patch } from "gql/generated/types";
-import { PatchRestartModal } from "pages/patch/index";
+import { PatchRestartModal } from "pages/patch/PatchRestartModal";
 
 interface RestartPatchProps {
   patchId: string;

--- a/src/pages/patch/PatchRestartModal.tsx
+++ b/src/pages/patch/PatchRestartModal.tsx
@@ -78,7 +78,7 @@ export const PatchRestartContent: React.FC<PatchRestartContentProps> = ({
       />
       <>
         {childPatches && (
-          <>
+          <div data-cy="select-downstream">
             <HR />
             <Accordion
               title={<StyledTitle> Select Downstream Tasks</StyledTitle>}
@@ -106,7 +106,7 @@ export const PatchRestartContent: React.FC<PatchRestartContentProps> = ({
                 />
               ))}
             />
-          </>
+          </div>
         )}
         <PatchRestartFooter
           setShouldAbortInProgressTasks={setShouldAbortInProgressTasks}


### PR DESCRIPTION
[EVG-14597](https://jira.mongodb.org/browse/EVG-14597)

### Description 
This lets people restart downstream tasks from the restart modal. I don't like that the "Restart" button becomes enabled when you select a task but doesn't get disabled when it's unselected, but I couldn't figure out how to make that happen easily. 

### Screenshots
![image](https://user-images.githubusercontent.com/13104717/127224343-abdbfaf4-9510-4715-b36b-681c401d1458.png)

### Testing 
Manual testing 
