### PR TITLE
EVG-12831  Add warning for squashing commits

### DIFF
--- a/src/pages/version/EnqueueModal.tsx
+++ b/src/pages/version/EnqueueModal.tsx
@@ -78,6 +78,9 @@ export const EnqueuePatchModal: React.FC<EnqueueProps> = ({
       data-cy="enqueue-modal"
     >
       <InputLabel htmlFor={COMMIT_MESSAGE_ID}>Commit Message</InputLabel>
+      <CommitSquashWarning>
+        Warning: submitting a patch to the commit queue will squash the commits.
+      </CommitSquashWarning>
       <StyledTextArea
         id={COMMIT_MESSAGE_ID}
         value={commitMessageValue}
@@ -90,6 +93,10 @@ export const EnqueuePatchModal: React.FC<EnqueueProps> = ({
 
 const StyledTextArea = styled(TextArea)`
   margin: 15px 0;
+`;
+
+const CommitSquashWarning = styled.div`
+  margin-top: 14px;
 `;
 
 const COMMIT_MESSAGE_ID = "commit-message-input";


### PR DESCRIPTION
[EVG-12831](https://jira.mongodb.org/browse/EVG-12831)

### Description 
This PR adds a description to `EnqueueModal.tsx` to inform users that their commits will be squashed when submitting a patch to the commit queue. Note: the message is quite basic, so if any additional features are requested I can commit follow-ups to this PR.

### Screenshots
<img width="1019" alt="Screen Shot 2021-10-19 at 3 51 37 PM" src="https://user-images.githubusercontent.com/47064971/137980731-eba27476-327d-4f3e-9aca-93f24233942a.png">


### Testing 
Tested manually.
