### PR TITLE
EVG-14964 Bypass cache for status

### DIFF
--- a/src/gql/GQLWrapper.tsx
+++ b/src/gql/GQLWrapper.tsx
@@ -52,6 +52,11 @@ const cache = new InMemoryCache({
             return mergeObjects(existing, incoming);
           },
         },
+        status: {
+          merge(_, incoming) {
+            return incoming;
+          },
+        },
       },
     },
     Patch: {

--- a/src/pages/Task.tsx
+++ b/src/pages/Task.tsx
@@ -43,7 +43,7 @@ export const Task: React.FC = () => {
     GetTaskQueryVariables
   >(GET_TASK, {
     variables: { taskId: id, execution: selectedExecution },
-    fetchPolicy: "network-only",
+    fetchPolicy: "no-cache",
     pollInterval,
     onError: (err) =>
       dispatchToast.error(


### PR DESCRIPTION
[EVG-14964](https://jira.mongodb.org/browse/EVG-14964)

### Description 
Sorry for the back and forth this should work and avoids breaking with the cache 


https://user-images.githubusercontent.com/4605522/130464019-855109c6-a8f4-481f-9d84-bd2d321890b8.mov

