### PR TITLE
EVG-16015 Quick fix for error on main

### DIFF
--- a/src/pages/task/taskTabs/buildBaronAndAnnotations/BuildBaron.test.tsx
+++ b/src/pages/task/taskTabs/buildBaronAndAnnotations/BuildBaron.test.tsx
@@ -129,6 +129,7 @@ describe("buildBaron", () => {
 const buildBaronQuery = {
   buildBaron: {
     buildBaronConfigured: true,
+    bbTicketCreationDefined: true,
     searchReturnInfo: {
       issues: [
         {


### PR DESCRIPTION
[EVG-16015](https://jira.mongodb.org/browse/EVG-<16015>)

A new field was added to the evergreen schema which causes a test to fail and create issues with the pre-commit hook.
