### PR TITLE
EVG-8290: Close menu on outside click

### DIFF
--- a/src/components/ButtonDropdown.tsx
+++ b/src/components/ButtonDropdown.tsx
@@ -1,4 +1,3 @@
-import React, { useState } from "react";
 import Icon from "@leafygreen-ui/icon";
 import { Menu, MenuItem } from "@leafygreen-ui/menu";
 import { Button } from "components/Button";
@@ -15,27 +14,22 @@ export const ButtonDropdown: React.FC<Props> = ({
   loading = false,
   dropdownItems,
   "data-cy": dataCy = "ellipsis-btn",
-}: Props) => {
-  const [open, setOpen] = useState(false);
-  return (
-    <Menu
-      trigger={
-        <Button
-          size="small"
-          data-cy={dataCy}
-          disabled={disabled}
-          loading={loading}
-          glyph={<Icon glyph="Ellipsis" />}
-          onClick={() => setOpen((curr) => !curr)}
-        />
-      }
-      data-cy="card-dropdown"
-      adjustOnMutation
-      open={open}
-    >
-      {dropdownItems}
-    </Menu>
-  );
-};
+}: Props) => (
+  <Menu
+    trigger={
+      <Button
+        size="small"
+        data-cy={dataCy}
+        disabled={disabled}
+        loading={loading}
+        glyph={<Icon glyph="Ellipsis" />}
+      />
+    }
+    data-cy="card-dropdown"
+    adjustOnMutation
+  >
+    {dropdownItems}
+  </Menu>
+);
 
 export const DropdownItem = MenuItem;


### PR DESCRIPTION
EVG-8290

### Description 
- While looking into [Mohamed's comment](https://jira.mongodb.org/browse/EVG-15288?focusedCommentId=4019765&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-4019765) I noticed that this was a usage issue, not a LG bug. LeafyGreen sets the trigger's `onClick` prop itself [here](https://github.com/mongodb/leafygreen-ui/blob/857a680a03d3523aafcc8773c6a23ca0cc1422a7/packages/menu/src/Menu.tsx#L367), so doing that on our end was overriding their logic around whether the menu should close.

### Screenshots
https://user-images.githubusercontent.com/9298431/132907864-dc56c9b2-6b65-40ca-b2a7-2b7434d457dc.mov