### PR TITLE
EVG-15759 Update Historytable to only show 7 columns by default

### DIFF
--- a/src/components/HistoryTable/Cell.tsx
+++ b/src/components/HistoryTable/Cell.tsx
@@ -37,10 +37,13 @@ const Circle = styled.div`
 const Cell = styled.div`
   display: flex;
   height: 100%;
-  width: 140px;
+  width: 150px;
+  margin: 0 5px;
   justify-content: center;
   align-items: center;
-  :hover {
-    cursor: pointer;
-  }
+`;
+
+export const HeaderCell = styled(Cell)`
+  word-wrap: anywhere;
+  text-align: center;
 `;

--- a/src/components/HistoryTable/HistoryTableContext.test.tsx
+++ b/src/components/HistoryTable/HistoryTableContext.test.tsx
@@ -172,51 +172,49 @@ describe("HistoryTableContext", () => {
       "enterprise-debian92-64",
       "enterprise-rhel-70-64-bit",
       "enterprise-rhel-72-s390x",
-      "enterprise-rhel-72-s390x-all-feature-flags",
-      "enterprise-rhel-72-s390x-inmem",
     ];
-    test("Should load in a set of columns and only display the first 8", () => {
+    test("Should load in a set of columns and only display the first 7", () => {
       const { result } = renderHook(() => useHistoryTable(), { wrapper });
       act(() => {
         result.current.addColumns(columns);
       });
-      expect(result.current.visibleColumns.length).toEqual(8);
-      expect(result.current.visibleColumns).toEqual(columns.slice(0, 8));
+      expect(result.current.visibleColumns.length).toEqual(7);
+      expect(result.current.visibleColumns).toEqual(columns.slice(0, 7));
     });
     test("Should be able to paginate forward on visible columns", () => {
       const { result } = renderHook(() => useHistoryTable(), { wrapper });
       act(() => {
         result.current.addColumns(columns);
       });
-      expect(result.current.visibleColumns.length).toEqual(8);
-      expect(result.current.visibleColumns).toEqual(columns.slice(0, 8));
+      expect(result.current.visibleColumns.length).toEqual(7);
+      expect(result.current.visibleColumns).toEqual(columns.slice(0, 7));
       act(() => {
         result.current.nextPage();
       });
-      // expect(result.current.visibleColumns.length).toEqual(8);
-      expect(result.current.visibleColumns).toEqual(columns.slice(8, 16));
+      expect(result.current.visibleColumns.length).toEqual(7);
+      expect(result.current.visibleColumns).toEqual(columns.slice(7, 14));
     });
     test("Should be able to paginate backwards on visible columns", () => {
       const { result } = renderHook(() => useHistoryTable(), { wrapper });
       act(() => {
         result.current.addColumns(columns);
       });
-      expect(result.current.visibleColumns.length).toEqual(8);
-      expect(result.current.visibleColumns).toEqual(columns.slice(0, 8));
+      expect(result.current.visibleColumns.length).toEqual(7);
+      expect(result.current.visibleColumns).toEqual(columns.slice(0, 7));
       expect(result.current.hasNextPage).toBeTruthy();
       expect(result.current.hasPreviousPage).toBeFalsy();
       act(() => {
         result.current.nextPage();
       });
       expect(result.current.hasPreviousPage).toBeTruthy();
-      expect(result.current.visibleColumns.length).toEqual(8);
-      expect(result.current.visibleColumns).toEqual(columns.slice(8, 16));
+      expect(result.current.visibleColumns.length).toEqual(7);
+      expect(result.current.visibleColumns).toEqual(columns.slice(7, 14));
       act(() => {
         result.current.previousPage();
       });
       expect(result.current.hasPreviousPage).toBeFalsy();
-      expect(result.current.visibleColumns.length).toEqual(8);
-      expect(result.current.visibleColumns).toEqual(columns.slice(0, 8));
+      expect(result.current.visibleColumns.length).toEqual(7);
+      expect(result.current.visibleColumns).toEqual(columns.slice(0, 7));
     });
     test("Should not be able to paginate backwards on non existant pages", () => {
       const { result } = renderHook(() => useHistoryTable(), { wrapper });
@@ -224,13 +222,13 @@ describe("HistoryTableContext", () => {
         result.current.addColumns(columns);
       });
       expect(result.current.hasPreviousPage).toBeFalsy();
-      expect(result.current.visibleColumns.length).toEqual(8);
-      expect(result.current.visibleColumns).toEqual(columns.slice(0, 8));
+      expect(result.current.visibleColumns.length).toEqual(7);
+      expect(result.current.visibleColumns).toEqual(columns.slice(0, 7));
       act(() => {
         result.current.previousPage();
       });
-      expect(result.current.visibleColumns.length).toEqual(8);
-      expect(result.current.visibleColumns).toEqual(columns.slice(0, 8));
+      expect(result.current.visibleColumns.length).toEqual(7);
+      expect(result.current.visibleColumns).toEqual(columns.slice(0, 7));
     });
   });
 });

--- a/src/components/HistoryTable/HistoryTableContext.test.tsx
+++ b/src/components/HistoryTable/HistoryTableContext.test.tsx
@@ -24,6 +24,7 @@ describe("HistoryTableContext", () => {
       previousPage: expect.any(Function),
       currentPage: 0,
       pageCount: 0,
+      columnLimit: 7,
     });
   });
   test("Should process new commits when they are passed in", () => {

--- a/src/components/HistoryTable/HistoryTableContext.tsx
+++ b/src/components/HistoryTable/HistoryTableContext.tsx
@@ -17,6 +17,7 @@ interface HistoryTableState {
   hasPreviousPage: boolean;
   pageCount: number;
   currentPage: number;
+  columnLimit: number;
 }
 
 const HistoryTableDispatchContext = createContext<any | null>(null);
@@ -29,6 +30,7 @@ const HistoryTableProvider: React.FC = ({ children }) => {
       visibleColumns,
       pageCount,
       currentPage,
+      columnLimit,
     },
     dispatch,
   ] = useReducer(reducer, {
@@ -80,6 +82,7 @@ const HistoryTableProvider: React.FC = ({ children }) => {
       hasPreviousPage: currentPage > 0,
       currentPage,
       pageCount,
+      columnLimit,
     }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [processedCommits, visibleColumns, processedCommitCount]

--- a/src/components/HistoryTable/HistoryTableContext.tsx
+++ b/src/components/HistoryTable/HistoryTableContext.tsx
@@ -40,7 +40,7 @@ const HistoryTableProvider: React.FC = ({ children }) => {
     currentPage: 0,
     pageCount: 0,
     columns: [],
-    columnLimit: 8,
+    columnLimit: 7,
   });
 
   const itemHeight = (index: number) => {

--- a/src/pages/taskHistory/ColumnHeaders.tsx
+++ b/src/pages/taskHistory/ColumnHeaders.tsx
@@ -13,7 +13,7 @@ interface ColumnHeadersProps {
   loading: boolean;
 }
 const ColumnHeaders: React.FC<ColumnHeadersProps> = ({ columns, loading }) => {
-  const { visibleColumns, addColumns } = useHistoryTable();
+  const { visibleColumns, addColumns, columnLimit } = useHistoryTable();
   useEffect(() => {
     if (columns) {
       addColumns(columns.map((c) => c.buildVariant));
@@ -36,7 +36,7 @@ const ColumnHeaders: React.FC<ColumnHeadersProps> = ({ columns, loading }) => {
         );
       })}
       {loading &&
-        Array.from(Array(8)).map((i) => (
+        Array.from(Array(columnLimit)).map((i) => (
           <HeaderCell key={`loading_cell_${i}`}>Loading...</HeaderCell>
         ))}
     </RowContainer>

--- a/src/pages/taskHistory/ColumnHeaders.tsx
+++ b/src/pages/taskHistory/ColumnHeaders.tsx
@@ -1,8 +1,9 @@
 import { useEffect } from "react";
 import styled from "@emotion/styled";
-import { context } from "components/HistoryTable";
+import { context, Cell } from "components/HistoryTable";
 
 const { useHistoryTable } = context;
+const { HeaderCell } = Cell;
 
 interface ColumnHeadersProps {
   columns: {
@@ -29,14 +30,14 @@ const ColumnHeaders: React.FC<ColumnHeadersProps> = ({ columns, loading }) => {
           return null;
         }
         return (
-          <Cell key={`header_cell_${cell.buildVariant}`}>
+          <HeaderCell key={`header_cell_${cell.buildVariant}`}>
             {cell.displayName}
-          </Cell>
+          </HeaderCell>
         );
       })}
       {loading &&
         Array.from(Array(8)).map((i) => (
-          <Cell key={`loading_cell_${i}`}>Loading...</Cell>
+          <HeaderCell key={`loading_cell_${i}`}>Loading...</HeaderCell>
         ))}
     </RowContainer>
   );
@@ -51,14 +52,6 @@ const LabelCellContainer = styled.div`
 const RowContainer = styled.div`
   display: flex;
   flex-direction: row;
-`;
-
-const Cell = styled.div`
-  display: flex;
-  height: 100%;
-  width: 140px;
-  justify-content: center;
-  align-items: center;
 `;
 
 export default ColumnHeaders;

--- a/src/pages/variantHistory/ColumnHeaders.tsx
+++ b/src/pages/variantHistory/ColumnHeaders.tsx
@@ -1,8 +1,10 @@
 import { useEffect } from "react";
 import styled from "@emotion/styled";
-import { context } from "components/HistoryTable";
+import { context, Cell } from "components/HistoryTable";
 
 const { useHistoryTable } = context;
+const { HeaderCell } = Cell;
+
 interface ColumnHeadersProps {
   columns: string[];
   loading: boolean;
@@ -24,11 +26,11 @@ const ColumnHeaders: React.FC<ColumnHeadersProps> = ({ columns, loading }) => {
         if (!cell) {
           return null;
         }
-        return <Cell key={`header_cell_${cell}`}>{cell}</Cell>;
+        return <HeaderCell key={`header_cell_${cell}`}>{cell}</HeaderCell>;
       })}
       {loading &&
         Array.from(Array(8)).map((i) => (
-          <Cell key={`loading_cell_${i}`}>Loading...</Cell>
+          <HeaderCell key={`loading_cell_${i}`}>Loading...</HeaderCell>
         ))}
     </RowContainer>
   );
@@ -43,15 +45,6 @@ const LabelCellContainer = styled.div`
 const RowContainer = styled.div`
   display: flex;
   flex-direction: row;
-`;
-
-const Cell = styled.div`
-  display: flex;
-  height: 100%;
-  width: 140px;
-  justify-content: center;
-  align-items: center;
-  text-overflow: ellipsis;
 `;
 
 export default ColumnHeaders;

--- a/src/pages/variantHistory/ColumnHeaders.tsx
+++ b/src/pages/variantHistory/ColumnHeaders.tsx
@@ -10,7 +10,7 @@ interface ColumnHeadersProps {
   loading: boolean;
 }
 const ColumnHeaders: React.FC<ColumnHeadersProps> = ({ columns, loading }) => {
-  const { visibleColumns, addColumns } = useHistoryTable();
+  const { visibleColumns, addColumns, columnLimit } = useHistoryTable();
   useEffect(() => {
     if (columns) {
       addColumns(columns);
@@ -29,7 +29,7 @@ const ColumnHeaders: React.FC<ColumnHeadersProps> = ({ columns, loading }) => {
         return <HeaderCell key={`header_cell_${cell}`}>{cell}</HeaderCell>;
       })}
       {loading &&
-        Array.from(Array(8)).map((i) => (
+        Array.from(Array(columnLimit)).map((i) => (
           <HeaderCell key={`loading_cell_${i}`}>Loading...</HeaderCell>
         ))}
     </RowContainer>


### PR DESCRIPTION
[EVG-15759](https://jira.mongodb.org/browse/EVG-15759)

### Description 
Limits to 7 columns and adds some padding in between columns as well as word breaking. 

### Screenshots
Before: 
![image](https://user-images.githubusercontent.com/4605522/139927290-9689b44b-6c8a-478e-aba8-00c1f5c2064c.png)

After:
![image](https://user-images.githubusercontent.com/4605522/139927247-d0b36cf3-1f28-4381-8504-d1d8226c5cc3.png)

