### PR TITLE
EVG-15557 Bypass UI for cypress test login

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -3,22 +3,25 @@ import { waitForGQL } from "../utils/networking";
 const GQL_QUERY = "gqlQuery";
 const LOGIN_COOKIE = "mci-token";
 const TOAST_COOKIE = "announcement-toast";
-
+const loginURL = "http://localhost:9090/login";
+const user = {
+  username: "admin",
+  password: "password",
+};
 Cypress.Cookies.defaults({
   preserve: TOAST_COOKIE,
 });
 
 function enterLoginCredentials() {
-  cy.get("input[name=username]").type("admin");
-  cy.get("input[name=password]").type("password");
+  cy.get("input[name=username]").type(user.username);
+  cy.get("input[name=password]").type(user.password);
   cy.get("button[id=login-submit]").click();
 }
 
 Cypress.Commands.add("login", () => {
   cy.getCookie(LOGIN_COOKIE).then((c) => {
     if (!c) {
-      cy.visit("/login");
-      enterLoginCredentials();
+      cy.request("POST", loginURL, { ...user });
     }
   });
 });


### PR DESCRIPTION
[EVG-15575](https://jira.mongodb.org/browse/EVG-15575)

### Description 
Cypress tests will now bypass the ui and instead perform a request to authenticate directly with evergreen. 
This is the recommended way of authenticating before tests.
https://docs.cypress.io/guides/getting-started/testing-your-app#Bypassing-your-UI

It should shave a second or 2 off of each test suite as well since we no longer have to wait for the login flow to complete before running each test. 

Shaved a whopping 52 seconds off our cypress tests. 
![image](https://user-images.githubusercontent.com/4605522/137007712-4e4e6b2b-2d2e-4e6a-bdba-eff2f0236cd1.png)

🤯 

We still have[ one test ](https://github.com/evergreen-ci/spruce/blob/055e7c23341ed054d25a34c386fb15b90d612db2/cypress/integration/auth.ts)which does go through the full auth flow but for most other tests we can/should skip it.