### PR TITLE
EVG-16057: Display both custom and BB created tickets

### DIFF
--- a/src/pages/task/taskTabs/buildBaronAndAnnotations/BBCreatedTickets.tsx
+++ b/src/pages/task/taskTabs/buildBaronAndAnnotations/BBCreatedTickets.tsx
@@ -1,108 +1,65 @@
 import React from "react";
-import { useQuery } from "@apollo/client";
-import { useToastContext } from "context/toast";
-import {
-  GetCustomCreatedIssuesQuery,
-  GetCustomCreatedIssuesQueryVariables,
-  GetCreatedTicketsQuery,
-  GetCreatedTicketsQueryVariables,
-} from "gql/generated/types";
-import {
-  GET_CREATED_TICKETS,
-  GET_JIRA_CUSTOM_CREATED_ISSUES,
-} from "gql/queries";
-import { CustomCreatedTicketsTable } from "./AnnotationTicketsTable";
+import { JiraTicket, IssueLink } from "gql/generated/types";
 import { TicketsTitle, TitleAndButtons } from "./BBComponents";
 import { FileTicket } from "./BBFileTicket";
-import { BuildBaronTable } from "./BuildBaronTable";
 
 interface CreatedTicketsProps {
   taskId: string;
   execution: number;
   buildBaronConfigured: boolean;
+  tickets: JiraTicket[] | IssueLink[];
 }
 
 export const CreatedTickets: React.FC<CreatedTicketsProps> = ({
   taskId,
   execution,
   buildBaronConfigured,
-}) => {
-  const dispatchToast = useToastContext();
-  const { data } = useQuery<
-    GetCreatedTicketsQuery,
-    GetCreatedTicketsQueryVariables
-  >(GET_CREATED_TICKETS, {
-    variables: { taskId },
-    onError(error) {
-      dispatchToast.error(
-        `There was an error getting tickets created for this task: ${error.message}`
-      );
-    },
-  });
-  const length = data?.bbGetCreatedTickets?.length ?? 0;
-  const tickets = data?.bbGetCreatedTickets;
-  return (
-    <>
-      {length > 0 && (
-        <>
-          <TitleAndButtons>
-            {/* @ts-expect-error */}
-            <TicketsTitle>Tickets Created From This Task </TicketsTitle>
-          </TitleAndButtons>
-          <BuildBaronTable jiraIssues={tickets} />{" "}
-        </>
-      )}
-      {buildBaronConfigured && (
+  tickets,
+}) => (
+  <>
+    {tickets?.length > 0 && (
+      <>
         <TitleAndButtons>
           {/* @ts-expect-error */}
-          {length === 0 && <TicketsTitle>Create a New Ticket</TicketsTitle>}
-          <FileTicket taskId={taskId} execution={execution} tickets={tickets} />
-        </TitleAndButtons>
-      )}
-    </>
-  );
-};
-
-// CUSTOM CREATED TICKETS
-interface CustomCreatedTicketProps {
-  taskId: string;
-  execution: number;
-}
-
-export const CustomCreatedTickets: React.FC<CustomCreatedTicketProps> = ({
-  taskId,
-  execution,
-}) => {
-  const dispatchToast = useToastContext();
-  const { data } = useQuery<
-    GetCustomCreatedIssuesQuery,
-    GetCustomCreatedIssuesQueryVariables
-  >(GET_JIRA_CUSTOM_CREATED_ISSUES, {
-    variables: { taskId, execution },
-    onError: (err) => {
-      dispatchToast.error(
-        `There was an error loading the ticket information from Jira: ${err.message}`
-      );
-    },
-  });
-  const tickets = data?.task?.annotation?.createdIssues;
-
-  return (
-    <>
-      {tickets?.length > 0 && (
-        <>
-          <TitleAndButtons>
-            {/* @ts-expect-error */}
-            <TicketsTitle>Tickets Created From This Task</TicketsTitle>
-          </TitleAndButtons>
-          <CustomCreatedTicketsTable createdIssues={tickets} />
-        </>
-      )}
+          <TicketsTitle>Tickets Created From This Task </TicketsTitle>
+        </TitleAndButtons>{" "}
+      </>
+    )}
+    {buildBaronConfigured && (
       <TitleAndButtons>
         {/* @ts-expect-error */}
         <TicketsTitle>Create a New Ticket</TicketsTitle>
         <FileTicket taskId={taskId} execution={execution} tickets={tickets} />
       </TitleAndButtons>
-    </>
-  );
-};
+    )}
+  </>
+);
+
+// CUSTOM CREATED TICKETS
+interface CustomCreatedTicketProps {
+  taskId: string;
+  execution: number;
+  tickets: JiraTicket[] | IssueLink[];
+}
+
+export const CustomCreatedTickets: React.FC<CustomCreatedTicketProps> = ({
+  taskId,
+  execution,
+  tickets,
+}) => (
+  <>
+    {tickets?.length > 0 && (
+      <>
+        <TitleAndButtons>
+          {/* @ts-expect-error */}
+          <TicketsTitle>Tickets Created From This Task</TicketsTitle>
+        </TitleAndButtons>
+      </>
+    )}
+    <TitleAndButtons>
+      {/* @ts-expect-error */}
+      <TicketsTitle>Create a New Ticket</TicketsTitle>
+      <FileTicket taskId={taskId} execution={execution} tickets={tickets} />
+    </TitleAndButtons>
+  </>
+);

--- a/src/pages/task/taskTabs/buildBaronAndAnnotations/BuildBaronContent.tsx
+++ b/src/pages/task/taskTabs/buildBaronAndAnnotations/BuildBaronContent.tsx
@@ -3,14 +3,24 @@ import { useQuery } from "@apollo/client";
 import { Skeleton } from "antd";
 import { StyledLink } from "components/styles";
 import { getJiraSearchUrl } from "constants/externalResources";
+import { useToastContext } from "context/toast";
 import {
   GetSpruceConfigQuery,
   BuildBaron,
   Annotation,
+  GetCustomCreatedIssuesQuery,
+  GetCustomCreatedIssuesQueryVariables,
+  GetCreatedTicketsQuery,
+  GetCreatedTicketsQueryVariables,
 } from "gql/generated/types";
-import { GET_SPRUCE_CONFIG } from "gql/queries";
+import {
+  GET_CREATED_TICKETS,
+  GET_JIRA_CUSTOM_CREATED_ISSUES,
+  GET_SPRUCE_CONFIG,
+} from "gql/queries";
 import { AnnotationNote } from "./AnnotationNote";
 import { Issues, SuspectedIssues } from "./AnnotationTickets";
+import { CustomCreatedTicketsTable } from "./AnnotationTicketsTable";
 import { TicketsTitle, TitleAndButtons } from "./BBComponents";
 import { CreatedTickets, CustomCreatedTickets } from "./BBCreatedTickets";
 import { BuildBaronTable } from "./BuildBaronTable";
@@ -42,19 +52,57 @@ export const BuildBaronContent: React.FC<BuildBaronCoreProps> = ({
   const jqlEscaped = encodeURIComponent(jiraSearchString);
   const jiraSearchLink = getJiraSearchUrl(jiraHost, jqlEscaped);
 
+  const dispatchToast = useToastContext();
+
+  const { data: customCreatedTickets } = useQuery<
+    GetCustomCreatedIssuesQuery,
+    GetCustomCreatedIssuesQueryVariables
+  >(GET_JIRA_CUSTOM_CREATED_ISSUES, {
+    variables: { taskId, execution },
+    onError: (err) => {
+      dispatchToast.error(
+        `There was an error loading the ticket information from Jira: ${err.message}`
+      );
+    },
+  });
+
+  const { data: BBCreatedTickets } = useQuery<
+    GetCreatedTicketsQuery,
+    GetCreatedTicketsQueryVariables
+  >(GET_CREATED_TICKETS, {
+    variables: { taskId },
+    onError(error) {
+      dispatchToast.error(
+        `There was an error getting tickets created for this task: ${error.message}`
+      );
+    },
+  });
+
+  const customTickets = customCreatedTickets?.task?.annotation?.createdIssues;
+  const BBtickets = BBCreatedTickets?.bbGetCreatedTickets;
+
   return (
     <div data-cy="bb-content">
       {loading && <Skeleton active title={false} paragraph={{ rows: 4 }} />}
       {bbData?.bbTicketCreationDefined ? (
-        <CustomCreatedTickets taskId={taskId} execution={execution} />
+        <CustomCreatedTickets
+          taskId={taskId}
+          execution={execution}
+          tickets={customTickets}
+        />
       ) : (
         <CreatedTickets
           taskId={taskId}
           execution={execution}
           buildBaronConfigured={bbData?.buildBaronConfigured}
+          tickets={BBtickets}
         />
       )}
+      {BBtickets?.length > 0 && <BuildBaronTable jiraIssues={BBtickets} />}
 
+      {customTickets?.length > 0 && (
+        <CustomCreatedTicketsTable createdIssues={customTickets} />
+      )}
       <AnnotationNote
         note={annotation?.note}
         taskId={taskId}
@@ -77,7 +125,6 @@ export const BuildBaronContent: React.FC<BuildBaronCoreProps> = ({
         selectedRowKey={selectedRowKey}
         setSelectedRowKey={setSelectedRowKey}
       />
-
       {bbData?.searchReturnInfo?.issues.length > 0 && (
         <>
           <TitleAndButtons>


### PR DESCRIPTION
[EVG-16057](https://jira.mongodb.org/browse/EVG-16057)

### Description 
Display both tables, custom created tickets and tickets filed with the button. This fits a new use case. 


### Testing 
Tested on staging 
