### PR TITLE
EVG-16021 Add a Codegen task 

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -157,14 +157,13 @@ functions:
         export PATH=/opt/nodejs/node-v16.13.0-linux-x64/bin:$PATH
         yarn analyze
 
-  yarn-codegen:
+  check-codegen:
     command: shell.exec
     params:
       working_dir: spruce
       shell: bash
       script: |
         export PATH=/opt/nodejs/node-v16.13.0-linux-x64/bin:$PATH
-        yarn codegen
         chmod +x check_codegen.sh
         ./check_codegen.sh
 
@@ -374,7 +373,7 @@ tasks:
     - func: get-project
     - func: sym-link
     - func: yarn-install
-    - func: yarn-codegen
+    - func: check-codegen
 
   - name: deploy_to_prod
     commands:

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -157,6 +157,17 @@ functions:
         export PATH=/opt/nodejs/node-v16.13.0-linux-x64/bin:$PATH
         yarn analyze
 
+  yarn-codegen:
+    command: shell.exec
+    params:
+      working_dir: spruce
+      shell: bash
+      script: |
+        export PATH=/opt/nodejs/node-v16.13.0-linux-x64/bin:$PATH
+        yarn codegen
+        chmod +x check_codegen.sh
+        ./check_codegen.sh
+
   run-cypress-tests:
     command: shell.exec
     params:
@@ -274,7 +285,6 @@ functions:
       script: |
         BUCKET=${bucket} AWS_ACCESS_KEY_ID=${aws_key} AWS_SECRET_ACCESS_KEY=${aws_secret}  yarn deploy; yarn upload-source-maps;
 
-
   build-prod:
     command: shell.exec
     params:
@@ -359,6 +369,12 @@ tasks:
     - func: setup-credentials
     - func: send-email
 
+  - name: check_codegen
+    commands:
+    - func: get-project
+    - func: sym-link
+    - func: yarn-install
+    - func: yarn-codegen
 
   - name: deploy_to_prod
     commands:
@@ -385,6 +401,7 @@ buildvariants:
     - name: coverage
     - name: e2e_test
     - name: storybook
+    - name: check_codegen
     - name: deploy_to_prod
       git_tag_only: true
       patchable: false

--- a/check_codegen.sh
+++ b/check_codegen.sh
@@ -1,4 +1,8 @@
-if [[ $(git status --porcelain | grep src/gql/generated/types.ts) ]]; then
+# This is a script which checks if yarn codegen was run it used by the check_codegen evergreen task
+BEFORE=$(git status --porcelain | grep src/gql/generated/types.ts)
+yarn codegen
+AFTER=$(git status --porcelain | grep src/gql/generated/types.ts)
+if [ "$BEFORE" != "$AFTER" ]; then
   echo "src/gql/types.ts is not up to date"
   echo "did you forget to run 'yarn codegen'?"
   exit 1

--- a/check_codegen.sh
+++ b/check_codegen.sh
@@ -3,5 +3,6 @@ if [[ $(git status --porcelain | grep src/gql/generated/types.ts) ]]; then
   echo "did you forget to run 'yarn codegen'?"
   exit 1
 else
+  echo "src/gql/types.ts is up to date"
   exit 0
 fi

--- a/check_codegen.sh
+++ b/check_codegen.sh
@@ -1,0 +1,7 @@
+if [[ $(git status --porcelain | grep src/gql/generated/types.ts) ]]; then
+  echo "src/gql/types.ts is not up to date"
+  echo "did you forget to run 'yarn codegen'?"
+  exit 1
+else
+  exit 0
+fi

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -29,6 +29,7 @@ export type Query = {
   project: Project;
   patchTasks: PatchTasks;
   taskTests: TaskTestResult;
+  taskTestSample?: Maybe<Array<TaskTestResultSample>>;
   taskFiles: TaskFiles;
   user: User;
   taskLogs: TaskLogs;
@@ -58,6 +59,8 @@ export type Query = {
   buildVariantsForTaskName?: Maybe<Array<Maybe<BuildVariantTuple>>>;
   projectSettings: ProjectSettings;
   repoSettings: RepoSettings;
+  projectEvents: ProjectEvents;
+  repoEvents: RepoEvents;
   hasVersion: Scalars["Boolean"];
 };
 
@@ -104,6 +107,11 @@ export type QueryTaskTestsArgs = {
   testName?: Maybe<Scalars["String"]>;
   statuses?: Array<Scalars["String"]>;
   groupId?: Maybe<Scalars["String"]>;
+};
+
+export type QueryTaskTestSampleArgs = {
+  tasks: Array<Scalars["String"]>;
+  filters: Array<TestFilter>;
 };
 
 export type QueryTaskFilesArgs = {
@@ -189,6 +197,18 @@ export type QueryProjectSettingsArgs = {
 
 export type QueryRepoSettingsArgs = {
   id: Scalars["String"];
+};
+
+export type QueryProjectEventsArgs = {
+  identifier: Scalars["String"];
+  limit?: Maybe<Scalars["Int"]>;
+  before?: Maybe<Scalars["Time"]>;
+};
+
+export type QueryRepoEventsArgs = {
+  id: Scalars["String"];
+  limit?: Maybe<Scalars["Int"]>;
+  before?: Maybe<Scalars["Time"]>;
 };
 
 export type QueryHasVersionArgs = {
@@ -470,6 +490,18 @@ export type VersionToRestart = {
   taskIds: Array<Scalars["String"]>;
 };
 
+export type TestFilter = {
+  testName: Scalars["String"];
+  testStatus: Scalars["String"];
+};
+
+export type TaskTestResultSample = {
+  taskId: Scalars["String"];
+  execution: Scalars["Int"];
+  totalTestCount: Scalars["Int"];
+  matchingFailedTestNames: Array<Scalars["String"]>;
+};
+
 export type MainlineCommits = {
   nextPageOrderNumber?: Maybe<Scalars["Int"]>;
   prevPageOrderNumber?: Maybe<Scalars["Int"]>;
@@ -503,7 +535,9 @@ export type Version = {
   patch?: Maybe<Patch>;
   childVersions?: Maybe<Array<Maybe<Version>>>;
   taskCount?: Maybe<Scalars["Int"]>;
+  /** @deprecated baseVersionId is deprecated, use baseVersion.id instead */
   baseVersionID?: Maybe<Scalars["String"]>;
+  baseVersion?: Maybe<Version>;
   versionTiming?: Maybe<VersionTiming>;
   parameters: Array<Parameter>;
   taskStatuses: Array<Scalars["String"]>;
@@ -1327,6 +1361,7 @@ export type Task = {
   activatedTime?: Maybe<Scalars["Time"]>;
   ami?: Maybe<Scalars["String"]>;
   annotation?: Maybe<Annotation>;
+  bbTicketCreationDefined: Scalars["Boolean"];
   baseTask?: Maybe<Task>;
   baseStatus?: Maybe<Scalars["String"]>;
   /** @deprecated baseTaskMetadata is deprecated. Use baseTask instead */
@@ -1408,7 +1443,7 @@ export type GroupedProjects = {
 };
 
 export type ProjectSettings = {
-  githubWebhooksEnabled: Scalars["Boolean"];
+  gitHubWebhooksEnabled: Scalars["Boolean"];
   projectRef?: Maybe<Project>;
   vars?: Maybe<ProjectVars>;
   aliases?: Maybe<Array<ProjectAlias>>;
@@ -1416,11 +1451,35 @@ export type ProjectSettings = {
 };
 
 export type RepoSettings = {
-  githubWebhooksEnabled: Scalars["Boolean"];
+  gitHubWebhooksEnabled: Scalars["Boolean"];
   projectRef?: Maybe<RepoRef>;
   vars?: Maybe<ProjectVars>;
   aliases?: Maybe<Array<ProjectAlias>>;
   subscriptions?: Maybe<Array<ProjectSubscription>>;
+};
+
+export type ProjectEvents = {
+  eventLogEntries: Array<ProjectEventLogEntry>;
+  count: Scalars["Int"];
+};
+
+export type ProjectEventLogEntry = {
+  timestamp: Scalars["Time"];
+  user: Scalars["String"];
+  before?: Maybe<ProjectSettings>;
+  after?: Maybe<ProjectSettings>;
+};
+
+export type RepoEvents = {
+  eventLogEntries: Array<RepoEventLogEntry>;
+  count: Scalars["Int"];
+};
+
+export type RepoEventLogEntry = {
+  timestamp: Scalars["Time"];
+  user: Scalars["String"];
+  before?: Maybe<RepoSettings>;
+  after?: Maybe<RepoSettings>;
 };
 
 export type ProjectVars = {


### PR DESCRIPTION
[EVG-16021](https://jira.mongodb.org/browse/EVG-16021)

### Description 
This adds a new evergreen task that validates if the codegen command was ran. This should help prevent mistyped queries from forgetting to run this command. Or to catch broken files from bad merge conflict resolutions.


### Testing 

Test with a broken types.ts file (Should fail)
https://spruce.mongodb.com/version/61c491baa4cf47367121f77f/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

Test with a valid types.ts file (Should Pass)
https://spruce.mongodb.com/version/61c491a7d6d80a2275c83078/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC