### PR TITLE
EVG-15825: Fix e2e_test task

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -348,9 +348,6 @@ tasks:
   - name: e2e_test
     commands:
     - func: get-evergreen-project
-    - func: run-make
-      vars:
-        target: get-go-imports
     - func: setup-mongodb
     - func: copy-cmdrc
     - func: run-make-background


### PR DESCRIPTION
EVG-15285

### Description 
- Remove call to `get-go-modules`. We don't need to explicitly call `mod-tidy` because installing the modules will be triggered by running the server via `make local-evergreen` (as per @Kimchelly)