### PR TITLE
EVG-15179 Hide breadcrumb link

### DIFF
--- a/cypress/integration/breadcrumbs.ts
+++ b/cypress/integration/breadcrumbs.ts
@@ -66,7 +66,7 @@ describe("Viewing a mainline commit", () => {
     cy.dataCy("bc-version").click();
     cy.url().should("include", "/version/5e4ff3abe3c3317e352062e4");
   });
-  it("Clicking on the commits link should take you to that versions waterfall", () => {
+  it.skip("Clicking on the commits link should take you to that versions waterfall", () => {
     cy.dataCy("bc-waterfall").should("include.text", "evergreen's commits");
     cy.contains("evergreen's commits").click();
     cy.url().should("include", "/commits/evergreen");

--- a/src/components/Breadcrumb/index.tsx
+++ b/src/components/Breadcrumb/index.tsx
@@ -151,7 +151,7 @@ const VersionBreadcrumb: React.FC<VersionBreadcrumbProps> = ({
               })
             }
           >
-            {project}&quot;s patches
+            {project}&apos;s patches
           </StyledBreadcrumbLink>
         </StyledP1>
       </Breadcrumb.Item>

--- a/src/components/Breadcrumb/index.tsx
+++ b/src/components/Breadcrumb/index.tsx
@@ -5,7 +5,7 @@ import { Breadcrumb } from "antd";
 import { useBreadcrumbAnalytics } from "analytics";
 import { StyledRouterLink } from "components/styles/StyledLink";
 import { H3, P1 } from "components/Typography";
-import { getVersionRoute, getCommitsRoute } from "constants/routes";
+import { getVersionRoute, getProjectPatchesRoute } from "constants/routes";
 import { useGetUserPatchesPageTitleAndLink } from "hooks";
 
 const { blue } = uiColors;
@@ -142,16 +142,16 @@ const VersionBreadcrumb: React.FC<VersionBreadcrumbProps> = ({
       <Breadcrumb.Item>
         <StyledP1>
           <StyledBreadcrumbLink
-            data-cy="bc-waterfall"
-            to={getCommitsRoute(project)}
+            data-cy="bc-my-patches"
+            to={getProjectPatchesRoute(project)}
             onClick={() =>
               analytics.sendEvent({
                 name: "Click Link",
-                link: "waterfall",
+                link: "myPatches",
               })
             }
           >
-            {`${project}'s commits`}
+            {project}&quot;s patches
           </StyledBreadcrumbLink>
         </StyledP1>
       </Breadcrumb.Item>


### PR DESCRIPTION
[EVG-15179](https://jira.mongodb.org/browse/EVG-15179)

### Description 
Show we dont accidentally expose mainline commits early. 
Should revert this when we launch mainline commits