### PR TITLE
EVG-15200: Fix filter dropdown on Version Restart modal

### DIFF
--- a/src/components/Accordion/index.tsx
+++ b/src/components/Accordion/index.tsx
@@ -58,7 +58,8 @@ const AnimatedAccordion = styled.div`
   /* This is used to calculate a fixed height for the Accordion since height
      transitions require a fixed height for their end height */
   max-height: ${(props: { hide: boolean }): string => !props.hide && "1500px"};
-  overflow-y: hidden;
+  overflow-y: ${(props: { hide: boolean }): string =>
+    props.hide ? "hidden" : "visible"};
   transition: max-height 0.3s ease-in-out;
 `;
 const ContentsContainer = styled.div`


### PR DESCRIPTION
EVG-15200

### Description 
- Don't clip overflow when accordion is open

### Screenshots
<img width="687" alt="image" src="https://user-images.githubusercontent.com/9298431/135289856-c0686432-1871-4e94-a978-dd072d7f7812.png">

### Testing 
- Manually tested all pages where `Accordion` appears
