### PR TITLE
EVG-14429: Navigate to task tab when clicking on build variant badges

### DIFF
--- a/cypress/integration/version/version_route.ts
+++ b/cypress/integration/version/version_route.ts
@@ -90,14 +90,14 @@ describe("Version route", () => {
       // click on a different tab first, so that we aren't on the task tab initially
       cy.dataCy("changes-tab").first().click();
       cy.dataCy("task-tab")
-        .invoke("attr", "aria-selected")
-        .should("equal", "false");
+        .should("have.attr", "aria-selected")
+        .and("equal", "false");
 
       // clicking on task status badge should move to the task tab
       cy.dataCy("grouped-task-status-badge").first().click();
       cy.dataCy("task-tab")
-        .invoke("attr", "aria-selected")
-        .should("equal", "true");
+        .should("have.attr", "aria-selected")
+        .and("equal", "true");
       cy.location("search").should(
         "include",
         "statuses=undispatched-umbrella,unscheduled,aborted,blocked"

--- a/cypress/integration/version/version_route.ts
+++ b/cypress/integration/version/version_route.ts
@@ -82,16 +82,23 @@ describe("Version route", () => {
         .first()
         .trigger("mouseover")
         .within(($el) => {
-          expect($el.text()).to.contain("1Undispatched");
+          expect($el.text()).to.contain("1Succeeded");
         });
     });
 
     it("Navigates to task tab and applies filters when clicking on grouped task status badge", () => {
+      // click on a different tab first, so that we aren't on the task tab initially
+      cy.dataCy("changes-tab").first().click();
+      cy.dataCy("task-tab")
+        .invoke("attr", "aria-selected")
+        .should("equal", "false");
+
+      // clicking on task status badge should move to the task tab
       cy.dataCy("grouped-task-status-badge").first().click();
-      cy.location("search").should(
-        "include",
-        "statuses=undispatched-umbrella,unscheduled,aborted,blocked"
-      );
+      cy.dataCy("task-tab")
+        .invoke("attr", "aria-selected")
+        .should("equal", "true");
+      cy.location("search").should("include", "statuses=success");
     });
   });
 

--- a/cypress/integration/version/version_route.ts
+++ b/cypress/integration/version/version_route.ts
@@ -82,7 +82,7 @@ describe("Version route", () => {
         .first()
         .trigger("mouseover")
         .within(($el) => {
-          expect($el.text()).to.contain("1Succeeded");
+          expect($el.text()).to.contain("1Undispatched");
         });
     });
 
@@ -98,7 +98,10 @@ describe("Version route", () => {
       cy.dataCy("task-tab")
         .invoke("attr", "aria-selected")
         .should("equal", "true");
-      cy.location("search").should("include", "statuses=success");
+      cy.location("search").should(
+        "include",
+        "statuses=undispatched-umbrella,unscheduled,aborted,blocked"
+      );
     });
   });
 

--- a/src/pages/version/Tabs.tsx
+++ b/src/pages/version/Tabs.tsx
@@ -76,6 +76,13 @@ export const Tabs: React.FC<Props> = ({ taskCount, childPatches, isPatch }) => {
     activeTabs.indexOf(defaultTab)
   );
 
+  // This is used when the URL updates to a different tab, as the tab component won't recognize any updates to the URL
+  useEffect(() => {
+    if (selectedTab !== activeTabs.indexOf(tab)) {
+      setSelectedTab(activeTabs.indexOf(tab));
+    }
+  }, [tab]); // eslint-disable-line react-hooks/exhaustive-deps
+
   // This is used to keep track of the first tab transition so we dont accidently trigger an analytics event for it
   const previousTab = usePrevious(selectedTab);
   useEffect(() => {


### PR DESCRIPTION
[EVG-14429](https://jira.mongodb.org/browse/EVG-14429)

### Description 
This PR makes it so that if a user is on a different tab like `Changes` or `Downstream Tasks` on the Patch page, clicking on a task status badge will bring them back to the `Tasks` tab (with the correct filters applied).

### Screenshots
https://user-images.githubusercontent.com/47064971/150021885-6b75986a-0d33-43e3-830b-cf9061bc7911.mov


### Testing 
- Edited e2e test in `version_route.ts`
