### PR TITLE
EVG-15506 Use updated build variant squares in place of grouped task squares

### DIFF
--- a/src/pages/version/BuildVariants.tsx
+++ b/src/pages/version/BuildVariants.tsx
@@ -78,13 +78,12 @@ const VariantTaskGroup: React.FC<VariantTaskGroupProps> = ({
   const groupedTasks = groupTasksByUmbrellaStatus(tasks);
   return (
     <VariantTasks>
-      {Object.values(groupedTasks).map(
-        ({ textColor, statuses, count, umbrellaStatus }) => (
+      {Object.entries(groupedTasks).map(
+        ([umbrellaStatus, { statuses, count }]) => (
           <GroupedTaskSquare
             key={`${variant}_${umbrellaStatus}`}
             statuses={statuses}
             count={count}
-            textColor={textColor}
             variant={variant}
             umbrellaStatus={umbrellaStatus}
           />

--- a/src/pages/version/buildVariants/GroupedTaskSquare.tsx
+++ b/src/pages/version/buildVariants/GroupedTaskSquare.tsx
@@ -10,7 +10,6 @@ import { applyStrictRegex } from "utils/string";
 interface Props {
   count: number;
   statuses: string[];
-  textColor: string;
   variant: string;
   umbrellaStatus: string;
 }

--- a/src/pages/version/buildVariants/buildVariants.test.ts
+++ b/src/pages/version/buildVariants/buildVariants.test.ts
@@ -28,20 +28,14 @@ describe("groupTasksByUmbrellaStatus", () => {
       "failed-umbrella": {
         count: 1,
         statuses: ["failed"],
-        textColor: "#8F221B",
-        fill: "#FCEBE2",
       },
       success: {
         count: 1,
         statuses: ["success"],
-        textColor: "#116149",
-        fill: "#E4F4E4",
       },
       "running-umbrella": {
         count: 1,
         statuses: ["started"],
-        textColor: "#86681D",
-        fill: "#FEF7E3",
       },
     });
   });
@@ -77,20 +71,14 @@ describe("groupTasksByUmbrellaStatus", () => {
       "failed-umbrella": {
         count: 2,
         statuses: ["failed", "task-timed-out"],
-        textColor: "#8F221B",
-        fill: "#FCEBE2",
       },
       success: {
         count: 1,
         statuses: ["success"],
-        textColor: "#116149",
-        fill: "#E4F4E4",
       },
       "running-umbrella": {
         count: 1,
         statuses: ["started"],
-        textColor: "#86681D",
-        fill: "#FEF7E3",
       },
     });
   });
@@ -126,20 +114,14 @@ describe("groupTasksByUmbrellaStatus", () => {
       "failed-umbrella": {
         count: 2,
         statuses: ["failed"],
-        textColor: "#8F221B",
-        fill: "#FCEBE2",
       },
       success: {
         count: 1,
         statuses: ["success"],
-        textColor: "#116149",
-        fill: "#E4F4E4",
       },
       "running-umbrella": {
         count: 1,
         statuses: ["started"],
-        textColor: "#86681D",
-        fill: "#FEF7E3",
       },
     });
   });

--- a/src/pages/version/buildVariants/utils.ts
+++ b/src/pages/version/buildVariants/utils.ts
@@ -1,21 +1,14 @@
-import {
-  mapTaskStatusToUmbrellaStatus,
-  mapUmbrellaStatusColors,
-} from "constants/task";
+import { mapTaskStatusToUmbrellaStatus } from "constants/task";
 
 export const groupTasksByUmbrellaStatus = (tasks: { status: string }[]) => {
   const result: {
     [key: string]: {
       count: number;
       statuses: string[];
-      textColor: string;
-      fill: string;
-      umbrellaStatus: string;
     };
   } = {};
   tasks.forEach((task) => {
     const umbrellaStatus = mapTaskStatusToUmbrellaStatus[task.status];
-    const { fill, text } = mapUmbrellaStatusColors[umbrellaStatus];
     if (result[umbrellaStatus]) {
       const groupedTask = result[umbrellaStatus];
       groupedTask.count += 1;
@@ -26,9 +19,6 @@ export const groupTasksByUmbrellaStatus = (tasks: { status: string }[]) => {
       result[umbrellaStatus] = {
         count: 1,
         statuses: [task.status],
-        umbrellaStatus,
-        textColor: text,
-        fill,
       };
     }
   });


### PR DESCRIPTION
[EVG-15506](https://jira.mongodb.org/browse/EVG-15506)

### Description 
This replaces the task squares we were using previously with the updated badges to make them more colorblind friendly 
### Screenshots
![image](https://user-images.githubusercontent.com/4605522/136266995-8f478197-b123-4ddd-a491-15c6620f51cb.png)

