### PR TITLE
EVG-15404: Prevent sidebar from covering toast

### DIFF
--- a/src/components/Banners/SlackNotificationBanner.tsx
+++ b/src/components/Banners/SlackNotificationBanner.tsx
@@ -130,7 +130,8 @@ export const SlackNotificationBanner = () => {
 const isNotificationSet = (field: string) =>
   field !== "" && field !== undefined;
 const StyledPageWrapper = styled(PageWrapper)`
-  padding-bottom: 0;
+  padding-bottom: 12px;
+  padding-top: 12px;
 `;
 
 const SubscribeButton = styled.span`

--- a/src/components/styles/SideNav.tsx
+++ b/src/components/styles/SideNav.tsx
@@ -18,7 +18,7 @@ export const SideNavItem = styled(LGSideNavItem)`
 
 export const SideNav = styled(LGSideNav)`
   grid-area: sidenav;
-  z-index: 10;
+  z-index: 1;
 `;
 
 export const SideNavGroup = LGSideNavGroup;

--- a/src/context/toast.tsx
+++ b/src/context/toast.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback, useEffect } from "react";
+import styled from "@emotion/styled";
 import Toast, { Variant } from "@leafygreen-ui/toast";
 import { WordBreak } from "components/Typography";
 import { TOAST_TIMEOUT } from "constants/index";
@@ -147,7 +148,7 @@ const ToastProvider: React.FC = ({ children }) => {
   return (
     <ToastDispatchContext.Provider value={toastContext}>
       {children}
-      <Toast
+      <StyledToast
         variant={visibleToast.variant}
         title={visibleToast?.title || variantToTitleMap[visibleToast?.variant]}
         body={<WordBreak>{visibleToast.message}</WordBreak>}
@@ -172,5 +173,9 @@ const useToastContext = (): DispatchToast => {
   }
   return context;
 };
+
+const StyledToast = styled(Toast)`
+  z-index: 10;
+`;
 
 export { ToastProvider, useToastContext };


### PR DESCRIPTION
EVG-15404

### Description 
- Prevent sidebar from blocking toast contents

### Screenshots
Also make slack banner look less awkward with padding
<img width="1552" alt="Screen Shot 2021-09-14 at 3 43 51 PM" src="https://user-images.githubusercontent.com/9298431/133323772-ac2b5d7e-ec7b-4970-8554-82b860982dd4.png">
