### PR TITLE
EVG-15576 Add styling to prevent depends-on badge from stretching to container width

### DIFF
--- a/src/pages/task/metadata/DependsOn.tsx
+++ b/src/pages/task/metadata/DependsOn.tsx
@@ -54,6 +54,10 @@ const Subtitle = styled(Disclaimer)`
   padding-bottom: 3px;
 `;
 
+const StyledBadge = styled(Badge)`
+  align-self: flex-start;
+`;
+
 const metStatusToIcon = {
   [MetStatus.Met]: <TaskStatusIcon status={TaskStatus.Succeeded} />,
   [MetStatus.Unmet]: <TaskStatusIcon status={TaskStatus.Failed} />,
@@ -61,11 +65,13 @@ const metStatusToIcon = {
 };
 
 const requiredStatusToBadge = {
-  [RequiredStatus.MustFail]: <Badge variant={Variant.Red}>Must fail</Badge>,
+  [RequiredStatus.MustFail]: (
+    <StyledBadge variant={Variant.Red}>Must fail</StyledBadge>
+  ),
   [RequiredStatus.MustFinish]: (
-    <Badge variant={Variant.Blue}>Must finish</Badge>
+    <StyledBadge variant={Variant.Blue}>Must finish</StyledBadge>
   ),
   [RequiredStatus.MustSucceed]: (
-    <Badge variant={Variant.Green}>Must succeed</Badge>
+    <StyledBadge variant={Variant.Green}>Must succeed</StyledBadge>
   ),
 };


### PR DESCRIPTION
[EVG-15576](https://jira.mongodb.org/browse/EVG-15576)

### Description 
This PR adds a line of styling to prevent 'Depends On' badges (which appear under the metadata for a task) from stretching to the max container width.

### Screenshots
<img width="302" alt="Screen Shot 2021-10-19 at 3 43 29 PM" src="https://user-images.githubusercontent.com/47064971/137979652-9003c4e6-0066-40d8-8670-71d2a8183768.png">


### Testing 
Tested manually & ran existing tests to ensure they pass with changes.