### PR TITLE
EVG-13766 Support filtering for only commit queue patches on the project patches page

### DIFF
--- a/cypress/integration/myPatches/my_patches.ts
+++ b/cypress/integration/myPatches/my_patches.ts
@@ -71,19 +71,18 @@ describe("My Patches Page", () => {
     cy.dataCy("commit-queue-checkbox").should("be.checked");
     cy.contains(patchOnCommitQueue);
 
-    cy.dataCy("commit-queue-checkbox").click({ force: true });
+    cy.dataCy("commit-queue-checkbox").uncheck({ force: true });
     urlSearchParamsAreUpdated({
       pathname: MY_PATCHES_ROUTE,
       paramName: "commitQueue",
       search: "false",
     });
     cy.contains(patchOnCommitQueue).should("not.exist");
-    cy.dataCy("commit-queue-checkbox").click({ force: true });
+    cy.dataCy("commit-queue-checkbox").check({ force: true });
   });
 
   describe("Changing page number and page size", () => {
     before(() => {
-      cy.login();
       cy.visit(MY_PATCHES_ROUTE);
     });
     it("Displays the next page of results and updates URL when right arrow is clicked and next page exists", () => {
@@ -170,27 +169,6 @@ describe("My Patches Page", () => {
         paramName: "statuses",
         search: "all,created,started,succeeded,failed",
       });
-    });
-  });
-
-  describe("Show commit queue checkbox", () => {
-    beforeEach(() => {
-      cy.preserveCookies();
-    });
-
-    it("Should render with Show Commit Queue box checked when commitQueue not indicated in URL query param", () => {
-      cy.visit(MY_PATCHES_ROUTE);
-      cy.dataCy("commit-queue-checkbox").should("be.checked");
-    });
-
-    it("Should render with Show Commit Queue box unchecked when commitQueue is false in URL query param", () => {
-      cy.visit(`${MY_PATCHES_ROUTE}?commitQueue=false`);
-      cy.dataCy("commit-queue-checkbox").should("not.be.checked");
-    });
-
-    it("Should render with Show Commit Queue box checked when commitQueue is true in URL query param", () => {
-      cy.visit(`${MY_PATCHES_ROUTE}?commitQueue=true`);
-      cy.dataCy("commit-queue-checkbox").should("be.checked");
     });
   });
 });

--- a/cypress/integration/task/test_table.ts
+++ b/cypress/integration/task/test_table.ts
@@ -137,14 +137,15 @@ describe("Tests Table", () => {
   describe("Changing page number", () => {
     before(() => {
       cy.visit(TESTS_ROUTE);
+      // Asserts that the data in the table has loaded before running the tests
+      cy.get(".ant-pagination-simple-pager").should("contain.text", "/2");
     });
 
     it("Displays the next page of results and updates URL when right arrow is clicked and next page exists", () => {
       clickOnPageBtnAndAssertURLandTableResults(
         dataCyNextPage,
         secondPageDisplayNames,
-        1,
-        dataCyTableRows
+        1
       );
     });
 
@@ -152,8 +153,7 @@ describe("Tests Table", () => {
       clickOnPageBtnAndAssertURLandTableResults(
         dataCyNextPage,
         secondPageDisplayNames,
-        1,
-        dataCyTableRows
+        1
       );
     });
 
@@ -161,8 +161,7 @@ describe("Tests Table", () => {
       clickOnPageBtnAndAssertURLandTableResults(
         dataCyPrevPage,
         firstPageDisplayNames,
-        0,
-        dataCyTableRows
+        0
       );
     });
 
@@ -170,8 +169,7 @@ describe("Tests Table", () => {
       clickOnPageBtnAndAssertURLandTableResults(
         dataCyPrevPage,
         firstPageDisplayNames,
-        0,
-        dataCyTableRows
+        0
       );
     });
   });

--- a/cypress/utils/index.js
+++ b/cypress/utils/index.js
@@ -109,14 +109,13 @@ export const elementExistenceCheck = (
 export const clickOnPageBtnAndAssertURLandTableResults = (
   dataCyPageBtn,
   tableDisplayNames,
-  pageQueryParamValue,
-  dataCyTableRows
+  pageQueryParamValue
 ) => {
-  cy.wait(400);
+  cy.get(dataCyPageBtn).should("be.visible");
+  cy.get(dataCyPageBtn).should("not.be.disabled");
   cy.get(dataCyPageBtn).click();
-  cy.wait(400);
-  cy.get(dataCyTableRows).each(($el, index) => {
-    cy.wrap($el).contains(tableDisplayNames[index]);
+  tableDisplayNames.forEach((displayName) => {
+    cy.contains(displayName);
   });
   cy.location("search").should("include", `page=${pageQueryParamValue}`);
 };

--- a/src/components/PatchesPage/ListArea.tsx
+++ b/src/components/PatchesPage/ListArea.tsx
@@ -1,9 +1,7 @@
 import React from "react";
-import { ApolloError } from "@apollo/client";
 import styled from "@emotion/styled";
 import { Skeleton } from "antd";
 import { Analytics } from "analytics/addPageAction";
-import { PageWrapper } from "components/styles";
 import { PatchesPagePatchesFragment } from "gql/generated/types";
 import { PatchCard } from "./PatchCard";
 
@@ -16,13 +14,10 @@ export const ListArea: React.FC<{
       }
   >;
   patches?: PatchesPagePatchesFragment;
-  error?: ApolloError;
   pageType: "project" | "user";
-}> = ({ patches, error, analyticsObject, pageType }) => {
-  if (error) {
-    return <PageWrapper>ERROR</PageWrapper>;
-  }
-  if (!patches) {
+  loading: boolean;
+}> = ({ patches, loading, analyticsObject, pageType }) => {
+  if (loading) {
     return <StyledSkeleton active title={false} paragraph={{ rows: 4 }} />;
   }
   if (patches?.patches.length !== 0) {

--- a/src/components/PatchesPage/StatusSelector.tsx
+++ b/src/components/PatchesPage/StatusSelector.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Dropdown, TreeSelect } from "components/TreeSelect";
 import { useStatusesFilter } from "hooks";
 import {
-  MyPatchesQueryParams,
+  PatchPageQueryParams,
   PatchStatus,
   ALL_PATCH_STATUS,
 } from "types/patch";
@@ -11,7 +11,7 @@ export const StatusSelector: React.FC = () => {
   const {
     inputValue: statusVal,
     setAndSubmitInputValue: statusValOnChange,
-  } = useStatusesFilter({ urlParam: MyPatchesQueryParams.Statuses });
+  } = useStatusesFilter({ urlParam: PatchPageQueryParams.Statuses });
 
   return (
     <Dropdown

--- a/src/components/PatchesPage/index.tsx
+++ b/src/components/PatchesPage/index.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { ApolloError } from "@apollo/client";
 import styled from "@emotion/styled";
 import Checkbox from "@leafygreen-ui/checkbox";
 import Icon from "@leafygreen-ui/icon";
@@ -40,7 +39,7 @@ interface Props {
   >;
   pageTitle: string;
   patches?: PatchesPagePatchesFragment;
-  error?: ApolloError;
+  loading: boolean;
   pageType: "project" | "user";
 }
 
@@ -48,7 +47,7 @@ export const PatchesPage: React.FC<Props> = ({
   analyticsObject,
   pageTitle,
   patches,
-  error,
+  loading,
   pageType,
 }) => {
   const { search } = useLocation();
@@ -116,7 +115,7 @@ export const PatchesPage: React.FC<Props> = ({
       </PaginationRow>
       <ListArea
         patches={patches}
-        error={error}
+        loading={loading}
         pageType={pageType}
         analyticsObject={analyticsObject}
       />

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -20,7 +20,6 @@ export type Scalars = {
 };
 
 export type Query = {
-  userPatches: UserPatches;
   task?: Maybe<Task>;
   taskAllExecutions: Array<Task>;
   patch: Patch;
@@ -57,15 +56,6 @@ export type Query = {
   taskNamesForBuildVariant?: Maybe<Array<Scalars["String"]>>;
   buildVariantsForTaskName?: Maybe<Array<Maybe<BuildVariantTuple>>>;
   projectSettings: ProjectSettings;
-};
-
-export type QueryUserPatchesArgs = {
-  limit?: Maybe<Scalars["Int"]>;
-  page?: Maybe<Scalars["Int"]>;
-  patchName?: Maybe<Scalars["String"]>;
-  statuses?: Maybe<Array<Scalars["String"]>>;
-  userId?: Maybe<Scalars["String"]>;
-  includeCommitQueue?: Maybe<Scalars["Boolean"]>;
 };
 
 export type QueryTaskArgs = {
@@ -646,7 +636,8 @@ export type PatchesInput = {
   page?: Scalars["Int"];
   patchName?: Scalars["String"];
   statuses?: Array<Scalars["String"]>;
-  includeCommitQueue?: Scalars["Boolean"];
+  includeCommitQueue?: Maybe<Scalars["Boolean"]>;
+  onlyCommitQueue?: Maybe<Scalars["Boolean"]>;
 };
 
 export type CreateProjectInput = {
@@ -1396,6 +1387,7 @@ export type Project = {
   useRepoSettings: Scalars["Boolean"];
   repoRefId?: Maybe<Scalars["String"]>;
   isFavorite: Scalars["Boolean"];
+  validDefaultLoggers: Array<Scalars["String"]>;
   patches: Patches;
 };
 

--- a/src/hooks/useUpdateURLQueryParams.ts
+++ b/src/hooks/useUpdateURLQueryParams.ts
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useCallback } from "react";
 import { useHistory, useLocation } from "react-router-dom";
 import { queryString } from "utils";
 
@@ -7,8 +7,8 @@ const { stringifyQuery, parseQueryString } = queryString;
 export const useUpdateURLQueryParams = () => {
   const { replace } = useHistory();
   const { search, pathname } = useLocation();
-  const result = useMemo(
-    () => (nextQueryParams: StringMap) => {
+  const updateQueryParams = useCallback(
+    (nextQueryParams: StringMap) => {
       const joinedParams = {
         ...parseQueryString(search),
         ...nextQueryParams,
@@ -19,7 +19,7 @@ export const useUpdateURLQueryParams = () => {
     [replace, search, pathname]
   );
 
-  return result;
+  return updateQueryParams;
 };
 
 interface StringMap {

--- a/src/pages/UserPatches.tsx
+++ b/src/pages/UserPatches.tsx
@@ -7,6 +7,7 @@ import {
   getPatchesInputFromURLSearch,
 } from "components/PatchesPage";
 import { pollInterval } from "constants/index";
+import { useToastContext } from "context/toast";
 import {
   UserPatchesQuery,
   UserPatchesQueryVariables,
@@ -23,6 +24,7 @@ import { queryString } from "utils";
 const { parseQueryString } = queryString;
 
 export const UserPatches = () => {
+  const dispatchToast = useToastContext();
   const { id: userId } = useParams<{ id: string }>();
   const { search } = useLocation();
   const analyticsObject = useUserPatchesAnalytics();
@@ -42,7 +44,7 @@ export const UserPatches = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [parsed]);
 
-  const { data, startPolling, stopPolling, error } = useQuery<
+  const { data, startPolling, stopPolling, loading } = useQuery<
     UserPatchesQuery,
     UserPatchesQueryVariables
   >(GET_USER_PATCHES, {
@@ -54,7 +56,9 @@ export const UserPatches = () => {
       },
     },
     pollInterval,
-    fetchPolicy: "cache-and-network",
+    onError: (err) => {
+      dispatchToast.error(`Error while fetching user patches: ${err.message}`);
+    },
   });
   useNetworkStatus(startPolling, stopPolling);
   const { title: pageTitle } = useGetUserPatchesPageTitleAndLink(userId);
@@ -62,7 +66,7 @@ export const UserPatches = () => {
     <PatchesPage
       analyticsObject={analyticsObject}
       pageTitle={pageTitle}
-      error={error}
+      loading={loading}
       pageType="user"
       patches={data?.user.patches}
     />

--- a/src/types/patch.ts
+++ b/src/types/patch.ts
@@ -1,4 +1,4 @@
-export enum MyPatchesQueryParams {
+export enum PatchPageQueryParams {
   CommitQueue = "commitQueue",
   PatchName = "patchName",
   Statuses = "statuses",


### PR DESCRIPTION
[EVG-13766](https://jira.mongodb.org/browse/EVG-13766)

### Description 
Refactor patches pages to support filtering by only commit queue patches on project pages. Also a minor refactor on those pages since the default behavior for the project patches pages and the user pages are now slightly different. (User patches include commit queue patches by default / Project patches pages allow you to optionally only filter for commit queue patches.)
### Screenshots


https://user-images.githubusercontent.com/4605522/138978382-4bff1b09-263c-43ee-afee-3ae80d69acab.mov

### Testing 
On staging and current e2e tests
### Evergreen PR 
https://github.com/evergreen-ci/evergreen/pull/5137