### PR TITLE
EVG-16153: Update SpruceForm ui elements

### DIFF
--- a/src/components/Accordion/index.tsx
+++ b/src/components/Accordion/index.tsx
@@ -9,6 +9,8 @@ interface AccordionProps {
   showCaret?: boolean;
   contents: React.ReactNode;
   allowToggleFromTitle?: boolean;
+  defaultOpen?: boolean;
+  titleTag?: React.FC;
 }
 export const Accordion: React.FC<AccordionProps> = ({
   title,
@@ -17,13 +19,18 @@ export const Accordion: React.FC<AccordionProps> = ({
   toggleFromBottom = false,
   showCaret = true,
   allowToggleFromTitle = true,
+  defaultOpen = false,
+  titleTag,
 }) => {
-  const [isAccordionDisplayed, setIsAccordionDisplayed] = useState(false);
+  const [isAccordionDisplayed, setIsAccordionDisplayed] = useState(defaultOpen);
   const toggleAccordionHandler = (): void =>
     setIsAccordionDisplayed(!isAccordionDisplayed);
 
   const showToggledTitle = isAccordionDisplayed ? toggledTitle : title;
-  const titleComp = <>{toggledTitle ? showToggledTitle : title}</>;
+  const TitleTag = titleTag ?? "span";
+  const titleComp = (
+    <TitleTag>{toggledTitle ? showToggledTitle : title}</TitleTag>
+  );
   return (
     <>
       {toggleFromBottom && (

--- a/src/components/ProjectSettingsTabs/AccessTab/getFormSchema.ts
+++ b/src/components/ProjectSettingsTabs/AccessTab/getFormSchema.ts
@@ -75,7 +75,7 @@ export const getFormSchema = (
       "ui:rootFieldId": "admin",
       "ui:ObjectFieldTemplate": CardFieldTemplate,
       admins: {
-        "ui:buttonText": "Add Username",
+        "ui:addButtonText": "Add Username",
         "ui:description": getAdminsDescription(useRepoSettings),
         "ui:showLabel": false,
         options: {

--- a/src/components/ProjectSettingsTabs/Context.tsx
+++ b/src/components/ProjectSettingsTabs/Context.tsx
@@ -7,11 +7,7 @@ import { ProjectSettingsTabRoutes } from "constants/routes";
 /* Given a diff between a form's previous and current state, check if it represents an array field added with no content. */
 const isArrayPushUpdate = (diff: object): boolean =>
   Object.values(diff).every((val) => {
-    if (val === null) {
-      return false;
-    }
-
-    if (typeof val !== "object") {
+    if (val === null || typeof val !== "object") {
       return false;
     }
     // An empty object represents a new array element (i.e. blank input field)

--- a/src/components/ProjectSettingsTabs/Context.tsx
+++ b/src/components/ProjectSettingsTabs/Context.tsx
@@ -7,6 +7,10 @@ import { ProjectSettingsTabRoutes } from "constants/routes";
 /* Given a diff between a form's previous and current state, check if it represents an array field added with no content. */
 const isArrayPushUpdate = (diff: object): boolean =>
   Object.values(diff).every((val) => {
+    if (val === null) {
+      return false;
+    }
+
     if (typeof val !== "object") {
       return false;
     }
@@ -73,9 +77,7 @@ const reducer = (state: TabState, action: Action): TabState => {
 interface ProjectSettingsState {
   tabs: TabState;
   saveTab: (tab: ProjectSettingsTabRoutes) => void;
-  getTab: (
-    tab: ProjectSettingsTabRoutes
-  ) => TabState[ProjectSettingsTabRoutes.General]; // TODO: update type as all tabs are implemented
+  getTab: (tab: ProjectSettingsTabRoutes) => FormDataProps;
   updateForm: (
     tab: ProjectSettingsTabRoutes,
     save?: boolean

--- a/src/components/ProjectSettingsTabs/GeneralTab/getFormSchema.ts
+++ b/src/components/ProjectSettingsTabs/GeneralTab/getFormSchema.ts
@@ -329,7 +329,7 @@ export const getFormSchema = (
       },
       files: {
         filesIgnoredFromCache: {
-          "ui:buttonText": "Add File Pattern",
+          "ui:addButtonText": "Add File Pattern",
           "ui:field": "filesIgnoredFromCacheField",
           options: { useRepoSettings },
         },

--- a/src/components/ProjectSettingsTabs/VariablesTab/getFormSchema.ts
+++ b/src/components/ProjectSettingsTabs/VariablesTab/getFormSchema.ts
@@ -64,7 +64,7 @@ export const getFormSchema = (
   uiSchema: {
     "ui:ObjectFieldTemplate": CardFieldTemplate,
     vars: {
-      "ui:buttonText": "Add Variables",
+      "ui:addButtonText": "Add Variables",
       "ui:description": getDescription(useRepoSettings),
       "ui:fullWidth": true,
       "ui:showLabel": false,

--- a/src/components/SpruceForm/CustomFields.tsx
+++ b/src/components/SpruceForm/CustomFields.tsx
@@ -1,13 +1,22 @@
 import styled from "@emotion/styled";
-import { Description, Subtitle } from "@leafygreen-ui/typography";
-import { FieldProps } from "@rjsf/core";
+import { Description, H3, Subtitle } from "@leafygreen-ui/typography";
+import { Field } from "@rjsf/core";
 
-export const TitleField: React.FC<FieldProps> = ({ id, title }) => (
-  <>
-    {/* @ts-expect-error  */}
-    <StyledSubtitle id={id}>{title}</StyledSubtitle>
-  </>
-);
+export const TitleField: Field = ({ id, isSectionTitle, title }) => {
+  const Component = isSectionTitle ? StyledH3 : StyledSubtitle;
+  return (
+    <>
+      {/* @ts-expect-error  */}
+      <Component id={id}>{title}</Component>
+    </>
+  );
+};
+
+/* @ts-expect-error  */
+const StyledH3 = styled(H3)`
+  margin-top: 24px;
+  margin-bottom: 12px;
+`;
 
 /* @ts-expect-error  */
 const StyledSubtitle = styled(Subtitle)`
@@ -15,8 +24,12 @@ const StyledSubtitle = styled(Subtitle)`
   margin-bottom: 12px;
 `;
 
-export const DescriptionField: React.FC<FieldProps> = ({ id, description }) => (
-  <StyledDescription id={id}>{description}</StyledDescription>
+export const DescriptionField: Field = ({ id, description }) => (
+  <>
+    {description && (
+      <StyledDescription id={id}>{description}</StyledDescription>
+    )}
+  </>
 );
 
 const StyledDescription = styled(Description)`

--- a/src/components/SpruceForm/CustomFields.tsx
+++ b/src/components/SpruceForm/CustomFields.tsx
@@ -1,8 +1,15 @@
 import styled from "@emotion/styled";
 import { Description, H3, Subtitle } from "@leafygreen-ui/typography";
-import { Field } from "@rjsf/core";
+import { Field, FieldProps } from "@rjsf/core";
 
-export const TitleField: Field = ({ id, isSectionTitle, title }) => {
+type TitleFieldProps = Pick<FieldProps, "id" | "title" | "uiSchema">;
+
+export const TitleField: React.FC<TitleFieldProps> = ({
+  id,
+  title,
+  uiSchema,
+}) => {
+  const isSectionTitle = uiSchema?.["ui:sectionTitle"] ?? false;
   const Component = isSectionTitle ? StyledH3 : StyledSubtitle;
   return (
     /* @ts-expect-error */

--- a/src/components/SpruceForm/CustomFields.tsx
+++ b/src/components/SpruceForm/CustomFields.tsx
@@ -5,10 +5,8 @@ import { Field } from "@rjsf/core";
 export const TitleField: Field = ({ id, isSectionTitle, title }) => {
   const Component = isSectionTitle ? StyledH3 : StyledSubtitle;
   return (
-    <>
-      {/* @ts-expect-error  */}
-      <Component id={id}>{title}</Component>
-    </>
+    /* @ts-expect-error */
+    <Component id={id}>{title}</Component>
   );
 };
 
@@ -24,13 +22,10 @@ const StyledSubtitle = styled(Subtitle)`
   margin-bottom: 12px;
 `;
 
-export const DescriptionField: Field = ({ id, description }) => (
-  <>
-    {description && (
-      <StyledDescription id={id}>{description}</StyledDescription>
-    )}
-  </>
-);
+export const DescriptionField: Field = ({ id, description }) =>
+  description ? (
+    <StyledDescription id={id}>{description}</StyledDescription>
+  ) : null;
 
 const StyledDescription = styled(Description)`
   margin-bottom: 12px;

--- a/src/components/SpruceForm/FieldTemplates.tsx
+++ b/src/components/SpruceForm/FieldTemplates.tsx
@@ -2,6 +2,7 @@ import styled from "@emotion/styled";
 import Button from "@leafygreen-ui/button";
 import {
   ArrayFieldTemplateProps,
+  FieldProps,
   FieldTemplateProps,
   ObjectFieldTemplateProps,
 } from "@rjsf/core";
@@ -24,7 +25,9 @@ export const DefaultFieldTemplate: React.FC<FieldTemplateProps> = ({
 }) => {
   const isNullType = schema.type === "null";
   // fields is incorrectly typed in FieldTemplateProps, so cast to avoid type error
-  const { TitleField } = fields as any;
+  const { TitleField } = (fields as unknown) as {
+    TitleField: React.StatelessComponent<Partial<FieldProps>>;
+  };
   const { "ui:sectionTitle": sectionTitle = false } = uiSchema;
   return (
     !hidden && (
@@ -133,7 +136,7 @@ type ArrayContainerProps = {
 };
 
 const ArrayContainer = styled.div`
-  ${({ hasChildren }) => hasChildren && "margin-buttom: 24px;"}
+  ${({ hasChildren }) => hasChildren && "margin-bottom: 24px;"}
   min-width: min-content;
   width: ${({ fullWidth }: ArrayContainerProps): string =>
     fullWidth ? "100%" : "60%"};

--- a/src/components/SpruceForm/FieldTemplates.tsx
+++ b/src/components/SpruceForm/FieldTemplates.tsx
@@ -6,6 +6,7 @@ import {
   ObjectFieldTemplateProps,
 } from "@rjsf/core";
 import Icon from "components/Icon";
+import { Unpacked } from "types/utils";
 import { SpruceFormContainer } from "./Container";
 import ElementWrapper from "./ElementWrapper";
 
@@ -13,15 +14,75 @@ import ElementWrapper from "./ElementWrapper";
 export const DefaultFieldTemplate: React.FC<FieldTemplateProps> = ({
   classNames,
   children,
+  description,
+  fields,
   hidden,
-}) => !hidden && <div className={classNames}>{children}</div>;
+  id,
+  label,
+  schema,
+  uiSchema,
+}) => {
+  const isNullType = schema.type === "null";
+  // fields is incorrectly typed in FieldTemplateProps, so cast to avoid type error
+  const { TitleField } = fields as any;
+  const { "ui:sectionTitle": sectionTitle = false } = uiSchema;
+  return (
+    !hidden && (
+      <>
+        {isNullType && (
+          <TitleField id={id} title={label} isSectionTitle={sectionTitle} />
+        )}
+        {isNullType && <>{description}</>}
+        <div className={classNames}>{children}</div>
+      </>
+    )
+  );
+};
+
+const ArrayItem: React.FC<
+  { topAlignDelete: boolean } & Unpacked<ArrayFieldTemplateProps["items"]>
+> = ({
+  children,
+  disabled,
+  hasRemove,
+  index,
+  onDropIndexClick,
+  readonly,
+  topAlignDelete,
+}) => (
+  <ArrayItemRow key={index} topAlignDelete={topAlignDelete}>
+    {children}
+    {hasRemove && (
+      <DeleteButtonWrapper>
+        <Button
+          onClick={onDropIndexClick(index)}
+          disabled={disabled || readonly}
+          leftGlyph={<Icon glyph="Trash" />}
+          data-cy="delete-item-button"
+        />
+      </DeleteButtonWrapper>
+    )}
+  </ArrayItemRow>
+);
+
+const ArrayItemRow = styled.div`
+  align-items: ${({ topAlignDelete }: { topAlignDelete: boolean }) =>
+    topAlignDelete ? "flex-start" : "flex-end"};
+  display: flex;
+
+  .field-object {
+    flex-grow: 1;
+  }
+`;
 
 export const ArrayFieldTemplate: React.FC<ArrayFieldTemplateProps> = ({
   canAdd,
   DescriptionField,
+  disabled,
   idSchema,
   items,
   onAddClick,
+  readonly,
   required,
   schema,
   title,
@@ -30,9 +91,12 @@ export const ArrayFieldTemplate: React.FC<ArrayFieldTemplateProps> = ({
 }) => {
   const id = idSchema.$id;
   const description = uiSchema["ui:description"] || schema.description;
-  const buttonText = uiSchema["ui:buttonText"] || "Add";
+  const addButtonSize = uiSchema["ui:addButtonSize"] || "small";
+  const addButtonText = uiSchema["ui:addButtonText"] || "Add";
   const fullWidth = !!uiSchema["ui:fullWidth"];
   const showLabel = uiSchema["ui:showLabel"] !== false;
+  const topAlignDelete = uiSchema["ui:topAlignDelete"] ?? false;
+  const isDisabled = disabled || readonly;
   return (
     <>
       {showLabel && (
@@ -41,67 +105,42 @@ export const ArrayFieldTemplate: React.FC<ArrayFieldTemplateProps> = ({
       {description && (
         <DescriptionField id={`${id}__description`} description={description} />
       )}
-      {canAdd && (
+      {!readonly && canAdd && (
         <ElementWrapper>
           <Button
             data-cy="add-button"
+            disabled={isDisabled}
             leftGlyph={<Icon glyph="Plus" />}
             onClick={onAddClick}
-            size="small"
+            size={addButtonSize}
           >
-            {buttonText}
+            {addButtonText}
           </Button>
         </ElementWrapper>
       )}
-      <ArrayContainer fullWidth={fullWidth}>
-        {items.map(
-          ({
-            children,
-            disabled,
-            hasRemove,
-            index,
-            onDropIndexClick,
-            readonly,
-          }) => (
-            <ArrayItemRow key={index}>
-              {children}
-              {hasRemove && (
-                <DeleteButtonWrapper>
-                  <Button
-                    onClick={onDropIndexClick(index)}
-                    disabled={disabled || readonly}
-                    leftGlyph={<Icon glyph="Trash" />}
-                    data-cy="delete-item-button"
-                  />
-                </DeleteButtonWrapper>
-              )}
-            </ArrayItemRow>
-          )
-        )}
+      <ArrayContainer fullWidth={fullWidth} hasChildren={!!items?.length}>
+        {items.map((p) => (
+          <ArrayItem key={p.key} topAlignDelete={topAlignDelete} {...p} />
+        ))}
       </ArrayContainer>
     </>
   );
 };
 
+type ArrayContainerProps = {
+  hasChildren: boolean;
+  fullWidth?: boolean;
+};
+
 const ArrayContainer = styled.div`
-  margin-bottom: 24px;
+  ${({ hasChildren }) => hasChildren && "margin-buttom: 24px;"}
   min-width: min-content;
-  width: ${(props: { fullWidth?: boolean }): string =>
-    props.fullWidth ? "100%" : "60%"};
-`;
-
-const ArrayItemRow = styled.div`
-  align-items: flex-start;
-  display: flex;
-
-  .field-object {
-    flex-grow: 1;
-  }
+  width: ${({ fullWidth }: ArrayContainerProps): string =>
+    fullWidth ? "100%" : "60%"};
 `;
 
 const DeleteButtonWrapper = styled(ElementWrapper)`
   margin-left: 16px;
-  margin-top: 20px;
 `;
 
 export const CardFieldTemplate: React.FC<ObjectFieldTemplateProps> = ({

--- a/src/components/SpruceForm/FieldTemplates.tsx
+++ b/src/components/SpruceForm/FieldTemplates.tsx
@@ -2,13 +2,13 @@ import styled from "@emotion/styled";
 import Button from "@leafygreen-ui/button";
 import {
   ArrayFieldTemplateProps,
-  FieldProps,
   FieldTemplateProps,
   ObjectFieldTemplateProps,
 } from "@rjsf/core";
 import Icon from "components/Icon";
 import { Unpacked } from "types/utils";
 import { SpruceFormContainer } from "./Container";
+import { TitleField as CustomTitleField } from "./CustomFields";
 import ElementWrapper from "./ElementWrapper";
 
 // Custom field template that does not render fields' titles, as this is handled by LeafyGreen widgets
@@ -16,7 +16,6 @@ export const DefaultFieldTemplate: React.FC<FieldTemplateProps> = ({
   classNames,
   children,
   description,
-  fields,
   hidden,
   id,
   label,
@@ -24,16 +23,11 @@ export const DefaultFieldTemplate: React.FC<FieldTemplateProps> = ({
   uiSchema,
 }) => {
   const isNullType = schema.type === "null";
-  // fields is incorrectly typed in FieldTemplateProps, so cast to avoid type error
-  const { TitleField } = (fields as unknown) as {
-    TitleField: React.StatelessComponent<Partial<FieldProps>>;
-  };
-  const { "ui:sectionTitle": sectionTitle = false } = uiSchema;
   return (
     !hidden && (
       <>
         {isNullType && (
-          <TitleField id={id} title={label} isSectionTitle={sectionTitle} />
+          <CustomTitleField id={id} title={label} uiSchema={uiSchema} />
         )}
         {isNullType && <>{description}</>}
         <div className={classNames}>{children}</div>

--- a/src/components/SpruceForm/LeafyGreenWidgets.tsx
+++ b/src/components/SpruceForm/LeafyGreenWidgets.tsx
@@ -43,7 +43,7 @@ export const LeafyGreenTextInput: React.FC<WidgetProps> = ({
         <TextInput
           data-cy={dataCy}
           value={value === null || value === undefined ? null : `${value}`}
-          // @ts-ignore
+          // @ts-expect-error
           aria-labelledby={ariaLabelledBy}
           label={ariaLabelledBy ? undefined : label}
           placeholder={placeholder || undefined}
@@ -135,7 +135,7 @@ export const LeafyGreenSelect: React.FC<WidgetProps> = ({
       <MaxWidthContainer>
         <Select
           allowDeselect={allowDeselect !== false}
-          // @ts-ignore
+          // @ts-expect-error
           aria-labelledby={ariaLabelledBy}
           label={ariaLabelledBy ? undefined : label}
           value={value}

--- a/src/components/SpruceForm/LeafyGreenWidgets.tsx
+++ b/src/components/SpruceForm/LeafyGreenWidgets.tsx
@@ -28,7 +28,12 @@ export const LeafyGreenTextInput: React.FC<WidgetProps> = ({
   readonly,
   formContext,
 }) => {
-  const { description, "data-cy": dataCy, emptyValue } = options;
+  const {
+    ariaLabelledBy,
+    description,
+    "data-cy": dataCy,
+    emptyValue,
+  } = options;
   const errors = getInputErrors(rawErrors);
   const hasError = !!errors?.length;
   const { readonlyAsDisabled = true } = formContext;
@@ -38,7 +43,9 @@ export const LeafyGreenTextInput: React.FC<WidgetProps> = ({
         <TextInput
           data-cy={dataCy}
           value={value === null || value === undefined ? null : `${value}`}
-          label={label}
+          // @ts-ignore
+          aria-labelledby={ariaLabelledBy}
+          label={ariaLabelledBy ? undefined : label}
           placeholder={placeholder || undefined}
           description={description as string}
           disabled={disabled || (readonlyAsDisabled && readonly)}
@@ -227,7 +234,7 @@ export const LeafyGreenRadioBox: React.FC<WidgetProps> = ({
       >
         {enumOptions.map((o) => (
           <StyledRadioBox
-            key={o.value}
+            key={valueMap.indexOf(o.value)}
             value={valueMap.indexOf(o.value)}
             disabled={disabled}
           >

--- a/src/components/SpruceForm/SpruceForm.test.tsx
+++ b/src/components/SpruceForm/SpruceForm.test.tsx
@@ -1,28 +1,41 @@
-import { render, fireEvent } from "test_utils";
+import { render, fireEvent, waitFor } from "test_utils";
 import { SpruceForm, SpruceFormContainer } from ".";
 
 describe("spruceForm", () => {
   it("should render as expected", () => {
     const onChange = jest.fn();
-    const { container, getByLabelText } = render(
+    const {
+      container,
+      getAllByRole,
+      getByLabelText,
+      queryByDataCy,
+      queryByText,
+    } = render(
       <SpruceFormContainer title="Just a test">
         <SpruceForm
           schema={basicForm.schema}
           formData={basicForm.formData}
           onChange={onChange}
+          uiSchema={basicForm.uiSchema}
         />
       </SpruceFormContainer>
     );
     expect(getByLabelText("Project Cloning Method")).toBeInTheDocument();
     expect(container.firstChild).toMatchSnapshot();
+
+    expect(queryByText("Username Label")).not.toBeInTheDocument();
+    expect(queryByDataCy("add-button")).toHaveTextContent("New User");
+    expect(getAllByRole("heading", { level: 3 })[1]).toHaveTextContent(
+      "Manage Access"
+    );
   });
-  it("updating the form should trigger a callback and update the form state", () => {
+  it("updating the form should trigger a callback and update the form state", async () => {
     let data = {};
     const onChange = jest.fn((x) => {
       const { formData } = x;
       data = formData;
     });
-    const { queryByDataCy } = render(
+    const { queryAllByDataCy, queryByDataCy } = render(
       <SpruceFormContainer title="Just a test">
         <SpruceForm
           schema={basicForm.schema}
@@ -35,12 +48,21 @@ describe("spruceForm", () => {
     fireEvent.change(queryByDataCy("valid-projects-input"), {
       target: { value: "new value" },
     });
+    await fireEvent.click(queryByDataCy("add-button"));
+    await waitFor(() =>
+      expect(queryAllByDataCy("new-user-input")).toHaveLength(2)
+    );
+    fireEvent.change(queryAllByDataCy("new-user-input")[1], {
+      target: { value: "new-user" },
+    });
     // eslint-disable-next-line jest/prefer-called-with
     expect(onChange).toHaveBeenCalled();
     expect(queryByDataCy("valid-projects-input")).toHaveValue("new value");
     expect(data).toStrictEqual({
       ...basicForm.formData,
+      access: null,
       validProjects: "new value",
+      users: ["initial-user", "new-user"],
     });
   });
 });
@@ -60,23 +82,48 @@ const basicForm = {
         title: "Valid Projects",
         placeholder: "Sample input",
       },
+      access: {
+        type: "null" as "null",
+        title: "Manage Access",
+      },
+      users: {
+        type: "array" as "array",
+        title: "Users",
+        items: {
+          type: "string" as "string",
+          title: "Username Label",
+        },
+      },
     },
   },
   formData: {
     cloneMethod: "legacy-ssh",
     validProjects: "spruce",
+    users: ["initial-user"],
   },
   uiSchema: {
+    cloneMethod: {
+      "ui:options": {
+        label: false,
+      },
+    },
     validProjects: {
       "ui:widget": "textarea",
       "ui:options": {
         "data-cy": "valid-projects-input",
         label: false,
       },
-      cloneMethod: {
-        "ui:options": {
-          label: false,
-        },
+    },
+    access: {
+      "ui:rootFieldId": "access",
+      "ui:sectionTitle": true,
+    },
+    users: {
+      "ui:addButtonText": "New User",
+      "ui:data-cy": "new-user-input",
+      items: {
+        "ui:ariaLabelledBy": "root_access",
+        "ui:data-cy": "new-user-input",
       },
     },
   },

--- a/src/components/SpruceForm/SpruceForm.test.tsx
+++ b/src/components/SpruceForm/SpruceForm.test.tsx
@@ -48,7 +48,7 @@ describe("spruceForm", () => {
     fireEvent.change(queryByDataCy("valid-projects-input"), {
       target: { value: "new value" },
     });
-    await fireEvent.click(queryByDataCy("add-button"));
+    fireEvent.click(queryByDataCy("add-button"));
     await waitFor(() =>
       expect(queryAllByDataCy("new-user-input")).toHaveLength(2)
     );

--- a/src/components/SpruceForm/__snapshots__/SpruceForm.stories.storyshot
+++ b/src/components/SpruceForm/__snapshots__/SpruceForm.stories.storyshot
@@ -136,7 +136,7 @@ exports[`storybook Storyshots Spruce Form Example 1 1`] = `
               </button>
             </div>
             <div
-              className="css-18s7j4r-ArrayContainer e7smmlm1"
+              className="css-fwqti9-ArrayContainer e7smmlm1"
             >
               <div
                 className="css-1hhgr19-ArrayItemRow e7smmlm2"

--- a/src/components/SpruceForm/__snapshots__/SpruceForm.stories.storyshot
+++ b/src/components/SpruceForm/__snapshots__/SpruceForm.stories.storyshot
@@ -12,7 +12,7 @@ exports[`storybook Storyshots Spruce Form Example 1 1`] = `
   >
     <form
       className="rjsf"
-      noValidate={false}
+      noValidate={true}
       onSubmit={[Function]}
     >
       <div
@@ -136,10 +136,10 @@ exports[`storybook Storyshots Spruce Form Example 1 1`] = `
               </button>
             </div>
             <div
-              className="css-1iijkzv-ArrayContainer e7smmlm2"
+              className="css-18s7j4r-ArrayContainer e7smmlm1"
             >
               <div
-                className="css-scktrh-ArrayItemRow e7smmlm1"
+                className="css-1hhgr19-ArrayItemRow e7smmlm2"
               >
                 <div
                   className="form-group field field-object"
@@ -252,7 +252,7 @@ exports[`storybook Storyshots Spruce Form Example 1 1`] = `
                   </fieldset>
                 </div>
                 <div
-                  className="css-1w3q9da-ElementWrapper-DeleteButtonWrapper e7smmlm0"
+                  className="css-x2ce4n-ElementWrapper-DeleteButtonWrapper e7smmlm0"
                 >
                   <button
                     aria-disabled={false}
@@ -346,7 +346,7 @@ exports[`storybook Storyshots Spruce Form Example 2 1`] = `
   >
     <form
       className="rjsf"
-      noValidate={false}
+      noValidate={true}
       onSubmit={[Function]}
     >
       <div
@@ -632,7 +632,7 @@ exports[`storybook Storyshots Spruce Form Example 3 1`] = `
   >
     <form
       className="rjsf"
-      noValidate={false}
+      noValidate={true}
       onSubmit={[Function]}
     >
       <div

--- a/src/components/SpruceForm/__snapshots__/SpruceForm.test.tsx.snap
+++ b/src/components/SpruceForm/__snapshots__/SpruceForm.test.tsx.snap
@@ -409,7 +409,7 @@ exports[`spruceForm should render as expected 1`] = `
 }
 
 .emotion-36 {
-  margin-buttom: 24px;
+  margin-bottom: 24px;
   min-width: -webkit-min-content;
   min-width: -moz-min-content;
   min-width: min-content;

--- a/src/components/SpruceForm/__snapshots__/SpruceForm.test.tsx.snap
+++ b/src/components/SpruceForm/__snapshots__/SpruceForm.test.tsx.snap
@@ -204,7 +204,7 @@ exports[`spruceForm should render as expected 1`] = `
   margin-left: 6px;
 }
 
-.emotion-21 {
+.emotion-19 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -214,7 +214,7 @@ exports[`spruceForm should render as expected 1`] = `
   flex-direction: column;
 }
 
-.emotion-22 {
+.emotion-20 {
   font-size: 14px;
   font-weight: bold;
   line-height: 16px;
@@ -222,7 +222,219 @@ exports[`spruceForm should render as expected 1`] = `
   color: #3D4F58;
 }
 
+.emotion-21 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  position: relative;
+  z-index: 0;
+}
+
+.emotion-21:hover>[data-leafygreen-ui="interaction-ring"] {
+  box-shadow: 0 0 0 3px #E7EEEC;
+}
+
+.emotion-22 {
+  width: 100%;
+  height: 100%;
+  font-family: inherit;
+  font-size: 100%;
+  width: 100%;
+  min-height: 64px;
+  resize: none;
+  border-radius: 4px;
+  margin: 0;
+  padding: 10px 12px 1px 12px;
+  font-size: 14px;
+  font-weight: normal;
+  font-family: Akzidenz,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 16px;
+  z-index: 1;
+  border: 1px solid;
+  -webkit-transition: border-color 150ms ease-in-out;
+  transition: border-color 150ms ease-in-out;
+  color: #21313C;
+  background-color: #FFFFFF;
+  border-color: #B8C4C2;
+}
+
+.emotion-22:focus {
+  outline: none;
+}
+
+.emotion-22:disabled {
+  cursor: not-allowed;
+}
+
+.emotion-22:focus {
+  border-color: #FFFFFF;
+}
+
+.emotion-22:disabled {
+  color: #89979B;
+  background-color: #E7EEEC;
+}
+
 .emotion-23 {
+  -webkit-transition: all 150ms ease-in-out;
+  transition: all 150ms ease-in-out;
+  position: absolute;
+  z-index: -1;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  pointer-events: none;
+  border-radius: 4px;
+}
+
+.emotion-24 {
+  margin-top: 24px;
+  margin-bottom: 12px;
+}
+
+.emotion-27 {
+  margin-top: 16px;
+  margin-bottom: 12px;
+}
+
+.emotion-29 {
+  margin: unset;
+  font-family: Akzidenz,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  color: #21313C;
+  font-size: 18px;
+  line-height: 24px;
+  letter-spacing: 0px;
+}
+
+.emotion-32 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  appearance: none;
+  padding: 0;
+  margin: 0;
+  background-color: transparent;
+  border: 0px solid transparent;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  border-radius: 4px;
+  -webkit-transition: all 150ms ease-in-out;
+  transition: all 150ms ease-in-out;
+  position: relative;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  cursor: pointer;
+  z-index: 0;
+  background-color: #F9FBFA;
+  border: 1px solid #89979B;
+  box-shadow: 0px 1px 2px rgba(6, 22, 33, 0.3);
+  color: #3D4F58;
+  font-size: 14px;
+  height: 28px;
+}
+
+.emotion-32:focus {
+  outline: none;
+}
+
+.emotion-32:disabled {
+  pointer-events: none;
+}
+
+.emotion-32:active,
+.emotion-32:focus,
+.emotion-32:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-32:focus {
+  color: #3D4F58;
+}
+
+.emotion-32:hover,
+.emotion-32:active {
+  color: #3D4F58;
+  background-color: #FFFFFF;
+  border: 1px solid #5D6C74;
+  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.3),0px 0px 0px 3px #E7EEEC;
+}
+
+.emotion-32:focus {
+  background: #FFFFFF;
+  border: 1px solid #5D6C74;
+  box-shadow: 0px 4px 4px rgba(0, 124, 173, 0.4),0px 0px 0px 3px #019EE2;
+}
+
+.emotion-34 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
+  width: 100%;
+  pointer-events: none;
+  position: relative;
+  z-index: 0;
+  font-family: Akzidenz,'Helvetica Neue',Helvetica,Arial,sans-serif;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  padding-left: 12px;
+  padding-right: 12px;
+}
+
+.emotion-35 {
+  color: #5D6C74;
+  height: 16px;
+  width: 16px;
+  margin-right: 6px;
+}
+
+.emotion-36 {
+  margin-buttom: 24px;
+  min-width: -webkit-min-content;
+  min-width: -moz-min-content;
+  min-width: min-content;
+  width: 60%;
+}
+
+.emotion-38 {
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-38 .field-object {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.emotion-45 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -235,7 +447,7 @@ exports[`spruceForm should render as expected 1`] = `
   z-index: 0;
 }
 
-.emotion-24 {
+.emotion-46 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -249,11 +461,11 @@ exports[`spruceForm should render as expected 1`] = `
   width: 100%;
 }
 
-.emotion-24:hover>[data-leafygreen-ui="interaction-ring"] {
+.emotion-46:hover>[data-leafygreen-ui="interaction-ring"] {
   box-shadow: 0 0 0 3px #E7EEEC;
 }
 
-.emotion-25 {
+.emotion-47 {
   width: 100%;
   height: 100%;
   font-family: inherit;
@@ -276,38 +488,38 @@ exports[`spruceForm should render as expected 1`] = `
   border-color: #89979B;
 }
 
-.emotion-25::-webkit-input-placeholder {
+.emotion-47::-webkit-input-placeholder {
   color: #89979B;
 }
 
-.emotion-25::-moz-placeholder {
+.emotion-47::-moz-placeholder {
   color: #89979B;
 }
 
-.emotion-25:-ms-input-placeholder {
+.emotion-47:-ms-input-placeholder {
   color: #89979B;
 }
 
-.emotion-25::placeholder {
+.emotion-47::placeholder {
   color: #89979B;
 }
 
-.emotion-25:disabled {
+.emotion-47:disabled {
   cursor: not-allowed;
 }
 
-.emotion-25:focus {
+.emotion-47:focus {
   border: 1px solid #FFFFFF;
 }
 
-.emotion-25:disabled {
+.emotion-47:disabled {
   color: #89979B;
   background-color: #E7EEEC;
 }
 
-.emotion-25:disabled:-webkit-autofill,
-.emotion-25:disabled:-webkit-autofill:hover,
-.emotion-25:disabled:-webkit-autofill:focus {
+.emotion-47:disabled:-webkit-autofill,
+.emotion-47:disabled:-webkit-autofill:hover,
+.emotion-47:disabled:-webkit-autofill:focus {
   -webkit-appearance: none;
   -moz-appearance: none;
   -ms-appearance: none;
@@ -317,20 +529,7 @@ exports[`spruceForm should render as expected 1`] = `
   -webkit-box-shadow: 0 0 0px 1000px #E7EEEC inset;
 }
 
-.emotion-26 {
-  -webkit-transition: all 150ms ease-in-out;
-  transition: all 150ms ease-in-out;
-  position: absolute;
-  z-index: -1;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  pointer-events: none;
-  border-radius: 4px;
-}
-
-.emotion-27 {
+.emotion-49 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -344,6 +543,84 @@ exports[`spruceForm should render as expected 1`] = `
   z-index: 1;
 }
 
+.emotion-50 {
+  margin-bottom: 20px;
+  margin-left: 16px;
+}
+
+.emotion-52 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  appearance: none;
+  padding: 0;
+  margin: 0;
+  background-color: transparent;
+  border: 0px solid transparent;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  border-radius: 4px;
+  -webkit-transition: all 150ms ease-in-out;
+  transition: all 150ms ease-in-out;
+  position: relative;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  cursor: pointer;
+  z-index: 0;
+  background-color: #F9FBFA;
+  border: 1px solid #89979B;
+  box-shadow: 0px 1px 2px rgba(6, 22, 33, 0.3);
+  color: #3D4F58;
+  font-size: 14px;
+  height: 36px;
+}
+
+.emotion-52:focus {
+  outline: none;
+}
+
+.emotion-52:disabled {
+  pointer-events: none;
+}
+
+.emotion-52:active,
+.emotion-52:focus,
+.emotion-52:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-52:focus {
+  color: #3D4F58;
+}
+
+.emotion-52:hover,
+.emotion-52:active {
+  color: #3D4F58;
+  background-color: #FFFFFF;
+  border: 1px solid #5D6C74;
+  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.3),0px 0px 0px 3px #E7EEEC;
+}
+
+.emotion-52:focus {
+  background: #FFFFFF;
+  border: 1px solid #5D6C74;
+  box-shadow: 0px 4px 4px rgba(0, 124, 173, 0.4),0px 0px 0px 3px #019EE2;
+}
+
+.emotion-55 {
+  color: #3D4F58;
+  height: 16px;
+  width: 16px;
+  vertical-align: text-top;
+}
+
 <div>
   <h3
     class="emotion-0 emotion-1 emotion-2"
@@ -355,6 +632,7 @@ exports[`spruceForm should render as expected 1`] = `
   >
     <form
       class="rjsf"
+      novalidate=""
     >
       <div
         class="form-group field field-object"
@@ -433,42 +711,171 @@ exports[`spruceForm should render as expected 1`] = `
               class="emotion-6 emotion-7"
             >
               <div
-                class="emotion-8 emotion-9"
+                class="emotion-19"
               >
+                <label
+                  class="emotion-20"
+                  for="textarea-1"
+                >
+                  Valid Projects
+                </label>
                 <div
                   class="emotion-21"
                 >
-                  <label
+                  <textarea
                     class="emotion-22"
-                    for="textinput-1"
+                    data-cy="valid-projects-input"
+                    id="textarea-1"
+                    title="Valid Projects"
                   >
-                    Valid Projects
-                  </label>
+                    spruce
+                  </textarea>
                   <div
                     class="emotion-23"
+                    data-leafygreen-ui="interaction-ring"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+          <h3
+            class="emotion-24 emotion-25 emotion-2"
+            id="root_access"
+          >
+            Manage Access
+          </h3>
+          <div
+            class="form-group field field-null"
+          />
+          <div
+            class="form-group field field-array"
+          >
+            <h6
+              class="emotion-27 emotion-28 emotion-29"
+              id="root_users__title"
+            >
+              Users
+            </h6>
+            <div
+              class="emotion-6 emotion-7"
+            >
+              <button
+                aria-disabled="false"
+                class="emotion-32"
+                data-cy="add-button"
+                type="button"
+              >
+                <div
+                  class="emotion-12"
+                />
+                <div
+                  class="emotion-34"
+                >
+                  <svg
+                    alt=""
+                    aria-hidden="true"
+                    class="emotion-35"
+                    fill="none"
+                    height="16"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    width="16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M7.5 2a1 1 0 00-1 1v3.5H3a1 1 0 00-1 1v1a1 1 0 001 1h3.5V13a1 1 0 001 1h1a1 1 0 001-1V9.5H13a1 1 0 001-1v-1a1 1 0 00-1-1H9.5V3a1 1 0 00-1-1h-1z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                  New User
+                </div>
+              </button>
+            </div>
+            <div
+              class="emotion-36 emotion-37"
+            >
+              <div
+                class="emotion-38 emotion-39"
+              >
+                <div
+                  class="form-group field field-string"
+                >
+                  <div
+                    class="emotion-6 emotion-7"
                   >
                     <div
-                      class="emotion-24"
+                      class="emotion-8 emotion-9"
                     >
-                      <input
-                        aria-label="Valid Projects"
-                        autocomplete="on"
-                        class="emotion-25"
-                        id="textinput-1"
-                        required=""
-                        type="text"
-                        value="spruce"
-                      />
                       <div
-                        class="emotion-26"
-                        data-leafygreen-ui="interaction-ring"
-                      />
+                        class="emotion-19"
+                      >
+                        <div
+                          class="emotion-45"
+                        >
+                          <div
+                            class="emotion-46"
+                          >
+                            <input
+                              aria-label="Username Label"
+                              aria-labelledby="root_access"
+                              autocomplete="on"
+                              class="emotion-47"
+                              data-cy="new-user-input"
+                              id="textinput-1"
+                              required=""
+                              type="text"
+                              value="initial-user"
+                            />
+                            <div
+                              class="emotion-23"
+                              data-leafygreen-ui="interaction-ring"
+                            />
+                          </div>
+                          <div
+                            class="emotion-49"
+                            data-leafygreen-ui="icon-selector"
+                          />
+                        </div>
+                      </div>
                     </div>
-                    <div
-                      class="emotion-27"
-                      data-leafygreen-ui="icon-selector"
-                    />
                   </div>
+                </div>
+                <div
+                  class="emotion-50 emotion-51"
+                >
+                  <button
+                    aria-disabled="false"
+                    class="emotion-52"
+                    data-cy="delete-item-button"
+                    type="button"
+                  >
+                    <div
+                      class="emotion-12"
+                    />
+                    <div
+                      class="emotion-34"
+                    >
+                      <svg
+                        aria-label="Trash Icon"
+                        class="emotion-55"
+                        fill="none"
+                        height="16"
+                        role="img"
+                        viewBox="0 0 16 16"
+                        width="16"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M5 2a1 1 0 011-1h4a1 1 0 011 1h2a1 1 0 011 1v1H2V3a1 1 0 011-1h2zm9 3H2l1.678 8.392A2 2 0 005.64 15h4.72a2 2 0 001.962-1.608L14 5z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </button>
                 </div>
               </div>
             </div>

--- a/src/components/SpruceForm/index.tsx
+++ b/src/components/SpruceForm/index.tsx
@@ -38,6 +38,7 @@ export const SpruceForm: React.FC<SpruceFormProps> = ({
     validate={validate}
     customFormats={customFormats}
     liveValidate
+    noHtml5Validate
   >
     {/*  Need to pass in an empty fragment child to remove default submit button */}
     <></>


### PR DESCRIPTION
EVG-16153

### Description 
Break up some of the UI work from EVG-15081. This PR includes general changes that are not specific to the GitHub/Commit Queue page, but are used by this page
- Improve support for `null` type fields
- Better array customization
- Add new `sectionTitle` flag to expand form's text hierarchy
- Support hiding input labels by using LeafyGreen's text input's `ariaLabelledBy` prop

### Evergreen PR 
- Update unit tests & snapshot