### PR TITLE
EVG-15487 Give deploys a higher priority

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -396,6 +396,7 @@ buildvariants:
     - name: deploy_to_prod
       git_tag_only: true
       patchable: false
+      priority: 100
 
 post:
   - func: attach-results


### PR DESCRIPTION
[EVG-15487](https://jira.mongodb.org/browse/EVG-15487)

### Description 
Spruce deploys are arguably pretty important and should have a high priority than most other tasks. 
Tagging @ablack12  and @bsamek  to make sure it's ok to do this. 

