### PR TITLE
EVG-14764 Add loading state to Tests table

### DIFF
--- a/src/pages/task/taskTabs/TestsTable.tsx
+++ b/src/pages/task/taskTabs/TestsTable.tsx
@@ -108,8 +108,7 @@ export const TestsTable: React.FC = () => {
     }),
   }));
 
-  // initial request for task tests
-  const { data, startPolling, stopPolling } = useQuery<
+  const { loading, data, startPolling, stopPolling } = useQuery<
     TaskTestsQuery,
     TaskTestsQueryVariables
   >(GET_TASK_TESTS, {
@@ -174,6 +173,7 @@ export const TestsTable: React.FC = () => {
           dataSource={testResults}
           getPopupContainer={(trigger: HTMLElement) => trigger}
           onChange={tableChangeHandler}
+          loading={loading}
         />
       </TableContainer>
     </>

--- a/src/pages/task/taskTabs/TestsTable.tsx
+++ b/src/pages/task/taskTabs/TestsTable.tsx
@@ -108,7 +108,7 @@ export const TestsTable: React.FC = () => {
     }),
   }));
 
-  const { loading, data, startPolling, stopPolling } = useQuery<
+  const { data, loading, startPolling, stopPolling } = useQuery<
     TaskTestsQuery,
     TaskTestsQueryVariables
   >(GET_TASK_TESTS, {


### PR DESCRIPTION
[EVG-14764](https://jira.mongodb.org/browse/EVG-14764)

### Description 
Currently, it is unclear that tests exist for some tasks because "No Data" is displayed while the tests are loading. This PR adds a loading state to the Tests table to inform the user if tests are still loading.

### Screenshots
https://user-images.githubusercontent.com/47064971/140333575-6dd2f3ad-bbcd-49db-a663-b84ab77f4958.mov

### Testing 
- Tested with a patch on `yarn prod` 
