### PR TITLE
EVG-14964 Fix Known-Issue only appearing after a second 

### DIFF
--- a/src/components/PatchTabs/Tasks.tsx
+++ b/src/components/PatchTabs/Tasks.tsx
@@ -51,19 +51,19 @@ export const Tasks: React.FC<Props> = ({ taskCount }) => {
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const { data, loading, startPolling, stopPolling } = useQuery<
+  const { data, startPolling, stopPolling } = useQuery<
     PatchTasksQuery,
     PatchTasksQueryVariables
   >(GET_PATCH_TASKS, {
     variables: queryVariables,
     pollInterval,
-    fetchPolicy: "cache-and-network",
+    fetchPolicy: "no-cache",
     onError: (err) => {
       dispatchToast.error(`Error fetching patch tasks ${err}`);
     },
   });
   let showSkeleton = true;
-  if (data && !loading) {
+  if (data) {
     showSkeleton = false;
   }
   useNetworkStatus(startPolling, stopPolling);

--- a/src/components/PatchTabs/Tasks.tsx
+++ b/src/components/PatchTabs/Tasks.tsx
@@ -28,7 +28,6 @@ const { getPageFromSearch, getLimitFromSearch } = url;
 interface Props {
   taskCount: number;
 }
-let nTimes = 0;
 
 export const Tasks: React.FC<Props> = ({ taskCount }) => {
   const { id: versionId } = useParams<{ id: string }>();
@@ -57,7 +56,7 @@ export const Tasks: React.FC<Props> = ({ taskCount }) => {
   >(GET_PATCH_TASKS, {
     variables: queryVariables,
     pollInterval,
-    fetchPolicy: "no-cache",
+    fetchPolicy: "cache-and-network",
     onError: (err) => {
       dispatchToast.error(`Error fetching patch tasks ${err}`);
     },
@@ -68,8 +67,6 @@ export const Tasks: React.FC<Props> = ({ taskCount }) => {
   }
   useNetworkStatus(startPolling, stopPolling);
   const { patchTasks } = data || {};
-  console.log(`Rendered component${nTimes}`);
-  nTimes += 1;
   return (
     <>
       <TaskFilters />

--- a/src/components/PatchTabs/Tasks.tsx
+++ b/src/components/PatchTabs/Tasks.tsx
@@ -51,7 +51,7 @@ export const Tasks: React.FC<Props> = ({ taskCount }) => {
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const { data, startPolling, stopPolling } = useQuery<
+  const { data, loading, startPolling, stopPolling } = useQuery<
     PatchTasksQuery,
     PatchTasksQueryVariables
   >(GET_PATCH_TASKS, {
@@ -63,7 +63,7 @@ export const Tasks: React.FC<Props> = ({ taskCount }) => {
     },
   });
   let showSkeleton = true;
-  if (data) {
+  if (data && !loading) {
     showSkeleton = false;
   }
   useNetworkStatus(startPolling, stopPolling);

--- a/src/pages/Task.tsx
+++ b/src/pages/Task.tsx
@@ -43,7 +43,7 @@ export const Task: React.FC = () => {
     GetTaskQueryVariables
   >(GET_TASK, {
     variables: { taskId: id, execution: selectedExecution },
-    fetchPolicy: "network-only",
+    fetchPolicy: "no-cache",
     pollInterval,
     onError: (err) =>
       dispatchToast.error(


### PR DESCRIPTION
[EVG-14964 ](https://jira.mongodb.org/browse/EVG-14964 )

### Description 
when clicking into a task and then using the back button, there is a second where we load bad data until the new request refreshes it. Instead, we want to wait and only show the data once the query is done loading. 


### Testing 
tested on staging to make sure the bug is gone with this fix. 
