### PR TITLE
EVG-14563 Apply default sort on Patch page when clearing filters 

### DIFF
--- a/cypress/integration/version/task_filters.ts
+++ b/cypress/integration/version/task_filters.ts
@@ -7,6 +7,7 @@ const patch = {
 const path = `/version/${patch.id}`;
 const pathTasks = `${path}/tasks`;
 const pathURLWithFilters = `${pathTasks}?page=0&sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC&statuses=failed,success,running-umbrella,dispatched,started&taskName=test-thirdparty&variant=ubuntu`;
+const defaultPath = `${pathTasks}?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC`;
 
 describe("Tasks filters", () => {
   before(() => {
@@ -24,7 +25,7 @@ describe("Tasks filters", () => {
     cy.dataCy("tasks-table").should("exist");
     cy.dataCy("clear-all-filters").click();
     cy.location().should((loc) => {
-      expect(loc.href).to.equal(loc.origin + pathTasks);
+      expect(loc.href).to.equal(loc.origin + defaultPath);
     });
     cy.toggleTableFilter(1);
     cy.dataCy("taskname-input-wrapper")

--- a/src/components/PatchTabs/Tasks.tsx
+++ b/src/components/PatchTabs/Tasks.tsx
@@ -4,14 +4,15 @@ import styled from "@emotion/styled";
 import Button from "@leafygreen-ui/button";
 import { Skeleton } from "antd";
 import every from "lodash.every";
-import { useParams, useLocation, useHistory } from "react-router-dom";
+import { useParams, useLocation } from "react-router-dom";
+// import { useParams, useLocation, useHistory } from "react-router-dom";
 import { usePatchAnalytics } from "analytics";
 import { PageSizeSelector } from "components/PageSizeSelector";
 import { Pagination } from "components/Pagination";
 import { ResultCountLabel } from "components/ResultCountLabel";
 import { TableControlOuterRow, TableControlInnerRow } from "components/styles";
 import { pollInterval } from "constants/index";
-import { getVersionRoute } from "constants/routes";
+// import { getVersionRoute } from "constants/routes";
 import { useToastContext } from "context/toast";
 import { PatchTasksQuery, PatchTasksQueryVariables } from "gql/generated/types";
 import { GET_PATCH_TASKS } from "gql/queries";
@@ -32,7 +33,7 @@ export const Tasks: React.FC<Props> = ({ taskCount }) => {
   const { id: versionId } = useParams<{ id: string }>();
 
   const { search } = useLocation();
-  const router = useHistory();
+  // const router = useHistory();
   const patchAnalytics = usePatchAnalytics();
   const dispatchToast = useToastContext();
 
@@ -48,6 +49,18 @@ export const Tasks: React.FC<Props> = ({ taskCount }) => {
       });
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const onClearAll = () => {
+    patchAnalytics.sendEvent({ name: "Clear all filter" });
+    // router.push(getVersionRoute(versionId)); // Ask about this
+    updateQueryParams({
+      statuses: [],
+      baseStatuses: [],
+      taskName: undefined,
+      variant: undefined,
+      sorts: "STATUS:ASC;BASE_STATUS:DESC",
+    });
+  };
 
   const { data, startPolling, stopPolling } = useQuery<
     PatchTasksQuery,
@@ -80,10 +93,7 @@ export const Tasks: React.FC<Props> = ({ taskCount }) => {
             denominator={taskCount}
           />
           <PaddedButton // @ts-expect-error
-            onClick={() => {
-              patchAnalytics.sendEvent({ name: "Clear all filter" });
-              router.push(getVersionRoute(versionId));
-            }}
+            onClick={() => onClearAll()}
             data-cy="clear-all-filters"
           >
             Clear All Filters

--- a/src/components/PatchTabs/Tasks.tsx
+++ b/src/components/PatchTabs/Tasks.tsx
@@ -5,14 +5,12 @@ import Button from "@leafygreen-ui/button";
 import { Skeleton } from "antd";
 import every from "lodash.every";
 import { useParams, useLocation } from "react-router-dom";
-// import { useParams, useLocation, useHistory } from "react-router-dom";
 import { usePatchAnalytics } from "analytics";
 import { PageSizeSelector } from "components/PageSizeSelector";
 import { Pagination } from "components/Pagination";
 import { ResultCountLabel } from "components/ResultCountLabel";
 import { TableControlOuterRow, TableControlInnerRow } from "components/styles";
 import { pollInterval } from "constants/index";
-// import { getVersionRoute } from "constants/routes";
 import { useToastContext } from "context/toast";
 import { PatchTasksQuery, PatchTasksQueryVariables } from "gql/generated/types";
 import { GET_PATCH_TASKS } from "gql/queries";
@@ -33,7 +31,6 @@ export const Tasks: React.FC<Props> = ({ taskCount }) => {
   const { id: versionId } = useParams<{ id: string }>();
 
   const { search } = useLocation();
-  // const router = useHistory();
   const patchAnalytics = usePatchAnalytics();
   const dispatchToast = useToastContext();
 
@@ -49,18 +46,6 @@ export const Tasks: React.FC<Props> = ({ taskCount }) => {
       });
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
-
-  const onClearAll = () => {
-    patchAnalytics.sendEvent({ name: "Clear all filter" });
-    // router.push(getVersionRoute(versionId)); // Ask about this
-    updateQueryParams({
-      statuses: [],
-      baseStatuses: [],
-      taskName: undefined,
-      variant: undefined,
-      sorts: "STATUS:ASC;BASE_STATUS:DESC",
-    });
-  };
 
   const { data, startPolling, stopPolling } = useQuery<
     PatchTasksQuery,
@@ -80,6 +65,18 @@ export const Tasks: React.FC<Props> = ({ taskCount }) => {
   }
   useNetworkStatus(startPolling, stopPolling);
   const { patchTasks } = data || {};
+
+  const onClearAll = () => {
+    patchAnalytics.sendEvent({ name: "Clear all filter" });
+    updateQueryParams({
+      statuses: [],
+      baseStatuses: [],
+      taskName: undefined,
+      variant: undefined,
+      page: undefined,
+      sorts: "STATUS:ASC;BASE_STATUS:DESC",
+    });
+  };
 
   return (
     <>


### PR DESCRIPTION
[EVG-14563](https://jira.mongodb.org/browse/EVG-14563)

### Description 
This PR makes it so that when a user presses the "Clear All Filters" button, the default sorting is applied to the Patch page. (Previously, clicking the button would cause all sorting to be cleared.)

### Screenshots
https://user-images.githubusercontent.com/47064971/138209639-8c210678-7198-41f3-be44-ac370893800a.mov

### Testing 
Edited `task_filters.ts` test to pass with frontend changes.
