### PR TITLE
EVG-14930 Support unmatching tooltip and inactive

### DIFF
--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -175,6 +175,7 @@ export type QueryBbGetCreatedTicketsArgs = {
 
 export type QueryMainlineCommitsArgs = {
   options: MainlineCommitsOptions;
+  buildVariantOptions?: Maybe<BuildVariantOptions>;
 };
 
 export type QueryTaskNamesForBuildVariantArgs = {

--- a/src/gql/queries/get-mainline-commits.graphql
+++ b/src/gql/queries/get-mainline-commits.graphql
@@ -3,7 +3,10 @@ query MainlineCommits(
   $buildVariantOptionsForTask: BuildVariantOptions!
   $buildVariantOptions: BuildVariantOptions!
 ) {
-  mainlineCommits(options: $mainlineCommitsOptions) {
+  mainlineCommits(
+    options: $mainlineCommitsOptions
+    buildVariantOptions: $buildVariantOptions
+  ) {
     versions {
       version {
         id

--- a/src/pages/commits/CommitsWrapper.tsx
+++ b/src/pages/commits/CommitsWrapper.tsx
@@ -59,7 +59,10 @@ export const CommitsWrapper: React.FC<Props> = ({
             ) : (
               <ColumnContainer key={rolledUpVersions[0].id}>
                 <InactiveCommitLine />
-                <InactiveCommits rolledUpVersions={rolledUpVersions} />
+                <InactiveCommits
+                  hasFilters={hasTaskFilter}
+                  rolledUpVersions={rolledUpVersions}
+                />
               </ColumnContainer>
             )
           )}

--- a/src/pages/commits/InactiveCommits/index.tsx
+++ b/src/pages/commits/InactiveCommits/index.tsx
@@ -17,9 +17,11 @@ type rolledUpVersion = {
 };
 interface InactiveCommitsProps {
   rolledUpVersions: rolledUpVersion[];
+  hasFilters?: boolean;
 }
 export const InactiveCommits: React.FC<InactiveCommitsProps> = ({
   rolledUpVersions,
+  hasFilters = false,
 }) => {
   const versionCount = rolledUpVersions.length;
 
@@ -63,15 +65,16 @@ export const InactiveCommits: React.FC<InactiveCommitsProps> = ({
         <ButtonContainer>
           <ButtonText data-cy="inactive-commits-button">
             <TopText>{`${versionCount}`} </TopText>
-            inactive
+            {hasFilters ? "unmatching" : "inactive"}
           </ButtonText>
         </ButtonContainer>
       }
       triggerEvent="click"
+      popoverZIndex={10}
     >
       <TooltipContainer data-cy="inactive-commits-tooltip">
         <TitleText>
-          {`${versionCount}`} Inactive{" "}
+          {`${versionCount}`} {hasFilters ? "Unmatching" : "Inactive"}{" "}
           {`Commit${versionCount !== 1 ? "s" : ""}`}
         </TitleText>
         {returnedCommits}


### PR DESCRIPTION
[EVG-<number>](https://jira.mongodb.org/browse/EVG-<number>)

### Description 
Mainline commit tooltips will display inactive when there are no filters and unmatching when there are

### Screenshots
![image](https://user-images.githubusercontent.com/4605522/133855937-56ebefd7-0a18-4c0b-ba61-be2d30d1fd13.png)
![image](https://user-images.githubusercontent.com/4605522/133856009-bb697abe-5cf6-4956-b1e2-97edcdaa44d9.png)



### Evergreen PR 
https://github.com/evergreen-ci/evergreen/pull/5038