### PR TITLE
EVG-15826: update evergreen YAML for Go module changes

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -8,7 +8,6 @@ modules:
 - name: evergreen
   repo: git@github.com:evergreen-ci/evergreen.git
   branch: main
-  prefix: build
 
 #######################################
 #              Functions              #
@@ -36,29 +35,29 @@ functions:
           gobin: /opt/golang/go1.16/bin/go
           MONGODB_URL: ${mongodb_url}
           DECOMPRESS: ${decompress}
-        working_dir: spruce/build/evergreen
+        working_dir: spruce/evergreen
         command: make get-mongodb
     - command: subprocess.exec
       type: setup
       params:
         background: true
-        working_dir: spruce/build/evergreen
+        working_dir: spruce/evergreen
         command: make start-mongod
     - command: subprocess.exec
       type: setup
       params:
-        working_dir: spruce/build/evergreen
+        working_dir: spruce/evergreen
         command: make check-mongod
     - command: subprocess.exec
       type: setup
       params:
-        working_dir: spruce/build/evergreen
+        working_dir: spruce/evergreen
         command: make init-rs
 
   run-make:
     command: subprocess.exec
     params:
-      working_dir: spruce/build/evergreen
+      working_dir: spruce/evergreen
       binary: make
       args: ["${make_args|}", "${target}"]
       background: false
@@ -68,7 +67,7 @@ functions:
   run-make-background:
     command: subprocess.exec
     params:
-      working_dir: spruce/build/evergreen
+      working_dir: spruce/evergreen
       binary: make
       args: ["${make_args|}", "${target}"]
       background: true
@@ -81,7 +80,7 @@ functions:
     params:
       working_dir: spruce
       script: |
-        ln -s build/evergreen/graphql/schema.graphql sdlschema.graphql
+        ln -s evergreen/graphql/schema.graphql sdlschema.graphql
 
   yarn-start:
     command: shell.exec
@@ -216,7 +215,7 @@ functions:
       aws_key: ${aws_key}
       aws_secret: ${aws_secret}
       local_files_include_filter:
-        ["build/evergreen/server_logs.txt"]
+        ["evergreen/server_logs.txt"]
       remote_file: spruce/${task_id}/
       bucket: mciuploads
       content_type: text/plain

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -344,9 +344,6 @@ tasks:
   - name: e2e_test
     commands:
     - func: get-evergreen-project
-    - func: run-make
-      vars:
-        target: get-go-imports
     - func: setup-mongodb
     - func: copy-cmdrc
     - func: run-make-background

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -8,7 +8,7 @@ modules:
 - name: evergreen
   repo: git@github.com:evergreen-ci/evergreen.git
   branch: main
-  prefix: gopath/src/github.com/evergreen-ci
+  prefix: build
 
 #######################################
 #              Functions              #
@@ -33,51 +33,47 @@ functions:
       type: setup
       params:
         env:
-          gobin: /opt/golang/go1.9/bin/go
+          gobin: /opt/golang/go1.16/bin/go
           MONGODB_URL: ${mongodb_url}
           DECOMPRESS: ${decompress}
-        working_dir: spruce/gopath/src/github.com/evergreen-ci/evergreen
+        working_dir: spruce/build/evergreen
         command: make get-mongodb
     - command: subprocess.exec
       type: setup
       params:
         background: true
-        working_dir: spruce/gopath/src/github.com/evergreen-ci/evergreen
+        working_dir: spruce/build/evergreen
         command: make start-mongod
     - command: subprocess.exec
       type: setup
       params:
-        working_dir: spruce/gopath/src/github.com/evergreen-ci/evergreen
+        working_dir: spruce/build/evergreen
         command: make check-mongod
     - command: subprocess.exec
       type: setup
       params:
-        working_dir: spruce/gopath/src/github.com/evergreen-ci/evergreen
+        working_dir: spruce/build/evergreen
         command: make init-rs
 
   run-make:
     command: subprocess.exec
     params:
-      working_dir: spruce/gopath/src/github.com/evergreen-ci/evergreen
+      working_dir: spruce/build/evergreen
       binary: make
       args: ["${make_args|}", "${target}"]
       background: false
       env:
-        GOPATH: ${workdir}/spruce/gopath
-        GO_BIN_PATH: /opt/golang/go1.16/bin/go
         GOROOT: /opt/golang/go1.16
 
   run-make-background:
     command: subprocess.exec
     params:
-      working_dir: spruce/gopath/src/github.com/evergreen-ci/evergreen
+      working_dir: spruce/build/evergreen
       binary: make
       args: ["${make_args|}", "${target}"]
       background: true
       env:
         SETTINGS_OVERRIDE: file
-        GOPATH: ${workdir}/spruce/gopath
-        GO_BIN_PATH: /opt/golang/go1.16/bin/go
         GOROOT: /opt/golang/go1.16
 
   sym-link:
@@ -85,7 +81,7 @@ functions:
     params:
       working_dir: spruce
       script: |
-        ln -s gopath/src/github.com/evergreen-ci/evergreen/graphql/schema.graphql sdlschema.graphql
+        ln -s build/evergreen/graphql/schema.graphql sdlschema.graphql
 
   yarn-start:
     command: shell.exec
@@ -220,7 +216,7 @@ functions:
       aws_key: ${aws_key}
       aws_secret: ${aws_secret}
       local_files_include_filter:
-        ["gopath/src/github.com/evergreen-ci/evergreen/server_logs.txt"]
+        ["build/evergreen/server_logs.txt"]
       remote_file: spruce/${task_id}/
       bucket: mciuploads
       content_type: text/plain

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Spruce is the React UI for MongoDB's continuous integration software.
 3. Run `yarn`
 4. Start a local evergreen server by doing the following:
 
-- Clone the evergreen repo into your go path
+- Clone the evergreen repo
 - Run `make local-evergreen`
 
 5. Run `yarn run dev`. This will launch the app and point it at the local evergreen server you just ran.


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15826

### Description 
Spruce has a dependency on how Evergreen builds its local server for CI testing, Since Evergreen uses modules, it's no longer tied to a `GOPATH`. I updated the evergreen YAML to reflect this. I put it in the `build` directory instead of `gopath/src/github.com/evergreen-ci`, but if you prefer it to be somewhere else, let me know. The location doesn't really matter that much.

* Clean up the usages of `GOPATH` (no longer necessary) and `GO_BIN_PATH` (no longer used for Evergreen Go builds).
* Update the README slightly since Evergreen no longer depends on `GOPATH`.

### Screenshots
N/A

### Testing 
N/A

### Evergreen PR 
N/A
