### PR TITLE
EVG-15131: remove base status sorter in tests table

### DIFF
--- a/src/pages/task/taskTabs/testsTable/TestsTableCore.tsx
+++ b/src/pages/task/taskTabs/testsTable/TestsTableCore.tsx
@@ -242,7 +242,6 @@ const getColumnsTemplate = (
     title: <span data-cy="base-status-column">Base Status</span>,
     dataIndex: "baseStatus",
     key: TestSortCategory.BaseStatus,
-    sorter: true,
     render: (status: string): JSX.Element => (
       <span>
         <Badge


### PR DESCRIPTION
[EVG-15131](https://jira.mongodb.org/browse/EVG-15131)

### Description 
Removes the base test status sort toggle until feature is supported. [Here](https://github.com/evergreen-ci/evergreen/blob/main/graphql/resolvers.go#L1268-L1280) are the available sort params in the TaskTests resolver



