### PR TITLE
EVG-16113 Add link to history page from test results table

### DIFF
--- a/src/constants/routes.test.ts
+++ b/src/constants/routes.test.ts
@@ -5,6 +5,8 @@ import {
   getVersionRoute,
   getSpawnHostRoute,
   getPatchRoute,
+  getTaskHistoryRoute,
+  getVariantHistoryRoute,
 } from "./routes";
 
 describe("getTaskRoute", () => {
@@ -85,5 +87,108 @@ describe("getPatchRoute", () => {
     expect(
       getPatchRoute("somePatchId", { configure: true, tab: "someTab" })
     ).toBe("/patch/somePatchId/configure/someTab?");
+  });
+});
+
+describe("getTaskHistoryRoute", () => {
+  it("generates a link to the task history page", () => {
+    expect(getTaskHistoryRoute("someProject", "someTaskId")).toBe(
+      "/task-history/someProject/someTaskId"
+    );
+  });
+  it("generates a link with failing or passing tests", () => {
+    expect(
+      getTaskHistoryRoute("someProject", "someTaskId", {
+        failingTests: ["someFailingTest"],
+      })
+    ).toBe("/task-history/someProject/someTaskId?failed=someFailingTest");
+    expect(
+      getTaskHistoryRoute("someProject", "someTaskId", {
+        failingTests: ["someFailingTest", "someOtherFailingTest"],
+      })
+    ).toBe(
+      "/task-history/someProject/someTaskId?failed=someFailingTest,someOtherFailingTest"
+    );
+    expect(
+      getTaskHistoryRoute("someProject", "someTaskId", {
+        passingTests: ["somePassingTests"],
+      })
+    ).toBe("/task-history/someProject/someTaskId?passed=somePassingTests");
+    expect(
+      getTaskHistoryRoute("someProject", "someTaskId", {
+        passingTests: ["somePassingTests", "someOtherPassingTests"],
+      })
+    ).toBe(
+      "/task-history/someProject/someTaskId?passed=somePassingTests,someOtherPassingTests"
+    );
+  });
+  it("generates a link with failing and passing tests", () => {
+    expect(
+      getTaskHistoryRoute("someProject", "someTaskId", {
+        failingTests: ["someFailingTest"],
+        passingTests: ["somePassingTests"],
+      })
+    ).toBe(
+      "/task-history/someProject/someTaskId?failed=someFailingTest&passed=somePassingTests"
+    );
+    expect(
+      getTaskHistoryRoute("someProject", "someTaskId", {
+        failingTests: ["someFailingTest", "someOtherFailingTest"],
+        passingTests: ["somePassingTests", "someOtherPassingTests"],
+      })
+    ).toBe(
+      "/task-history/someProject/someTaskId?failed=someFailingTest,someOtherFailingTest&passed=somePassingTests,someOtherPassingTests"
+    );
+  });
+});
+describe("getVariantHistoryRoute", () => {
+  it("generates a link to the variant history page", () => {
+    expect(getVariantHistoryRoute("someProject", "someVariantId")).toBe(
+      "/variant-history/someProject/someVariantId"
+    );
+  });
+  it("generates a link with failing or passing tests", () => {
+    expect(
+      getVariantHistoryRoute("someProject", "someVariant", {
+        failingTests: ["someFailingTest"],
+      })
+    ).toBe("/variant-history/someProject/someVariant?failed=someFailingTest");
+    expect(
+      getVariantHistoryRoute("someProject", "someVariant", {
+        failingTests: ["someFailingTest", "someOtherFailingTest"],
+      })
+    ).toBe(
+      "/variant-history/someProject/someVariant?failed=someFailingTest,someOtherFailingTest"
+    );
+    expect(
+      getVariantHistoryRoute("someProject", "someVariant", {
+        passingTests: ["somePassingTests"],
+      })
+    ).toBe("/variant-history/someProject/someVariant?passed=somePassingTests");
+    expect(
+      getVariantHistoryRoute("someProject", "someVariant", {
+        passingTests: ["somePassingTests", "someOtherPassingTests"],
+      })
+    ).toBe(
+      "/variant-history/someProject/someVariant?passed=somePassingTests,someOtherPassingTests"
+    );
+  });
+  it("generates a link with failing and passing tests", () => {
+    expect(
+      getVariantHistoryRoute("someProject", "someVariant", {
+        failingTests: ["someFailingTest"],
+        passingTests: ["somePassingTests"],
+      })
+    ).toBe(
+      "/variant-history/someProject/someVariant?failed=someFailingTest&passed=somePassingTests"
+    );
+    expect(
+      getVariantHistoryRoute("someProject", "someVariant", {
+        failingTests: ["someFailingTest", "someOtherFailingTest"],
+        passingTests: ["somePassingTests", "someOtherPassingTests"],
+      })
+    ).toBe(
+      "/variant-history/someProject/someVariant?failed=someFailingTest,someOtherFailingTest&passed=somePassingTests,someOtherPassingTests"
+    );
   });
 });

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -1,7 +1,9 @@
+import { TestStatus } from "types/history";
 import { PatchTab } from "types/patch";
 import { PatchTasksQueryParams, TaskTab } from "types/task";
-import { queryString } from "utils";
+import { queryString, array } from "utils";
 
+const { toArray } = array;
 const { stringifyQuery } = queryString;
 
 export enum PageNames {
@@ -213,10 +215,41 @@ export const getCommitsRoute = (projectId: string = "") =>
 
 export const getVariantHistoryRoute = (
   projectIdentifier: string,
-  variantName: string
-) => `${paths.variantHistory}/${projectIdentifier}/${variantName}`;
+  variantName: string,
+  filters?: {
+    failingTests?: string[];
+    passingTests?: string[];
+  }
+) => {
+  if (filters) {
+    const failingTests = toArray(filters.failingTests);
+    const passingTests = toArray(filters.passingTests);
 
+    const queryParams = stringifyQuery({
+      [TestStatus.Failed]: failingTests,
+      [TestStatus.Passed]: passingTests,
+    });
+    return `${paths.variantHistory}/${projectIdentifier}/${variantName}?${queryParams}`;
+  }
+  return `${paths.variantHistory}/${projectIdentifier}/${variantName}`;
+};
 export const getTaskHistoryRoute = (
   projectIdentifier: string,
-  taskName: string
-) => `${paths.taskHistory}/${projectIdentifier}/${taskName}`;
+  taskName: string,
+  filters?: {
+    failingTests?: string[];
+    passingTests?: string[];
+  }
+) => {
+  if (filters) {
+    const failingTests = toArray(filters.failingTests);
+    const passingTests = toArray(filters.passingTests);
+
+    const queryParams = stringifyQuery({
+      [TestStatus.Failed]: failingTests,
+      [TestStatus.Passed]: passingTests,
+    });
+    return `${paths.taskHistory}/${projectIdentifier}/${taskName}?${queryParams}`;
+  }
+  return `${paths.taskHistory}/${projectIdentifier}/${taskName}`;
+};

--- a/src/pages/task/taskTabs/testsTable/LogsColumn.tsx
+++ b/src/pages/task/taskTabs/testsTable/LogsColumn.tsx
@@ -1,56 +1,74 @@
 import styled from "@emotion/styled";
 import Button from "@leafygreen-ui/button";
+import { Link } from "react-router-dom";
 import { Analytics } from "analytics/addPageAction";
+import { getTaskHistoryRoute } from "constants/routes";
 import { TestResult } from "gql/generated/types";
+import { TestStatus } from "types/test";
+import { isBeta } from "utils/environmentalVariables";
 
 interface Props {
   taskAnalytics: Analytics<
     | { name: "Click Logs Lobster Button" }
     | { name: "Click Logs HTML Button" }
     | { name: "Click Logs Raw Button" }
+    | { name: "Click See History Button" }
   >;
   testResult: TestResult;
+  task: {
+    name: string;
+    projectIdentifier: string;
+  };
 }
 
-export const LogsColumn: React.FC<Props> = ({ testResult, taskAnalytics }) => {
+export const LogsColumn: React.FC<Props> = ({
+  testResult,
+  taskAnalytics,
+  task,
+}) => {
+  const { status, testFile } = testResult;
   const { url: urlHTML, urlRaw, urlLobster } = testResult.logs ?? {};
+  const { projectIdentifier, name } = task ?? {};
+
+  let filters;
+  if (status === TestStatus.Fail) {
+    filters = {
+      failingTests: [testFile],
+    };
+  }
   return (
-    <>
+    <ButtonWrapper>
       {urlLobster && (
-        <ButtonWrapper>
-          <Button
-            data-cy="test-table-lobster-btn"
-            size="xsmall"
-            target="_blank"
-            variant="default"
-            href={urlLobster}
-            onClick={() =>
-              taskAnalytics.sendEvent({
-                name: "Click Logs Lobster Button",
-              })
-            }
-          >
-            Lobster
-          </Button>
-        </ButtonWrapper>
+        <Button
+          data-cy="test-table-lobster-btn"
+          size="xsmall"
+          target="_blank"
+          variant="default"
+          href={urlLobster}
+          onClick={() =>
+            taskAnalytics.sendEvent({
+              name: "Click Logs Lobster Button",
+            })
+          }
+        >
+          Lobster
+        </Button>
       )}
       {urlHTML && (
-        <ButtonWrapper>
-          <Button
-            data-cy="test-table-html-btn"
-            size="xsmall"
-            target="_blank"
-            variant="default"
-            href={urlHTML}
-            onClick={() =>
-              taskAnalytics.sendEvent({
-                name: "Click Logs HTML Button",
-              })
-            }
-          >
-            HTML
-          </Button>
-        </ButtonWrapper>
+        <Button
+          data-cy="test-table-html-btn"
+          size="xsmall"
+          target="_blank"
+          variant="default"
+          href={urlHTML}
+          onClick={() =>
+            taskAnalytics.sendEvent({
+              name: "Click Logs HTML Button",
+            })
+          }
+        >
+          HTML
+        </Button>
       )}
       {urlRaw && (
         <Button
@@ -66,10 +84,27 @@ export const LogsColumn: React.FC<Props> = ({ testResult, taskAnalytics }) => {
           Raw
         </Button>
       )}
-    </>
+      {isBeta() && filters && (
+        <Button
+          size="xsmall"
+          as={Link}
+          data-cy="task-history"
+          key="task-history"
+          onClick={() => {
+            taskAnalytics.sendEvent({ name: "Click See History Button" });
+          }}
+          to={getTaskHistoryRoute(projectIdentifier, name, filters)}
+        >
+          See history
+        </Button>
+      )}
+    </ButtonWrapper>
   );
 };
 
-const ButtonWrapper = styled("span")`
-  margin-right: 8px;
+const ButtonWrapper = styled.div`
+  > * {
+    margin-right: 8px;
+    margin-top: 8px;
+  }
 `;

--- a/src/pages/task/taskTabs/testsTable/getColumnsTemplate.tsx
+++ b/src/pages/task/taskTabs/testsTable/getColumnsTemplate.tsx
@@ -23,6 +23,10 @@ interface GetColumnsTemplateParams {
   onColumnHeaderClick?: (sortField) => void;
   statusSelectorProps: TreeSelectProps;
   testNameInputProps: InputFilterProps;
+  task: {
+    name: string;
+    projectIdentifier: string;
+  };
 }
 
 export const getColumnsTemplate = ({
@@ -30,6 +34,7 @@ export const getColumnsTemplate = ({
   onColumnHeaderClick = () => undefined,
   statusSelectorProps,
   testNameInputProps,
+  task,
 }: GetColumnsTemplateParams): ColumnProps<TestResult>[] => [
   {
     title: <span data-cy="name-column">Name</span>,
@@ -100,7 +105,7 @@ export const getColumnsTemplate = ({
     key: "logs",
     sorter: false,
     render: (a, b): JSX.Element => (
-      <LogsColumn taskAnalytics={taskAnalytics} testResult={b} />
+      <LogsColumn taskAnalytics={taskAnalytics} testResult={b} task={task} />
     ),
   },
 ];


### PR DESCRIPTION
[EVG-16113](https://jira.mongodb.org/browse/EVG-16113)

### Description 
Adds a see history button that links to the task history page with filters applied for failing tests. Will not scroll to the selected task however since that functionality is in milestone 3.
### Screenshots
![image](https://user-images.githubusercontent.com/4605522/149992107-a233ac89-2eb1-4240-87b8-7dcb0345d371.png)
![image](https://user-images.githubusercontent.com/4605522/149992161-0bee7104-6fd8-46ae-b986-bd8f658a3e0f.png)

### Testing 
Unit tests for link generation functionality. 

