### PR TITLE
EVG-15379: Pass groupID to Lobster Test Log URL

### DIFF
--- a/cypress/integration/job_logs.ts
+++ b/cypress/integration/job_logs.ts
@@ -16,7 +16,7 @@ describe("Job Logs", () => {
       .should("have.attr", "href")
       .and(
         "equal",
-        `https://www.evergreen.mongodb.com/lobster/evergreen/complete-test/${taskId}/0/llama`
+        `https://evergreen.mongodb.com/lobster/evergreen/complete-test/${taskId}/0/llama`
       );
     cy.dataCy("testlog-link").each(($el, index) => {
       expect($el.text()).to.eq(testNames[index]);

--- a/src/constants/externalResources.test.ts
+++ b/src/constants/externalResources.test.ts
@@ -10,18 +10,41 @@ describe("getLobsterTestLogUrl", () => {
     const testId = "testId";
     const execution = 44;
     expect(
-      getLobsterTestLogUrl({ taskId, execution, testId, lineNum: 0 })
+      getLobsterTestLogUrl({
+        taskId,
+        execution,
+        testId,
+        lineNum: 0,
+        groupId: "",
+      })
     ).toEqual(path);
-    expect(getLobsterTestLogUrl({ taskId, execution, testId })).toEqual(path);
     expect(
-      getLobsterTestLogUrl({ taskId, execution, testId, lineNum: 10 })
+      getLobsterTestLogUrl({ taskId, execution, testId, groupId: "" })
+    ).toEqual(path);
+    expect(
+      getLobsterTestLogUrl({
+        taskId,
+        execution,
+        testId,
+        lineNum: 10,
+        groupId: "",
+      })
     ).toEqual(`${path}#shareLine=10`);
     expect(
-      getLobsterTestLogUrl({ taskId, execution, testId, lineNum: 10 })
+      getLobsterTestLogUrl({
+        taskId,
+        execution,
+        testId,
+        lineNum: 10,
+        groupId: "",
+      })
     ).toEqual(`/lobster/evergreen/test/taskId/44/testId#shareLine=10`);
-    expect(getLobsterTestLogUrl({ taskId, execution, testId })).toEqual(
-      `/lobster/evergreen/test/taskId/44/testId`
-    );
+    expect(
+      getLobsterTestLogUrl({ taskId, execution, testId, groupId: "" })
+    ).toEqual(`/lobster/evergreen/test/taskId/44/testId`);
+    expect(
+      getLobsterTestLogUrl({ taskId, execution, testId, groupId: "group" })
+    ).toEqual(`/lobster/evergreen/test/taskId/44/testId/group`);
   });
 });
 

--- a/src/constants/externalResources.ts
+++ b/src/constants/externalResources.ts
@@ -57,8 +57,8 @@ export const getLobsterTestLogUrl = ({
   groupId,
 }: GetLobsterTestLogUrlParams) =>
   taskId && Number.isFinite(execution) && testId
-    ? `${getLobsterURL()}/lobster/evergreen/test/${taskId}/${execution}/${testId}/${
-        groupId || ""
+    ? `${getLobsterURL()}/lobster/evergreen/test/${taskId}/${execution}/${testId}${
+        groupId ? `/${groupId}` : ""
       }${lineNum ? `#shareLine=${lineNum}` : ""}`
     : "";
 

--- a/src/constants/externalResources.ts
+++ b/src/constants/externalResources.ts
@@ -58,7 +58,7 @@ export const getLobsterTestLogUrl = ({
 }: GetLobsterTestLogUrlParams) =>
   taskId && Number.isFinite(execution) && testId
     ? `${getLobsterURL()}/lobster/evergreen/test/${taskId}/${execution}/${testId}/${
-        groupId ? `/${groupId}` : ""
+        groupId || ""
       }${lineNum ? `#shareLine=${lineNum}` : ""}`
     : "";
 

--- a/src/constants/externalResources.ts
+++ b/src/constants/externalResources.ts
@@ -46,6 +46,7 @@ interface GetLobsterTestLogUrlParams {
   execution: number;
   testId: string;
   lineNum?: number;
+  groupId: string;
 }
 
 export const getLobsterTestLogUrl = ({
@@ -53,11 +54,12 @@ export const getLobsterTestLogUrl = ({
   execution,
   testId,
   lineNum,
+  groupId,
 }: GetLobsterTestLogUrlParams) =>
   taskId && Number.isFinite(execution) && testId
-    ? `${getLobsterURL()}/lobster/evergreen/test/${taskId}/${execution}/${testId}${
-        lineNum ? `#shareLine=${lineNum}` : ""
-      }`
+    ? `${getLobsterURL()}/lobster/evergreen/test/${taskId}/${execution}/${testId}/${
+        groupId ? `/${groupId}` : ""
+      }${lineNum ? `#shareLine=${lineNum}` : ""}`
     : "";
 
 interface GetLobsterTestLogCompleteUrlParams {

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -55,6 +55,7 @@ export type Query = {
   mainlineCommits?: Maybe<MainlineCommits>;
   taskNamesForBuildVariant?: Maybe<Array<Scalars["String"]>>;
   buildVariantsForTaskName?: Maybe<Array<Maybe<BuildVariantTuple>>>;
+  projectSettings: ProjectSettings;
 };
 
 export type QueryUserPatchesArgs = {
@@ -186,9 +187,15 @@ export type QueryBuildVariantsForTaskNameArgs = {
   taskName: Scalars["String"];
 };
 
+export type QueryProjectSettingsArgs = {
+  identifier: Scalars["String"];
+};
+
 export type Mutation = {
   addFavoriteProject: Project;
   removeFavoriteProject: Project;
+  attachProjectToRepo: Project;
+  detachProjectFromRepo: Project;
   schedulePatch: Patch;
   schedulePatchTasks?: Maybe<Scalars["String"]>;
   unschedulePatchTasks?: Maybe<Scalars["String"]>;
@@ -231,6 +238,14 @@ export type MutationAddFavoriteProjectArgs = {
 
 export type MutationRemoveFavoriteProjectArgs = {
   identifier: Scalars["String"];
+};
+
+export type MutationAttachProjectToRepoArgs = {
+  projectId: Scalars["String"];
+};
+
+export type MutationDetachProjectFromRepoArgs = {
+  projectId: Scalars["String"];
 };
 
 export type MutationSchedulePatchArgs = {
@@ -776,6 +791,9 @@ export type FileDiff = {
 export type PatchTriggerAlias = {
   alias: Scalars["String"];
   childProject: Scalars["String"];
+  taskSpecifiers?: Maybe<Array<Maybe<TaskSpecifier>>>;
+  status?: Maybe<Scalars["String"]>;
+  parentAsModule?: Maybe<Scalars["String"]>;
 };
 
 export type UserPatches = {
@@ -1059,19 +1077,184 @@ export type GroupedProjects = {
   projects: Array<Project>;
 };
 
+export type ProjectSettings = {
+  githubWebhooksEnabled: Scalars["Boolean"];
+  projectRef?: Maybe<Project>;
+  vars?: Maybe<ProjectVars>;
+  aliases?: Maybe<Array<Maybe<ProjectAlias>>>;
+  subscriptions?: Maybe<Array<Maybe<ProjectSubscription>>>;
+};
+
+export type ProjectVars = {
+  vars?: Maybe<Scalars["StringMap"]>;
+  privateVars?: Maybe<Array<Maybe<Scalars["String"]>>>;
+};
+
+export type ProjectAlias = {
+  id: Scalars["String"];
+  alias: Scalars["String"];
+  gitTag: Scalars["String"];
+  variant: Scalars["String"];
+  task: Scalars["String"];
+  remotePath: Scalars["String"];
+  variantTags: Array<Scalars["String"]>;
+  taskTags: Array<Scalars["String"]>;
+};
+
+export type ProjectSubscription = {
+  id: Scalars["String"];
+  resourceType: Scalars["String"];
+  trigger: Scalars["String"];
+  selectors: Array<Selector>;
+  regexSelectors: Array<Selector>;
+  subscriber?: Maybe<ProjectSubscriber>;
+  ownerType: Scalars["String"];
+  triggerData?: Maybe<Scalars["StringMap"]>;
+};
+
+export type Selector = {
+  type: Scalars["String"];
+  data: Scalars["String"];
+};
+
+export type ProjectSubscriber = {
+  type: Scalars["String"];
+  subscriber: Subscriber;
+};
+
+export type Subscriber = {
+  githubPRSubscriber?: Maybe<GithubPrSubscriber>;
+  githubCheckSubscriber?: Maybe<GithubCheckSubscriber>;
+  webhookSubscriber?: Maybe<WebhookSubscriber>;
+  jiraIssueSubscriber?: Maybe<JiraIssueSubscriber>;
+  jiraCommentSubscriber?: Maybe<Scalars["String"]>;
+  emailSubscriber?: Maybe<Scalars["String"]>;
+  slackSubscriber?: Maybe<Scalars["String"]>;
+};
+
+export type GithubPrSubscriber = {
+  owner: Scalars["String"];
+  repo: Scalars["String"];
+  ref: Scalars["String"];
+  prNumber?: Maybe<Scalars["Int"]>;
+};
+
+export type GithubCheckSubscriber = {
+  owner: Scalars["String"];
+  repo: Scalars["String"];
+  ref: Scalars["String"];
+};
+
+export type JiraIssueSubscriber = {
+  project: Scalars["String"];
+  issueType: Scalars["String"];
+};
+
+export type WebhookSubscriber = {
+  url: Scalars["String"];
+  secret: Scalars["String"];
+  headers: Array<Maybe<WebhookHeader>>;
+};
+
+export type WebhookHeader = {
+  key: Scalars["String"];
+  value: Scalars["String"];
+};
+
 export type Project = {
-  displayName: Scalars["String"];
   id: Scalars["String"];
   identifier: Scalars["String"];
-  isFavorite: Scalars["Boolean"];
+  displayName: Scalars["String"];
+  enabled?: Maybe<Scalars["Boolean"]>;
+  private?: Maybe<Scalars["Boolean"]>;
   owner: Scalars["String"];
-  patches: Patches;
   repo: Scalars["String"];
+  branch: Scalars["String"];
+  remotePath: Scalars["String"];
+  patchingDisabled?: Maybe<Scalars["Boolean"]>;
+  repotrackerDisabled?: Maybe<Scalars["Boolean"]>;
+  dispatchingDisabled?: Maybe<Scalars["Boolean"]>;
+  prTestingEnabled?: Maybe<Scalars["Boolean"]>;
+  githubChecksEnabled?: Maybe<Scalars["Boolean"]>;
+  batchTime?: Maybe<Scalars["Int"]>;
+  deactivatePrevious?: Maybe<Scalars["Boolean"]>;
+  defaultLogger?: Maybe<Scalars["String"]>;
+  notifyOnBuildFailure?: Maybe<Scalars["Boolean"]>;
+  triggers?: Maybe<Array<Maybe<TriggerAlias>>>;
+  patchTriggerAliases?: Maybe<Array<Maybe<PatchTriggerAlias>>>;
+  githubTriggerAliases?: Maybe<Array<Maybe<Scalars["String"]>>>;
+  periodicBuilds?: Maybe<Array<Maybe<PeriodicBuild>>>;
+  cedarTestResultsEnabled?: Maybe<Scalars["Boolean"]>;
+  commitQueue?: Maybe<CommitQueueParams>;
+  admins?: Maybe<Array<Maybe<Scalars["String"]>>>;
   spawnHostScriptPath: Scalars["String"];
+  tracksPushEvents?: Maybe<Scalars["Boolean"]>;
+  taskSync?: Maybe<TaskSyncOptions>;
+  gitTagAuthorizedUsers?: Maybe<Array<Maybe<Scalars["String"]>>>;
+  gitTagAuthorizedTeams?: Maybe<Array<Maybe<Scalars["String"]>>>;
+  gitTagVersionsEnabled?: Maybe<Scalars["Boolean"]>;
+  filesIgnoredFromCache?: Maybe<Array<Maybe<Scalars["String"]>>>;
+  disabledStatsCache?: Maybe<Scalars["Boolean"]>;
+  workstationConfig?: Maybe<WorkstationConfig>;
+  hidden?: Maybe<Scalars["Boolean"]>;
+  useRepoSettings: Scalars["Boolean"];
+  repoRefId?: Maybe<Scalars["String"]>;
+  isFavorite: Scalars["Boolean"];
+  patches: Patches;
 };
 
 export type ProjectPatchesArgs = {
   patchesInput: PatchesInput;
+};
+
+export type TriggerAlias = {
+  project?: Maybe<Scalars["String"]>;
+  level: Scalars["String"];
+  definitionID: Scalars["String"];
+  buildVariantRegex: Scalars["String"];
+  taskRegex: Scalars["String"];
+  status: Scalars["String"];
+  dateCutoff: Scalars["Int"];
+  configFile: Scalars["String"];
+  generateFile: Scalars["String"];
+  command: Scalars["String"];
+  alias: Scalars["String"];
+};
+
+export type PeriodicBuild = {
+  id: Scalars["String"];
+  configFile: Scalars["String"];
+  intervalHours: Scalars["Int"];
+  alias: Scalars["String"];
+  message: Scalars["String"];
+  nextRunTime: Scalars["Time"];
+};
+
+export type CommitQueueParams = {
+  enabled?: Maybe<Scalars["Boolean"]>;
+  mergeMethod?: Maybe<Scalars["String"]>;
+  message?: Maybe<Scalars["String"]>;
+};
+
+export type TaskSyncOptions = {
+  configEnabled: Scalars["Boolean"];
+  patchEnabled: Scalars["Boolean"];
+};
+
+export type WorkstationConfig = {
+  setupCommands?: Maybe<Array<Maybe<WorkstationSetupCommand>>>;
+  gitClone: Scalars["Boolean"];
+};
+
+export type WorkstationSetupCommand = {
+  Command: Scalars["String"];
+  Directory?: Maybe<Scalars["String"]>;
+};
+
+export type TaskSpecifier = {
+  patchAlias: Scalars["String"];
+  taskRegex: Scalars["String"];
+  variantRegex: Scalars["String"];
 };
 
 export type File = {
@@ -2669,6 +2852,7 @@ export type GetTestsQuery = {
       lineNum?: Maybe<number>;
       taskId?: Maybe<string>;
       testFile: string;
+      logTestName?: Maybe<string>;
     }>;
   };
 };

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -31,7 +31,7 @@ export type Query = {
   taskTests: TaskTestResult;
   taskFiles: TaskFiles;
   user: User;
-  taskLogs: RecentTaskLogs;
+  taskLogs: TaskLogs;
   patchBuildVariants: Array<GroupedBuildVariant>;
   commitQueue: CommitQueue;
   userSettings?: Maybe<UserSettings>;
@@ -199,6 +199,8 @@ export type Mutation = {
   schedulePatch: Patch;
   schedulePatchTasks?: Maybe<Scalars["String"]>;
   unschedulePatchTasks?: Maybe<Scalars["String"]>;
+  restartVersions?: Maybe<Array<Version>>;
+  /** @deprecated Field no longer supported */
   restartPatch?: Maybe<Scalars["String"]>;
   scheduleUndispatchedBaseTasks?: Maybe<Array<Task>>;
   enqueuePatch: Patch;
@@ -260,6 +262,12 @@ export type MutationSchedulePatchTasksArgs = {
 export type MutationUnschedulePatchTasksArgs = {
   patchId: Scalars["String"];
   abort: Scalars["Boolean"];
+};
+
+export type MutationRestartVersionsArgs = {
+  versionId: Scalars["String"];
+  abort: Scalars["Boolean"];
+  versionsToRestart: Array<VersionToRestart>;
 };
 
 export type MutationRestartPatchArgs = {
@@ -403,6 +411,11 @@ export type MutationEditSpawnHostArgs = {
 export type MutationBbCreateTicketArgs = {
   taskId: Scalars["String"];
   execution?: Maybe<Scalars["Int"]>;
+};
+
+export type VersionToRestart = {
+  versionId: Scalars["String"];
+  taskIds: Array<Scalars["String"]>;
 };
 
 export type MainlineCommits = {
@@ -963,11 +976,16 @@ export type TestResult = {
   taskId?: Maybe<Scalars["String"]>;
   execution?: Maybe<Scalars["Int"]>;
   logTestName?: Maybe<Scalars["String"]>;
-  lineNum?: Maybe<Scalars["Int"]>;
 };
 
 export type TestLog = {
+  url?: Maybe<Scalars["String"]>;
+  urlRaw?: Maybe<Scalars["String"]>;
+  urlLobster?: Maybe<Scalars["String"]>;
+  lineNum?: Maybe<Scalars["Int"]>;
+  /** @deprecated htmlDisplayURL deprecated, use url instead (EVG-15418) */
   htmlDisplayURL?: Maybe<Scalars["String"]>;
+  /** @deprecated rawDisplayURL deprecated, use urlRaw instead (EVG-15418) */
   rawDisplayURL?: Maybe<Scalars["String"]>;
 };
 
@@ -1274,7 +1292,9 @@ export type UserPatchesArgs = {
   patchesInput: PatchesInput;
 };
 
-export type RecentTaskLogs = {
+export type TaskLogs = {
+  taskId: Scalars["String"];
+  execution: Scalars["Int"];
   eventLogs: Array<TaskEventLogEntry>;
   taskLogs: Array<LogMessage>;
   systemLogs: Array<LogMessage>;
@@ -2728,8 +2748,11 @@ export type TaskTestsQuery = {
       duration?: Maybe<number>;
       execution?: Maybe<number>;
       taskId?: Maybe<string>;
-      lineNum?: Maybe<number>;
-      logs: { htmlDisplayURL?: Maybe<string>; rawDisplayURL?: Maybe<string> };
+      logs: {
+        lineNum?: Maybe<number>;
+        htmlDisplayURL?: Maybe<string>;
+        rawDisplayURL?: Maybe<string>;
+      };
     }>;
   };
 };
@@ -2849,10 +2872,10 @@ export type GetTestsQuery = {
       execution?: Maybe<number>;
       groupID?: Maybe<string>;
       id: string;
-      lineNum?: Maybe<number>;
       taskId?: Maybe<string>;
       testFile: string;
       logTestName?: Maybe<string>;
+      logs: { lineNum?: Maybe<number> };
     }>;
   };
 };

--- a/src/gql/queries/get-task-tests.graphql
+++ b/src/gql/queries/get-task-tests.graphql
@@ -1,43 +1,43 @@
-  query TaskTests(
-    $dir: SortDirection
-    $id: String!
-    $cat: TestSortCategory
-    $pageNum: Int
-    $limitNum: Int
-    $statusList: [String!]!
-    $testName: String!
-    $execution: Int
+query TaskTests(
+  $dir: SortDirection
+  $id: String!
+  $cat: TestSortCategory
+  $pageNum: Int
+  $limitNum: Int
+  $statusList: [String!]!
+  $testName: String!
+  $execution: Int
+) {
+  taskTests(
+    taskId: $id
+    sortCategory: $cat
+    sortDirection: $dir
+    page: $pageNum
+    limit: $limitNum
+    statuses: $statusList
+    testName: $testName
+    execution: $execution
   ) {
-    taskTests(
-      taskId: $id
-      sortCategory: $cat
-      sortDirection: $dir
-      page: $pageNum
-      limit: $limitNum
-      statuses: $statusList
-      testName: $testName
-      execution: $execution
-    ) {
-      testResults {
-        groupID
-        logTestName
-        displayTestName
-        testFile
-        id
-        status
-        baseStatus
-        testFile
-        displayTestName
-        duration
-        logs {
-          htmlDisplayURL
-          rawDisplayURL
-        }
-        execution
-        taskId
+    testResults {
+      groupID
+      logTestName
+      displayTestName
+      testFile
+      id
+      status
+      baseStatus
+      testFile
+      displayTestName
+      duration
+      logs {
         lineNum
+        htmlDisplayURL
+        rawDisplayURL
       }
-      filteredTestCount
-      totalTestCount
+      execution
+      taskId
     }
+    filteredTestCount
+    totalTestCount
   }
+}

--- a/src/gql/queries/get-tests.graphql
+++ b/src/gql/queries/get-tests.graphql
@@ -11,7 +11,9 @@ query GetTests($execution: Int, $groupId: String, $taskId: String!) {
       execution
       groupID
       id
-      lineNum
+      logs {
+        lineNum
+      }
       taskId
       testFile
       logTestName

--- a/src/gql/queries/get-tests.graphql
+++ b/src/gql/queries/get-tests.graphql
@@ -14,6 +14,7 @@ query GetTests($execution: Int, $groupId: String, $taskId: String!) {
       lineNum
       taskId
       testFile
+      logTestName
     }
   }
 }

--- a/src/pages/JobLogs.tsx
+++ b/src/pages/JobLogs.tsx
@@ -114,7 +114,14 @@ export const JobLogs = () => {
               </SubtitleContainer>
             ) : null}
             {testResults?.map(
-              ({ id, lineNum, displayTestName, logTestName, testFile, ...test }) => (
+              ({
+                id,
+                lineNum,
+                displayTestName,
+                logTestName,
+                testFile,
+                ...test
+              }) => (
                 <StyledLink
                   href={getLobsterTestLogUrl({
                     taskId: test.taskId,

--- a/src/pages/JobLogs.tsx
+++ b/src/pages/JobLogs.tsx
@@ -114,12 +114,12 @@ export const JobLogs = () => {
               </SubtitleContainer>
             ) : null}
             {testResults?.map(
-              ({ id, lineNum, displayTestName, testFile, ...test }) => (
+              ({ id, lineNum, displayTestName, logTestName, testFile, ...test }) => (
                 <StyledLink
                   href={getLobsterTestLogUrl({
                     taskId: test.taskId,
                     execution: test.execution,
-                    testId: id,
+                    testId: logTestName || testFile,
                     lineNum,
                   })}
                   data-cy="testlog-link"

--- a/src/pages/JobLogs.tsx
+++ b/src/pages/JobLogs.tsx
@@ -120,6 +120,7 @@ export const JobLogs = () => {
                 displayTestName,
                 logTestName,
                 testFile,
+                groupID,
                 ...test
               }) => (
                 <StyledLink
@@ -128,6 +129,7 @@ export const JobLogs = () => {
                     execution: test.execution,
                     testId: logTestName || testFile,
                     lineNum,
+                    groupId: groupID,
                   })}
                   data-cy="testlog-link"
                   key={id}

--- a/src/pages/JobLogs.tsx
+++ b/src/pages/JobLogs.tsx
@@ -116,7 +116,7 @@ export const JobLogs = () => {
             {testResults?.map(
               ({
                 id,
-                lineNum,
+                logs,
                 displayTestName,
                 logTestName,
                 testFile,
@@ -128,7 +128,7 @@ export const JobLogs = () => {
                     taskId: test.taskId,
                     execution: test.execution,
                     testId: logTestName || testFile,
-                    lineNum,
+                    lineNum: logs.lineNum,
                     groupId: groupID,
                   })}
                   data-cy="testlog-link"

--- a/src/pages/task/taskTabs/testsTable/TestsTableCore.tsx
+++ b/src/pages/task/taskTabs/testsTable/TestsTableCore.tsx
@@ -271,7 +271,8 @@ const getColumnsTemplate = (
     key: "logs",
     sorter: false,
     render: (a, b): JSX.Element => {
-      const { execution, lineNum, taskId, groupID, logTestName, testFile } = b || {};
+      const { execution, lineNum, taskId, groupID, logTestName, testFile } =
+        b || {};
       const { htmlDisplayURL, rawDisplayURL } = b?.logs ?? {};
       const hasLobsterLink = isLogkeeperLink(htmlDisplayURL);
       const lobsterLink = hasLobsterLink

--- a/src/pages/task/taskTabs/testsTable/TestsTableCore.tsx
+++ b/src/pages/task/taskTabs/testsTable/TestsTableCore.tsx
@@ -271,7 +271,7 @@ const getColumnsTemplate = (
     key: "logs",
     sorter: false,
     render: (a, b): JSX.Element => {
-      const { execution, lineNum, taskId, groupID, logTestName, testFile } =
+      const { execution, taskId, groupID, logTestName, testFile, logs } =
         b || {};
       const { htmlDisplayURL, rawDisplayURL } = b?.logs ?? {};
       const hasLobsterLink = isLogkeeperLink(htmlDisplayURL);
@@ -281,7 +281,7 @@ const getColumnsTemplate = (
             taskId,
             execution,
             testId: logTestName || testFile,
-            lineNum,
+            lineNum: logs.lineNum,
             groupId: groupID,
           });
 

--- a/src/pages/task/taskTabs/testsTable/TestsTableCore.tsx
+++ b/src/pages/task/taskTabs/testsTable/TestsTableCore.tsx
@@ -271,12 +271,18 @@ const getColumnsTemplate = (
     key: "logs",
     sorter: false,
     render: (a, b): JSX.Element => {
-      const { execution, lineNum, taskId, id } = b || {};
+      const { execution, lineNum, taskId, groupID, logTestName, testFile } = b || {};
       const { htmlDisplayURL, rawDisplayURL } = b?.logs ?? {};
       const hasLobsterLink = isLogkeeperLink(htmlDisplayURL);
       const lobsterLink = hasLobsterLink
         ? getUpdatedLobsterUrl(htmlDisplayURL)
-        : getLobsterTestLogUrl({ taskId, execution, testId: id, lineNum });
+        : getLobsterTestLogUrl({
+            taskId,
+            execution,
+            testId: logTestName || testFile,
+            lineNum,
+            groupId: groupID,
+          });
 
       return (
         <>


### PR DESCRIPTION
[EVG-15379](https://jira.mongodb.org/browse/EVG-15379)

### Description 
Lobster will now build the test log url using a groupId passed from spruce.

### Evergreen PR 
https://github.com/evergreen-ci/lobster/pull/114/files
https://github.com/evergreen-ci/evergreen/pull/5017