### PR TITLE
EVG-15816: waterfall page links to build variant history

### DIFF
--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -208,3 +208,8 @@ export const getCommitQueueRoute = (projectId: string) =>
 
 export const getCommitsRoute = (projectId: string) =>
   `${paths.commits}/${projectId}`;
+
+export const getVariantHistoryRoute = (
+  projectId: string,
+  variantName: string
+) => `${paths.variantHistory}/${projectId}/${variantName}`;

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -89,6 +89,7 @@ export type QueryPatchTasksArgs = {
   baseStatuses?: Maybe<Array<Scalars["String"]>>;
   variant?: Maybe<Scalars["String"]>;
   taskName?: Maybe<Scalars["String"]>;
+  includeEmptyActivation?: Maybe<Scalars["Boolean"]>;
 };
 
 export type QueryTaskTestsArgs = {
@@ -1257,6 +1258,7 @@ export type Task = {
   annotation?: Maybe<Annotation>;
   baseTask?: Maybe<Task>;
   baseStatus?: Maybe<Scalars["String"]>;
+  /** @deprecated baseTaskMetadata is deprecated. Use baseTask instead */
   baseTaskMetadata?: Maybe<BaseTaskMetadata>;
   blocked: Scalars["Boolean"];
   buildId: Scalars["String"];
@@ -1734,6 +1736,7 @@ export type JiraConfig = {
 
 export type UiConfig = {
   userVoice?: Maybe<Scalars["String"]>;
+  defaultProject: Scalars["String"];
 };
 
 export type CloudProviderConfig = {
@@ -2872,6 +2875,7 @@ export type MainlineCommitsQuery = {
     prevPageOrderNumber?: Maybe<number>;
     versions: Array<{
       version?: Maybe<{
+        projectIdentifier: string;
         id: string;
         author: string;
         createTime: Date;

--- a/src/gql/queries/get-mainline-commits.graphql
+++ b/src/gql/queries/get-mainline-commits.graphql
@@ -9,6 +9,7 @@ query MainlineCommits(
   ) {
     versions {
       version {
+        projectIdentifier
         id
         author
         createTime

--- a/src/pages/commits/ActiveCommits/BuildVariantCard.tsx
+++ b/src/pages/commits/ActiveCommits/BuildVariantCard.tsx
@@ -1,14 +1,12 @@
 import styled from "@emotion/styled";
-import { uiColors } from "@leafygreen-ui/palette";
-import { Body } from "@leafygreen-ui/typography";
 import { GroupedTaskStatusBadge } from "components/GroupedTaskStatusBadge";
+import { StyledRouterLink } from "components/styles";
+import { getVariantHistoryRoute } from "constants/routes";
 import {
   groupStatusesByUmbrellaStatus,
   isFailedTaskStatus,
 } from "utils/statuses";
 import { WaterfallTaskStatusIcon } from "./buildVariantCard/WaterfallTaskStatusIcon";
-
-const { gray } = uiColors;
 
 type taskList = {
   id: string;
@@ -22,6 +20,7 @@ interface Props {
   tasks?: taskList;
   shouldGroupTasks: boolean;
   versionId: string;
+  projectIdentifier: string;
 }
 export const BuildVariantCard: React.FC<Props> = ({
   buildVariantDisplayName,
@@ -29,6 +28,7 @@ export const BuildVariantCard: React.FC<Props> = ({
   tasks,
   shouldGroupTasks,
   versionId,
+  projectIdentifier,
 }) => {
   let render = null;
   if (shouldGroupTasks) {
@@ -40,30 +40,22 @@ export const BuildVariantCard: React.FC<Props> = ({
     );
     render = (
       <>
-        <IconContainer>
-          <RenderGroupedIcons
-            tasks={nonFailingTasks}
-            versionId={versionId}
-            variant={variant}
-          />
-        </IconContainer>
-        <IconContainer>
-          <RenderTaskIcons tasks={failingTasks} />
-        </IconContainer>
+        <RenderGroupedIcons
+          tasks={nonFailingTasks}
+          versionId={versionId}
+          variant={variant}
+        />
+        <RenderTaskIcons tasks={failingTasks} />
       </>
     );
   } else {
-    render = (
-      <>
-        <IconContainer>
-          <RenderTaskIcons tasks={tasks} />
-        </IconContainer>
-      </>
-    );
+    render = <RenderTaskIcons tasks={tasks} />;
   }
   return (
     <Container>
-      <Label>{buildVariantDisplayName}</Label>
+      <Label to={getVariantHistoryRoute(projectIdentifier, variant)}>
+        {buildVariantDisplayName}
+      </Label>
       {render}
     </Container>
   );
@@ -86,8 +78,11 @@ const RenderGroupedIcons: React.FC<RenderGroupedIconsProps> = ({
   const { stats } = groupStatusesByUmbrellaStatus(
     tasks.map(({ status }) => ({ status, count: 1 }))
   );
+  if (!stats.length) {
+    return null;
+  }
   return (
-    <>
+    <IconContainer>
       {stats.map(({ count, umbrellaStatus, statusCounts }) => (
         <GroupedTaskStatusBadgeWrapper
           key={umbrellaStatus}
@@ -102,7 +97,7 @@ const RenderGroupedIcons: React.FC<RenderGroupedIconsProps> = ({
           />
         </GroupedTaskStatusBadgeWrapper>
       ))}
-    </>
+    </IconContainer>
   );
 };
 
@@ -110,35 +105,36 @@ interface RenderTaskIconsProps {
   tasks: taskList;
 }
 
-const RenderTaskIcons: React.FC<RenderTaskIconsProps> = ({ tasks }) => (
-  <>
-    {tasks.map(({ id, status, displayName, timeTaken }) => (
-      <WaterfallTaskStatusIcon
-        key={id}
-        taskId={id}
-        status={status}
-        displayName={displayName}
-        timeTaken={timeTaken}
-      />
-    ))}
-  </>
-);
-const Label = styled(Body)`
-  color: ${gray.dark2};
-  font-size: 14px;
+const RenderTaskIcons: React.FC<RenderTaskIconsProps> = ({ tasks }) =>
+  tasks.length ? (
+    <IconContainer>
+      {tasks.map(({ id, status, displayName, timeTaken }) => (
+        <WaterfallTaskStatusIcon
+          key={id}
+          taskId={id}
+          status={status}
+          displayName={displayName}
+          timeTaken={timeTaken}
+        />
+      ))}
+    </IconContainer>
+  ) : null;
+
+const Label = styled(StyledRouterLink)`
   word-break: break-word;
-  margin-bottom: 24px;
 `;
 
 const IconContainer = styled.div`
   display: flex;
   flex-direction: row;
-  margin-bottom: 16px;
+  margin-bottom: 8px;
+  margin-top: 8px;
   flex-wrap: wrap;
 `;
 
 const Container = styled.div`
   width: 160px;
+  margin-bottom: 16px;
 `;
 
 const GroupedTaskStatusBadgeWrapper = styled.div`

--- a/src/pages/commits/ActiveCommits/CommitChart.stories.tsx
+++ b/src/pages/commits/ActiveCommits/CommitChart.stories.tsx
@@ -43,6 +43,7 @@ export const PercentChart = () => (
 const versions: MainlineCommitsQuery["mainlineCommits"]["versions"] = [
   {
     version: {
+      projectIdentifier: "spruce",
       id: "123",
       createTime: new Date("2021-06-16T23:38:13Z"),
       message: "SERVER-57332 Create skeleton InternalDocumentSourceDensify",
@@ -61,6 +62,7 @@ const versions: MainlineCommitsQuery["mainlineCommits"]["versions"] = [
   },
   {
     version: {
+      projectIdentifier: "spruce",
       id: "12",
       createTime: new Date("2021-06-16T23:38:13Z"),
       message: "SERVER-57333 Some complicated server commit",
@@ -78,6 +80,7 @@ const versions: MainlineCommitsQuery["mainlineCommits"]["versions"] = [
   },
   {
     version: {
+      projectIdentifier: "spruce",
       id: "13",
       createTime: new Date("2021-06-16T23:38:13Z"),
       message: "SERVER-57332 Create skeleton InternalDocumentSourceDensify",
@@ -95,6 +98,7 @@ const versions: MainlineCommitsQuery["mainlineCommits"]["versions"] = [
   },
   {
     version: {
+      projectIdentifier: "spruce",
       id: "14",
       createTime: new Date("2021-06-16T23:38:13Z"),
       message: "SERVER-57333 Some complicated server commit",
@@ -112,6 +116,7 @@ const versions: MainlineCommitsQuery["mainlineCommits"]["versions"] = [
   },
   {
     version: {
+      projectIdentifier: "spruce",
       id: "15",
       createTime: new Date("2021-06-16T23:38:13Z"),
       message: "SERVER-57332 Create skeleton InternalDocumentSourceDensify",
@@ -129,6 +134,7 @@ const versions: MainlineCommitsQuery["mainlineCommits"]["versions"] = [
   },
   {
     version: {
+      projectIdentifier: "spruce",
       id: "16",
       createTime: new Date("2021-06-16T23:38:13Z"),
       message: "SERVER-57333 Some complicated server commit",
@@ -147,6 +153,7 @@ const versions: MainlineCommitsQuery["mainlineCommits"]["versions"] = [
   },
   {
     version: {
+      projectIdentifier: "spruce",
       id: "17",
       createTime: new Date("2021-06-16T23:38:13Z"),
       message: "SERVER-57333 Some complicated server commit",

--- a/src/pages/commits/ActiveCommits/index.tsx
+++ b/src/pages/commits/ActiveCommits/index.tsx
@@ -48,6 +48,7 @@ export const ActiveCommit: React.FC<Props> = ({
           tasks={tasks}
           key={`${version.id}_${variant}`}
           shouldGroupTasks={!hasTaskFilter}
+          projectIdentifier={version.projectIdentifier}
         />
       ))}
     </ColumnContainer>


### PR DESCRIPTION
[EVG-15816](https://jira.mongodb.org/browse/EVG-15816)

### Description 
These changes were cherry-picked from https://github.com/evergreen-ci/spruce/pull/966 with some styling improvements. 

### Screenshots
![Screen Shot 2021-11-09 at 12 17 51 PM](https://user-images.githubusercontent.com/10734386/140973538-1a98ef8c-1d7d-486f-b448-541826283cf0.png)


### Testing 
  < add a description of how you tested it >

### Evergreen PR 
  < link to a corresponding evergreen PR if applicable >
