### PR TITLE
EVG-13953: History table date separator

### DIFF
--- a/src/components/HistoryTable/Row.tsx
+++ b/src/components/HistoryTable/Row.tsx
@@ -6,6 +6,7 @@ import { getTaskRoute } from "constants/routes";
 import { TaskStatus } from "types/task";
 import { useHistoryTable } from "./HistoryTableContext";
 import { HistoryTableIcon } from "./HistoryTableIcon";
+import { DateSeparator } from "./row/DateSeparator";
 import { rowType } from "./utils";
 
 const Row: React.FC<ListChildComponentProps> = ({ index, style }) => {
@@ -17,7 +18,7 @@ const Row: React.FC<ListChildComponentProps> = ({ index, style }) => {
   const commit = getItem(index);
   if (commit.type === rowType.DATE_SEPARATOR) {
     // TODO: add date separator component
-    return <DateSeparator style={style}>{commit.date}</DateSeparator>;
+    return <DateSeparator style={style} date={commit.date} />;
   }
   if (commit.type === rowType.COMMIT && commit.commit) {
     const {
@@ -86,14 +87,6 @@ const Cell = styled.div`
   :hover {
     cursor: pointer;
   }
-`;
-
-const DateSeparator = styled.div`
-  width: 100%;
-  padding-right: 40px;
-  background-color: lightblue;
-  display: flex;
-  align-items: center;
 `;
 
 const FoldedCommitContainer = styled.div`

--- a/src/components/HistoryTable/row/DateSeparator.tsx
+++ b/src/components/HistoryTable/row/DateSeparator.tsx
@@ -1,0 +1,49 @@
+import { CSSProperties } from "react";
+import styled from "@emotion/styled";
+import { uiColors } from "@leafygreen-ui/palette";
+import { Body } from "@leafygreen-ui/typography";
+import { format, utcToZonedTime } from "date-fns-tz";
+import { useUserTimeZone } from "hooks/useUserTimeZone";
+
+const { gray } = uiColors;
+interface DateSeparatorProps {
+  style: CSSProperties;
+  date: Date;
+}
+
+export const DateSeparator: React.FC<DateSeparatorProps> = ({
+  style,
+  date,
+}) => {
+  const tz = useUserTimeZone();
+  return (
+    <Container style={style}>
+      <DateWrapper>
+        {format(utcToZonedTime(new Date(date), tz), "MMM d")}
+      </DateWrapper>
+      <StyledHr />
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  width: 100%;
+  padding-right: 40px;
+  display: flex;
+  align-items: center;
+`;
+
+const StyledHr = styled.hr`
+  width: 100%;
+  border-top: 1px dashed ${gray.light1};
+  border-color: ${gray.light1};
+  border-style: dashed;
+  border-width: 1 0 0 0;
+`;
+
+const DateWrapper = styled(Body)`
+  white-space: nowrap;
+  padding-right: 28px;
+  text-transform: uppercase;
+  color: ${gray.dark2}; ;
+`;


### PR DESCRIPTION
[EVG-13953](https://jira.mongodb.org/browse/EVG-13953)

### Description 
I used the hr component for the separator but can switch it to SVG if ya'll think the dash and dash spacing should be increased. 

Screenshot: 
![Screen Shot 2021-10-06 at 5 33 58 PM](https://user-images.githubusercontent.com/10734386/136286534-754bab3e-ee69-4daa-a0d6-f13d385da978.png)


Design:
![Screen Shot 2021-10-06 at 5 30 19 PM](https://user-images.githubusercontent.com/10734386/136286116-b14c2287-7d18-450f-add4-a394c8581325.png)

