### PR TITLE
EVG-15287: Add trigger aliases on configure page

### DIFF
--- a/cypress/integration/version/unscheduled_patch/configure_patch.ts
+++ b/cypress/integration/version/unscheduled_patch/configure_patch.ts
@@ -442,6 +442,65 @@ describe("Configure Patch Page", () => {
         cy.get("[data-selected=true]").its("length").should("eq", 6);
       });
     });
+
+    describe.only("Selecting a trigger alias", () => {
+      before(() => {
+        cy.dataCy("trigger-alias-list-item")
+          .contains("logkeeper-alias")
+          .click();
+      });
+
+      it("Should show no tasks", () => {
+        cy.dataCy("downstream-patch-checkbox").should("have.length", 0);
+      });
+
+      it("Should update the 'Select all' label", () => {
+        cy.dataCy("select-all-checkbox")
+          .siblings("span")
+          .contains("Select all tasks in this trigger alias");
+      });
+
+      it("Clicking select all should update the task count", () => {
+        cy.dataCy("trigger-alias-list-item")
+          .find('[data-cy="task-count-badge"]')
+          .should("not.exist");
+
+        cy.dataCy("select-all-checkbox").check({
+          force: true,
+        });
+
+        cy.dataCy("selected-task-disclaimer").contains(
+          `0 tasks across 0 build variants, 1 trigger alias`
+        );
+
+        const countBadge = cy
+          .dataCy("trigger-alias-list-item")
+          .find('[data-cy="task-count-badge"]');
+        countBadge.should("exist");
+        countBadge.should("have.text", 1);
+      });
+
+      it("Cmd+click will select the clicked trigger alias along with the build variant and will show a checkbox for the trigger alias", () => {
+        cy.get("body").type("{meta}", {
+          release: false,
+        });
+
+        cy.dataCy("build-variant-list-item").contains("Windows").click();
+        cy.dataCy("downstream-patch-checkbox").should("have.length", 1);
+
+        cy.get("[data-selected=true]").its("length").should("eq", 2);
+      });
+
+      it("Updates the badge count when the trigger alias is deselected", () => {
+        cy.dataCy("downstream-patch-checkbox").uncheck({
+          force: true,
+        });
+
+        cy.dataCy("trigger-alias-list-item")
+          .find('[data-cy="task-count-badge"]')
+          .should("not.exist");
+      });
+    });
   });
 
   //   Using mocked responses because we are unable to schedule a patch because of a missing github token

--- a/cypress/integration/version/unscheduled_patch/configure_patch.ts
+++ b/cypress/integration/version/unscheduled_patch/configure_patch.ts
@@ -451,7 +451,7 @@ describe("Configure Patch Page", () => {
       });
 
       it("Should show no tasks", () => {
-        cy.dataCy("downstream-patch-checkbox").should("have.length", 0);
+        cy.dataCy("alias-checkbox").should("have.length", 0);
       });
 
       it("Should update the 'Select all' label", () => {
@@ -486,13 +486,13 @@ describe("Configure Patch Page", () => {
         });
 
         cy.dataCy("build-variant-list-item").contains("Windows").click();
-        cy.dataCy("downstream-patch-checkbox").should("have.length", 1);
+        cy.dataCy("alias-checkbox").should("have.length", 1);
 
         cy.get("[data-selected=true]").its("length").should("eq", 2);
       });
 
       it("Updates the badge count when the trigger alias is deselected", () => {
-        cy.dataCy("downstream-patch-checkbox").uncheck({
+        cy.dataCy("alias-checkbox").uncheck({
           force: true,
         });
 

--- a/cypress/integration/version/unscheduled_patch/configure_patch.ts
+++ b/cypress/integration/version/unscheduled_patch/configure_patch.ts
@@ -443,7 +443,7 @@ describe("Configure Patch Page", () => {
       });
     });
 
-    describe.only("Selecting a trigger alias", () => {
+    describe("Selecting a trigger alias", () => {
       before(() => {
         cy.dataCy("trigger-alias-list-item")
           .contains("logkeeper-alias")

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -2313,6 +2313,7 @@ export type ConfigurePatchQuery = {
         tasks: Array<string>;
       }>;
     }>;
+    patchTriggerAliases: Array<{ alias: string; childProject: string }>;
   } & BasePatchFragment;
 };
 

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -2313,6 +2313,12 @@ export type ConfigurePatchQuery = {
         tasks: Array<string>;
       }>;
     }>;
+    childPatches?: Maybe<
+      Array<{
+        projectIdentifier: string;
+        variantsTasks: Array<Maybe<{ name: string; tasks: Array<string> }>>;
+      }>
+    >;
     patchTriggerAliases: Array<{ alias: string; childProject: string }>;
   } & BasePatchFragment;
 };

--- a/src/gql/queries/get-patch-configure.graphql
+++ b/src/gql/queries/get-patch-configure.graphql
@@ -13,6 +13,13 @@ query ConfigurePatch($id: String!) {
         tasks
       }
     }
+    childPatches {
+      projectIdentifier
+      variantsTasks {
+        name
+        tasks
+      }
+    }
     patchTriggerAliases {
       alias
       childProject

--- a/src/gql/queries/get-patch-configure.graphql
+++ b/src/gql/queries/get-patch-configure.graphql
@@ -1,18 +1,21 @@
 #import "../fragments/basePatch.graphql"
 
-  query ConfigurePatch($id: String!) {
-    patch(id: $id) {
-      ...basePatch
-      time {
-        submittedAt
+query ConfigurePatch($id: String!) {
+  patch(id: $id) {
+    ...basePatch
+    time {
+      submittedAt
+    }
+    project {
+      variants {
+        name
+        displayName
+        tasks
       }
-      project {
-        variants {
-          name
-          displayName
-          tasks
-        }
-      }
-
+    }
+    patchTriggerAliases {
+      alias
+      childProject
     }
   }
+}

--- a/src/hooks/useConfigurePatch.ts
+++ b/src/hooks/useConfigurePatch.ts
@@ -73,7 +73,7 @@ const reducer = (state: ConfigurePatchState, action: Action) => {
     case "setSelectedAliases":
       return {
         ...state,
-        setSelectedAliases: action.aliases,
+        selectedAliases: action.aliases,
       };
     case "setPatchParams":
       return {

--- a/src/hooks/useConfigurePatch.ts
+++ b/src/hooks/useConfigurePatch.ts
@@ -103,7 +103,7 @@ const reducer = (state: ConfigurePatchState, action: Action) => {
       };
 
     default:
-      throw new Error();
+      throw new Error("Unknown action type");
   }
 };
 

--- a/src/hooks/useConfigurePatch.ts
+++ b/src/hooks/useConfigurePatch.ts
@@ -1,0 +1,246 @@
+import { useEffect, useReducer } from "react";
+import { useHistory, useLocation, useParams } from "react-router-dom";
+import { getPatchRoute } from "constants/routes";
+import {
+  ConfigurePatchQuery,
+  ParameterInput,
+  PatchTriggerAlias,
+  VariantTask,
+} from "gql/generated/types";
+import { PatchTab } from "types/patch";
+import { queryString, string } from "utils";
+import { convertArrayToObject, mapStringArrayToObject } from "utils/array";
+
+const { omitTypename } = string;
+const { parseQueryString } = queryString;
+
+type ConfigurePatchState = {
+  description: string;
+  selectedBuildVariants: string[];
+  selectedBuildVariantTasks: VariantTasksState;
+  patchParams: ParameterInput[];
+  selectedTab: number;
+  disableBuildVariantSelect: boolean;
+  selectedDownstreamPatches: DownstreamPatchState;
+};
+
+type Action =
+  | { type: "setDescription"; description: string }
+  | { type: "setSelectedBuildVariants"; buildVariants: string[] }
+  | { type: "setPatchParams"; params: ParameterInput[] }
+  | { type: "setSelectedBuildVariantTasks"; variantTasks: VariantTasksState }
+  | { type: "setSelectedTab"; tabIndex: number }
+  | {
+      type: "updatePatchData";
+      description: string;
+      buildVariants: string[];
+      params: ParameterInput[];
+      variantTasks: VariantTasksState;
+      downstreamPatches: DownstreamPatchState;
+    }
+  | {
+      type: "setSelectedDownstreamPatches";
+      downstreamPatches: DownstreamPatchState;
+    };
+
+const initialState = ({ selectedTab = 0 }: { selectedTab: number }) => ({
+  description: "",
+  selectedBuildVariants: [],
+  selectedBuildVariantTasks: {},
+  patchParams: null,
+  selectedTab,
+  disableBuildVariantSelect: tabToIndexMap[selectedTab] === PatchTab.Tasks,
+  selectedDownstreamPatches: {},
+});
+
+const reducer = (state: ConfigurePatchState, action: Action) => {
+  switch (action.type) {
+    case "setDescription":
+      return {
+        ...state,
+        description: action.description,
+      };
+    case "setSelectedBuildVariants":
+      return {
+        ...state,
+        selectedBuildVariants: action.buildVariants,
+      };
+    case "setSelectedBuildVariantTasks":
+      return {
+        ...state,
+        selectedBuildVariantTasks: action.variantTasks,
+      };
+    case "setSelectedDownstreamPatches":
+      return {
+        ...state,
+        selectedDownstreamPatches: action.downstreamPatches,
+      };
+    case "setPatchParams":
+      return {
+        ...state,
+        patchParams: omitTypename(action.params),
+      };
+    case "setSelectedTab": {
+      let tab = indexToTabMap.indexOf(PatchTab.Tasks);
+      if (action.tabIndex !== -1 && action.tabIndex < indexToTabMap.length) {
+        tab = action.tabIndex;
+      }
+      return {
+        ...state,
+        selectedTab: tab,
+        disableBuildVariantSelect:
+          indexToTabMap[action.tabIndex] !== PatchTab.Tasks,
+      };
+    }
+    case "updatePatchData":
+      return {
+        ...state,
+        description: action.description,
+        selectedBuildVariants: action.buildVariants,
+        patchParams: omitTypename(action.params),
+        selectedBuildVariantTasks: action.variantTasks,
+        selectedDownstreamPatches: action.downstreamPatches,
+      };
+
+    default:
+      throw new Error();
+  }
+};
+
+const indexToTabMap = [PatchTab.Tasks, PatchTab.Changes, PatchTab.Parameters];
+
+const tabToIndexMap = {
+  [PatchTab.Tasks]: 0,
+  [PatchTab.Changes]: 1,
+  [PatchTab.Parameters]: 2,
+};
+
+export type DownstreamPatchState = {
+  [alias: string]: boolean;
+};
+export type TasksState = {
+  [task: string]: boolean;
+};
+export type VariantTasksState = {
+  [variant: string]: TasksState;
+};
+
+interface HookResult extends ConfigurePatchState {
+  setDescription: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  setPatchParams: (patchParams: ParameterInput[]) => void;
+  setSelectedBuildVariants: (variants: string[]) => void;
+  setSelectedBuildVariantTasks: (variantTasks: VariantTasksState) => void;
+  setSelectedDownstreamPatches: (
+    downstreamPatches: DownstreamPatchState
+  ) => void;
+  setSelectedTab: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+export const useConfigurePatch = (
+  patch: ConfigurePatchQuery["patch"],
+  variants: ConfigurePatchQuery["patch"]["project"]["variants"]
+): HookResult => {
+  const history = useHistory();
+  const location = useLocation();
+  const { tab } = useParams<{ tab: PatchTab | null }>();
+
+  const { id } = patch;
+
+  const [state, dispatch] = useReducer(
+    reducer,
+    initialState({
+      selectedTab: tabToIndexMap[tab || PatchTab.Configure],
+    })
+  );
+
+  const { selectedTab } = state;
+
+  useEffect(() => {
+    const query = parseQueryString(location.search);
+    history.replace(
+      getPatchRoute(id, {
+        configure: true,
+        tab: indexToTabMap[selectedTab],
+        ...query,
+      })
+    );
+  }, [selectedTab]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    if (patch) {
+      dispatch({
+        type: "updatePatchData",
+        description: patch.description,
+        buildVariants: [variants[0]?.name],
+        params: patch.parameters,
+        variantTasks: initializeTaskState(variants, patch.variantsTasks),
+        downstreamPatches: initializeDownstreamPatchState(
+          patch.patchTriggerAliases
+        ),
+      });
+    }
+  }, [patch, variants]);
+
+  const setDescription = (e) =>
+    dispatch({ type: "setDescription", description: e.target.value });
+  const setSelectedBuildVariants = (buildVariants: string[]) =>
+    dispatch({ type: "setSelectedBuildVariants", buildVariants });
+  const setSelectedBuildVariantTasks = (variantTasks) =>
+    dispatch({
+      type: "setSelectedBuildVariantTasks",
+      variantTasks,
+    });
+  const setSelectedDownstreamPatches = (
+    downstreamPatches: DownstreamPatchState
+  ) =>
+    dispatch({
+      type: "setSelectedDownstreamPatches",
+      downstreamPatches,
+    });
+  const setSelectedTab = (i) =>
+    dispatch({ type: "setSelectedTab", tabIndex: i });
+  const setPatchParams = (params) =>
+    dispatch({ type: "setPatchParams", params });
+
+  return {
+    ...state,
+    setDescription,
+    setPatchParams,
+    setSelectedBuildVariants,
+    setSelectedBuildVariantTasks,
+    setSelectedDownstreamPatches,
+    setSelectedTab,
+  };
+};
+
+// Takes in variant tasks and default selected tasks and returns an object
+// With merged variant and default selected tasks auto selected.
+const initializeTaskState = (
+  variantTasks: VariantTask[],
+  defaultSelectedTasks: VariantTask[]
+) => {
+  const defaultTasks = convertArrayToObject(defaultSelectedTasks, "name");
+  return variantTasks.reduce(
+    (prev, { name: variant, tasks }) => ({
+      ...prev,
+      [variant]: {
+        ...mapStringArrayToObject(tasks, false),
+        ...(defaultTasks[variant]
+          ? mapStringArrayToObject(defaultTasks[variant].tasks, true)
+          : {}),
+      },
+    }),
+    {}
+  );
+};
+
+const initializeDownstreamPatchState = (
+  patchTriggerAliases: PatchTriggerAlias[]
+) =>
+  patchTriggerAliases.reduce(
+    (prev, { alias }) => ({
+      ...prev,
+      [alias]: false,
+    }),
+    {}
+  );

--- a/src/hooks/useConfigurePatch.ts
+++ b/src/hooks/useConfigurePatch.ts
@@ -8,11 +8,11 @@ import {
   VariantTask,
 } from "gql/generated/types";
 import { PatchTab } from "types/patch";
-import { queryString, string } from "utils";
-import { convertArrayToObject, mapStringArrayToObject } from "utils/array";
+import { array, queryString, string } from "utils";
 
-const { omitTypename } = string;
+const { convertArrayToObject, mapStringArrayToObject } = array;
 const { parseQueryString } = queryString;
+const { omitTypename } = string;
 
 type ConfigurePatchState = {
   description: string;
@@ -126,7 +126,7 @@ export type VariantTasksState = {
 };
 
 interface HookResult extends ConfigurePatchState {
-  setDescription: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  setDescription: (description: string) => void;
   setPatchParams: (patchParams: ParameterInput[]) => void;
   setSelectedBuildVariants: (variants: string[]) => void;
   setSelectedBuildVariantTasks: (variantTasks: VariantTasksState) => void;
@@ -181,8 +181,8 @@ export const useConfigurePatch = (
     }
   }, [patch, variants]);
 
-  const setDescription = (e) =>
-    dispatch({ type: "setDescription", description: e.target.value });
+  const setDescription = (description) =>
+    dispatch({ type: "setDescription", description });
   const setSelectedBuildVariants = (buildVariants: string[]) =>
     dispatch({ type: "setSelectedBuildVariants", buildVariants });
   const setSelectedBuildVariantTasks = (variantTasks) =>

--- a/src/pages/configurePatch/ConfigurePatchCore.tsx
+++ b/src/pages/configurePatch/ConfigurePatchCore.tsx
@@ -18,7 +18,6 @@ import {
   SchedulePatchMutationVariables,
   VariantTasks,
   ConfigurePatchQuery,
-  Patch,
   PatchTriggerAlias,
   ProjectBuildVariant,
 } from "gql/generated/types";
@@ -84,13 +83,9 @@ export const ConfigurePatchCore: React.FC<Props> = ({ patch }) => {
   const onClickSchedule = async (): Promise<void> => {
     const configurePatchParam: PatchConfigure = {
       description,
-      variantsTasks: getGqlVariantTasksParamFromState(
-        selectedBuildVariantTasks
-      ),
+      variantsTasks: toGQLVariantTasksType(selectedBuildVariantTasks),
       parameters: patchParams,
-      patchTriggerAliases: getGqlDownstreamPatchesFromState(
-        selectedDownstreamPatches
-      ),
+      patchTriggerAliases: toGQLDownstreamPatchType(selectedDownstreamPatches),
     };
     schedulePatch({
       variables: { patchId: id, configure: configurePatchParam },
@@ -116,7 +111,7 @@ export const ConfigurePatchCore: React.FC<Props> = ({ patch }) => {
         data-cy="patch-name-input"
         value={description}
         size="large"
-        onChange={setDescription}
+        onChange={(e) => setDescription(e.target.value)}
       />
       <PageLayout>
         <PageSider>
@@ -202,7 +197,9 @@ const getPatchTriggerAliasEntries = (
   }));
 };
 
-const getChildPatchEntries = (childPatches: Partial<Patch>[]) => {
+const getChildPatchEntries = (
+  childPatches: ConfigurePatchQuery["patch"]["childPatches"]
+) => {
   if (!childPatches) {
     return [];
   }
@@ -213,7 +210,7 @@ const getChildPatchEntries = (childPatches: Partial<Patch>[]) => {
   }));
 };
 
-const getGqlVariantTasksParamFromState = (
+const toGQLVariantTasksType = (
   selectedVariantTasks: VariantTasksState
 ): VariantTasks[] =>
   Object.entries(selectedVariantTasks)
@@ -229,7 +226,7 @@ const getGqlVariantTasksParamFromState = (
     })
     .filter(({ tasks }) => tasks.length);
 
-const getGqlDownstreamPatchesFromState = (
+const toGQLDownstreamPatchType = (
   selectedDownstreamPatches: DownstreamPatchState
 ) =>
   Object.entries(selectedDownstreamPatches)

--- a/src/pages/configurePatch/ConfigurePatchCore.tsx
+++ b/src/pages/configurePatch/ConfigurePatchCore.tsx
@@ -23,7 +23,7 @@ import {
 } from "gql/generated/types";
 import { SCHEDULE_PATCH } from "gql/mutations";
 import {
-  DownstreamPatchState,
+  AliasState,
   VariantTasksState,
   useConfigurePatch,
 } from "hooks/useConfigurePatch";
@@ -52,15 +52,15 @@ export const ConfigurePatchCore: React.FC<Props> = ({ patch }) => {
     description,
     disableBuildVariantSelect,
     patchParams,
+    selectedAliases,
     selectedBuildVariants,
     selectedBuildVariantTasks,
-    selectedDownstreamPatches,
     selectedTab,
     setDescription,
     setPatchParams,
+    setSelectedAliases,
     setSelectedBuildVariants,
     setSelectedBuildVariantTasks,
-    setSelectedDownstreamPatches,
     setSelectedTab,
   } = useConfigurePatch(patch, variants);
 
@@ -85,7 +85,7 @@ export const ConfigurePatchCore: React.FC<Props> = ({ patch }) => {
       description,
       variantsTasks: toGQLVariantTasksType(selectedBuildVariantTasks),
       parameters: patchParams,
-      patchTriggerAliases: toGQLDownstreamPatchType(selectedDownstreamPatches),
+      patchTriggerAliases: toGQLAliasType(selectedAliases),
     };
     schedulePatch({
       variables: { patchId: id, configure: configurePatchParam },
@@ -124,7 +124,7 @@ export const ConfigurePatchCore: React.FC<Props> = ({ patch }) => {
             aliases={[
               ...getPatchTriggerAliasEntries(
                 patchTriggerAliases,
-                selectedDownstreamPatches
+                selectedAliases
               ),
               ...getChildPatchEntries(childPatches),
             ]}
@@ -148,8 +148,8 @@ export const ConfigurePatchCore: React.FC<Props> = ({ patch }) => {
                   activated={activated}
                   loading={loadingScheduledPatch}
                   onClickSchedule={onClickSchedule}
-                  selectedDownstreamPatches={selectedDownstreamPatches}
-                  setSelectedDownstreamPatches={setSelectedDownstreamPatches}
+                  selectedAliases={selectedAliases}
+                  setSelectedAliases={setSelectedAliases}
                   childPatches={childPatches}
                 />
               </Tab>
@@ -185,7 +185,7 @@ const getVariantEntries = (
 
 const getPatchTriggerAliasEntries = (
   patchTriggerAliases: PatchTriggerAlias[],
-  selectedDownstreamPatches: DownstreamPatchState
+  selectedAliases: AliasState
 ) => {
   if (!patchTriggerAliases) {
     return [];
@@ -193,7 +193,7 @@ const getPatchTriggerAliasEntries = (
   return patchTriggerAliases.map(({ alias, childProject }) => ({
     displayName: `${alias} (${childProject})`,
     name: alias,
-    taskCount: selectedDownstreamPatches[alias] ? 1 : 0,
+    taskCount: selectedAliases[alias] ? 1 : 0,
   }));
 };
 
@@ -226,10 +226,8 @@ const toGQLVariantTasksType = (
     })
     .filter(({ tasks }) => tasks.length);
 
-const toGQLDownstreamPatchType = (
-  selectedDownstreamPatches: DownstreamPatchState
-) =>
-  Object.entries(selectedDownstreamPatches)
+const toGQLAliasType = (selectedAliases: AliasState) =>
+  Object.entries(selectedAliases)
     .filter(([, isSelected]) => isSelected)
     .map(([alias]) => alias);
 

--- a/src/pages/configurePatch/ConfigurePatchCore.tsx
+++ b/src/pages/configurePatch/ConfigurePatchCore.tsx
@@ -142,7 +142,15 @@ export const ConfigurePatchCore: React.FC<Props> = ({ patch }) => {
     })
   );
 
-  const { project, id, author, time, activated, patchTriggerAliases } = patch;
+  const {
+    project,
+    id,
+    author,
+    time,
+    activated,
+    childPatches,
+    patchTriggerAliases,
+  } = patch;
   const { variants } = project;
 
   const [schedulePatch, { loading: loadingScheduledPatch }] = useMutation<
@@ -250,11 +258,21 @@ export const ConfigurePatchCore: React.FC<Props> = ({ patch }) => {
                   ).length
                 : 0,
             }))}
-            aliases={patchTriggerAliases.map(({ alias, childProject }) => ({
-              displayName: `${alias} (${childProject})`,
-              name: alias,
-              taskCount: selectedDownstreamPatches[alias] ? 1 : 0,
-            }))}
+            aliases={[
+              ...patchTriggerAliases.map(({ alias, childProject }) => ({
+                displayName: `${alias} (${childProject})`,
+                name: alias,
+                taskCount: selectedDownstreamPatches[alias] ? 1 : 0,
+              })),
+              ...childPatches.map(({ projectIdentifier, variantsTasks }) => ({
+                displayName: projectIdentifier,
+                name: projectIdentifier,
+                taskCount: variantsTasks.reduce(
+                  (c, v) => c + v.tasks.length,
+                  0
+                ),
+              })),
+            ]}
             selectedBuildVariants={selectedBuildVariants}
             setSelectedBuildVariants={(buildVariants) =>
               dispatch({ type: "setSelectedBuildVariants", buildVariants })
@@ -291,6 +309,7 @@ export const ConfigurePatchCore: React.FC<Props> = ({ patch }) => {
                       patches,
                     })
                   }
+                  childPatches={childPatches}
                 />
               </Tab>
               <Tab data-cy="changes-tab" name="Changes">

--- a/src/pages/configurePatch/ConfigurePatchCore.tsx
+++ b/src/pages/configurePatch/ConfigurePatchCore.tsx
@@ -1,17 +1,16 @@
-import React, { useEffect, useReducer } from "react";
 import { useMutation } from "@apollo/client";
 import styled from "@emotion/styled";
 import { Tab } from "@leafygreen-ui/tabs";
 import { Body } from "@leafygreen-ui/typography";
 import { Input } from "antd";
-import { useHistory, useLocation, useParams } from "react-router-dom";
+import { useHistory } from "react-router-dom";
 import { MetadataCard } from "components/MetadataCard";
 import { CodeChanges } from "components/PatchTabs/CodeChanges";
 import { ParametersContent } from "components/PatchTabs/ParametersContent";
 import { PageContent, PageLayout, PageSider } from "components/styles";
 import { StyledTabs } from "components/styles/StyledTabs";
 import { P2 } from "components/Typography";
-import { getPatchRoute, getVersionRoute } from "constants/routes";
+import { getVersionRoute } from "constants/routes";
 import { useToastContext } from "context/toast";
 import {
   SchedulePatchMutation,
@@ -19,128 +18,22 @@ import {
   SchedulePatchMutationVariables,
   VariantTasks,
   ConfigurePatchQuery,
-  VariantTask,
-  ParameterInput,
-  PatchTriggerAlias,
 } from "gql/generated/types";
 import { SCHEDULE_PATCH } from "gql/mutations";
-import { PatchTab } from "types/patch";
-import { queryString, string } from "utils";
-import { convertArrayToObject, mapStringArrayToObject } from "utils/array";
-import { ConfigureBuildVariants } from "./configurePatchCore/ConfigureBuildVariants";
-import { ConfigureTasks } from "./configurePatchCore/ConfigureTasks";
 import {
   DownstreamPatchState,
   VariantTasksState,
-} from "./configurePatchCore/state";
-
-const { omitTypename } = string;
-const { parseQueryString } = queryString;
-
-type configurePatchState = {
-  description: string;
-  selectedBuildVariants: string[];
-  selectedBuildVariantTasks: VariantTasksState;
-  patchParams: ParameterInput[];
-  selectedTab: number;
-  disableBuildVariantSelect: boolean;
-  selectedDownstreamPatches: DownstreamPatchState;
-};
-
-type Action =
-  | { type: "setDescription"; description: string }
-  | { type: "setSelectedBuildVariants"; buildVariants: string[] }
-  | { type: "setPatchParams"; params: ParameterInput[] }
-  | { type: "setSelectedBuildVariantTasks"; variantTasks: VariantTasksState }
-  | { type: "setSelectedTab"; tabIndex: number }
-  | {
-      type: "updatePatchData";
-      description: string;
-      buildVariants: string[];
-      params: ParameterInput[];
-      variantTasks: VariantTasksState;
-      patches: DownstreamPatchState;
-    }
-  | { type: "setSelectedDownstreamPatches"; patches: DownstreamPatchState };
-
-const initialState = ({ selectedTab = 0 }: { selectedTab: number }) => ({
-  description: "",
-  selectedBuildVariants: [],
-  selectedBuildVariantTasks: {},
-  patchParams: null,
-  selectedTab,
-  disableBuildVariantSelect: tabToIndexMap[selectedTab] === PatchTab.Tasks,
-  selectedDownstreamPatches: {},
-});
-const reducer = (state: configurePatchState, action: Action) => {
-  switch (action.type) {
-    case "setDescription":
-      return {
-        ...state,
-        description: action.description,
-      };
-    case "setSelectedBuildVariants":
-      return {
-        ...state,
-        selectedBuildVariants: action.buildVariants,
-      };
-    case "setSelectedBuildVariantTasks":
-      return {
-        ...state,
-        selectedBuildVariantTasks: action.variantTasks,
-      };
-    case "setSelectedDownstreamPatches":
-      return {
-        ...state,
-        selectedDownstreamPatches: action.patches,
-      };
-    case "setPatchParams":
-      return {
-        ...state,
-        patchParams: omitTypename(action.params),
-      };
-    case "setSelectedTab": {
-      let tab = indexToTabMap.indexOf(PatchTab.Tasks);
-      if (action.tabIndex !== -1 && action.tabIndex < indexToTabMap.length) {
-        tab = action.tabIndex;
-      }
-      return {
-        ...state,
-        selectedTab: tab,
-        disableBuildVariantSelect:
-          indexToTabMap[action.tabIndex] !== PatchTab.Tasks,
-      };
-    }
-    case "updatePatchData":
-      return {
-        ...state,
-        description: action.description,
-        selectedBuildVariants: action.buildVariants,
-        patchParams: omitTypename(action.params),
-        selectedBuildVariantTasks: action.variantTasks,
-        selectedDownstreamPatches: action.patches,
-      };
-
-    default:
-      throw new Error();
-  }
-};
+  useConfigurePatch,
+} from "hooks/useConfigurePatch";
+import { ConfigureBuildVariants } from "./configurePatchCore/ConfigureBuildVariants";
+import { ConfigureTasks } from "./configurePatchCore/ConfigureTasks";
 
 interface Props {
   patch: ConfigurePatchQuery["patch"];
 }
 export const ConfigurePatchCore: React.FC<Props> = ({ patch }) => {
-  const dispatchToast = useToastContext();
   const history = useHistory();
-  const location = useLocation();
-  const { tab } = useParams<{ tab: PatchTab | null }>();
-
-  const [state, dispatch] = useReducer(
-    reducer,
-    initialState({
-      selectedTab: tabToIndexMap[tab || PatchTab.Configure],
-    })
-  );
+  const dispatchToast = useToastContext();
 
   const {
     project,
@@ -152,6 +45,22 @@ export const ConfigurePatchCore: React.FC<Props> = ({ patch }) => {
     patchTriggerAliases,
   } = patch;
   const { variants } = project;
+
+  const {
+    description,
+    disableBuildVariantSelect,
+    patchParams,
+    selectedBuildVariants,
+    selectedBuildVariantTasks,
+    selectedDownstreamPatches,
+    selectedTab,
+    setDescription,
+    setPatchParams,
+    setSelectedBuildVariants,
+    setSelectedBuildVariantTasks,
+    setSelectedDownstreamPatches,
+    setSelectedTab,
+  } = useConfigurePatch(patch, variants);
 
   const [schedulePatch, { loading: loadingScheduledPatch }] = useMutation<
     SchedulePatchMutation,
@@ -169,43 +78,9 @@ export const ConfigurePatchCore: React.FC<Props> = ({ patch }) => {
     },
   });
 
-  const {
-    description,
-    selectedBuildVariants,
-    selectedBuildVariantTasks,
-    patchParams,
-    selectedTab,
-    disableBuildVariantSelect,
-    selectedDownstreamPatches,
-  } = state;
-
-  useEffect(() => {
-    const query = parseQueryString(location.search);
-    history.replace(
-      getPatchRoute(id, {
-        configure: true,
-        tab: indexToTabMap[selectedTab],
-        ...query,
-      })
-    );
-  }, [selectedTab]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  useEffect(() => {
-    if (patch) {
-      dispatch({
-        type: "updatePatchData",
-        description: patch.description,
-        buildVariants: [variants[0]?.name],
-        params: patch.parameters,
-        variantTasks: initializeTaskState(variants, patch.variantsTasks),
-        patches: initializeDownstreamPatchState(patch.patchTriggerAliases),
-      });
-    }
-  }, [patch, variants]);
-
   const onClickSchedule = async (): Promise<void> => {
     const configurePatchParam: PatchConfigure = {
-      description: state.description,
+      description,
       variantsTasks: getGqlVariantTasksParamFromState(
         selectedBuildVariantTasks
       ),
@@ -238,9 +113,7 @@ export const ConfigurePatchCore: React.FC<Props> = ({ patch }) => {
         data-cy="patch-name-input"
         value={description}
         size="large"
-        onChange={(e) =>
-          dispatch({ type: "setDescription", description: e.target.value })
-        }
+        onChange={setDescription}
       />
       <PageLayout>
         <PageSider>
@@ -274,9 +147,7 @@ export const ConfigurePatchCore: React.FC<Props> = ({ patch }) => {
               })),
             ]}
             selectedBuildVariants={selectedBuildVariants}
-            setSelectedBuildVariants={(buildVariants) =>
-              dispatch({ type: "setSelectedBuildVariants", buildVariants })
-            }
+            setSelectedBuildVariants={setSelectedBuildVariants}
             disabled={disableBuildVariantSelect}
           />
         </PageSider>
@@ -284,31 +155,19 @@ export const ConfigurePatchCore: React.FC<Props> = ({ patch }) => {
           <PageContent>
             <StyledTabs
               selected={selectedTab}
-              setSelected={(i) =>
-                dispatch({ type: "setSelectedTab", tabIndex: i })
-              }
+              setSelected={setSelectedTab}
               aria-label="Configure Patch Tabs"
             >
               <Tab data-cy="tasks-tab" name="Configure">
                 <ConfigureTasks
                   selectedBuildVariants={selectedBuildVariants}
                   selectedBuildVariantTasks={selectedBuildVariantTasks}
-                  setSelectedBuildVariantTasks={(variantTasks) =>
-                    dispatch({
-                      type: "setSelectedBuildVariantTasks",
-                      variantTasks,
-                    })
-                  }
+                  setSelectedBuildVariantTasks={setSelectedBuildVariantTasks}
                   activated={activated}
                   loading={loadingScheduledPatch}
                   onClickSchedule={onClickSchedule}
                   selectedDownstreamPatches={selectedDownstreamPatches}
-                  setSelectedDownstreamPatches={(patches) =>
-                    dispatch({
-                      type: "setSelectedDownstreamPatches",
-                      patches,
-                    })
-                  }
+                  setSelectedDownstreamPatches={setSelectedDownstreamPatches}
                   childPatches={childPatches}
                 />
               </Tab>
@@ -319,9 +178,7 @@ export const ConfigurePatchCore: React.FC<Props> = ({ patch }) => {
                 <ParametersContent
                   patchActivated={activated}
                   patchParameters={patchParams}
-                  setPatchParams={(params) =>
-                    dispatch({ type: "setPatchParams", params })
-                  }
+                  setPatchParams={setPatchParams}
                 />
               </Tab>
             </StyledTabs>
@@ -354,46 +211,6 @@ const getGqlDownstreamPatchesFromState = (
   Object.entries(selectedDownstreamPatches)
     .filter(([, isSelected]) => isSelected)
     .map(([alias]) => alias);
-
-// Takes in variant tasks and default selected tasks and returns an object
-// With merged variant and default selected tasks auto selected.
-const initializeTaskState = (
-  variantTasks: VariantTask[],
-  defaultSelectedTasks: VariantTask[]
-) => {
-  const defaultTasks = convertArrayToObject(defaultSelectedTasks, "name");
-  return variantTasks.reduce(
-    (prev, { name: variant, tasks }) => ({
-      ...prev,
-      [variant]: {
-        ...mapStringArrayToObject(tasks, false),
-        ...(defaultTasks[variant]
-          ? mapStringArrayToObject(defaultTasks[variant].tasks, true)
-          : {}),
-      },
-    }),
-    {}
-  );
-};
-
-const initializeDownstreamPatchState = (
-  patchTriggerAliases: PatchTriggerAlias[]
-) =>
-  patchTriggerAliases.reduce(
-    (prev, { alias }) => ({
-      ...prev,
-      [alias]: false,
-    }),
-    {}
-  );
-
-const indexToTabMap = [PatchTab.Tasks, PatchTab.Changes, PatchTab.Parameters];
-
-const tabToIndexMap = {
-  [PatchTab.Tasks]: 0,
-  [PatchTab.Changes]: 1,
-  [PatchTab.Parameters]: 2,
-};
 
 const StyledInput = styled(Input)`
   margin-bottom: 16px;

--- a/src/pages/configurePatch/configurePatchCore/ConfigureBuildVariants.tsx
+++ b/src/pages/configurePatch/configurePatchCore/ConfigureBuildVariants.tsx
@@ -183,7 +183,7 @@ const reducer = (state: State, action: Action) => {
         numButtonsPressed: state.numButtonsPressed - 1,
       };
     default:
-      throw new Error("Unknown action type");
+      throw new Error();
   }
 };
 

--- a/src/pages/configurePatch/configurePatchCore/ConfigureBuildVariants.tsx
+++ b/src/pages/configurePatch/configurePatchCore/ConfigureBuildVariants.tsx
@@ -6,16 +6,20 @@ import { uiColors } from "@leafygreen-ui/palette";
 import { Body } from "@leafygreen-ui/typography";
 import { inactiveElementStyle, SiderCard } from "components/styles";
 import { Divider } from "components/styles/Divider";
-import { ProjectBuildVariant } from "gql/generated/types";
 import { array } from "utils";
-import { VariantTasksState } from "./state";
 
 const { toggleArray } = array;
 const { green } = uiColors;
 
+interface MenuItemProps {
+  displayName: string;
+  name: string;
+  taskCount: number;
+}
+
 interface Props {
-  variants: ProjectBuildVariant[];
-  selectedVariantTasks: VariantTasksState;
+  variants: MenuItemProps[];
+  aliases?: MenuItemProps[];
   selectedBuildVariants: string[];
   setSelectedBuildVariants: (bv: string[]) => void;
   disabled: boolean;
@@ -23,7 +27,7 @@ interface Props {
 
 export const ConfigureBuildVariants: React.FC<Props> = ({
   variants,
-  selectedVariantTasks,
+  aliases,
   selectedBuildVariants,
   setSelectedBuildVariants,
   disabled,
@@ -88,51 +92,72 @@ export const ConfigureBuildVariants: React.FC<Props> = ({
   return (
     <DisableWrapper data-cy="build-variant-select-wrapper" disabled={disabled}>
       <UserSelectWrapper isHotKeyPressed={state.numButtonsPressed !== 0}>
-        {/* @ts-expect-error */}
-        <StyledSiderCard>
-          <Container>
-            <Body weight="medium">Select Build Variants and Tasks</Body>
-            <Divider />
-          </Container>
-          <ScrollableBuildVariantContainer>
-            {variants.map(({ displayName, name }) => {
-              const taskCount = selectedVariantTasks[name]
-                ? Object.values(selectedVariantTasks[name]).filter((v) => v)
-                    .length
-                : 0;
-              const isSelected = selectedBuildVariants.includes(name);
-              return (
-                <BuildVariant
-                  data-cy="build-variant-list-item"
-                  data-selected={isSelected}
-                  key={name}
-                  isSelected={isSelected}
-                  onClick={getClickVariantHandler(name)}
-                >
-                  <VariantName>
-                    <Body weight={isSelected ? "medium" : "regular"}>
-                      {displayName}
-                    </Body>
-                  </VariantName>
-                  {taskCount > 0 && (
-                    <StyledBadge
-                      data-cy="task-count-badge"
-                      variant={
-                        isSelected ? Variant.DarkGray : Variant.LightGray
-                      }
-                    >
-                      {taskCount}
-                    </StyledBadge>
-                  )}
-                </BuildVariant>
-              );
-            })}
-          </ScrollableBuildVariantContainer>
-        </StyledSiderCard>
+        <Card
+          handleClick={getClickVariantHandler}
+          menuItems={variants}
+          title="Select Build Variants and Tasks"
+          selectedMenuItems={selectedBuildVariants}
+          dataCyPrefix="build-variant"
+        />
+        {aliases && (
+          <Card
+            handleClick={getClickVariantHandler}
+            menuItems={aliases}
+            title="Select Downstream Tasks"
+            selectedMenuItems={selectedBuildVariants}
+            dataCyPrefix="trigger-alias"
+          />
+        )}
       </UserSelectWrapper>
     </DisableWrapper>
   );
 };
+
+const Card: React.FC<{
+  dataCyPrefix: string;
+  handleClick: (variantName: string) => (e) => void;
+  menuItems: MenuItemProps[];
+  selectedMenuItems: string[];
+  title: string;
+}> = ({ dataCyPrefix, handleClick, menuItems, selectedMenuItems, title }) => (
+  <>
+    {/* @ts-expect-error */}
+    <StyledSiderCard>
+      <Container>
+        <Body weight="medium">{title}</Body>
+        <Divider />
+      </Container>
+      <ScrollableBuildVariantContainer>
+        {menuItems.map(({ displayName, name, taskCount }) => {
+          const isSelected = selectedMenuItems.includes(name);
+          return (
+            <BuildVariant
+              data-cy={`${dataCyPrefix}-list-item`}
+              data-selected={isSelected}
+              key={name}
+              isSelected={isSelected}
+              onClick={handleClick(name)}
+            >
+              <VariantName>
+                <Body weight={isSelected ? "medium" : "regular"}>
+                  {displayName}
+                </Body>
+              </VariantName>
+              {taskCount > 0 && (
+                <StyledBadge
+                  data-cy="task-count-badge"
+                  variant={isSelected ? Variant.DarkGray : Variant.LightGray}
+                >
+                  {taskCount}
+                </StyledBadge>
+              )}
+            </BuildVariant>
+          );
+        })}
+      </ScrollableBuildVariantContainer>
+    </StyledSiderCard>
+  </>
+);
 
 const hotKeys = new Set(["Meta", "Shift", "Control"]);
 interface State {

--- a/src/pages/configurePatch/configurePatchCore/ConfigureBuildVariants.tsx
+++ b/src/pages/configurePatch/configurePatchCore/ConfigureBuildVariants.tsx
@@ -93,19 +93,19 @@ export const ConfigureBuildVariants: React.FC<Props> = ({
     <DisableWrapper data-cy="build-variant-select-wrapper" disabled={disabled}>
       <UserSelectWrapper isHotKeyPressed={state.numButtonsPressed !== 0}>
         <Card
-          handleClick={getClickVariantHandler}
+          onClick={getClickVariantHandler}
           menuItems={variants}
           title="Select Build Variants and Tasks"
           selectedMenuItems={selectedBuildVariants}
-          dataCyPrefix="build-variant"
+          data-cy="build-variant-list-item"
         />
         {aliases && (
           <Card
-            handleClick={getClickVariantHandler}
+            onClick={getClickVariantHandler}
             menuItems={aliases}
             title="Select Downstream Tasks"
             selectedMenuItems={selectedBuildVariants}
-            dataCyPrefix="trigger-alias"
+            data-cy="trigger-alias-list-item"
           />
         )}
       </UserSelectWrapper>
@@ -113,13 +113,21 @@ export const ConfigureBuildVariants: React.FC<Props> = ({
   );
 };
 
-const Card: React.FC<{
-  dataCyPrefix: string;
-  handleClick: (variantName: string) => (e) => void;
+interface CardProps {
+  "data-cy": string;
+  onClick: (variantName: string) => (e) => void;
   menuItems: MenuItemProps[];
   selectedMenuItems: string[];
   title: string;
-}> = ({ dataCyPrefix, handleClick, menuItems, selectedMenuItems, title }) => (
+}
+
+const Card: React.FC<CardProps> = ({
+  "data-cy": dataCy,
+  onClick,
+  menuItems,
+  selectedMenuItems,
+  title,
+}) => (
   <>
     {/* @ts-expect-error */}
     <StyledSiderCard>
@@ -132,11 +140,11 @@ const Card: React.FC<{
           const isSelected = selectedMenuItems.includes(name);
           return (
             <BuildVariant
-              data-cy={`${dataCyPrefix}-list-item`}
+              data-cy={dataCy}
               data-selected={isSelected}
               key={name}
               isSelected={isSelected}
-              onClick={handleClick(name)}
+              onClick={onClick(name)}
             >
               <VariantName>
                 <Body weight={isSelected ? "medium" : "regular"}>
@@ -175,7 +183,7 @@ const reducer = (state: State, action: Action) => {
         numButtonsPressed: state.numButtonsPressed - 1,
       };
     default:
-      throw new Error();
+      throw new Error("Unknown action type");
   }
 };
 

--- a/src/pages/configurePatch/configurePatchCore/ConfigureTasks.tsx
+++ b/src/pages/configurePatch/configurePatchCore/ConfigureTasks.tsx
@@ -5,7 +5,7 @@ import Checkbox from "@leafygreen-ui/checkbox";
 import { Disclaimer } from "@leafygreen-ui/typography";
 import every from "lodash.every";
 import { Button } from "components/Button";
-import { Patch } from "gql/generated/types";
+import { ConfigurePatchQuery } from "gql/generated/types";
 import {
   DownstreamPatchState,
   VariantTasksState,
@@ -27,7 +27,7 @@ interface Props {
   setSelectedDownstreamPatches: (
     downstreamPatches: DownstreamPatchState
   ) => void;
-  childPatches: Array<Partial<Patch>>;
+  childPatches: ConfigurePatchQuery["patch"]["childPatches"];
 }
 
 export const ConfigureTasks: React.FC<Props> = ({
@@ -139,8 +139,6 @@ export const ConfigureTasks: React.FC<Props> = ({
         </Button>
         <Checkbox
           data-cy="select-all-checkbox"
-          data-state={selectAllCheckboxState}
-          // TODO: Fix indeterminate state handling after PD-1386
           indeterminate={selectAllCheckboxState === CheckboxState.INDETERMINITE}
           onChange={onClickSelectAll}
           label={selectAllCheckboxCopy}
@@ -159,11 +157,9 @@ export const ConfigureTasks: React.FC<Props> = ({
         {Object.entries(currentTasks).map(([name, status]) => (
           <Checkbox
             data-cy="task-checkbox"
-            data-state={status}
             key={name}
             onChange={onClickCheckbox(name)}
             label={name}
-            // TODO: Fix indeterminate state handling after PD-1386
             indeterminate={status === CheckboxState.INDETERMINITE}
             checked={status === CheckboxState.CHECKED}
           />
@@ -177,20 +173,18 @@ export const ConfigureTasks: React.FC<Props> = ({
             {Object.entries(currentDownstreamPatches).map(([name, status]) => (
               <Checkbox
                 data-cy="downstream-patch-checkbox"
-                data-state={status}
                 key={name}
                 onChange={onClickCheckbox(name)}
                 label={name}
-                // TODO: Fix indeterminate state handling after PD-1386
                 indeterminate={status === CheckboxState.INDETERMINITE}
                 checked={status === CheckboxState.CHECKED}
                 disabled={activated}
               />
             ))}
+            {/* Represent child patches invoked from CLI as read-only */}
             {currentChildPatches.map(({ projectIdentifier }) => (
               <Checkbox
                 data-cy="downstream-patch-checkbox"
-                data-state={CheckboxState.CHECKED}
                 key={projectIdentifier}
                 label={projectIdentifier}
                 disabled
@@ -210,7 +204,6 @@ export const ConfigureTasks: React.FC<Props> = ({
                   {taskList.map((taskName) => (
                     <Checkbox
                       data-cy="child-patch-checkbox"
-                      data-state={CheckboxState.CHECKED}
                       key={taskName}
                       label={taskName}
                       checked

--- a/src/pages/configurePatch/configurePatchCore/ConfigureTasks.tsx
+++ b/src/pages/configurePatch/configurePatchCore/ConfigureTasks.tsx
@@ -69,6 +69,8 @@ export const ConfigureTasks: React.FC<Props> = ({
     childPatches,
     selectedBuildVariants
   );
+
+  // Show details related to child patches (i.e. list all variants/tasks) only if it is the only menu item selected
   const enumerateChildPatches =
     currentChildPatches.length === 1 && selectedBuildVariants.length === 1;
 
@@ -276,10 +278,15 @@ const getVisibleDownstreamPatches = (p, selectedBuildVariants) => {
   return visiblePatches;
 };
 
-const getVisibleChildPatches = (childPatches, selectedBuildVariants) =>
-  childPatches.filter(({ projectIdentifier }) =>
+const getVisibleChildPatches = (childPatches, selectedBuildVariants) => {
+  if (!childPatches) {
+    return [];
+  }
+
+  return childPatches.filter(({ projectIdentifier }) =>
     selectedBuildVariants.includes(projectIdentifier)
   );
+};
 
 const deduplicateTasks = (
   currentTasks: {

--- a/src/pages/configurePatch/configurePatchCore/ConfigureTasks.tsx
+++ b/src/pages/configurePatch/configurePatchCore/ConfigureTasks.tsx
@@ -228,13 +228,8 @@ const getSelectAllCheckboxState = (
   }
 
   let state;
-  const allTaskStatuses = Object.entries(buildVariants).map(
-    ([, checked]) => checked
-  );
-
-  const allAliasStatuses = Object.entries(aliases).map(
-    ([, checked]) => checked
-  );
+  const allTaskStatuses = Object.values(buildVariants);
+  const allAliasStatuses = Object.values(aliases);
 
   const hasSelectedTasks =
     allTaskStatuses.includes(CheckboxState.CHECKED) ||
@@ -253,11 +248,14 @@ const getSelectAllCheckboxState = (
   return state;
 };
 
-const getVisibleAliases = (p, selectedBuildVariants) => {
+const getVisibleAliases = (
+  selectedAliases: AliasState,
+  selectedBuildVariants: string[]
+): { [key: string]: CheckboxState } => {
   const visiblePatches = {};
-  Object.entries(p).forEach(([alias]) => {
+  Object.entries(selectedAliases).forEach(([alias]) => {
     if (selectedBuildVariants.includes(alias)) {
-      visiblePatches[alias] = p[alias]
+      visiblePatches[alias] = selectedAliases[alias]
         ? CheckboxState.CHECKED
         : CheckboxState.UNCHECKED;
     }

--- a/src/pages/configurePatch/configurePatchCore/ConfigureTasks.tsx
+++ b/src/pages/configurePatch/configurePatchCore/ConfigureTasks.tsx
@@ -6,7 +6,10 @@ import { Disclaimer } from "@leafygreen-ui/typography";
 import every from "lodash.every";
 import { Button } from "components/Button";
 import { Patch } from "gql/generated/types";
-import { DownstreamPatchState, VariantTasksState } from "./state";
+import {
+  DownstreamPatchState,
+  VariantTasksState,
+} from "hooks/useConfigurePatch";
 
 enum CheckboxState {
   CHECKED = "CHECKED",
@@ -21,7 +24,9 @@ interface Props {
   loading: boolean;
   onClickSchedule: () => void;
   selectedDownstreamPatches: DownstreamPatchState;
-  setSelectedDownstreamPatches: (patches: DownstreamPatchState) => void;
+  setSelectedDownstreamPatches: (
+    downstreamPatches: DownstreamPatchState
+  ) => void;
   childPatches: Array<Partial<Patch>>;
 }
 

--- a/src/pages/configurePatch/configurePatchCore/ConfigureTasks.tsx
+++ b/src/pages/configurePatch/configurePatchCore/ConfigureTasks.tsx
@@ -76,11 +76,11 @@ export const ConfigureTasks: React.FC<Props> = ({
     const selectedBuildVariantsCopy = { ...selectedBuildVariantTasks };
     const selectedDownstreamPatchesCopy = { ...selectedDownstreamPatches };
     selectedBuildVariants.forEach((v) => {
-      if (selectedBuildVariantsCopy?.[v]) {
+      if (selectedBuildVariantsCopy?.[v] !== undefined) {
         Object.keys(selectedBuildVariantsCopy[v]).forEach((task) => {
           selectedBuildVariantsCopy[v][task] = e.target.checked;
         });
-      } else if (selectedDownstreamPatchesCopy?.[v]) {
+      } else if (selectedDownstreamPatchesCopy?.[v] !== undefined) {
         selectedDownstreamPatchesCopy[v] = e.target.checked;
       }
     });

--- a/src/pages/configurePatch/configurePatchCore/state.ts
+++ b/src/pages/configurePatch/configurePatchCore/state.ts
@@ -1,3 +1,6 @@
+export type DownstreamPatchState = {
+  [alias: string]: boolean;
+};
 export type TasksState = {
   [task: string]: boolean;
 };

--- a/src/pages/configurePatch/configurePatchCore/state.ts
+++ b/src/pages/configurePatch/configurePatchCore/state.ts
@@ -1,9 +1,0 @@
-export type DownstreamPatchState = {
-  [alias: string]: boolean;
-};
-export type TasksState = {
-  [task: string]: boolean;
-};
-export type VariantTasksState = {
-  [variant: string]: TasksState;
-};


### PR DESCRIPTION
EVG-15287

### Description 
- Add "Downstream Tasks" section on patch configure page, allowing aliases to be scheduled from the UI _only_ if the patch has not yet run
- Also show child patches that have been invoked via `--trigger-alias` on the CLI; these patches are read-only on the UI and interaction is disabled
- Upcoming work
  - Show name of trigger used to invoke child patch (EVG-15385)
  - Attach tasks/variants to aliases so that users can see which tasks will be run

### Screenshots
<img width="1552" alt="image" src="https://user-images.githubusercontent.com/9298431/132708128-47237663-2112-4274-86b1-bc2385fb4dc6.png">
<img width="1552" alt="image" src="https://user-images.githubusercontent.com/9298431/132708147-5fe97f1f-0a87-4323-9f3d-a299aa914f54.png">
<img width="1552" alt="image" src="https://user-images.githubusercontent.com/9298431/132708178-ee8e51de-5710-4b3f-be35-2dd9bbf7f66a.png">

### Testing 
- Staging has some good data for testing this page; `yarn run staging` and visit http://localhost:3000/patch/61378d50b237365d9b57e1aa/configure/tasks
- Add integration tests