### PR TITLE
EVG-15780 Manage commitCount for table rows

### DIFF
--- a/src/components/HistoryTable/HistoryTable.tsx
+++ b/src/components/HistoryTable/HistoryTable.tsx
@@ -18,7 +18,12 @@ const HistoryTable: React.FC<HistoryTableProps> = ({
   recentlyFetchedCommits,
   children,
 }) => {
-  const { itemHeight, fetchNewCommit, isItemLoaded } = useHistoryTable();
+  const {
+    itemHeight,
+    fetchNewCommit,
+    isItemLoaded,
+    commitCount,
+  } = useHistoryTable();
   const listRef = useRef<List>(null);
   useEffect(() => {
     if (recentlyFetchedCommits) {
@@ -38,13 +43,13 @@ const HistoryTable: React.FC<HistoryTableProps> = ({
       {({ height, width }) => (
         <InfiniteLoader
           isItemLoaded={isItemLoaded}
-          itemCount={10000}
+          itemCount={commitCount}
           loadMoreItems={loadMoreItems}
         >
           {({ onItemsRendered }) => (
             <List
               height={height}
-              itemCount={10000}
+              itemCount={commitCount}
               itemSize={itemHeight}
               onItemsRendered={onItemsRendered}
               ref={listRef}

--- a/src/components/HistoryTable/HistoryTableContext.test.tsx
+++ b/src/components/HistoryTable/HistoryTableContext.test.tsx
@@ -25,6 +25,7 @@ describe("historyTableContext", () => {
       currentPage: 0,
       pageCount: 0,
       columnLimit: 7,
+      commitCount: 0,
     });
   });
   it("should process new commits when they are passed in", () => {
@@ -88,7 +89,28 @@ describe("historyTableContext", () => {
       commit: splitMainlineCommitDataPart2.versions[0].version,
     });
   });
-
+  it("should handle calculating the commitCount based off of the passed in values", () => {
+    const { result } = renderHook(() => useHistoryTable(), { wrapper });
+    const commitDate1 = {
+      ...mainlineCommitData,
+      versions: [mainlineCommitData.versions[0]],
+      prevPageOrderNumber: null,
+    };
+    const commitDate2 = {
+      ...mainlineCommitData,
+      versions: [mainlineCommitData.versions[2]],
+      nextPageOrderNumber: null,
+      prevPageOrderNumber: 6798,
+    };
+    act(() => {
+      result.current.fetchNewCommit(commitDate1);
+    });
+    expect(result.current.commitCount).toBe(6798);
+    act(() => {
+      result.current.fetchNewCommit(commitDate2);
+    });
+    expect(result.current.commitCount).toBe(4);
+  });
   it("should add a line separator between commits when they are a different date", () => {
     const { result } = renderHook(() => useHistoryTable(), { wrapper });
     const commitDate1 = {

--- a/src/components/HistoryTable/HistoryTableContext.test.tsx
+++ b/src/components/HistoryTable/HistoryTableContext.test.tsx
@@ -25,7 +25,7 @@ describe("historyTableContext", () => {
       currentPage: 0,
       pageCount: 0,
       columnLimit: 7,
-      commitCount: 0,
+      commitCount: 10,
     });
   });
   it("should process new commits when they are passed in", () => {

--- a/src/components/HistoryTable/HistoryTableContext.tsx
+++ b/src/components/HistoryTable/HistoryTableContext.tsx
@@ -45,7 +45,7 @@ const HistoryTableProvider: React.FC = ({ children }) => {
     pageCount: 0,
     columns: [],
     columnLimit: 7,
-    commitCount: 0,
+    commitCount: 10,
   });
 
   const itemHeight = (index: number) => {

--- a/src/components/HistoryTable/HistoryTableContext.tsx
+++ b/src/components/HistoryTable/HistoryTableContext.tsx
@@ -18,6 +18,7 @@ interface HistoryTableState {
   pageCount: number;
   currentPage: number;
   columnLimit: number;
+  commitCount: number;
 }
 
 const HistoryTableDispatchContext = createContext<any | null>(null);
@@ -31,6 +32,7 @@ const HistoryTableProvider: React.FC = ({ children }) => {
       pageCount,
       currentPage,
       columnLimit,
+      commitCount,
     },
     dispatch,
   ] = useReducer(reducer, {
@@ -43,6 +45,7 @@ const HistoryTableProvider: React.FC = ({ children }) => {
     pageCount: 0,
     columns: [],
     columnLimit: 7,
+    commitCount: 0,
   });
 
   const itemHeight = (index: number) => {
@@ -83,6 +86,7 @@ const HistoryTableProvider: React.FC = ({ children }) => {
       currentPage,
       pageCount,
       columnLimit,
+      commitCount,
     }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [processedCommits, visibleColumns, processedCommitCount]

--- a/src/components/HistoryTable/historyTableContextReducer.ts
+++ b/src/components/HistoryTable/historyTableContextReducer.ts
@@ -23,6 +23,7 @@ interface HistoryTableState {
   pageCount: number;
   columns: string[];
   columnLimit: number;
+  commitCount: number;
 }
 
 export const reducer = (state: HistoryTableState, action: Action) => {
@@ -39,11 +40,26 @@ export const reducer = (state: HistoryTableState, action: Action) => {
           action.commits.versions,
           state.processedCommits
         );
+        let { commitCount } = state;
+        // If there are no previous commits, we can set the commitCount to be the first commit's order.
+        if (action.commits.prevPageOrderNumber == null) {
+          for (let i = 0; i < action.commits.versions.length; i++) {
+            if (action.commits.versions[i].version) {
+              // We set the commitCount to double the order number just so we have room for non commit rows (date separators) and (folded commits)
+              commitCount = action.commits.versions[i].version.order * 2;
+              break;
+            }
+          }
+          // if we have no more commits we have processed everything and know how many commits we have so set the value to that
+        } else if (action.commits.nextPageOrderNumber == null) {
+          commitCount = processedCommits.length;
+        }
         return {
           ...state,
           commitCache: updatedObjectCache,
           processedCommits,
           processedCommitCount: processedCommits.length,
+          commitCount,
         };
       }
       return state;

--- a/src/pages/TaskHistory.tsx
+++ b/src/pages/TaskHistory.tsx
@@ -36,7 +36,7 @@ export const TaskHistory = () => {
   }>();
 
   usePageTitle(`Task History | ${projectId} | ${taskName}`);
-  const [nextPageOrderNumber, setNextPageOrderNumber] = useState(0);
+  const [nextPageOrderNumber, setNextPageOrderNumber] = useState(null);
   const variables = {
     mainlineCommitsOptions: {
       projectID: projectId,

--- a/src/pages/VariantHistory.tsx
+++ b/src/pages/VariantHistory.tsx
@@ -38,7 +38,7 @@ export const VariantHistory = () => {
   }>();
 
   usePageTitle(`Variant History | ${projectId} | ${variantName}`);
-  const [nextPageOrderNumber, setNextPageOrderNumber] = useState(0);
+  const [nextPageOrderNumber, setNextPageOrderNumber] = useState(null);
   const variables = {
     mainlineCommitsOptions: {
       projectID: projectId,


### PR DESCRIPTION
[EVG-15780](https://jira.mongodb.org/browse/EVG-15780)

### Description 
This allows us to dynamically keep track of how many rows we need for the history table. So we can avoid a situation in which we don't have enough rows or we have more rows then we need. This can not be calculated on the server since we dynamically generate  some of the rows on the front end (For folded commits and date separators). So it tries to estimate the value and refine that estimate as the user scrolls and we fetch more data.

