### PR TITLE
EVG-15465: Represent test names with testFile only instead of testFile and displayTestName

### DIFF
--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -2821,7 +2821,6 @@ export type TaskTestsQuery = {
       status: string;
       baseStatus?: Maybe<string>;
       duration?: Maybe<number>;
-      displayTestName?: Maybe<string>;
       logs: {
         url?: Maybe<string>;
         urlRaw?: Maybe<string>;
@@ -2944,7 +2943,6 @@ export type GetTestsQuery = {
     testResults: Array<{
       id: string;
       testFile: string;
-      displayTestName?: Maybe<string>;
       logs: { url?: Maybe<string>; urlLobster?: Maybe<string> };
     }>;
   };

--- a/src/gql/queries/get-task-tests.graphql
+++ b/src/gql/queries/get-task-tests.graphql
@@ -30,7 +30,6 @@ query TaskTests(
         urlRaw
         urlLobster
       }
-      displayTestName
     }
     filteredTestCount
     totalTestCount

--- a/src/gql/queries/get-tests.graphql
+++ b/src/gql/queries/get-tests.graphql
@@ -13,7 +13,6 @@ query GetTests($execution: Int, $groupId: String, $taskId: String!) {
         urlLobster
       }
       testFile
-      displayTestName
     }
   }
 }

--- a/src/pages/JobLogs.tsx
+++ b/src/pages/JobLogs.tsx
@@ -110,7 +110,7 @@ export const JobLogs = () => {
                 </Subtitle>
               </SubtitleContainer>
             ) : null}
-            {testResults?.map(({ id, logs, testFile, displayTestName }) => {
+            {testResults?.map(({ id, logs, testFile }) => {
               const { urlLobster, url } = logs;
               return (
                 <StyledLink
@@ -124,7 +124,7 @@ export const JobLogs = () => {
                     });
                   }}
                 >
-                  {displayTestName || testFile}
+                  {testFile}
                 </StyledLink>
               );
             })}

--- a/src/pages/task/taskTabs/testsTable/getColumnsTemplate.tsx
+++ b/src/pages/task/taskTabs/testsTable/getColumnsTemplate.tsx
@@ -34,9 +34,7 @@ export const getColumnsTemplate = ({
     dataIndex: "testFile",
     key: TestSortCategory.TestName,
     width: "40%",
-    render: (name, { displayTestName }) => (
-      <WordBreak>{displayTestName || name}</WordBreak>
-    ),
+    render: (testFile) => <WordBreak>{testFile}</WordBreak>,
     sorter: true,
     ...getColumnSearchFilterProps(testNameInputProps),
   },


### PR DESCRIPTION
[EVG-15465](https://jira.mongodb.org/browse/EVG-15465)

### Description 
testFile represents test names as of https://github.com/evergreen-ci/evergreen/pull/5048