### PR TITLE
EVG-15838: Shorten githash to 7 characters

### DIFF
--- a/src/components/Breadcrumb/index.tsx
+++ b/src/components/Breadcrumb/index.tsx
@@ -7,6 +7,7 @@ import { StyledRouterLink } from "components/styles";
 import { H3, P1 } from "components/Typography";
 import { getVersionRoute, getProjectPatchesRoute } from "constants/routes";
 import { useGetUserPatchesPageTitleAndLink } from "hooks";
+import { shortenGithash } from "utils/string";
 
 const { blue } = uiColors;
 
@@ -136,9 +137,7 @@ const VersionBreadcrumb: React.FC<VersionBreadcrumbProps> = ({
 }) => {
   const { project, revision, id } = versionMetadata;
   // We need to case on revision since periodic builds do not have a revision
-  const breadcrumbText = revision.length
-    ? revision.substring(0, 7)
-    : id.substring(0, 7);
+  const breadcrumbText = shortenGithash(revision.length ? revision : id);
   return (
     <>
       <Breadcrumb.Item>

--- a/src/components/CommitChartLabel/CommitChartLabel.test.tsx
+++ b/src/components/CommitChartLabel/CommitChartLabel.test.tsx
@@ -2,13 +2,14 @@ import { MockedProvider } from "@apollo/client/testing";
 import userEvent from "@testing-library/user-event";
 import { getSpruceConfigMock } from "gql/mocks/getSpruceConfig";
 import { renderWithRouterMatch, waitFor } from "test_utils/test-utils";
+import { shortenGithash } from "utils/string";
 import CommitChartLabel from ".";
 
 const RenderCommitChartLabel = (version) => () => (
   <MockedProvider mocks={[getSpruceConfigMock]}>
     <CommitChartLabel
       versionId={version.id}
-      githash={version.revision.substring(0, 5)}
+      githash={shortenGithash(version.revision)}
       createTime={version.createTime}
       author={version.author}
       message={version.message}
@@ -22,7 +23,7 @@ describe("commitChartLabel", () => {
       RenderCommitChartLabel(versionShort)
     );
     expect(queryByDataCy("commit-label")).toHaveTextContent(
-      "4137c 6/16/21 11:38 PMMohamed Khelif"
+      "4137c33 6/16/21 11:38 PMMohamed Khelif"
     );
   });
 
@@ -30,7 +31,7 @@ describe("commitChartLabel", () => {
     const { queryByText } = renderWithRouterMatch(
       RenderCommitChartLabel(versionShort)
     );
-    expect(queryByText("4137c").closest("a")).toHaveAttribute(
+    expect(queryByText("4137c33").closest("a")).toHaveAttribute(
       "href",
       "/version/123/tasks"
     );
@@ -54,7 +55,7 @@ describe("commitChartLabel", () => {
     );
     expect(queryByText("more")).toBeInTheDocument();
     expect(queryByDataCy("commit-label")).toHaveTextContent(
-      "4137c 6/16/21 11:38 PMMohamed Khelif -SERVER-57332 Create skeleton Internal...more"
+      "4137c33 6/16/21 11:38 PMMohamed Khelif -SERVER-57332 Create skeleton Internal...more"
     );
   });
 

--- a/src/components/CommitChartLabel/index.tsx
+++ b/src/components/CommitChartLabel/index.tsx
@@ -11,6 +11,7 @@ import {
 } from "gql/generated/types";
 import { GET_SPRUCE_CONFIG } from "gql/queries";
 import { string } from "utils";
+import { shortenGithash } from "utils/string";
 import { jiraLinkify } from "utils/string/jiraLinkify";
 
 const { gray } = uiColors;
@@ -44,7 +45,7 @@ const CommitChartLabel: React.FC<Props> = ({
     <LabelContainer data-cy="commit-label">
       <LabelText>
         <StyledRouterLink to={getVersionRoute(versionId)}>
-          {githash.substring(0, 6)}
+          {shortenGithash(githash)}
         </StyledRouterLink>{" "}
         {shortDate(createDate)}
       </LabelText>

--- a/src/pages/Version.tsx
+++ b/src/pages/Version.tsx
@@ -32,7 +32,8 @@ import {
 } from "gql/queries";
 import { usePageTitle, useNetworkStatus } from "hooks";
 import { PageDoesNotExist } from "pages/404";
-import { githubPRLinkify } from "utils/string";
+import { shortenGithash, githubPRLinkify } from "utils/string";
+
 import { jiraLinkify } from "utils/string/jiraLinkify";
 import { BuildVariants } from "./version/BuildVariants";
 import { ActionButtons } from "./version/index";
@@ -144,9 +145,7 @@ export const VersionPage: React.FC = () => {
   const isPatchOnCommitQueue = commitQueuePosition !== null;
 
   // If a revision exists
-  const versionText = revision?.length
-    ? revision?.substring(0, 7)
-    : id.substring(0, 7);
+  const versionText = shortenGithash(revision?.length ? revision : id);
   const title = isPatch ? `Patch - ${patchNumber}` : `Version - ${versionText}`;
   usePageTitle(title);
 

--- a/src/pages/commits/ActiveCommits/index.tsx
+++ b/src/pages/commits/ActiveCommits/index.tsx
@@ -3,6 +3,7 @@ import styled from "@emotion/styled";
 import CommitChartLabel from "components/CommitChartLabel";
 import { MainlineCommitsQuery } from "gql/generated/types";
 import { ChartTypes } from "types/commits";
+import { shortenGithash } from "utils/string";
 import { BuildVariantCard } from "./BuildVariantCard";
 import { CommitChart } from "./CommitChart";
 import { ColorCount } from "./utils";
@@ -34,7 +35,7 @@ export const ActiveCommit: React.FC<Props> = ({
       />
       <CommitChartLabel
         versionId={version.id}
-        githash={version.revision.substring(0, 5)}
+        githash={shortenGithash(version.revision)}
         createTime={version.createTime}
         author={version.author}
         message={version.message}

--- a/src/pages/spawn/spawnHost/spawnHostModal/SetupScriptForm.tsx
+++ b/src/pages/spawn/spawnHost/spawnHostModal/SetupScriptForm.tsx
@@ -10,6 +10,7 @@ import {
 } from "gql/generated/types";
 import { GET_SPAWN_TASK } from "gql/queries";
 import { queryString } from "utils";
+import { shortenGithash } from "utils/string";
 import { Action as SpawnHostModalAction } from "./useSpawnHostModalState";
 
 const { getString, parseQueryString } = queryString;
@@ -96,7 +97,7 @@ export const SetupScriptForm: React.FC<SetupScriptFormProps> = ({
             label={
               <>
                 Load data for <b>{displayName}</b> on <b>{buildVariant}</b> @{" "}
-                <b>{revision.substring(0, 5)}</b> onto host at startup
+                <b>{shortenGithash(revision)}</b> onto host at startup
               </>
             }
             data-cy="parent-checkbox"

--- a/src/utils/string/index.ts
+++ b/src/utils/string/index.ts
@@ -161,3 +161,9 @@ export const sortFunctionDate = (a, b, key) => {
  * @return {string} A regex that strictly matches on the input.
  */
 export const applyStrictRegex = (str: string) => `^${str}$`;
+
+/**
+ * @param str - A string that represents a githash
+ * @return {string} A shortenend version of the input string.
+ */
+export const shortenGithash = (str: string) => str.substring(0, 7);

--- a/src/utils/string/index.ts
+++ b/src/utils/string/index.ts
@@ -166,4 +166,4 @@ export const applyStrictRegex = (str: string) => `^${str}$`;
  * @param str - A string that represents a githash
  * @return {string} A shortenend version of the input string.
  */
-export const shortenGithash = (str: string) => str.substring(0, 7);
+export const shortenGithash = (str: string) => str?.substring(0, 7);

--- a/src/utils/string/string.test.ts
+++ b/src/utils/string/string.test.ts
@@ -5,6 +5,7 @@ import {
   omitTypename,
   getDateCopy,
   applyStrictRegex,
+  shortenGithash,
 } from ".";
 
 describe("msToDuration", () => {
@@ -271,5 +272,15 @@ describe("applyStrictRegex", () => {
     expect("dog".match(re)).toBeTruthy();
     expect("dog ".match(re)).toBeFalsy();
     expect("adog".match(re)).toBeFalsy();
+  });
+});
+
+describe("shortenGithash", () => {
+  it("shortens githash to 7 characters", () => {
+    expect(shortenGithash("01234567")).toBe("0123456");
+    expect(shortenGithash("012")).toBe("012");
+  });
+  it("handles undefined input", () => {
+    expect(shortenGithash(undefined)).toBeUndefined();
   });
 });


### PR DESCRIPTION
[EVG-15838](https://jira.mongodb.org/browse/EVG-15838)

### Description 
These code changes shorten all occurrences of githash displays to 7 characters
