### PR TITLE
EVG-16104 Use node 16 for deploy-to-prod task

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -282,6 +282,7 @@ functions:
     params:
       working_dir: spruce
       script: |
+        export PATH=/opt/nodejs/node-v16.13.0-linux-x64/bin:$PATH
         BUCKET=${bucket} AWS_ACCESS_KEY_ID=${aws_key} AWS_SECRET_ACCESS_KEY=${aws_secret}  yarn deploy; yarn upload-source-maps;
 
   build-prod:


### PR DESCRIPTION
[EVG-16014](https://jira.mongodb.org/browse/EVG-16104)

### Description 
Should resolve the failure in https://spruce.mongodb.com/task/spruce_ubuntu1604_deploy_to_prod__v2.26.0_22_01_12_12_13_51/logs?execution=0

Unable to test without running that task which would result in a deploy but fairly confident this is the fix. 