### PR TITLE
EVG-15579 Update failed label to also represent timed out

### DIFF
--- a/src/components/GroupedTaskStatusBadge/__snapshots__/GroupedTaskStatusBadge.stories.storyshot
+++ b/src/components/GroupedTaskStatusBadge/__snapshots__/GroupedTaskStatusBadge.stories.storyshot
@@ -86,7 +86,7 @@ exports[`storybook Storyshots Grouped Task Status Badge Grouped Task Status Badg
         <span
           className="css-oqj204-Status emc61an1"
         >
-          Failed
+          Failed / Timed Out
         </span>
       </div>
     </a>

--- a/src/constants/task.ts
+++ b/src/constants/task.ts
@@ -6,7 +6,7 @@ const { gray, red, yellow, green } = uiColors;
 
 export const taskStatusToCopy = {
   [TaskStatus.ScheduledUmbrella]: "Scheduled",
-  [TaskStatus.FailedUmbrella]: "Failed",
+  [TaskStatus.FailedUmbrella]: "Failed / Timed Out",
   [TaskStatus.RunningUmbrella]: "Running",
   [TaskStatus.SystemFailureUmbrella]: "System Failed",
   [TaskStatus.UndispatchedUmbrella]: "Undispatched",


### PR DESCRIPTION
[EVG-15779](https://jira.mongodb.org/browse/EVG-15579)

### Description 
Umbrella status now also shows timed out
### Screenshots
![image](https://user-images.githubusercontent.com/4605522/149023722-b7468b3d-8510-4e01-b772-dbf23b9e3453.png)

