### PR TITLE
EVG-13902 Create manifest link

### DIFF
--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -16,6 +16,7 @@ export type Scalars = {
   Time: Date;
   Duration: number;
   StringMap: { [key: string]: any };
+  Map: any;
 };
 
 export type Query = {
@@ -413,6 +414,7 @@ export type Version = {
   parameters: Array<Parameter>;
   taskStatuses: Array<Scalars["String"]>;
   baseTaskStatuses: Array<Scalars["String"]>;
+  manifest?: Maybe<Manifest>;
 };
 
 export type VersionTaskStatusCountsArgs = {
@@ -421,6 +423,16 @@ export type VersionTaskStatusCountsArgs = {
 
 export type VersionBuildVariantsArgs = {
   options?: Maybe<BuildVariantOptions>;
+};
+
+export type Manifest = {
+  id: Scalars["String"];
+  revision: Scalars["String"];
+  project: Scalars["String"];
+  branch: Scalars["String"];
+  isBase: Scalars["Boolean"];
+  moduleOverrides?: Maybe<Scalars["StringMap"]>;
+  modules?: Maybe<Scalars["Map"]>;
 };
 
 export type VersionTiming = {
@@ -2610,6 +2622,15 @@ export type VersionQuery = {
       timeTaken?: Maybe<number>;
     }>;
     parameters: Array<{ key: string; value: string }>;
+    manifest?: Maybe<{
+      id: string;
+      revision: string;
+      project: string;
+      branch: string;
+      isBase: boolean;
+      moduleOverrides?: Maybe<{ [key: string]: any }>;
+      modules?: Maybe<any>;
+    }>;
     patch?: Maybe<{
       id: string;
       patchNumber: number;

--- a/src/gql/queries/get-version.graphql
+++ b/src/gql/queries/get-version.graphql
@@ -25,6 +25,15 @@ query Version($id: String!) {
       key
       value
     }
+    manifest {
+      id
+      revision
+      project
+      branch
+      isBase
+      moduleOverrides
+      modules
+    }
     patch {
       id
       patchNumber

--- a/src/pages/version/ManifestBlob.tsx
+++ b/src/pages/version/ManifestBlob.tsx
@@ -4,7 +4,7 @@ import { Manifest } from "gql/generated/types";
 import { string } from "utils";
 
 const { omitTypename } = string;
-// typescript interface with manifest that is an object of key-value pairs
+
 interface Props {
   manifest: Manifest;
 }

--- a/src/pages/version/ManifestBlob.tsx
+++ b/src/pages/version/ManifestBlob.tsx
@@ -1,25 +1,12 @@
 import { StyledLink } from "components/styles";
 import { P2 } from "components/Typography";
+import { Manifest } from "gql/generated/types";
 import { string } from "utils";
 
 const { omitTypename } = string;
 // typescript interface with manifest that is an object of key-value pairs
 interface Props {
-  manifest: {
-    id: string;
-    revision: string;
-    project: string;
-    branch: string;
-    isBase: boolean;
-    moduleOverrides?: {
-      [key: string]: string;
-    };
-    modules?: {
-      [key: string]: {
-        [key: string]: string;
-      };
-    };
-  };
+  manifest: Manifest;
 }
 
 const ManifestBlob: React.FC<Props> = ({ manifest }) => {

--- a/src/pages/version/ManifestBlob.tsx
+++ b/src/pages/version/ManifestBlob.tsx
@@ -1,0 +1,44 @@
+import { StyledLink } from "components/styles";
+import { P2 } from "components/Typography";
+import { string } from "utils";
+
+const { omitTypename } = string;
+// typescript interface with manifest that is an object of key-value pairs
+interface Props {
+  manifest: {
+    id: string;
+    revision: string;
+    project: string;
+    branch: string;
+    isBase: boolean;
+    moduleOverrides?: {
+      [key: string]: string;
+    };
+    modules?: {
+      [key: string]: {
+        [key: string]: string;
+      };
+    };
+  };
+}
+
+const ManifestBlob: React.FC<Props> = ({ manifest }) => {
+  const cleanedManifest = omitTypename(manifest);
+  const blob = new Blob([JSON.stringify(cleanedManifest, null, 3)], {
+    type: "text/json",
+  });
+  return (
+    <P2>
+      Version Manifest:{" "}
+      <StyledLink
+        data-cy="manifest-link"
+        href={URL.createObjectURL(blob)}
+        target="__blank"
+      >
+        Here
+      </StyledLink>
+    </P2>
+  );
+};
+
+export default ManifestBlob;

--- a/src/pages/version/ManifestBlob.tsx
+++ b/src/pages/version/ManifestBlob.tsx
@@ -29,13 +29,12 @@ const ManifestBlob: React.FC<Props> = ({ manifest }) => {
   });
   return (
     <P2>
-      Version Manifest:{" "}
       <StyledLink
         data-cy="manifest-link"
         href={URL.createObjectURL(blob)}
         target="__blank"
       >
-        Here
+        Version Manifest
       </StyledLink>
     </P2>
   );

--- a/src/pages/version/Metadata.tsx
+++ b/src/pages/version/Metadata.tsx
@@ -4,6 +4,7 @@ import { StyledLink, StyledRouterLink } from "components/styles";
 import { P2 } from "components/Typography";
 import { getCommitQueueRoute, getProjectPatchesRoute } from "constants/routes";
 import { environmentalVariables, string } from "utils";
+import ManifestBlob from "./ManifestBlob";
 import { ParametersModal } from "./ParametersModal";
 
 const { msToDuration, getDateCopy } = string;
@@ -30,6 +31,21 @@ interface Props {
       key: string;
       value: string;
     }[];
+    manifest?: {
+      id: string;
+      revision: string;
+      project: string;
+      branch: string;
+      isBase: boolean;
+      moduleOverrides?: {
+        [key: string]: string;
+      };
+      modules?: {
+        [key: string]: {
+          [key: string]: string;
+        };
+      };
+    };
   };
 }
 
@@ -47,6 +63,7 @@ export const Metadata: React.FC<Props> = ({ loading, version }) => {
     baseVersionID,
     isPatch,
     parameters,
+    manifest,
   } = version || {};
   const { makespan, timeTaken } = versionTiming || {};
   return (
@@ -69,11 +86,12 @@ export const Metadata: React.FC<Props> = ({ loading, version }) => {
       <P2>{`Submitted by: ${author}`}</P2>
       {baseVersionID && revision && (
         <P2>
+          Base commit:{" "}
           <StyledLink
             data-cy="patch-base-commit"
             href={`${getUiUrl()}/version/${baseVersionID}`}
           >
-            Base commit: {revision.slice(0, 10)}
+            {revision.slice(0, 10)}
           </StyledLink>
         </P2>
       )}
@@ -87,6 +105,7 @@ export const Metadata: React.FC<Props> = ({ loading, version }) => {
           </StyledRouterLink>
         </P2>
       )}
+      {manifest && <ManifestBlob manifest={manifest} />}
       <ParametersModal parameters={parameters} />
     </MetadataCard>
   );


### PR DESCRIPTION
[EVG-13902](https://jira.mongodb.org/browse/EVG-13902)

### Description 
Creates a link in the version metadata that opens the manifest in a new tab

### Screenshots
![image](https://user-images.githubusercontent.com/4605522/128726652-0377656f-a96e-48da-b0b3-d21606d1a92e.png)

opens this
![image](https://user-images.githubusercontent.com/4605522/128726209-dfaa16b9-dd69-4ea0-a3d4-40cba392a818.png)

### Testing 
Tested manually. I couldn't figure out a way to write any tests for this
CreateObjectURL isn't supported in jest and can't really be mocked since it does some stuff behind the scenes to generate the url.
Can't test in cypress because `createObjectURL` changes the domain name by prepending a `blob` to the link and cypress wont allow cross origin requests.
### Evergreen PR 
https://github.com/evergreen-ci/evergreen/pull/4904