### PR TITLE
EVG-15515 Fix Downstream Tasks cutting off after the 25th task

### DIFF
--- a/src/components/Accordion/index.tsx
+++ b/src/components/Accordion/index.tsx
@@ -57,7 +57,7 @@ const AnimatedAccordion = styled.div`
   max-height: 0;
   /* This is used to calculate a fixed height for the Accordion since height
      transitions require a fixed height for their end height */
-  max-height: ${(props: { hide: boolean }): string => !props.hide && "1500px"};
+  max-height: ${(props: { hide: boolean }): string => !props.hide && "6000px"};
   overflow-y: ${(props: { hide: boolean }): string =>
     props.hide ? "hidden" : "visible"};
   transition: max-height 0.3s ease-in-out;


### PR DESCRIPTION
[EVG-15515](https://jira.mongodb.org/browse/EVG-15515)

### Description 
The accordion had a max height of 1500px which cut off the downstream tasks after the 25th task. 

### Screenshots
Before:
![image](https://user-images.githubusercontent.com/13104717/135689428-5ad6ff62-2b80-46c5-802e-18ba2234423f.png)

After: 
![image](https://user-images.githubusercontent.com/13104717/135689348-43bbcb8d-b016-420f-ad83-736cbcb9fc77.png)


### Testing 
Tested on staging 

