### PR TITLE
EVG-15443: Render variant tasks for aliases

### DIFF
--- a/cypress/integration/version/unscheduled_patch/configure_patch.ts
+++ b/cypress/integration/version/unscheduled_patch/configure_patch.ts
@@ -453,6 +453,7 @@ describe("Configure Patch Page", () => {
       it("Should show one disabled task", () => {
         cy.dataCy("alias-task-checkbox").should("have.length", 1);
         cy.dataCy("alias-task-checkbox").should("have.attr", "disabled");
+        cy.dataCy("alias-task-checkbox").should("not.be.checked");
       });
 
       it("Should update the 'Select all' label", () => {
@@ -461,7 +462,7 @@ describe("Configure Patch Page", () => {
           .contains("Add alias to patch");
       });
 
-      it("Clicking select all should update the task count", () => {
+      it("Clicking select all should update the task count and select the disabled task", () => {
         cy.dataCy("trigger-alias-list-item")
           .find('[data-cy="task-count-badge"]')
           .should("not.exist");
@@ -479,6 +480,8 @@ describe("Configure Patch Page", () => {
           .find('[data-cy="task-count-badge"]');
         countBadge.should("exist");
         countBadge.should("have.text", 1);
+
+        cy.dataCy("alias-task-checkbox").should("be.checked");
       });
 
       it("Cmd+click will select the clicked trigger alias along with the build variant and will show a checkbox for the trigger alias", () => {

--- a/cypress/integration/version/unscheduled_patch/configure_patch.ts
+++ b/cypress/integration/version/unscheduled_patch/configure_patch.ts
@@ -450,8 +450,9 @@ describe("Configure Patch Page", () => {
           .click();
       });
 
-      it("Should show no tasks", () => {
-        cy.dataCy("alias-checkbox").should("have.length", 0);
+      it("Should show one disabled task", () => {
+        cy.dataCy("alias-task-checkbox").should("have.length", 1);
+        cy.dataCy("alias-task-checkbox").should("have.attr", "disabled");
       });
 
       it("Should update the 'Select all' label", () => {

--- a/cypress/integration/version/unscheduled_patch/configure_patch.ts
+++ b/cypress/integration/version/unscheduled_patch/configure_patch.ts
@@ -457,7 +457,7 @@ describe("Configure Patch Page", () => {
       it("Should update the 'Select all' label", () => {
         cy.dataCy("select-all-checkbox")
           .siblings("span")
-          .contains("Select all tasks in this trigger alias");
+          .contains("Add alias to patch");
       });
 
       it("Clicking select all should update the task count", () => {

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -812,6 +812,7 @@ export type PatchTriggerAlias = {
   taskSpecifiers?: Maybe<Array<Maybe<TaskSpecifier>>>;
   status?: Maybe<Scalars["String"]>;
   parentAsModule?: Maybe<Scalars["String"]>;
+  variantsTasks: Array<Maybe<VariantTask>>;
 };
 
 export type UserPatches = {
@@ -2599,7 +2600,11 @@ export type ConfigurePatchQuery = {
         variantsTasks: Array<Maybe<{ name: string; tasks: Array<string> }>>;
       }>
     >;
-    patchTriggerAliases: Array<{ alias: string; childProject: string }>;
+    patchTriggerAliases: Array<{
+      alias: string;
+      childProject: string;
+      variantsTasks: Array<Maybe<{ name: string; tasks: Array<string> }>>;
+    }>;
     childPatchAliases?: Maybe<Array<{ alias: string; patchId: string }>>;
   } & BasePatchFragment;
 };

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -808,7 +808,10 @@ export type ChildPatchAlias = {
 
 export type PatchTriggerAlias = {
   alias: Scalars["String"];
-  childProject: Scalars["String"];
+  /** @deprecated Field no longer supported */
+  childProject?: Maybe<Scalars["String"]>;
+  childProjectId: Scalars["String"];
+  childProjectIdentifier: Scalars["String"];
   taskSpecifiers?: Maybe<Array<Maybe<TaskSpecifier>>>;
   status?: Maybe<Scalars["String"]>;
   parentAsModule?: Maybe<Scalars["String"]>;
@@ -2602,7 +2605,8 @@ export type ConfigurePatchQuery = {
     >;
     patchTriggerAliases: Array<{
       alias: string;
-      childProject: string;
+      childProjectId: string;
+      childProjectIdentifier: string;
       variantsTasks: Array<Maybe<{ name: string; tasks: Array<string> }>>;
     }>;
     childPatchAliases?: Maybe<Array<{ alias: string; patchId: string }>>;

--- a/src/gql/queries/get-patch-configure.graphql
+++ b/src/gql/queries/get-patch-configure.graphql
@@ -23,7 +23,8 @@ query ConfigurePatch($id: String!) {
     }
     patchTriggerAliases {
       alias
-      childProject
+      childProjectId
+      childProjectIdentifier
       variantsTasks {
         name
         tasks

--- a/src/gql/queries/get-patch-configure.graphql
+++ b/src/gql/queries/get-patch-configure.graphql
@@ -24,6 +24,10 @@ query ConfigurePatch($id: String!) {
     patchTriggerAliases {
       alias
       childProject
+      variantsTasks {
+        name
+        tasks
+      }
     }
     childPatchAliases {
       alias

--- a/src/hooks/useConfigurePatch.ts
+++ b/src/hooks/useConfigurePatch.ts
@@ -115,10 +115,11 @@ const tabToIndexMap = {
   [PatchTab.Parameters]: 2,
 };
 
-// Extract the type of a child patch from array of child patches in this query so we can add an alias field
+// Helper to extract type T from an array of type T
 type Unpacked<T> = T extends (infer U)[] ? U : T;
 
-export interface ChildPatchComplete
+// Extract the type of a child patch and append alias field
+export interface ChildPatchAliased
   extends Unpacked<ConfigurePatchQuery["patch"]["childPatches"]> {
   alias: string;
 }

--- a/src/hooks/useConfigurePatch.ts
+++ b/src/hooks/useConfigurePatch.ts
@@ -8,6 +8,7 @@ import {
   VariantTask,
 } from "gql/generated/types";
 import { PatchTab } from "types/patch";
+import { Unpacked } from "types/utils";
 import { array, queryString, string } from "utils";
 
 const { convertArrayToObject, mapStringArrayToObject } = array;
@@ -114,9 +115,6 @@ const tabToIndexMap = {
   [PatchTab.Changes]: 1,
   [PatchTab.Parameters]: 2,
 };
-
-// Helper to extract type T from an array of type T
-type Unpacked<T> = T extends (infer U)[] ? U : T;
 
 // Extract the type of a child patch and append alias field
 export interface ChildPatchAliased

--- a/src/hooks/useConfigurePatch.ts
+++ b/src/hooks/useConfigurePatch.ts
@@ -115,6 +115,14 @@ const tabToIndexMap = {
   [PatchTab.Parameters]: 2,
 };
 
+// Extract the type of a child patch from array of child patches in this query so we can add an alias field
+type Unpacked<T> = T extends (infer U)[] ? U : T;
+
+export interface ChildPatchComplete
+  extends Unpacked<ConfigurePatchQuery["patch"]["childPatches"]> {
+  alias: string;
+}
+
 export type AliasState = {
   [alias: string]: boolean;
 };

--- a/src/pages/configurePatch/ConfigurePatchCore.tsx
+++ b/src/pages/configurePatch/ConfigurePatchCore.tsx
@@ -26,7 +26,7 @@ import {
 import { SCHEDULE_PATCH } from "gql/mutations";
 import {
   AliasState,
-  ChildPatchComplete,
+  ChildPatchAliased,
   VariantTasksState,
   useConfigurePatch,
 } from "hooks/useConfigurePatch";
@@ -52,7 +52,7 @@ export const ConfigurePatchCore: React.FC<Props> = ({ patch }) => {
   } = patch;
   const { variants } = project;
 
-  const childPatchesWithAliases: ChildPatchComplete[] = childPatches
+  const childPatchesWithAliases: ChildPatchAliased[] = childPatches
     ? childPatches.map((cp) => {
         const { alias = id } =
           childPatchAliases.find(({ patchId }) => cp.id === patchId) || {};
@@ -222,7 +222,7 @@ const getPatchTriggerAliasEntries = (
   }));
 };
 
-const getChildPatchEntries = (childPatches: ChildPatchComplete[]) => {
+const getChildPatchEntries = (childPatches: ChildPatchAliased[]) => {
   if (!childPatches) {
     return [];
   }

--- a/src/pages/configurePatch/ConfigurePatchCore.tsx
+++ b/src/pages/configurePatch/ConfigurePatchCore.tsx
@@ -213,13 +213,15 @@ const getPatchTriggerAliasEntries = (
   if (!selectableAliases) {
     return [];
   }
-  return selectableAliases.map(({ alias, childProject, variantsTasks }) => ({
-    displayName: `${alias} (${childProject})`,
-    name: alias,
-    taskCount: selectedAliases[alias]
-      ? variantsTasks.reduce((count, { tasks }) => count + tasks.length, 0)
-      : 0,
-  }));
+  return selectableAliases.map(
+    ({ alias, childProjectIdentifier, variantsTasks }) => ({
+      displayName: `${alias} (${childProjectIdentifier})`,
+      name: alias,
+      taskCount: selectedAliases[alias]
+        ? variantsTasks.reduce((count, { tasks }) => count + tasks.length, 0)
+        : 0,
+    })
+  );
 };
 
 const getChildPatchEntries = (childPatches: ChildPatchAliased[]) => {

--- a/src/pages/configurePatch/ConfigurePatchCore.tsx
+++ b/src/pages/configurePatch/ConfigurePatchCore.tsx
@@ -52,13 +52,12 @@ export const ConfigurePatchCore: React.FC<Props> = ({ patch }) => {
   } = patch;
   const { variants } = project;
 
-  const childPatchesWithAliases: ChildPatchAliased[] = childPatches
-    ? childPatches.map((cp) => {
-        const { alias = id } =
-          childPatchAliases.find(({ patchId }) => cp.id === patchId) || {};
-        return { ...cp, alias };
-      })
-    : [];
+  const childPatchesWithAliases: ChildPatchAliased[] =
+    childPatches?.map((cp) => {
+      const { alias = id } =
+        childPatchAliases.find(({ patchId }) => cp.id === patchId) || {};
+      return { ...cp, alias };
+    }) ?? [];
 
   const selectableAliases = useMemo(
     () => filterAliases(patchTriggerAliases, childPatchAliases || []),

--- a/src/pages/configurePatch/ConfigurePatchCore.tsx
+++ b/src/pages/configurePatch/ConfigurePatchCore.tsx
@@ -52,13 +52,13 @@ export const ConfigurePatchCore: React.FC<Props> = ({ patch }) => {
   } = patch;
   const { variants } = project;
 
-  const childPatchesWithAliases: ChildPatchComplete[] = childPatches.map(
-    (cp) => {
-      const { alias = id } =
-        childPatchAliases.find(({ patchId }) => cp.id === patchId) || {};
-      return { ...cp, alias };
-    }
-  );
+  const childPatchesWithAliases: ChildPatchComplete[] = childPatches
+    ? childPatches.map((cp) => {
+        const { alias = id } =
+          childPatchAliases.find(({ patchId }) => cp.id === patchId) || {};
+        return { ...cp, alias };
+      })
+    : [];
 
   const selectableAliases = useMemo(
     () => filterAliases(patchTriggerAliases, childPatchAliases || []),

--- a/src/pages/configurePatch/configurePatchCore/ConfigureTasks.tsx
+++ b/src/pages/configurePatch/configurePatchCore/ConfigureTasks.tsx
@@ -2,9 +2,11 @@ import React from "react";
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import Checkbox from "@leafygreen-ui/checkbox";
+import Tooltip from "@leafygreen-ui/tooltip";
 import { Disclaimer } from "@leafygreen-ui/typography";
 import every from "lodash.every";
 import { Button } from "components/Button";
+import Icon from "components/Icon";
 import { PatchTriggerAlias } from "gql/generated/types";
 import {
   AliasState,
@@ -150,17 +152,34 @@ export const ConfigureTasks: React.FC<Props> = ({
         >
           Schedule
         </Button>
-        <Checkbox
-          data-cy="select-all-checkbox"
-          indeterminate={selectAllCheckboxState === CheckboxState.INDETERMINITE}
-          onChange={onClickSelectAll}
-          label={selectAllCheckboxCopy}
-          checked={selectAllCheckboxState === CheckboxState.CHECKED}
-          disabled={
-            (activated && Object.entries(currentAliases).length > 0) ||
-            enumerateChildPatchTasks
-          }
-        />
+        <div>
+          <InlineCheckbox
+            data-cy="select-all-checkbox"
+            indeterminate={
+              selectAllCheckboxState === CheckboxState.INDETERMINITE
+            }
+            onChange={onClickSelectAll}
+            label={selectAllCheckboxCopy}
+            checked={selectAllCheckboxState === CheckboxState.CHECKED}
+            disabled={
+              (activated && Object.entries(currentAliases).length > 0) ||
+              enumerateChildPatchTasks
+            }
+          />
+          {enumerateChildPatchTasks && (
+            <Tooltip
+              justify="middle"
+              triggerEvent="hover"
+              trigger={
+                <IconContainer>
+                  <Icon glyph="InfoWithCircle" />
+                </IconContainer>
+              }
+            >
+              Aliases specified via CLI cannot be edited.
+            </Tooltip>
+          )}
+        </div>
       </Actions>
       <StyledDisclaimer data-cy="selected-task-disclaimer">
         {selectedTaskDisclaimerCopy}
@@ -397,4 +416,11 @@ const TabContentWrapper = styled.div`
 `;
 const H4 = styled.h4`
   margin-top: 16px;
+`;
+const IconContainer = styled.span`
+  margin-left: 8px;
+`;
+// @ts-expect-error
+const InlineCheckbox = styled(Checkbox)`
+  display: inline-flex;
 `;

--- a/src/pages/configurePatch/configurePatchCore/ConfigureTasks.tsx
+++ b/src/pages/configurePatch/configurePatchCore/ConfigureTasks.tsx
@@ -75,10 +75,16 @@ export const ConfigureTasks: React.FC<Props> = ({
   );
 
   // Show details related to child patches (i.e. list all variants/tasks) only if it is the only menu item selected
-  const enumerateChildPatches =
+  const enumerateChildPatchTasks =
     currentChildPatches.length === 1 && selectedBuildVariants.length === 1;
-  const enumerateAliases =
+  const enumerateAliasTasks =
     currentAliasTasks.length === 1 && selectedBuildVariants.length === 1;
+
+  // Only show name of alias or child patch if other build variants are also selected
+  const shorthandChildPatchesAndAliases =
+    (Object.entries(currentAliases).length > 0 ||
+      currentChildPatches.length > 0) &&
+    selectedBuildVariants.length > 1;
 
   const onClickCheckbox = (taskName: string) => (e) => {
     const selectedBuildVariantsCopy = { ...selectedBuildVariantTasks };
@@ -113,7 +119,7 @@ export const ConfigureTasks: React.FC<Props> = ({
   const selectAllCheckboxState = getSelectAllCheckboxState(
     currentTasks,
     currentAliases,
-    enumerateChildPatches
+    enumerateChildPatchTasks
   );
   const selectAllCheckboxCopy =
     Object.entries(currentTasks).length === 0
@@ -147,7 +153,7 @@ export const ConfigureTasks: React.FC<Props> = ({
           checked={selectAllCheckboxState === CheckboxState.CHECKED}
           disabled={
             (activated && Object.entries(currentAliases).length > 0) ||
-            enumerateChildPatches
+            enumerateChildPatchTasks
           }
         />
       </Actions>
@@ -167,8 +173,7 @@ export const ConfigureTasks: React.FC<Props> = ({
         ))}
       </Tasks>
       {/* Include a checkbox representing downstream tasks only if a child patch or alias is selected */}
-      {(Object.entries(currentAliases).length > 0 ||
-        currentChildPatches.length > 0) && (
+      {shorthandChildPatchesAndAliases && (
         <>
           <H4>Downstream Tasks</H4>
           <Tasks>
@@ -196,21 +201,23 @@ export const ConfigureTasks: React.FC<Props> = ({
           </Tasks>
         </>
       )}
-      {enumerateChildPatches && (
+      {enumerateChildPatchTasks && (
         <>
           {currentChildPatches[0].variantsTasks.map((variantTasks) => (
             <VariantTasksList
               {...variantTasks}
+              data-cy="child-patch-task-checkbox"
               status={CheckboxState.CHECKED}
             />
           ))}
         </>
       )}
-      {enumerateAliases && (
+      {enumerateAliasTasks && (
         <>
           {currentAliasTasks[0].variantsTasks.map(
             ({ name, tasks: aliasTasks }) => (
               <VariantTasksList
+                data-cy="alias-task-checkbox"
                 name={name}
                 status={currentAliases[currentAliasTasks[0].alias]}
                 tasks={aliasTasks}
@@ -224,12 +231,14 @@ export const ConfigureTasks: React.FC<Props> = ({
 };
 
 interface VariantTasksListProps {
+  "data-cy": string;
   name: string;
   status: CheckboxState;
   tasks: string[];
 }
 
 const VariantTasksList: React.FC<VariantTasksListProps> = ({
+  "data-cy": dataCy,
   name,
   status,
   tasks,
@@ -239,7 +248,7 @@ const VariantTasksList: React.FC<VariantTasksListProps> = ({
     <Tasks>
       {tasks.map((taskName) => (
         <Checkbox
-          data-cy="child-patch-checkbox"
+          data-cy={dataCy}
           key={taskName}
           label={taskName}
           checked={status === CheckboxState.CHECKED}
@@ -257,9 +266,9 @@ const getSelectAllCheckboxState = (
   aliases: {
     [alias: string]: CheckboxState;
   },
-  enumerateChildPatches: boolean
+  enumerateChildPatchTasks: boolean
 ): CheckboxState => {
-  if (enumerateChildPatches) {
+  if (enumerateChildPatchTasks) {
     return CheckboxState.CHECKED;
   }
 

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -1,0 +1,2 @@
+// Helper to extract type T from an array of type T
+export type Unpacked<T> = T extends (infer U)[] ? U : T;


### PR DESCRIPTION
EVG-15443

### Description 
- Display variants/tasks that would be run by scheduling an alias. Use these tasks to update the sidebar's badge count.

### Screenshots
<img width="1057" alt="image" src="https://user-images.githubusercontent.com/9298431/135488199-9937436f-db05-4d20-b988-d50c6b8fb2cc.png">
<img width="1552" alt="image" src="https://user-images.githubusercontent.com/9298431/135651421-07e43d08-5722-47dd-aa7c-d95acfefd10d.png">

### Testing 
- Add integration test to ensure that the one task associated with the "logkeeper" alias renders correctly
- I set up staging so that you can view a patch with both a child patch and an alias [here](https://spruce-staging.corp.mongodb.com/patch/6155cb4997b1d3345c40835f/configure/tasks). Or run your own on staging:
  ```
  evergreen -c ~/.evergreen-staging.yml patch -p mci --trigger-alias e2e
  ```

### Evergreen PR 
https://github.com/evergreen-ci/evergreen/pull/5047
https://github.com/evergreen-ci/evergreen/pull/5072