### PR TITLE
EVG-15621 Deploy email cleanup

### DIFF
--- a/cli-scripts/notify-email.js
+++ b/cli-scripts/notify-email.js
@@ -1,46 +1,46 @@
 /* eslint-disable no-console */
-const { exec } = require("child_process");
+const { execSync } = require("child_process");
 const { getLatestCommitsSinceLastRelease } = require("./deploy-utils");
 
 // this script gets the current user email, the latest git commit hash of
 // the current branch and sends an email to a recipient that will forward
 // the message to a slack channel
-const sendEmail = async () =>
-  exec("git config user.email", async (emailErr, email) => {
-    if (emailErr) {
-      console.error(errorMessage, emailErr);
-    } else {
-      const formattedEmail = email.trim();
-      exec("git rev-parse HEAD", async (commitHashErr, commitHash) => {
-        if (commitHashErr) {
-          console.error(errorMessage, commitHashErr);
-        } else {
-          const formattedCommitHash = commitHash.substr(0, 9);
-          const today = new Date();
-          const day = prependZero(`${today.getDate()}`);
-          const month = prependZero(`${today.getMonth() + 1}`);
-          const dateStr = `${today.getFullYear()}/${month}/${day}`;
-          const recipient = process.env.REACT_APP_DEPLOYS_EMAIL;
-          const subject = `${dateStr} Spruce deploy ${formattedCommitHash}`;
-          const messageBody = await getLatestCommitsSinceLastRelease();
-          const formattedBody = messageBody.replace("\n", "<br />");
-          exec(
-            `evergreen notify email -f ${formattedEmail} -r ${recipient} -s "${subject}" -b "${formattedBody} <br/>Check it out <a href="${process.env.REACT_APP_SPRUCE_URL}">here!</a>"`,
-            (notifyErr, notifyStdOut, notifyStdErr) => {
-              if (notifyErr) {
-                console.error(errorMessage, notifyErr);
-              } else {
-                console.log(notifyStdOut);
-                console.log(notifyStdErr);
-              }
-            }
-          );
-        }
-      });
-    }
-  });
+const sendEmail = async () => {
+  try {
+    const email = await execSync("git config user.email", {
+      encoding: "utf8",
+    });
+    const formattedEmail = email.trim();
+    const commitHash = await execSync("git rev-parse HEAD", {
+      encoding: "utf8",
+    });
+
+    const formattedCommitHash = commitHash.substr(0, 9);
+    const today = new Date();
+    const day = prependZero(`${today.getDate()}`);
+    const month = prependZero(`${today.getMonth() + 1}`);
+    const dateStr = `${today.getFullYear()}/${month}/${day}`;
+    const recipient = process.env.REACT_APP_DEPLOYS_EMAIL;
+
+    const subject = `${dateStr} Spruce deploy to ${formattedCommitHash}`;
+    const messageBody = await getLatestCommitsSinceLastRelease();
+    const formattedBody = messageBody.replaceAll("\n", "<br/>");
+
+    const emailNotification = await execSync(
+      `evergreen notify email -f ${formattedEmail} -r ${recipient} -s "${subject}" -b "${formattedBody} <br/>Check it out <a href="${process.env.REACT_APP_SPRUCE_URL}">here!</a>"`,
+      {
+        encoding: "utf8",
+      }
+    );
+    console.log(emailNotification);
+    console.log(`Email sent to ${recipient}`);
+    console.log(`Subject: ${subject}`);
+    console.log(`Body: ${formattedBody}`);
+  } catch (err) {
+    console.error("Encountered an error when sending the commit email: ");
+    console.error(err);
+  }
+};
 
 sendEmail();
-
-const errorMessage = "Error sending message to slack";
 const prependZero = (strNum) => (strNum.length < 2 ? `0${strNum}` : strNum);

--- a/cli-scripts/notify-email.js
+++ b/cli-scripts/notify-email.js
@@ -19,7 +19,7 @@ const sendEmail = async () => {
     const today = new Date();
     const day = prependZero(`${today.getDate()}`);
     const month = prependZero(`${today.getMonth() + 1}`);
-    const dateStr = `${today.getFullYear()}/${month}/${day}`;
+    const dateStr = `${today.getFullYear()}-${month}-${day}`;
     const recipient = process.env.REACT_APP_DEPLOYS_EMAIL;
 
     const subject = `${dateStr} Spruce deploy to ${formattedCommitHash}`;


### PR DESCRIPTION
[EVG-15621](https://jira.mongodb.org/browse/EVG-15621)

### Description 
Just cleaning up this file.
Removing the callback hell that was occurring and instead just performing the steps in serial. 
Should clean up the format of the deploy email to be more consistent with the other deploy projects deploy emails.

Tagging @bsamek  for any comments about the structure of the email. I also think you may have reviewed this script in the past. 

I have not included the link to the revert email in this ticket and will do it in a follow up ticket once i think about the logic a bit more.

![image](https://user-images.githubusercontent.com/4605522/137541786-1d84264d-7f74-415f-8756-ab2d0821dfb4.png)


