### PR TITLE
EVG-13626 Make SpawnHostButton test pass

### DIFF
--- a/src/pages/commits/ActiveCommits/buildVariantCard/WaterfallTaskStatusIcon.test.tsx
+++ b/src/pages/commits/ActiveCommits/buildVariantCard/WaterfallTaskStatusIcon.test.tsx
@@ -36,9 +36,9 @@ test("Tooltip should contain task name, duration, list of failing test names and
       queryByText("jstests/multiVersion/remove_invalid_index_options.js")
     ).toBeVisible();
   });
-  // await waitFor(() => {
-  //   expect(queryByText("and 2 more")).toBeVisible();
-  // });
+  await waitFor(() => {
+    expect(queryByText("and 2 more")).toBeVisible();
+  });
 });
 
 test("Icon should link to task page", async () => {

--- a/src/pages/commits/ActiveCommits/buildVariantCard/WaterfallTaskStatusIcon.test.tsx
+++ b/src/pages/commits/ActiveCommits/buildVariantCard/WaterfallTaskStatusIcon.test.tsx
@@ -36,9 +36,9 @@ test("Tooltip should contain task name, duration, list of failing test names and
       queryByText("jstests/multiVersion/remove_invalid_index_options.js")
     ).toBeVisible();
   });
-  await waitFor(() => {
-    expect(queryByText("and 2 more")).toBeVisible();
-  });
+  // await waitFor(() => {
+  //   expect(queryByText("and 2 more")).toBeVisible();
+  // });
 });
 
 test("Icon should link to task page", async () => {

--- a/src/pages/spawn/spawnHost/SpawnHostButton.test.tsx
+++ b/src/pages/spawn/spawnHost/SpawnHostButton.test.tsx
@@ -10,7 +10,6 @@ import {
   GET_SPRUCE_CONFIG,
 } from "gql/queries";
 import {
-  act,
   renderWithRouterMatch as render,
   waitFor,
 } from "test_utils/test-utils";
@@ -271,7 +270,7 @@ const twoHostsThreeLimitMock = {
   },
 };
 
-test.skip("Disables the spawn host button when the number of hosts that currently exist are greater than or equal to the max number of spawn hosts per user", () => {
+test("Disables the spawn host button when the number of hosts that currently exist are greater than or equal to the max number of spawn hosts per user", async () => {
   const { queryByDataCy } = render(() => (
     <MockedProvider
       mocks={[
@@ -287,10 +286,12 @@ test.skip("Disables the spawn host button when the number of hosts that currentl
       <SpawnHostButton />
     </MockedProvider>
   ));
-  waitFor(() => expect(queryByDataCy("spawn-host-button")).toBeDisabled());
+  await waitFor(() =>
+    expect(queryByDataCy("spawn-host-button")).toBeDisabled()
+  );
 });
 
-test.skip("Enables the spawn host button when the number of hosts that currently exist is less than the max number of spawn hosts per user", async () => {
+test("Enables the spawn host button when the number of hosts that currently exist is less than the max number of spawn hosts per user", async () => {
   const { queryByDataCy } = render(() => (
     <MockedProvider
       mocks={[
@@ -306,6 +307,7 @@ test.skip("Enables the spawn host button when the number of hosts that currently
       <SpawnHostButton />
     </MockedProvider>
   ));
-  await act(() => new Promise((resolve) => setTimeout(resolve, 0)));
-  waitFor(() => expect(queryByDataCy("spawn-host-button")).not.toBeDisabled());
+  await waitFor(() =>
+    expect(queryByDataCy("spawn-host-button")).not.toBeDisabled()
+  );
 });


### PR DESCRIPTION
[EVG-13626](https://jira.mongodb.org/browse/EVG-13626)

### Description 
This PR modifies `SpawnHostButton.test.tsx` such that it passes (previously, the test suite was skipped over entirely).

### Screenshots
<img width="1099" alt="Screen Shot 2021-11-02 at 1 46 16 PM" src="https://user-images.githubusercontent.com/47064971/139923509-ea4e3127-2ca1-41c5-bd0c-0f9124aa2dcc.png">

### Testing 
- Ran `yarn test`
