### PR TITLE
EVG-15385: Attach aliases to child patches

### DIFF
--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -801,6 +801,11 @@ export type FileDiff = {
   description: Scalars["String"];
 };
 
+export type ChildPatchAlias = {
+  alias: Scalars["String"];
+  patchId: Scalars["String"];
+};
+
 export type PatchTriggerAlias = {
   alias: Scalars["String"];
   childProject: Scalars["String"];
@@ -834,6 +839,7 @@ export type Patch = {
   variants: Array<Scalars["String"]>;
   tasks: Array<Scalars["String"]>;
   childPatches?: Maybe<Array<Patch>>;
+  childPatchAliases?: Maybe<Array<ChildPatchAlias>>;
   variantsTasks: Array<Maybe<VariantTask>>;
   activated: Scalars["Boolean"];
   alias?: Maybe<Scalars["String"]>;
@@ -2518,11 +2524,13 @@ export type ConfigurePatchQuery = {
     }>;
     childPatches?: Maybe<
       Array<{
+        id: string;
         projectIdentifier: string;
         variantsTasks: Array<Maybe<{ name: string; tasks: Array<string> }>>;
       }>
     >;
     patchTriggerAliases: Array<{ alias: string; childProject: string }>;
+    childPatchAliases?: Maybe<Array<{ alias: string; patchId: string }>>;
   } & BasePatchFragment;
 };
 

--- a/src/gql/queries/get-patch-configure.graphql
+++ b/src/gql/queries/get-patch-configure.graphql
@@ -14,6 +14,7 @@ query ConfigurePatch($id: String!) {
       }
     }
     childPatches {
+      id
       projectIdentifier
       variantsTasks {
         name
@@ -23,6 +24,10 @@ query ConfigurePatch($id: String!) {
     patchTriggerAliases {
       alias
       childProject
+    }
+    childPatchAliases {
+      alias
+      patchId
     }
   }
 }

--- a/src/pages/configurePatch/configurePatchCore/ConfigureBuildVariants.tsx
+++ b/src/pages/configurePatch/configurePatchCore/ConfigureBuildVariants.tsx
@@ -99,7 +99,7 @@ export const ConfigureBuildVariants: React.FC<Props> = ({
           selectedMenuItems={selectedBuildVariants}
           data-cy="build-variant-list-item"
         />
-        {aliases && (
+        {aliases?.length > 0 && (
           <Card
             onClick={getClickVariantHandler}
             menuItems={aliases}


### PR DESCRIPTION
EVG-15385

### Description 
- Label child patches with the alias that invoked them; also remove this alias from the list of aliases that can be scheduled
- Fix bug where "Select downstream tasks" sidebar was showing for projects with no available downstream tasks

### Testing
- Local data isn't properly configured to test this case so I omitted integration tests. Would like to address this in a future app PR!
- Staging links to test
  - http://localhost:3000/patch/6148b54697b1d33369655ab8/configure/tasks
  - http://localhost:3000/patch/6007393897b1d37434957d04/configure/tasks ("select downstream tasks" does not appear on this page)

### Evergreen PR 
https://github.com/evergreen-ci/evergreen/pull/5036