### PR TITLE
EVG-14680 Resolve incorrect display of TaskLogs between executions

### DIFF
--- a/src/gql/GQLWrapper.tsx
+++ b/src/gql/GQLWrapper.tsx
@@ -44,6 +44,9 @@ const cache = new InMemoryCache({
     User: {
       keyFields: ["userId"],
     },
+    TaskLogs: {
+      keyFields: ["execution", "taskId"],
+    },
     Task: {
       keyFields: ["execution", "id"],
       fields: {

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -2419,7 +2419,11 @@ export type AgentLogsQueryVariables = Exact<{
 }>;
 
 export type AgentLogsQuery = {
-  taskLogs: { agentLogs: Array<LogMessageFragment> };
+  taskLogs: {
+    execution: number;
+    taskId: string;
+    agentLogs: Array<LogMessageFragment>;
+  };
 };
 
 export type GetAnnotationEventDataQueryVariables = Exact<{
@@ -2660,6 +2664,8 @@ export type EventLogsQueryVariables = Exact<{
 
 export type EventLogsQuery = {
   taskLogs: {
+    execution: number;
+    taskId: string;
     eventLogs: Array<{
       timestamp?: Maybe<Date>;
       eventType?: Maybe<string>;
@@ -3150,7 +3156,11 @@ export type SystemLogsQueryVariables = Exact<{
 }>;
 
 export type SystemLogsQuery = {
-  taskLogs: { systemLogs: Array<LogMessageFragment> };
+  taskLogs: {
+    execution: number;
+    taskId: string;
+    systemLogs: Array<LogMessageFragment>;
+  };
 };
 
 export type GetTaskAllExecutionsQueryVariables = Exact<{
@@ -3188,7 +3198,11 @@ export type TaskLogsQueryVariables = Exact<{
 }>;
 
 export type TaskLogsQuery = {
-  taskLogs: { taskLogs: Array<LogMessageFragment> };
+  taskLogs: {
+    execution: number;
+    taskId: string;
+    taskLogs: Array<LogMessageFragment>;
+  };
 };
 
 export type GetTaskNamesForBuildVariantQueryVariables = Exact<{

--- a/src/gql/queries/get-agent-logs.graphql
+++ b/src/gql/queries/get-agent-logs.graphql
@@ -1,9 +1,11 @@
 #import "../fragments/logMessage.graphql"
 
 query AgentLogs($id: String!, $execution: Int) {
-taskLogs(taskId: $id, execution: $execution) {
+  taskLogs(taskId: $id, execution: $execution) {
+    execution
+    taskId
     agentLogs {
-    ...logMessage
+      ...logMessage
     }
-}
+  }
 }

--- a/src/gql/queries/get-event-logs.graphql
+++ b/src/gql/queries/get-event-logs.graphql
@@ -1,17 +1,19 @@
-  query EventLogs($id: String!, $execution: Int) {
-    taskLogs(taskId: $id, execution: $execution) {
-      eventLogs {
+query EventLogs($id: String!, $execution: Int) {
+  taskLogs(taskId: $id, execution: $execution) {
+    execution
+    taskId
+    eventLogs {
+      timestamp
+      eventType
+      data {
+        hostId
+        jiraIssue
+        jiraLink
+        priority
+        status
         timestamp
-        eventType
-        data {
-          hostId
-          jiraIssue
-          jiraLink
-          priority
-          status
-          timestamp
-          userId
-        }
+        userId
       }
     }
   }
+}

--- a/src/gql/queries/get-system-logs.graphql
+++ b/src/gql/queries/get-system-logs.graphql
@@ -1,9 +1,11 @@
 #import "../fragments/logMessage.graphql"
 
 query SystemLogs($id: String!, $execution: Int) {
-taskLogs(taskId: $id, execution: $execution) {
+  taskLogs(taskId: $id, execution: $execution) {
+    execution
+    taskId
     systemLogs {
-    ...logMessage
+      ...logMessage
     }
-}
+  }
 }

--- a/src/gql/queries/get-task-logs.graphql
+++ b/src/gql/queries/get-task-logs.graphql
@@ -2,6 +2,8 @@
 
 query TaskLogs($id: String!, $execution: Int) {
   taskLogs(taskId: $id, execution: $execution) {
+    execution
+    taskId
     taskLogs {
       ...logMessage
     }

--- a/src/pages/task/taskTabs/logs/LogTypes.tsx
+++ b/src/pages/task/taskTabs/logs/LogTypes.tsx
@@ -170,7 +170,7 @@ const useRenderBody: React.FC<{
 }) => {
   const taskAnalytics = useTaskAnalytics();
   const updateQueryParams = useUpdateURLQueryParams();
-  const noLogs = !!(error || !data.length);
+  const noLogs = !!((error && !data) || !data.length);
   const onChangeLog = (event: React.ChangeEvent<HTMLInputElement>): void => {
     const nextLogType = event.target.value as LogTypes;
     updateQueryParams({ [QueryParams.LogType]: nextLogType });


### PR DESCRIPTION
[EVG-14680](https://jira.mongodb.org/browse/EVG-14680)

### Description 
This is a very specific bug that seems to only occur in one situation.


When you restart a task, the execution for that task will show `No logs` (as the task has not run yet). Switching to another execution whose logs are _already in the cache_ will cause `No logs` to persist, which is not correct. However, this behavior will only persist for **one** execution. Here is an example:

https://user-images.githubusercontent.com/47064971/141480405-07e85eac-e76d-428b-84a6-584ff2835b7c.mov



The root cause appears to be that we determine a `noLogs` status based on if an error occurs. For some reason, switching to another execution whose logs are already in the cache will return both an error and the data that we want to display. This behavior is shown below:

https://user-images.githubusercontent.com/47064971/141481714-ccb277ce-9993-45c8-8c59-2326035d9ffd.mov

I don't believe an error should be returned if Apollo is just looking up the cache, so I can't explain why the error persists. Since returning `undefined` data and an error should be equivalent in this situation, this PR modifies how we determine the `noLogs` status.

### Screenshots
https://user-images.githubusercontent.com/47064971/141482156-d1853053-c8ac-4940-861a-58aad559a8f1.mov

### Testing 
- Tested manually with `yarn prod`
