### PR TITLE
EVG-16119: Linkify & trim column headers on Variant/Task History pages

### DIFF
--- a/src/components/HistoryTable/Cell.tsx
+++ b/src/components/HistoryTable/Cell.tsx
@@ -3,6 +3,7 @@ import { uiColors } from "@leafygreen-ui/palette";
 import Tooltip from "@leafygreen-ui/tooltip";
 import { Skeleton } from "antd";
 import { Link } from "react-router-dom";
+import { ConditionalWrapper } from "components/ConditionalWrapper";
 import { inactiveElementStyle, StyledRouterLink } from "components/styles";
 import { getTaskRoute } from "constants/routes";
 import { TaskStatus } from "types/task";
@@ -77,20 +78,21 @@ export const ColumnHeaderCell: React.FC<ColumnHeaderCellProps> = ({
   fullDisplayName,
 }) => (
   <HeaderCell data-cy="header-cell">
-    {trimmedDisplayName === fullDisplayName ? (
-      <StyledRouterLink to={link}>{fullDisplayName}</StyledRouterLink>
-    ) : (
-      <Tooltip
-        align="top"
-        justify="middle"
-        trigger={
-          <StyledRouterLink to={link}>{trimmedDisplayName}</StyledRouterLink>
-        }
-        triggerEvent="hover"
-      >
-        {fullDisplayName}
-      </Tooltip>
-    )}
+    <ConditionalWrapper
+      condition={trimmedDisplayName !== fullDisplayName}
+      wrapper={(children) => (
+        <Tooltip
+          align="top"
+          justify="middle"
+          trigger={children}
+          triggerEvent="hover"
+        >
+          {fullDisplayName}
+        </Tooltip>
+      )}
+    >
+      <StyledRouterLink to={link}>{trimmedDisplayName}</StyledRouterLink>
+    </ConditionalWrapper>
   </HeaderCell>
 );
 

--- a/src/components/HistoryTable/Cell.tsx
+++ b/src/components/HistoryTable/Cell.tsx
@@ -113,7 +113,7 @@ const Cell = styled.div<{ inactive?: boolean }>`
 `;
 
 export const HeaderCell = styled(Cell)`
+  word-break: break-all; // Safari
   word-wrap: anywhere;
-  word-break: break-word; // Safari
   text-align: center;
 `;

--- a/src/components/HistoryTable/Cell.tsx
+++ b/src/components/HistoryTable/Cell.tsx
@@ -1,8 +1,9 @@
 import styled from "@emotion/styled";
 import { uiColors } from "@leafygreen-ui/palette";
+import Tooltip from "@leafygreen-ui/tooltip";
 import { Skeleton } from "antd";
 import { Link } from "react-router-dom";
-import { inactiveElementStyle } from "components/styles";
+import { inactiveElementStyle, StyledRouterLink } from "components/styles";
 import { getTaskRoute } from "constants/routes";
 import { TaskStatus } from "types/task";
 import { HistoryTableIcon } from "./HistoryTableIcon";
@@ -46,10 +47,51 @@ export const EmptyCell = () => (
   </Cell>
 );
 
-export const LoadingCell = () => (
-  <Cell data-cy="loading-cell">
-    <Skeleton.Avatar active shape="circle" size={statusIconSize} />
-  </Cell>
+interface LoadingCellProps {
+  isHeader?: boolean;
+}
+export const LoadingCell: React.FC<LoadingCellProps> = ({
+  isHeader = false,
+}) => (
+  <>
+    {isHeader ? (
+      <HeaderCell data-cy="loading-header-cell">
+        <Skeleton active title paragraph={false} />
+      </HeaderCell>
+    ) : (
+      <Cell data-cy="loading-cell">
+        <Skeleton.Avatar active shape="circle" size={statusIconSize} />
+      </Cell>
+    )}
+  </>
+);
+
+interface ColumnHeaderCellProps {
+  link: string;
+  trimmedDisplayName: string;
+  fullDisplayName: string;
+}
+export const ColumnHeaderCell: React.FC<ColumnHeaderCellProps> = ({
+  link,
+  trimmedDisplayName,
+  fullDisplayName,
+}) => (
+  <HeaderCell data-cy="header-cell">
+    {trimmedDisplayName === fullDisplayName ? (
+      <StyledRouterLink to={link}>{fullDisplayName}</StyledRouterLink>
+    ) : (
+      <Tooltip
+        align="top"
+        justify="middle"
+        trigger={
+          <StyledRouterLink to={link}>{trimmedDisplayName}</StyledRouterLink>
+        }
+        triggerEvent="hover"
+      >
+        {fullDisplayName}
+      </Tooltip>
+    )}
+  </HeaderCell>
 );
 
 const Circle = styled.div`

--- a/src/components/HistoryTable/Cell.tsx
+++ b/src/components/HistoryTable/Cell.tsx
@@ -72,5 +72,6 @@ const Cell = styled.div<{ inactive?: boolean }>`
 
 export const HeaderCell = styled(Cell)`
   word-wrap: anywhere;
+  word-break: break-word; // Safari
   text-align: center;
 `;

--- a/src/constants/history.ts
+++ b/src/constants/history.ts
@@ -1,7 +1,5 @@
 // for taskHistory ColumnHeaders.tsx
 export const taskHistoryMaxLength = 50;
-export const taskHistoryTrailingLength = 15;
 
 // for variantHistory ColumnHeaders.tsx
 export const variantHistoryMaxLength = 50;
-export const variantHistoryTrailingLength = 10;

--- a/src/constants/history.ts
+++ b/src/constants/history.ts
@@ -1,0 +1,7 @@
+// for taskHistory ColumnHeaders.tsx
+export const taskHistoryMaxLength = 50;
+export const taskHistoryTrailingLength = 15;
+
+// for variantHistory ColumnHeaders.tsx
+export const variantHistoryMaxLength = 50;
+export const variantHistoryTrailingLength = 10;

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -893,7 +893,7 @@ export type BuildBaronSettingsInput = {
 
 export type TaskAnnotationSettingsInput = {
   jiraCustomFields?: Maybe<Array<JiraFieldInput>>;
-  fileTicketWebhook: WebhookInput;
+  fileTicketWebhook?: Maybe<WebhookInput>;
 };
 
 export type JiraFieldInput = {

--- a/src/pages/TaskHistory.tsx
+++ b/src/pages/TaskHistory.tsx
@@ -132,7 +132,11 @@ const TaskHistoryContents: React.FC = () => {
           <ColumnPaginationButtons />
         </PaginationFilterWrapper>
         <div>
-          <ColumnHeaders loading={loading} columns={selectedColumns} />
+          <ColumnHeaders
+            projectId={projectId}
+            loading={loading}
+            columns={selectedColumns}
+          />
           <TableWrapper>
             <HistoryTable
               recentlyFetchedCommits={mainlineCommits}

--- a/src/pages/VariantHistory.tsx
+++ b/src/pages/VariantHistory.tsx
@@ -131,7 +131,11 @@ export const VariantHistoryContents: React.FC = () => {
           <ColumnPaginationButtons />
         </PaginationFilterWrapper>
         <div>
-          <ColumnHeaders loading={loading} columns={selectedColumns} />
+          <ColumnHeaders
+            projectId={projectId}
+            loading={loading}
+            columns={selectedColumns}
+          />
           <TableWrapper>
             <HistoryTable
               recentlyFetchedCommits={mainlineCommits}

--- a/src/pages/taskHistory/ColumnHeaders.test.tsx
+++ b/src/pages/taskHistory/ColumnHeaders.test.tsx
@@ -1,9 +1,6 @@
 import { context } from "components/HistoryTable";
 import { HistoryTableReducerState } from "components/HistoryTable/historyTableContextReducer";
-import {
-  taskHistoryMaxLength as maxLength,
-  taskHistoryTrailingLength as trailingLength,
-} from "constants/history";
+import { taskHistoryMaxLength as maxLength } from "constants/history";
 import {
   fireEvent,
   renderWithRouterMatch as render,
@@ -12,14 +9,10 @@ import {
 import { string } from "utils";
 import ColumnHeaders from "./ColumnHeaders";
 
-const { trimMiddleText } = string;
+const { trimStringFromMiddle } = string;
 const { HistoryTableProvider } = context;
 const longVariantName = "really_really_really_really_really_long_variant_name";
-const trimmedVariantName = trimMiddleText(
-  longVariantName,
-  maxLength,
-  trailingLength
-);
+const trimmedVariantName = trimStringFromMiddle(longVariantName, maxLength);
 
 const initialState: HistoryTableReducerState = {
   loadedCommits: [],

--- a/src/pages/taskHistory/ColumnHeaders.test.tsx
+++ b/src/pages/taskHistory/ColumnHeaders.test.tsx
@@ -1,0 +1,171 @@
+import { MockedProvider, MockedResponse } from "@apollo/client/testing";
+import { context } from "components/HistoryTable";
+import { HistoryTableReducerState } from "components/HistoryTable/historyTableContextReducer";
+import {
+  fireEvent,
+  renderWithRouterMatch as render,
+  waitFor,
+} from "test_utils";
+import { string } from "utils";
+import ColumnHeaders from "./ColumnHeaders";
+
+const { trimMiddleText } = string;
+const { HistoryTableProvider } = context;
+const longVariantName = "really_really_really_really_really_long_variant_name";
+const trimmedVariantName = trimMiddleText(longVariantName, 50, 15);
+
+const initialState: HistoryTableReducerState = {
+  loadedCommits: [],
+  processedCommits: [],
+  processedCommitCount: 0,
+  commitCache: new Map(),
+  currentPage: 0,
+  pageCount: 0,
+  columns: [],
+  historyTableFilters: [],
+  commitCount: 10,
+  visibleColumns: [],
+  columnLimit: 7,
+};
+
+interface wrapperProps {
+  children: React.ReactNode;
+  mocks?: MockedResponse[];
+  state?: Partial<HistoryTableReducerState>;
+}
+
+const wrapper: React.FC<wrapperProps> = ({ children, mocks = [], state }) => (
+  <MockedProvider mocks={mocks}>
+    <HistoryTableProvider initialState={{ ...initialState, ...state }}>
+      {children}
+    </HistoryTableProvider>
+  </MockedProvider>
+);
+
+describe("columnHeaders (Task History)", () => {
+  it("renders an initial skeleton for the 7 column headers when loading", () => {
+    const { queryAllByDataCy } = render(
+      () => <ColumnHeaders projectId="evergreen" columns={[]} loading />,
+      {
+        wrapper,
+      }
+    );
+    expect(queryAllByDataCy("loading-header-cell")).toHaveLength(7);
+  });
+
+  it("renders the column headers properly when not loading", async () => {
+    const { queryAllByDataCy } = render(
+      () => (
+        <ColumnHeaders
+          loading={false}
+          projectId="evergreen"
+          columns={[
+            { displayName: "variant1", buildVariant: "variant1" },
+            { displayName: "variant2", buildVariant: "variant2" },
+            { displayName: "variant3", buildVariant: "variant3" },
+          ]}
+        />
+      ),
+      {
+        wrapper: ({ children }) =>
+          wrapper({
+            children,
+            state: {
+              visibleColumns: ["variant1", "variant2", "variant3"],
+            },
+          }),
+      }
+    );
+    expect(queryAllByDataCy("loading-header-cell")).toHaveLength(0);
+    expect(queryAllByDataCy("header-cell")).toHaveLength(3);
+  });
+
+  it("should link to corresponding /variant-history/:projectId/:variantName page", async () => {
+    const { queryByRole } = render(
+      () => (
+        <ColumnHeaders
+          loading={false}
+          projectId="evergreen"
+          columns={[{ displayName: "variant1", buildVariant: "variant1" }]}
+        />
+      ),
+      {
+        wrapper: ({ children }) =>
+          wrapper({
+            children,
+            state: {
+              visibleColumns: ["variant1"],
+            },
+          }),
+      }
+    );
+    expect(queryByRole("link")).toHaveAttribute(
+      "href",
+      "/variant-history/evergreen/variant1"
+    );
+  });
+
+  it("should truncate the variant name when only if it is too long", async () => {
+    const { queryByText } = render(
+      () => (
+        <ColumnHeaders
+          loading={false}
+          projectId="evergreen"
+          columns={[
+            {
+              displayName: longVariantName,
+              buildVariant: longVariantName,
+            },
+            { displayName: "variant2", buildVariant: "variant2" },
+          ]}
+        />
+      ),
+      {
+        wrapper: ({ children }) =>
+          wrapper({
+            children,
+            state: {
+              visibleColumns: [longVariantName, "variant2"],
+            },
+          }),
+      }
+    );
+
+    await waitFor(() => {
+      expect(queryByText(longVariantName)).toBeNull();
+    });
+    await waitFor(() => {
+      expect(queryByText("variant2")).toBeVisible();
+    });
+  });
+
+  it("should show a tooltip with the full name when hovering over a truncated variant name", async () => {
+    const { queryByText } = render(
+      () => (
+        <ColumnHeaders
+          loading={false}
+          projectId="evergreen"
+          columns={[
+            {
+              displayName: longVariantName,
+              buildVariant: longVariantName,
+            },
+          ]}
+        />
+      ),
+      {
+        wrapper: ({ children }) =>
+          wrapper({
+            children,
+            state: {
+              visibleColumns: [longVariantName],
+            },
+          }),
+      }
+    );
+    fireEvent.mouseEnter(queryByText(trimmedVariantName));
+    await waitFor(() => {
+      expect(queryByText(longVariantName)).toBeVisible();
+    });
+  });
+});

--- a/src/pages/taskHistory/ColumnHeaders.test.tsx
+++ b/src/pages/taskHistory/ColumnHeaders.test.tsx
@@ -1,4 +1,3 @@
-import { MockedProvider, MockedResponse } from "@apollo/client/testing";
 import { context } from "components/HistoryTable";
 import { HistoryTableReducerState } from "components/HistoryTable/historyTableContextReducer";
 import {
@@ -30,16 +29,13 @@ const initialState: HistoryTableReducerState = {
 
 interface wrapperProps {
   children: React.ReactNode;
-  mocks?: MockedResponse[];
   state?: Partial<HistoryTableReducerState>;
 }
 
-const wrapper: React.FC<wrapperProps> = ({ children, mocks = [], state }) => (
-  <MockedProvider mocks={mocks}>
-    <HistoryTableProvider initialState={{ ...initialState, ...state }}>
-      {children}
-    </HistoryTableProvider>
-  </MockedProvider>
+const wrapper: React.FC<wrapperProps> = ({ children, state }) => (
+  <HistoryTableProvider initialState={{ ...initialState, ...state }}>
+    {children}
+  </HistoryTableProvider>
 );
 
 describe("columnHeaders (Task History)", () => {

--- a/src/pages/taskHistory/ColumnHeaders.test.tsx
+++ b/src/pages/taskHistory/ColumnHeaders.test.tsx
@@ -86,7 +86,12 @@ describe("columnHeaders (Task History)", () => {
         <ColumnHeaders
           loading={false}
           projectId="evergreen"
-          columns={[{ displayName: "variant1", buildVariant: "variant1" }]}
+          columns={[
+            {
+              displayName: "variant1",
+              buildVariant: "real-variant-name",
+            },
+          ]}
         />
       ),
       {
@@ -94,18 +99,18 @@ describe("columnHeaders (Task History)", () => {
           wrapper({
             children,
             state: {
-              visibleColumns: ["variant1"],
+              visibleColumns: ["real-variant-name"],
             },
           }),
       }
     );
     expect(queryByRole("link")).toHaveAttribute(
       "href",
-      "/variant-history/evergreen/variant1"
+      "/variant-history/evergreen/real-variant-name"
     );
   });
 
-  it("should truncate the variant name when only if it is too long", async () => {
+  it("should truncate the variant name only if it is too long", async () => {
     const { queryByText } = render(
       () => (
         <ColumnHeaders

--- a/src/pages/taskHistory/ColumnHeaders.test.tsx
+++ b/src/pages/taskHistory/ColumnHeaders.test.tsx
@@ -1,6 +1,10 @@
 import { context } from "components/HistoryTable";
 import { HistoryTableReducerState } from "components/HistoryTable/historyTableContextReducer";
 import {
+  taskHistoryMaxLength as maxLength,
+  taskHistoryTrailingLength as trailingLength,
+} from "constants/history";
+import {
   fireEvent,
   renderWithRouterMatch as render,
   waitFor,
@@ -11,7 +15,11 @@ import ColumnHeaders from "./ColumnHeaders";
 const { trimMiddleText } = string;
 const { HistoryTableProvider } = context;
 const longVariantName = "really_really_really_really_really_long_variant_name";
-const trimmedVariantName = trimMiddleText(longVariantName, 50, 15);
+const trimmedVariantName = trimMiddleText(
+  longVariantName,
+  maxLength,
+  trailingLength
+);
 
 const initialState: HistoryTableReducerState = {
   loadedCommits: [],
@@ -43,6 +51,8 @@ describe("columnHeaders (Task History)", () => {
     const { queryAllByDataCy } = render(
       () => <ColumnHeaders projectId="evergreen" columns={[]} loading />,
       {
+        route: "/task-history/evergreen/some_task",
+        path: "/task-history/:projectId/:taskName",
         wrapper,
       }
     );
@@ -63,6 +73,8 @@ describe("columnHeaders (Task History)", () => {
         />
       ),
       {
+        route: "/task-history/evergreen/some_task",
+        path: "/task-history/:projectId/:taskName",
         wrapper: ({ children }) =>
           wrapper({
             children,
@@ -91,6 +103,8 @@ describe("columnHeaders (Task History)", () => {
         />
       ),
       {
+        route: "/task-history/evergreen/some_task",
+        path: "/task-history/:projectId/:taskName",
         wrapper: ({ children }) =>
           wrapper({
             children,
@@ -122,6 +136,8 @@ describe("columnHeaders (Task History)", () => {
         />
       ),
       {
+        route: "/task-history/evergreen/some_task",
+        path: "/task-history/:projectId/:taskName",
         wrapper: ({ children }) =>
           wrapper({
             children,
@@ -155,6 +171,8 @@ describe("columnHeaders (Task History)", () => {
         />
       ),
       {
+        route: "/task-history/evergreen/some_task",
+        path: "/task-history/:projectId/:taskName",
         wrapper: ({ children }) =>
           wrapper({
             children,

--- a/src/pages/taskHistory/ColumnHeaders.test.tsx
+++ b/src/pages/taskHistory/ColumnHeaders.test.tsx
@@ -11,7 +11,8 @@ import ColumnHeaders from "./ColumnHeaders";
 
 const { trimStringFromMiddle } = string;
 const { HistoryTableProvider } = context;
-const longVariantName = "really_really_really_really_really_long_variant_name";
+const longVariantName =
+  "really_really_really_really_really_really_long_variant_name";
 const trimmedVariantName = trimStringFromMiddle(longVariantName, maxLength);
 
 const initialState: HistoryTableReducerState = {

--- a/src/pages/taskHistory/ColumnHeaders.test.tsx
+++ b/src/pages/taskHistory/ColumnHeaders.test.tsx
@@ -29,12 +29,12 @@ const initialState: HistoryTableReducerState = {
   columnLimit: 7,
 };
 
-interface wrapperProps {
+interface WrapperProps {
   children: React.ReactNode;
   state?: Partial<HistoryTableReducerState>;
 }
 
-const wrapper: React.FC<wrapperProps> = ({ children, state }) => (
+const wrapper: React.FC<WrapperProps> = ({ children, state }) => (
   <HistoryTableProvider initialState={{ ...initialState, ...state }}>
     {children}
   </HistoryTableProvider>

--- a/src/pages/taskHistory/ColumnHeaders.tsx
+++ b/src/pages/taskHistory/ColumnHeaders.tsx
@@ -1,15 +1,12 @@
 import styled from "@emotion/styled";
-import Tooltip from "@leafygreen-ui/tooltip";
-import { Skeleton } from "antd";
 import { context, Cell } from "components/HistoryTable";
-import { StyledRouterLink } from "components/styles";
 import { getVariantHistoryRoute } from "constants/routes";
 import { array, string } from "utils";
 
 const { convertArrayToObject } = array;
 const { trimMiddleText } = string;
 const { useHistoryTable } = context;
-const { HeaderCell } = Cell;
+const { LoadingCell, ColumnHeaderCell } = Cell;
 
 const maxLength = 50;
 const trailingLength = 15;
@@ -38,45 +35,22 @@ const ColumnHeaders: React.FC<ColumnHeadersProps> = ({
           return null;
         }
         return (
-          <HeaderCell
-            data-cy="header-cell"
-            key={`header_cell_${cell.buildVariant}`}
-          >
-            {cell.displayName.length < maxLength ? (
-              <StyledRouterLink
-                to={getVariantHistoryRoute(projectId, cell.buildVariant)}
-              >
-                {cell.displayName}
-              </StyledRouterLink>
-            ) : (
-              <Tooltip
-                align="top"
-                justify="middle"
-                trigger={
-                  <StyledRouterLink
-                    to={getVariantHistoryRoute(projectId, cell.buildVariant)}
-                  >
-                    {trimMiddleText(
-                      cell.displayName,
-                      maxLength,
-                      trailingLength
-                    )}
-                  </StyledRouterLink>
-                }
-                triggerEvent="hover"
-              >
-                {cell.displayName}
-              </Tooltip>
+          <ColumnHeaderCell
+            key={`header_cell_${cell.displayName}`}
+            link={getVariantHistoryRoute(projectId, cell.buildVariant)}
+            trimmedDisplayName={trimMiddleText(
+              cell.displayName,
+              maxLength,
+              trailingLength
             )}
-          </HeaderCell>
+            fullDisplayName={cell.displayName}
+          />
         );
       })}
       {loading &&
         Array.from(Array(columnLimit)).map((_, i) => (
           // eslint-disable-next-line react/no-array-index-key
-          <HeaderCell data-cy="loading-header-cell" key={`loading_cell_${i}`}>
-            <Skeleton active title paragraph={false} />
-          </HeaderCell>
+          <LoadingCell key={`loading_cell_${i}`} isHeader />
         ))}
     </RowContainer>
   );

--- a/src/pages/taskHistory/ColumnHeaders.tsx
+++ b/src/pages/taskHistory/ColumnHeaders.tsx
@@ -1,5 +1,9 @@
 import styled from "@emotion/styled";
 import { context, Cell } from "components/HistoryTable";
+import {
+  taskHistoryMaxLength as maxLength,
+  taskHistoryTrailingLength as trailingLength,
+} from "constants/history";
 import { getVariantHistoryRoute } from "constants/routes";
 import { array, string } from "utils";
 
@@ -7,9 +11,6 @@ const { convertArrayToObject } = array;
 const { trimMiddleText } = string;
 const { useHistoryTable } = context;
 const { LoadingCell, ColumnHeaderCell } = Cell;
-
-const maxLength = 50;
-const trailingLength = 15;
 
 interface ColumnHeadersProps {
   projectId: string;

--- a/src/pages/taskHistory/ColumnHeaders.tsx
+++ b/src/pages/taskHistory/ColumnHeaders.tsx
@@ -1,20 +1,32 @@
 import styled from "@emotion/styled";
+import Tooltip from "@leafygreen-ui/tooltip";
 import { Skeleton } from "antd";
 import { context, Cell } from "components/HistoryTable";
-import { array } from "utils";
+import { StyledRouterLink } from "components/styles";
+import { getVariantHistoryRoute } from "constants/routes";
+import { array, string } from "utils";
 
 const { convertArrayToObject } = array;
+const { trimMiddleText } = string;
 const { useHistoryTable } = context;
 const { HeaderCell } = Cell;
 
+const maxLength = 50;
+const trailingLength = 15;
+
 interface ColumnHeadersProps {
+  projectId: string;
   columns: {
     displayName: string;
     buildVariant: string;
   }[];
   loading: boolean;
 }
-const ColumnHeaders: React.FC<ColumnHeadersProps> = ({ columns, loading }) => {
+const ColumnHeaders: React.FC<ColumnHeadersProps> = ({
+  projectId,
+  columns,
+  loading,
+}) => {
   const { visibleColumns, columnLimit } = useHistoryTable();
   const columnMap = convertArrayToObject(columns, "buildVariant");
   return (
@@ -26,15 +38,43 @@ const ColumnHeaders: React.FC<ColumnHeadersProps> = ({ columns, loading }) => {
           return null;
         }
         return (
-          <HeaderCell key={`header_cell_${cell.buildVariant}`}>
-            {cell.displayName}
+          <HeaderCell
+            data-cy="header-cell"
+            key={`header_cell_${cell.buildVariant}`}
+          >
+            {cell.displayName.length < maxLength ? (
+              <StyledRouterLink
+                to={getVariantHistoryRoute(projectId, cell.buildVariant)}
+              >
+                {cell.displayName}
+              </StyledRouterLink>
+            ) : (
+              <Tooltip
+                align="top"
+                justify="middle"
+                trigger={
+                  <StyledRouterLink
+                    to={getVariantHistoryRoute(projectId, cell.buildVariant)}
+                  >
+                    {trimMiddleText(
+                      cell.displayName,
+                      maxLength,
+                      trailingLength
+                    )}
+                  </StyledRouterLink>
+                }
+                triggerEvent="hover"
+              >
+                {cell.displayName}
+              </Tooltip>
+            )}
           </HeaderCell>
         );
       })}
       {loading &&
         Array.from(Array(columnLimit)).map((_, i) => (
           // eslint-disable-next-line react/no-array-index-key
-          <HeaderCell key={`loading_cell_${i}`}>
+          <HeaderCell data-cy="loading-header-cell" key={`loading_cell_${i}`}>
             <Skeleton active title paragraph={false} />
           </HeaderCell>
         ))}

--- a/src/pages/taskHistory/ColumnHeaders.tsx
+++ b/src/pages/taskHistory/ColumnHeaders.tsx
@@ -1,14 +1,11 @@
 import styled from "@emotion/styled";
 import { context, Cell } from "components/HistoryTable";
-import {
-  taskHistoryMaxLength as maxLength,
-  taskHistoryTrailingLength as trailingLength,
-} from "constants/history";
+import { taskHistoryMaxLength as maxLength } from "constants/history";
 import { getVariantHistoryRoute } from "constants/routes";
 import { array, string } from "utils";
 
 const { convertArrayToObject } = array;
-const { trimMiddleText } = string;
+const { trimStringFromMiddle } = string;
 const { useHistoryTable } = context;
 const { LoadingCell, ColumnHeaderCell } = Cell;
 
@@ -39,10 +36,9 @@ const ColumnHeaders: React.FC<ColumnHeadersProps> = ({
           <ColumnHeaderCell
             key={`header_cell_${cell.displayName}`}
             link={getVariantHistoryRoute(projectId, cell.buildVariant)}
-            trimmedDisplayName={trimMiddleText(
+            trimmedDisplayName={trimStringFromMiddle(
               cell.displayName,
-              maxLength,
-              trailingLength
+              maxLength
             )}
             fullDisplayName={cell.displayName}
           />

--- a/src/pages/variantHistory/ColumnHeaders.test.tsx
+++ b/src/pages/variantHistory/ColumnHeaders.test.tsx
@@ -59,7 +59,7 @@ describe("columnHeaders (Variant History)", () => {
         <ColumnHeaders
           loading={false}
           projectId="evergreen"
-          columns={["variant1", "variant2", "variant3"]}
+          columns={["task1", "task2", "task3"]}
         />
       ),
       {
@@ -67,7 +67,7 @@ describe("columnHeaders (Variant History)", () => {
           wrapper({
             children,
             state: {
-              visibleColumns: ["variant1", "variant2", "variant3"],
+              visibleColumns: ["task1", "task2", "task3"],
             },
           }),
       }
@@ -76,13 +76,13 @@ describe("columnHeaders (Variant History)", () => {
     expect(queryAllByDataCy("header-cell")).toHaveLength(3);
   });
 
-  it("should link to corresponding /variant-history/:projectId/:variantName page", async () => {
+  it("should link to corresponding /task-history/:projectId/:taskName page", async () => {
     const { queryByRole } = render(
       () => (
         <ColumnHeaders
           loading={false}
           projectId="evergreen"
-          columns={["variant1"]}
+          columns={["task1"]}
         />
       ),
       {
@@ -90,24 +90,24 @@ describe("columnHeaders (Variant History)", () => {
           wrapper({
             children,
             state: {
-              visibleColumns: ["variant1"],
+              visibleColumns: ["task1"],
             },
           }),
       }
     );
     expect(queryByRole("link")).toHaveAttribute(
       "href",
-      "/task-history/evergreen/variant1"
+      "/task-history/evergreen/task1"
     );
   });
 
-  it("should truncate the variant name when only if it is too long", async () => {
+  it("should truncate the task name only if it is too long", async () => {
     const { queryByText } = render(
       () => (
         <ColumnHeaders
           loading={false}
           projectId="evergreen"
-          columns={[longTaskName, "variant2"]}
+          columns={[longTaskName, "task2"]}
         />
       ),
       {
@@ -115,7 +115,7 @@ describe("columnHeaders (Variant History)", () => {
           wrapper({
             children,
             state: {
-              visibleColumns: [longTaskName, "variant2"],
+              visibleColumns: [longTaskName, "task2"],
             },
           }),
       }
@@ -125,11 +125,11 @@ describe("columnHeaders (Variant History)", () => {
       expect(queryByText(longTaskName)).toBeNull();
     });
     await waitFor(() => {
-      expect(queryByText("variant2")).toBeVisible();
+      expect(queryByText("task2")).toBeVisible();
     });
   });
 
-  it("should show a tooltip with the full name when hovering over a truncated variant name", async () => {
+  it("should show a tooltip with the full name when hovering over a truncated task name", async () => {
     const { queryByText } = render(
       () => (
         <ColumnHeaders

--- a/src/pages/variantHistory/ColumnHeaders.test.tsx
+++ b/src/pages/variantHistory/ColumnHeaders.test.tsx
@@ -1,0 +1,156 @@
+import { MockedProvider, MockedResponse } from "@apollo/client/testing";
+import { context } from "components/HistoryTable";
+import { HistoryTableReducerState } from "components/HistoryTable/historyTableContextReducer";
+import {
+  fireEvent,
+  renderWithRouterMatch as render,
+  waitFor,
+} from "test_utils";
+import { string } from "utils";
+import ColumnHeaders from "./ColumnHeaders";
+
+const { trimMiddleText } = string;
+const { HistoryTableProvider } = context;
+const longTaskName = "really_really_really_really_really_really_long_task_name";
+const trimmedTaskName = trimMiddleText(longTaskName, 50, 10);
+
+const initialState: HistoryTableReducerState = {
+  loadedCommits: [],
+  processedCommits: [],
+  processedCommitCount: 0,
+  commitCache: new Map(),
+  currentPage: 0,
+  pageCount: 0,
+  columns: [],
+  historyTableFilters: [],
+  commitCount: 10,
+  visibleColumns: [],
+  columnLimit: 7,
+};
+
+interface wrapperProps {
+  children: React.ReactNode;
+  mocks?: MockedResponse[];
+  state?: Partial<HistoryTableReducerState>;
+}
+
+const wrapper: React.FC<wrapperProps> = ({ children, mocks = [], state }) => (
+  <MockedProvider mocks={mocks}>
+    <HistoryTableProvider initialState={{ ...initialState, ...state }}>
+      {children}
+    </HistoryTableProvider>
+  </MockedProvider>
+);
+
+describe("columnHeaders (Variant History)", () => {
+  it("renders an initial skeleton for the 7 column headers when loading", () => {
+    const { queryAllByDataCy } = render(
+      () => <ColumnHeaders projectId="evergreen" columns={[]} loading />,
+      {
+        wrapper,
+      }
+    );
+    expect(queryAllByDataCy("loading-header-cell")).toHaveLength(7);
+  });
+
+  it("renders the column headers properly when not loading", async () => {
+    const { queryAllByDataCy } = render(
+      () => (
+        <ColumnHeaders
+          loading={false}
+          projectId="evergreen"
+          columns={["variant1", "variant2", "variant3"]}
+        />
+      ),
+      {
+        wrapper: ({ children }) =>
+          wrapper({
+            children,
+            state: {
+              visibleColumns: ["variant1", "variant2", "variant3"],
+            },
+          }),
+      }
+    );
+    expect(queryAllByDataCy("loading-header-cell")).toHaveLength(0);
+    expect(queryAllByDataCy("header-cell")).toHaveLength(3);
+  });
+
+  it("should link to corresponding /variant-history/:projectId/:variantName page", async () => {
+    const { queryByRole } = render(
+      () => (
+        <ColumnHeaders
+          loading={false}
+          projectId="evergreen"
+          columns={["variant1"]}
+        />
+      ),
+      {
+        wrapper: ({ children }) =>
+          wrapper({
+            children,
+            state: {
+              visibleColumns: ["variant1"],
+            },
+          }),
+      }
+    );
+    expect(queryByRole("link")).toHaveAttribute(
+      "href",
+      "/task-history/evergreen/variant1"
+    );
+  });
+
+  it("should truncate the variant name when only if it is too long", async () => {
+    const { queryByText } = render(
+      () => (
+        <ColumnHeaders
+          loading={false}
+          projectId="evergreen"
+          columns={[longTaskName, "variant2"]}
+        />
+      ),
+      {
+        wrapper: ({ children }) =>
+          wrapper({
+            children,
+            state: {
+              visibleColumns: [longTaskName, "variant2"],
+            },
+          }),
+      }
+    );
+
+    await waitFor(() => {
+      expect(queryByText(longTaskName)).toBeNull();
+    });
+    await waitFor(() => {
+      expect(queryByText("variant2")).toBeVisible();
+    });
+  });
+
+  it("should show a tooltip with the full name when hovering over a truncated variant name", async () => {
+    const { queryByText } = render(
+      () => (
+        <ColumnHeaders
+          loading={false}
+          projectId="evergreen"
+          columns={[longTaskName]}
+        />
+      ),
+      {
+        wrapper: ({ children }) =>
+          wrapper({
+            children,
+            state: {
+              visibleColumns: [longTaskName],
+            },
+          }),
+      }
+    );
+    fireEvent.mouseEnter(queryByText(trimmedTaskName));
+    await waitFor(() => {
+      expect(queryByText(longTaskName)).toBeVisible();
+    });
+  });
+});

--- a/src/pages/variantHistory/ColumnHeaders.test.tsx
+++ b/src/pages/variantHistory/ColumnHeaders.test.tsx
@@ -1,4 +1,3 @@
-import { MockedProvider, MockedResponse } from "@apollo/client/testing";
 import { context } from "components/HistoryTable";
 import { HistoryTableReducerState } from "components/HistoryTable/historyTableContextReducer";
 import {
@@ -30,16 +29,13 @@ const initialState: HistoryTableReducerState = {
 
 interface wrapperProps {
   children: React.ReactNode;
-  mocks?: MockedResponse[];
   state?: Partial<HistoryTableReducerState>;
 }
 
-const wrapper: React.FC<wrapperProps> = ({ children, mocks = [], state }) => (
-  <MockedProvider mocks={mocks}>
-    <HistoryTableProvider initialState={{ ...initialState, ...state }}>
-      {children}
-    </HistoryTableProvider>
-  </MockedProvider>
+const wrapper: React.FC<wrapperProps> = ({ children, state }) => (
+  <HistoryTableProvider initialState={{ ...initialState, ...state }}>
+    {children}
+  </HistoryTableProvider>
 );
 
 describe("columnHeaders (Variant History)", () => {

--- a/src/pages/variantHistory/ColumnHeaders.test.tsx
+++ b/src/pages/variantHistory/ColumnHeaders.test.tsx
@@ -28,12 +28,12 @@ const initialState: HistoryTableReducerState = {
   columnLimit: 7,
 };
 
-interface wrapperProps {
+interface WrapperProps {
   children: React.ReactNode;
   state?: Partial<HistoryTableReducerState>;
 }
 
-const wrapper: React.FC<wrapperProps> = ({ children, state }) => (
+const wrapper: React.FC<WrapperProps> = ({ children, state }) => (
   <HistoryTableProvider initialState={{ ...initialState, ...state }}>
     {children}
   </HistoryTableProvider>

--- a/src/pages/variantHistory/ColumnHeaders.test.tsx
+++ b/src/pages/variantHistory/ColumnHeaders.test.tsx
@@ -1,6 +1,10 @@
 import { context } from "components/HistoryTable";
 import { HistoryTableReducerState } from "components/HistoryTable/historyTableContextReducer";
 import {
+  variantHistoryMaxLength as maxLength,
+  variantHistoryTrailingLength as trailingLength,
+} from "constants/history";
+import {
   fireEvent,
   renderWithRouterMatch as render,
   waitFor,
@@ -11,7 +15,7 @@ import ColumnHeaders from "./ColumnHeaders";
 const { trimMiddleText } = string;
 const { HistoryTableProvider } = context;
 const longTaskName = "really_really_really_really_really_really_long_task_name";
-const trimmedTaskName = trimMiddleText(longTaskName, 50, 10);
+const trimmedTaskName = trimMiddleText(longTaskName, maxLength, trailingLength);
 
 const initialState: HistoryTableReducerState = {
   loadedCommits: [],

--- a/src/pages/variantHistory/ColumnHeaders.test.tsx
+++ b/src/pages/variantHistory/ColumnHeaders.test.tsx
@@ -1,9 +1,6 @@
 import { context } from "components/HistoryTable";
 import { HistoryTableReducerState } from "components/HistoryTable/historyTableContextReducer";
-import {
-  variantHistoryMaxLength as maxLength,
-  variantHistoryTrailingLength as trailingLength,
-} from "constants/history";
+import { variantHistoryMaxLength as maxLength } from "constants/history";
 import {
   fireEvent,
   renderWithRouterMatch as render,
@@ -12,10 +9,10 @@ import {
 import { string } from "utils";
 import ColumnHeaders from "./ColumnHeaders";
 
-const { trimMiddleText } = string;
+const { trimStringFromMiddle } = string;
 const { HistoryTableProvider } = context;
 const longTaskName = "really_really_really_really_really_really_long_task_name";
-const trimmedTaskName = trimMiddleText(longTaskName, maxLength, trailingLength);
+const trimmedTaskName = trimStringFromMiddle(longTaskName, maxLength);
 
 const initialState: HistoryTableReducerState = {
   loadedCommits: [],

--- a/src/pages/variantHistory/ColumnHeaders.tsx
+++ b/src/pages/variantHistory/ColumnHeaders.tsx
@@ -1,17 +1,30 @@
 import styled from "@emotion/styled";
+import Tooltip from "@leafygreen-ui/tooltip";
 import { Skeleton } from "antd";
 import { context, Cell } from "components/HistoryTable";
-import { array } from "utils";
+import { StyledRouterLink } from "components/styles";
+import { getTaskHistoryRoute } from "constants/routes";
+import { array, string } from "utils";
 
 const { mapStringArrayToObject } = array;
+const { trimMiddleText } = string;
 const { useHistoryTable } = context;
 const { HeaderCell } = Cell;
 
+const maxLength = 50;
+const trailingLength = 10;
+
 interface ColumnHeadersProps {
+  projectId: string;
   columns: string[];
   loading: boolean;
 }
-const ColumnHeaders: React.FC<ColumnHeadersProps> = ({ columns, loading }) => {
+
+const ColumnHeaders: React.FC<ColumnHeadersProps> = ({
+  projectId,
+  columns,
+  loading,
+}) => {
   const { visibleColumns, columnLimit } = useHistoryTable();
   const columnMap = mapStringArrayToObject(columns, "name");
 
@@ -23,12 +36,33 @@ const ColumnHeaders: React.FC<ColumnHeadersProps> = ({ columns, loading }) => {
         if (!cell) {
           return null;
         }
-        return <HeaderCell key={`header_cell_${vc}`}>{vc}</HeaderCell>;
+        return (
+          <HeaderCell data-cy="header-cell" key={`header_cell_${vc}`}>
+            {vc.length < maxLength ? (
+              <StyledRouterLink to={getTaskHistoryRoute(projectId, vc)}>
+                {vc}
+              </StyledRouterLink>
+            ) : (
+              <Tooltip
+                align="top"
+                justify="middle"
+                trigger={
+                  <StyledRouterLink to={getTaskHistoryRoute(projectId, vc)}>
+                    {trimMiddleText(vc, maxLength, trailingLength)}
+                  </StyledRouterLink>
+                }
+                triggerEvent="hover"
+              >
+                {vc}
+              </Tooltip>
+            )}
+          </HeaderCell>
+        );
       })}
       {loading &&
         Array.from(Array(columnLimit)).map((_, i) => (
           // eslint-disable-next-line react/no-array-index-key
-          <HeaderCell key={`loading_cell_${i}`}>
+          <HeaderCell data-cy="loading-header-cell" key={`loading_cell_${i}`}>
             <Skeleton active title paragraph={false} />
           </HeaderCell>
         ))}

--- a/src/pages/variantHistory/ColumnHeaders.tsx
+++ b/src/pages/variantHistory/ColumnHeaders.tsx
@@ -1,5 +1,10 @@
 import styled from "@emotion/styled";
 import { context, Cell } from "components/HistoryTable";
+import {
+  variantHistoryMaxLength as maxLength,
+  variantHistoryTrailingLength as trailingLength,
+} from "constants/history";
+
 import { getTaskHistoryRoute } from "constants/routes";
 import { array, string } from "utils";
 
@@ -7,10 +12,6 @@ const { mapStringArrayToObject } = array;
 const { trimMiddleText } = string;
 const { useHistoryTable } = context;
 const { LoadingCell, ColumnHeaderCell } = Cell;
-
-const maxLength = 50;
-const trailingLength = 10;
-
 interface ColumnHeadersProps {
   projectId: string;
   columns: string[];

--- a/src/pages/variantHistory/ColumnHeaders.tsx
+++ b/src/pages/variantHistory/ColumnHeaders.tsx
@@ -1,15 +1,12 @@
 import styled from "@emotion/styled";
 import { context, Cell } from "components/HistoryTable";
-import {
-  variantHistoryMaxLength as maxLength,
-  variantHistoryTrailingLength as trailingLength,
-} from "constants/history";
+import { variantHistoryMaxLength as maxLength } from "constants/history";
 
 import { getTaskHistoryRoute } from "constants/routes";
 import { array, string } from "utils";
 
 const { mapStringArrayToObject } = array;
-const { trimMiddleText } = string;
+const { trimStringFromMiddle } = string;
 const { useHistoryTable } = context;
 const { LoadingCell, ColumnHeaderCell } = Cell;
 interface ColumnHeadersProps {
@@ -38,7 +35,7 @@ const ColumnHeaders: React.FC<ColumnHeadersProps> = ({
           <ColumnHeaderCell
             key={`header_cell_${vc}`}
             link={getTaskHistoryRoute(projectId, vc)}
-            trimmedDisplayName={trimMiddleText(vc, maxLength, trailingLength)}
+            trimmedDisplayName={trimStringFromMiddle(vc, maxLength)}
             fullDisplayName={vc}
           />
         );

--- a/src/pages/variantHistory/ColumnHeaders.tsx
+++ b/src/pages/variantHistory/ColumnHeaders.tsx
@@ -1,15 +1,12 @@
 import styled from "@emotion/styled";
-import Tooltip from "@leafygreen-ui/tooltip";
-import { Skeleton } from "antd";
 import { context, Cell } from "components/HistoryTable";
-import { StyledRouterLink } from "components/styles";
 import { getTaskHistoryRoute } from "constants/routes";
 import { array, string } from "utils";
 
 const { mapStringArrayToObject } = array;
 const { trimMiddleText } = string;
 const { useHistoryTable } = context;
-const { HeaderCell } = Cell;
+const { LoadingCell, ColumnHeaderCell } = Cell;
 
 const maxLength = 50;
 const trailingLength = 10;
@@ -37,34 +34,18 @@ const ColumnHeaders: React.FC<ColumnHeadersProps> = ({
           return null;
         }
         return (
-          <HeaderCell data-cy="header-cell" key={`header_cell_${vc}`}>
-            {vc.length < maxLength ? (
-              <StyledRouterLink to={getTaskHistoryRoute(projectId, vc)}>
-                {vc}
-              </StyledRouterLink>
-            ) : (
-              <Tooltip
-                align="top"
-                justify="middle"
-                trigger={
-                  <StyledRouterLink to={getTaskHistoryRoute(projectId, vc)}>
-                    {trimMiddleText(vc, maxLength, trailingLength)}
-                  </StyledRouterLink>
-                }
-                triggerEvent="hover"
-              >
-                {vc}
-              </Tooltip>
-            )}
-          </HeaderCell>
+          <ColumnHeaderCell
+            key={`header_cell_${vc}`}
+            link={getTaskHistoryRoute(projectId, vc)}
+            trimmedDisplayName={trimMiddleText(vc, maxLength, trailingLength)}
+            fullDisplayName={vc}
+          />
         );
       })}
       {loading &&
         Array.from(Array(columnLimit)).map((_, i) => (
           // eslint-disable-next-line react/no-array-index-key
-          <HeaderCell data-cy="loading-header-cell" key={`loading_cell_${i}`}>
-            <Skeleton active title paragraph={false} />
-          </HeaderCell>
+          <LoadingCell key={`loading_cell_${i}`} isHeader />
         ))}
     </RowContainer>
   );

--- a/src/utils/string/index.ts
+++ b/src/utils/string/index.ts
@@ -176,10 +176,10 @@ export const shortenGithash = (str: string) => str?.substring(0, 7);
  * @return {string} The original or trimmed text.
  */
 export const trimStringFromMiddle = (text: string, maxLength: number) => {
-  const ellipsis = "...";
+  const ellipsis = "…";
   const numCharsToRemove = text.length - maxLength;
 
-  // if ellipsis would just make the string longer/same, just return original string
+  // if ellipsis would make the string longer/same, just return original string
   if (numCharsToRemove <= ellipsis.length) {
     return text;
   }

--- a/src/utils/string/index.ts
+++ b/src/utils/string/index.ts
@@ -169,7 +169,8 @@ export const applyStrictRegex = (str: string) => `^${str}$`;
 export const shortenGithash = (str: string) => str?.substring(0, 7);
 
 /**
- * Function that trims the middle portion of a string. ex: "Hello" -> "He...lo"
+ * Function that trims the middle portion of a string. ex: "EvergreenUI" -> "Ev...UI"
+ * If a string is longer than maxLength, it gets cropped exactly to maxLength.
  * @param {string} text - Text to trim
  * @param {number} maxLength - Max length before trimming text
  * @param {number} trailingLength - Desired length of trailing text
@@ -180,11 +181,13 @@ export const trimMiddleText = (
   maxLength: number,
   trailingLength: number
 ): string => {
+  const ellipsis = "...";
   if (text.length > maxLength) {
-    // eslint-disable-next-line
-    return `${text.substring(0, maxLength - trailingLength)}...${text.substring(
-      text.length - trailingLength
-    )}`;
+    return (
+      text.substring(0, maxLength - trailingLength - ellipsis.length) +
+      ellipsis +
+      text.substring(text.length - trailingLength)
+    );
   }
   return text;
 };

--- a/src/utils/string/index.ts
+++ b/src/utils/string/index.ts
@@ -170,26 +170,26 @@ export const shortenGithash = (str: string) => str?.substring(0, 7);
 
 /**
  * Function that trims the middle portion of a string. ex: "EvergreenUI" -> "Ev...UI"
- * The resulting length, if trimmed, is maxLength + 3 (due to ellipsis length).
- * @param {string} text - Text to trim
+ * The resulting length, if trimmed, is maxLength + 1 (due to ellipsis length).
+ * @param {string} str - Text to trim
  * @param {number} maxLength - Max length before trimming text
  * @return {string} The original or trimmed text.
  */
-export const trimStringFromMiddle = (text: string, maxLength: number) => {
+export const trimStringFromMiddle = (str: string, maxLength: number) => {
   const ellipsis = "…";
-  const numCharsToRemove = text.length - maxLength;
+  const numCharsToRemove = str.length - maxLength;
 
   // if ellipsis would make the string longer/same, just return original string
   if (numCharsToRemove <= ellipsis.length) {
-    return text;
+    return str;
   }
 
-  const midpoint = Math.floor(text.length / 2);
+  const midpoint = Math.floor(str.length / 2);
   const frontOffset = Math.floor(numCharsToRemove / 2);
   const backOffset = Math.ceil(numCharsToRemove / 2);
   return (
-    text.substring(0, midpoint - frontOffset) +
+    str.substring(0, midpoint - frontOffset) +
     ellipsis +
-    text.substring(midpoint + backOffset)
+    str.substring(midpoint + backOffset)
   );
 };

--- a/src/utils/string/index.ts
+++ b/src/utils/string/index.ts
@@ -167,3 +167,24 @@ export const applyStrictRegex = (str: string) => `^${str}$`;
  * @return {string} A shortenend version of the input string.
  */
 export const shortenGithash = (str: string) => str?.substring(0, 7);
+
+/**
+ * Function that trims the middle portion of a string. ex: "Hello" -> "He...lo"
+ * @param {string} text - Text to trim
+ * @param {number} maxLength - Max length before trimming text
+ * @param {number} trailingLength - Desired length of trailing text
+ * @return {string} The original or trimmed text.
+ */
+export const trimMiddleText = (
+  text: string,
+  maxLength: number,
+  trailingLength: number
+): string => {
+  if (text.length > maxLength) {
+    // eslint-disable-next-line
+    return `${text.substring(0, maxLength - trailingLength)}...${text.substring(
+      text.length - trailingLength
+    )}`;
+  }
+  return text;
+};

--- a/src/utils/string/index.ts
+++ b/src/utils/string/index.ts
@@ -170,24 +170,26 @@ export const shortenGithash = (str: string) => str?.substring(0, 7);
 
 /**
  * Function that trims the middle portion of a string. ex: "EvergreenUI" -> "Ev...UI"
- * If a string is longer than maxLength, it gets cropped exactly to maxLength.
+ * The resulting length, if trimmed, is maxLength + 3 (due to ellipsis length).
  * @param {string} text - Text to trim
  * @param {number} maxLength - Max length before trimming text
- * @param {number} trailingLength - Desired length of trailing text
  * @return {string} The original or trimmed text.
  */
-export const trimMiddleText = (
-  text: string,
-  maxLength: number,
-  trailingLength: number
-): string => {
+export const trimStringFromMiddle = (text: string, maxLength: number) => {
   const ellipsis = "...";
-  if (text.length > maxLength) {
-    return (
-      text.substring(0, maxLength - trailingLength - ellipsis.length) +
-      ellipsis +
-      text.substring(text.length - trailingLength)
-    );
+  const numCharsToRemove = text.length - maxLength;
+
+  // if ellipsis would just make the string longer/same, just return original string
+  if (numCharsToRemove <= ellipsis.length) {
+    return text;
   }
-  return text;
+
+  const midpoint = Math.floor(text.length / 2);
+  const frontOffset = Math.floor(numCharsToRemove / 2);
+  const backOffset = Math.ceil(numCharsToRemove / 2);
+  return (
+    text.substring(0, midpoint - frontOffset) +
+    ellipsis +
+    text.substring(midpoint + backOffset)
+  );
 };

--- a/src/utils/string/string.test.ts
+++ b/src/utils/string/string.test.ts
@@ -6,7 +6,7 @@ import {
   getDateCopy,
   applyStrictRegex,
   shortenGithash,
-  trimMiddleText,
+  trimStringFromMiddle,
 } from ".";
 
 describe("msToDuration", () => {
@@ -286,11 +286,12 @@ describe("shortenGithash", () => {
   });
 });
 
-describe("trimMiddleText", () => {
+describe("trimStringFromMiddle", () => {
   it("trims middle text according to specified params", () => {
-    expect(trimMiddleText("task_name", 7, 3)).toBe("t...ame");
+    expect(trimStringFromMiddle("task_name", 4)).toBe("ta...me"); // odd length
+    expect(trimStringFromMiddle("task_name2", 4)).toBe("ta...e2"); // even length
   });
   it("doesn't trim middle text if original text is smaller than maxLength specified", () => {
-    expect(trimMiddleText("task_name", 10, 1)).toBe("task_name");
+    expect(trimStringFromMiddle("task_name", 10)).toBe("task_name");
   });
 });

--- a/src/utils/string/string.test.ts
+++ b/src/utils/string/string.test.ts
@@ -288,8 +288,8 @@ describe("shortenGithash", () => {
 
 describe("trimStringFromMiddle", () => {
   it("trims middle text according to specified params", () => {
-    expect(trimStringFromMiddle("task_name", 4)).toBe("ta...me"); // odd length
-    expect(trimStringFromMiddle("task_name2", 4)).toBe("ta...e2"); // even length
+    expect(trimStringFromMiddle("task_name", 4)).toBe("ta…me"); // odd length
+    expect(trimStringFromMiddle("task_name2", 4)).toBe("ta…e2"); // even length
   });
   it("doesn't trim middle text if original text is smaller than maxLength specified", () => {
     expect(trimStringFromMiddle("task_name", 10)).toBe("task_name");

--- a/src/utils/string/string.test.ts
+++ b/src/utils/string/string.test.ts
@@ -6,6 +6,7 @@ import {
   getDateCopy,
   applyStrictRegex,
   shortenGithash,
+  trimMiddleText,
 } from ".";
 
 describe("msToDuration", () => {
@@ -282,5 +283,14 @@ describe("shortenGithash", () => {
   });
   it("handles undefined input", () => {
     expect(shortenGithash(undefined)).toBeUndefined();
+  });
+});
+
+describe("trimMiddleText", () => {
+  it("trims middle text according to specified params", () => {
+    expect(trimMiddleText("task_name", 7, 3)).toBe("task...ame");
+  });
+  it("doesn't trim middle text if original text is smaller than maxLength specified", () => {
+    expect(trimMiddleText("task_name", 10, 1)).toBe("task_name");
   });
 });

--- a/src/utils/string/string.test.ts
+++ b/src/utils/string/string.test.ts
@@ -288,7 +288,7 @@ describe("shortenGithash", () => {
 
 describe("trimMiddleText", () => {
   it("trims middle text according to specified params", () => {
-    expect(trimMiddleText("task_name", 7, 3)).toBe("task...ame");
+    expect(trimMiddleText("task_name", 7, 3)).toBe("t...ame");
   });
   it("doesn't trim middle text if original text is smaller than maxLength specified", () => {
     expect(trimMiddleText("task_name", 10, 1)).toBe("task_name");


### PR DESCRIPTION
[EVG-16119](https://jira.mongodb.org/browse/EVG-16119)

### Description 
This PR linkifies the column headers on the variant and task history pages. It also trims column headers by inserting an ellipsis (`...`) if a variant or task name exceeds a given length. If a variant or task name has been trimmed, a tooltip displaying the full name will appear when hovering over it; otherwise, no tooltip appears.

Also adds a small CSS fix to solve a visual bug that was occurring on Safari.

### Screenshots
https://user-images.githubusercontent.com/47064971/150229673-5e561fbf-2cc0-425a-a580-592f27eef34c.mov

### Testing 
- Added unit tests for `ColumnHeaders.tsx` in `pages/variantHistory` and `pages/taskHistory` folders
- Added a unit test for new function `trimMiddleText` in `utils/string/string.test.ts`
