### PR TITLE
EVG-14332 add task failed or blocked notification type

### DIFF
--- a/cypress/integration/subscription_modal.ts
+++ b/cypress/integration/subscription_modal.ts
@@ -20,7 +20,7 @@ describe("Subscription Modals - Shared functionality", () => {
     describe(description, () => {
       it("Display success toast after submitting a valid form and request succeeds", () => {
         openSubscriptionModal(route, dataCyToggleModalButton);
-        cy.dataTestId("trigger_0-option").click();
+        cy.contains("finishes").click();
         cy.dataTestId("notify-by-select").click();
         cy.dataTestId("jira-comment-option").click();
         cy.dataTestId("jira-comment-input").type("EVG-2000");
@@ -30,7 +30,7 @@ describe("Subscription Modals - Shared functionality", () => {
 
       it("Disable save button and display error message when populating form with negative percent value", () => {
         openSubscriptionModal(route, dataCyToggleModalButton);
-        cy.dataTestId("trigger_4-option").click();
+        cy.contains("changes by some percentage").click();
         cy.dataCy("percent-change-input").clear().type("-100");
         cy.dataTestId("notify-by-select").click();
         cy.dataTestId("jira-comment-option").click();
@@ -43,7 +43,7 @@ describe("Subscription Modals - Shared functionality", () => {
 
       it("Disable save button and display error message in modal when populating form with negative duration value", () => {
         openSubscriptionModal(route, dataCyToggleModalButton);
-        cy.dataTestId("trigger_3-option").click();
+        cy.contains("exceeds some duration").click();
         cy.dataCy("duration-secs-input").clear().type("-100");
         cy.dataTestId("notify-by-select").click();
         cy.dataTestId("jira-comment-option").click();
@@ -56,7 +56,7 @@ describe("Subscription Modals - Shared functionality", () => {
 
       it("Disable save button and display error message in modal when populating form with decimal duration value", () => {
         openSubscriptionModal(route, dataCyToggleModalButton);
-        cy.dataTestId("trigger_3-option").click();
+        cy.contains("exceeds some duration").click();
         cy.dataCy("duration-secs-input").clear().type(".33");
         cy.dataTestId("notify-by-select").click();
         cy.dataTestId("jira-comment-option").click();
@@ -69,7 +69,7 @@ describe("Subscription Modals - Shared functionality", () => {
 
       it("Display error toast when save subscription request fails", () => {
         openSubscriptionModal(route, dataCyToggleModalButton);
-        cy.dataTestId("trigger_0-option").click();
+        cy.contains("finishes").click();
         cy.dataTestId("notify-by-select").click();
         cy.dataTestId("jira-comment-option").click();
         cy.dataTestId("jira-comment-input").type("EVG-2000");

--- a/src/hooks/tests/useNotificationModal.test.tsx
+++ b/src/hooks/tests/useNotificationModal.test.tsx
@@ -53,7 +53,7 @@ it("Should have correctly formatted request payload after selecting options (tas
   act(() => {
     result.current.setExtraFieldInputVals({ "task-duration-secs": "33" });
     result.current.setTarget({ email: "email@email.com" });
-    result.current.setSelectedTriggerIndex(3);
+    result.current.setSelectedTriggerIndex(4);
   });
 
   expect(result.current.getRequestPayload()).toStrictEqual({

--- a/src/pages/task/actionButtons/TaskNotificationModal.tsx
+++ b/src/pages/task/actionButtons/TaskNotificationModal.tsx
@@ -88,7 +88,7 @@ export const triggers: Trigger[] = [
   },
   {
     trigger: "task-failed-or-blocked",
-    label: "this task fails or is blocked",
+    label: "This task fails or is blocked",
     resourceType: "TASK",
     payloadResourceIdKey: "id",
   },

--- a/src/pages/task/actionButtons/TaskNotificationModal.tsx
+++ b/src/pages/task/actionButtons/TaskNotificationModal.tsx
@@ -87,6 +87,12 @@ export const triggers: Trigger[] = [
     payloadResourceIdKey: "id",
   },
   {
+    trigger: "task-failed-or-blocked",
+    label: "this task fails or is blocked",
+    resourceType: "TASK",
+    payloadResourceIdKey: "id",
+  },
+  {
     trigger: "success",
     label: "This task succeeds",
     resourceType: "TASK",


### PR DESCRIPTION
[EVG-14332](https://jira.mongodb.org/browse/EVG-14332)

### Description 
Notify if the task is failed or blocked. (Could've made this just notify on blocked; I thought a bit about the reporter's use case / general use case for this and I think failed + blocked does make the most sense, but the work to add "just blocked" would be similar to this if it's ever requested in the future.)

### Screenshots
![image](https://user-images.githubusercontent.com/26798134/128554876-626db15a-0404-4950-a15d-dc81b4168bd3.png)

### Testing 
Tested on staging with blocked and failed task (pictures available on Evergreen PR).

### Evergreen PR 
https://github.com/evergreen-ci/evergreen/pull/4914
