### PR TITLE
EVG-15365 Add default fill color to play icon

### DIFF
--- a/src/pages/spawn/spawnHost/SpawnHostActionButton.tsx
+++ b/src/pages/spawn/spawnHost/SpawnHostActionButton.tsx
@@ -93,7 +93,7 @@ export const SpawnHostActionButton: React.FC<{ host: MyHost }> = ({ host }) => {
       {action ? (
         <PaddedButton
           disabled={loading}
-          glyph={<Icon glyph={glyph} />}
+          glyph={<Icon fill="black" glyph={glyph} />}
           size={Size.XSmall} // @ts-expect-error
           onClick={onClick(action)}
         />

--- a/src/pages/spawn/spawnHost/SpawnHostActionButton.tsx
+++ b/src/pages/spawn/spawnHost/SpawnHostActionButton.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from "react";
 import { useMutation, useLazyQuery } from "@apollo/client";
 import { Size } from "@leafygreen-ui/button";
+import { uiColors } from "@leafygreen-ui/palette";
 import { useSpawnAnalytics } from "analytics";
 import Icon from "components/Icon";
 import { PopconfirmWithCheckbox } from "components/Popconfirm";
@@ -18,6 +19,8 @@ import { GET_MY_HOSTS } from "gql/queries";
 import { useNetworkStatus } from "hooks";
 import { HostStatus } from "types/host";
 import { MyHost } from "types/spawn";
+
+const { gray } = uiColors;
 
 export const SpawnHostActionButton: React.FC<{ host: MyHost }> = ({ host }) => {
   const dispatchToast = useToastContext();
@@ -93,7 +96,7 @@ export const SpawnHostActionButton: React.FC<{ host: MyHost }> = ({ host }) => {
       {action ? (
         <PaddedButton
           disabled={loading}
-          glyph={<Icon fill="black" glyph={glyph} />}
+          glyph={<Icon fill={gray.dark2} glyph={glyph} />}
           size={Size.XSmall} // @ts-expect-error
           onClick={onClick(action)}
         />


### PR DESCRIPTION
[EVG-15365](https://jira.mongodb.org/browse/EVG-15365)

### Description 
For some reason the Play icon and only the Play icon had a fill value of none? 

### Screenshots
![image](https://user-images.githubusercontent.com/4605522/132560808-b4c01568-d3e5-4955-849a-09674a25449d.png)

