### PR TITLE
EVG-15483 Fix new ui toggle not accurately reflecting status

### DIFF
--- a/src/pages/preferences/preferencesTabs/NewUITab.tsx
+++ b/src/pages/preferences/preferencesTabs/NewUITab.tsx
@@ -1,4 +1,3 @@
-import React, { useState } from "react";
 import { useMutation } from "@apollo/client";
 import styled from "@emotion/styled";
 import Card from "@leafygreen-ui/card";
@@ -18,7 +17,6 @@ export const NewUITab: React.FC = () => {
   const { data, loadingComp } = useUserSettingsQuery();
   const { spruceV1, hasUsedSpruceBefore } =
     data?.userSettings?.useSpruceOptions ?? {};
-  const [checked, setChecked] = useState(spruceV1);
   const dispatchToast = useToastContext();
   const [updateUserSettings, { loading: updateLoading }] = useMutation<
     UpdateUserSettingsMutation,
@@ -36,25 +34,21 @@ export const NewUITab: React.FC = () => {
     return loadingComp;
   }
 
-  const handleToggle = async (c, e): Promise<void> => {
-    e.preventDefault();
-    setChecked(c);
+  const handleToggle = async (c: boolean) => {
     sendEvent({
       name: c ? "Opt into Spruce" : "Opt out of Spruce",
     });
-    try {
-      await updateUserSettings({
-        variables: {
-          userSettings: {
-            useSpruceOptions: {
-              spruceV1: c,
-              hasUsedSpruceBefore,
-            },
+    updateUserSettings({
+      variables: {
+        userSettings: {
+          useSpruceOptions: {
+            spruceV1: c,
+            hasUsedSpruceBefore,
           },
         },
-        refetchQueries: ["GetUserSettings"],
-      });
-    } catch (err) {}
+      },
+      refetchQueries: ["GetUserSettings"],
+    });
   };
   return (
     <>
@@ -65,7 +59,7 @@ export const NewUITab: React.FC = () => {
           (e.g. from the CLI, GitHub, etc.)
         </PaddedBody>
         <Toggle
-          checked={checked}
+          checked={spruceV1}
           disabled={updateLoading}
           onChange={handleToggle}
           aria-label="Toggle new evergreen ui"


### PR DESCRIPTION
[EVG-15843](https://jira.mongodb.org/browse/EVG-15483)

### Description 
The new ui toggle would sometimes become out of sync with the data returned in the user settings queries and wouldn't accurately reflect changes to the data. 
Its state was managed independently of the response from the query, Which caused the discrepancies. But now its state will reflect the data requested.

