### PR TITLE
EVG-16120 Snap commit chart labels to top of screen

### DIFF
--- a/src/components/Header/Navbar.tsx
+++ b/src/components/Header/Navbar.tsx
@@ -76,13 +76,14 @@ export const Navbar: React.FC = () => {
   );
 };
 
+export const navBarHeight = 64;
 const StyledNav = styled.nav`
   align-items: center;
   background-color: ${gray.dark3};
   display: flex;
   justify-content: space-between;
-  height: 64px;
-  line-height: 64px;
+  height: ${navBarHeight}px;
+  line-height: ${navBarHeight}px;
   padding: 0 36px;
 `;
 

--- a/src/components/StickyContainer/StickyContainer.stories.tsx
+++ b/src/components/StickyContainer/StickyContainer.stories.tsx
@@ -1,0 +1,34 @@
+import styled from "@emotion/styled";
+import { withKnobs, number } from "@storybook/addon-knobs";
+import StickyContainer from ".";
+
+export default {
+  title: "Sticky Container",
+  component: StickyContainer,
+  decorators: [withKnobs],
+};
+
+export const StickyContainerStory = () => (
+  <Page>
+    {Array.from({ length: 50 }).map((_, i) => (
+      // eslint-disable-next-line react/no-array-index-key
+      <div key={`${i}top`}>Some Element</div>
+    ))}
+    <StickyContainer offset={number("offset", 0)}>
+      <StickyElement>I am supposed to stick</StickyElement>
+    </StickyContainer>
+    {Array.from({ length: 50 }).map((_, i) => (
+      // eslint-disable-next-line react/no-array-index-key
+      <div key={`${i}bottom`}>Some Element</div>
+    ))}
+  </Page>
+);
+
+const StickyElement = styled.div`
+  background-color: blue;
+`;
+const Page = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 300px;
+`;

--- a/src/components/StickyContainer/__snapshots__/StickyContainer.stories.storyshot
+++ b/src/components/StickyContainer/__snapshots__/StickyContainer.stories.storyshot
@@ -1,0 +1,319 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`storybook Storyshots Sticky Container Sticky Container Story 1`] = `
+<div
+  className="css-sou4fc-Page e1h2hjem0"
+>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div />
+  <div
+    className="css-1gkww3q-StickyDiv-StickyContainer e1pdm2sm0"
+    offset={0}
+  >
+    <div
+      className="css-16bmt0k-StickyElement e1h2hjem1"
+    >
+      I am supposed to stick
+    </div>
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+  <div>
+    Some Element
+  </div>
+</div>
+`;

--- a/src/components/StickyContainer/index.tsx
+++ b/src/components/StickyContainer/index.tsx
@@ -1,0 +1,63 @@
+import { useRef, useEffect, useState } from "react";
+import { SerializedStyles } from "@emotion/react";
+import styled from "@emotion/styled";
+
+interface StickyContainerProps {
+  offset?: number;
+  styles?: SerializedStyles;
+  children: React.ReactNode;
+  containerRef?: React.RefObject<HTMLDivElement>;
+}
+
+const StickyContainer: React.FC<StickyContainerProps> = ({
+  children,
+  styles,
+  offset,
+  containerRef,
+}) => {
+  const ref = useRef<HTMLDivElement>(null);
+  const [sticky, setSticky] = useState(false);
+  const scrollableRef = (containerRef && containerRef.current) || window;
+  useEffect(() => {
+    scrollableRef.addEventListener("scroll", () => {
+      if (ref.current) {
+        const { top } = ref.current.getBoundingClientRect();
+        console.log("Firing scroll event", top);
+        if (top < offset) {
+          setSticky(true);
+        } else {
+          setSticky(false);
+        }
+      }
+    });
+    return () => {
+      scrollableRef.removeEventListener("scroll", () => {});
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  return (
+    <>
+      <div ref={ref} />
+      <StickyDiv sticky={sticky} css={sticky && styles} offset={offset}>
+        {children}
+      </StickyDiv>
+    </>
+  );
+};
+
+interface StickyDivProps {
+  sticky: boolean;
+  offset?: number;
+  css?: SerializedStyles;
+}
+const StickyDiv = styled.div<StickyDivProps>`
+  ${({ sticky, offset = 0, css }) =>
+    sticky &&
+    `
+        position: fixed;
+        top: ${offset}px;
+        ${css}
+  `}
+`;
+
+export default StickyContainer;

--- a/src/pages/Commits.tsx
+++ b/src/pages/Commits.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useQuery } from "@apollo/client";
 import styled from "@emotion/styled";
 import Cookies from "js-cookie";
@@ -45,6 +45,7 @@ const FAILED_STATUSES = [
 ];
 
 export const Commits = () => {
+  const pageWrapperRef = useRef<HTMLDivElement>(null);
   const dispatchToast = useToastContext();
   const { replace } = useHistory();
   const { search } = useLocation();
@@ -144,7 +145,7 @@ export const Commits = () => {
   ]);
 
   return (
-    <PageWrapper>
+    <PageWrapper ref={pageWrapperRef}>
       <PageContainer>
         <HeaderWrapper>
           <ElementWrapper width="35">
@@ -175,6 +176,7 @@ export const Commits = () => {
           hasTaskFilter={hasTaskFilter}
           hasFilters={hasFilters}
           onChangeChartType={onChangeChartType}
+          containerRef={pageWrapperRef}
         />
       </PageContainer>
     </PageWrapper>

--- a/src/pages/Commits.tsx
+++ b/src/pages/Commits.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { useQuery } from "@apollo/client";
 import styled from "@emotion/styled";
 import Cookies from "js-cookie";
@@ -18,7 +18,7 @@ import {
   MainlineCommitsQueryVariables,
 } from "gql/generated/types";
 import { GET_MAINLINE_COMMITS, GET_SPRUCE_CONFIG } from "gql/queries";
-import { usePageTitle, useNetworkStatus } from "hooks";
+import { usePageTitle, useNetworkStatus, useUpdateURLQueryParams } from "hooks";
 import {
   ChartToggleQueryParams,
   ChartTypes,
@@ -48,9 +48,17 @@ export const Commits = () => {
   const dispatchToast = useToastContext();
   const { replace } = useHistory();
   const { search } = useLocation();
-  const [currentChartType, setCurrentChartType] = useState<ChartTypes>(
-    DEFAULT_CHART_TYPE
-  );
+  const updateQueryParams = useUpdateURLQueryParams();
+  const parsed = parseQueryString(search);
+  const currentChartType =
+    (getString(parsed[ChartToggleQueryParams.chartType]) as ChartTypes) ||
+    DEFAULT_CHART_TYPE;
+
+  const onChangeChartType = (chartType: ChartTypes): void => {
+    updateQueryParams({
+      [ChartToggleQueryParams.chartType]: chartType,
+    });
+  };
 
   // get query params from url
   const { id: projectId } = useParams<{ id: string }>();
@@ -74,8 +82,6 @@ export const Commits = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [projectId]);
 
-  const parsed = parseQueryString(search);
-  const chartTypeParam = getString(parsed[ChartToggleQueryParams.chartType]);
   const filterStatuses = toArray(parsed[ProjectFilterOptions.Status]);
   const filterVariants = toArray(parsed[ProjectFilterOptions.BuildVariant]);
   const filterTasks = toArray(parsed[ProjectFilterOptions.Task]);
@@ -86,15 +92,6 @@ export const Commits = () => {
     parsed[MainlineCommitQueryParams.SkipOrderNumber]
   );
   const skipOrderNumber = parseInt(skipOrderNumberParam, 10) || undefined;
-
-  // set current chart type based on query param
-  useEffect(() => {
-    if (Object.values(ChartTypes).includes(chartTypeParam as ChartTypes)) {
-      setCurrentChartType(chartTypeParam as ChartTypes);
-    } else {
-      setCurrentChartType(DEFAULT_CHART_TYPE);
-    }
-  }, [chartTypeParam, setCurrentChartType]);
 
   const hasTaskFilter = filterTasks.length > 0;
 
@@ -177,6 +174,7 @@ export const Commits = () => {
           chartType={currentChartType}
           hasTaskFilter={hasTaskFilter}
           hasFilters={hasFilters}
+          onChangeChartType={onChangeChartType}
         />
       </PageContainer>
     </PageWrapper>

--- a/src/pages/commits/ActiveCommits/ChartToggle.tsx
+++ b/src/pages/commits/ActiveCommits/ChartToggle.tsx
@@ -3,38 +3,25 @@ import styled from "@emotion/styled";
 import { uiColors } from "@leafygreen-ui/palette";
 import { RadioGroup, Radio } from "@leafygreen-ui/radio-group";
 import { Label } from "@leafygreen-ui/typography";
-import { useLocation, useHistory } from "react-router-dom";
-import { ChartToggleQueryParams, ChartTypes } from "types/commits";
-import { queryString } from "utils";
+import { ChartTypes } from "types/commits";
 
 const { gray } = uiColors;
-const { stringifyQuery, parseQueryString } = queryString;
 
 export const ChartToggle: React.FC<{
   currentChartType: ChartTypes;
-}> = ({ currentChartType }) => {
-  const { pathname, search } = useLocation();
-  const { replace } = useHistory();
-
-  const onChangeChartType = (
-    event: React.ChangeEvent<HTMLInputElement>
-  ): void => {
-    const nextChartType = event.target.value;
-    replace(
-      `${pathname}?${stringifyQuery({
-        ...parseQueryString(search),
-        [ChartToggleQueryParams.chartType]: nextChartType,
-      })}`
-    );
+  onChangeChartType: (chartType: ChartTypes) => void;
+}> = ({ currentChartType, onChangeChartType }) => {
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const chartType = e.target.value as ChartTypes;
+    onChangeChartType(chartType);
   };
-
   return (
     <Container>
       <ToggleWrapper>
         <Label htmlFor="chart-toggle">View Options</Label>
         <StyledRadioGroup
           size="default"
-          onChange={onChangeChartType}
+          onChange={onChange}
           value={currentChartType}
           name="chart-select"
         >
@@ -42,7 +29,6 @@ export const ChartToggle: React.FC<{
             data-cy="cy-chart-absolute-radio"
             id="chart-radio-absolute"
             value={ChartTypes.Absolute}
-            checked={currentChartType === ChartTypes.Absolute}
           >
             <Label htmlFor="chart-radio-absolute">Absolute Number</Label>
           </Radio>
@@ -50,7 +36,6 @@ export const ChartToggle: React.FC<{
             data-cy="cy-chart-percent-radio"
             id="chart-radio-percent"
             value={ChartTypes.Percentage}
-            checked={currentChartType === ChartTypes.Percentage}
           >
             <Label htmlFor="chart-radio-percent">Percentage</Label>
           </Radio>

--- a/src/pages/commits/ActiveCommits/CommitChart.tsx
+++ b/src/pages/commits/ActiveCommits/CommitChart.tsx
@@ -1,6 +1,6 @@
-import React from "react";
 import styled from "@emotion/styled";
 import { ChartTypes } from "types/commits";
+import { commitChartHeight } from "../constants";
 import { CommitChartTooltip } from "./CommitChartTooltip";
 import { ColorCount, calculateBarHeight } from "./utils";
 
@@ -35,7 +35,7 @@ export const CommitChart: React.FC<Props> = ({
 );
 
 const ChartContainer = styled.div`
-  height: 224px;
+  height: ${commitChartHeight}px;
   display: flex;
   justify-content: flex-start;
   align-items: flex-end;

--- a/src/pages/commits/ActiveCommits/ProjectHealth.stories.tsx
+++ b/src/pages/commits/ActiveCommits/ProjectHealth.stories.tsx
@@ -7,7 +7,7 @@ import {
   FlexRowContainer,
   ProjectHealthWrapper,
 } from "../CommitsWrapper";
-import { InactiveCommits, InactiveCommitLine } from "../InactiveCommits/index";
+import InactiveCommits from "../InactiveCommits/index";
 import { Grid } from "./Grid";
 import { ActiveCommit } from "./index";
 import {
@@ -36,7 +36,6 @@ export const WaterfallAbsolute = () => (
           />
         ) : (
           <ColumnContainer key={rolledUpVersions[0].id}>
-            <InactiveCommitLine />
             <InactiveCommits rolledUpVersions={rolledUpVersions} />
           </ColumnContainer>
         )
@@ -62,7 +61,6 @@ export const WaterfallPercentage = () => (
           />
         ) : (
           <ColumnContainer key={rolledUpVersions[0].id}>
-            <InactiveCommitLine />
             <InactiveCommits rolledUpVersions={rolledUpVersions} />
           </ColumnContainer>
         )

--- a/src/pages/commits/ActiveCommits/ProjectHealth.stories.tsx
+++ b/src/pages/commits/ActiveCommits/ProjectHealth.stories.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { withKnobs, boolean } from "@storybook/addon-knobs";
 import StoryRouter from "storybook-react-router";
 import { ChartTypes } from "types/commits";
@@ -9,16 +10,20 @@ export default {
   decorators: [StoryRouter(), withKnobs],
 };
 
-export const ActualWaterfallPage = () => (
-  <CommitsWrapper
-    versions={versions}
-    isLoading={boolean("isLoading", false)}
-    error={null}
-    chartType={ChartTypes.Absolute}
-    hasTaskFilter={boolean("hasTaskFilter", false)}
-    hasFilters={boolean("hasFilters", false)}
-  />
-);
+export const ActualWaterfallPage = () => {
+  const [chartType, setChartType] = useState<ChartTypes>(ChartTypes.Absolute);
+  return (
+    <CommitsWrapper
+      versions={versions}
+      isLoading={boolean("isLoading", false)}
+      error={null}
+      chartType={chartType}
+      hasTaskFilter={boolean("hasTaskFilter", false)}
+      hasFilters={boolean("hasFilters", false)}
+      onChangeChartType={setChartType}
+    />
+  );
+};
 
 const versions = [
   {

--- a/src/pages/commits/ActiveCommits/ProjectHealth.stories.tsx
+++ b/src/pages/commits/ActiveCommits/ProjectHealth.stories.tsx
@@ -2,72 +2,22 @@ import { withKnobs, boolean } from "@storybook/addon-knobs";
 import StoryRouter from "storybook-react-router";
 import { ChartTypes } from "types/commits";
 import { TaskStatus } from "types/task";
-import {
-  ColumnContainer,
-  FlexRowContainer,
-  ProjectHealthWrapper,
-} from "../CommitsWrapper";
-import InactiveCommits from "../InactiveCommits/index";
-import { Grid } from "./Grid";
-import { ActiveCommit } from "./index";
-import {
-  getAllTaskStatsGroupedByColor,
-  findMaxGroupedTaskStats,
-} from "./utils";
+import { CommitsWrapper } from "../CommitsWrapper";
 
 export default {
   title: "Project Health Page",
   decorators: [StoryRouter(), withKnobs],
 };
 
-export const WaterfallAbsolute = () => (
-  <ProjectHealthWrapper>
-    <FlexRowContainer numCommits={versions.length}>
-      {versions.map(({ version, rolledUpVersions }) =>
-        version ? (
-          <ActiveCommit
-            key={version.id}
-            version={version}
-            chartType={ChartTypes.Absolute}
-            total={versionToGroupedTaskStatsMap[version.id].total}
-            max={max}
-            groupedTaskStats={versionToGroupedTaskStatsMap[version.id].stats}
-            hasTaskFilter={boolean("hasTaskFilter", false)}
-          />
-        ) : (
-          <ColumnContainer key={rolledUpVersions[0].id}>
-            <InactiveCommits rolledUpVersions={rolledUpVersions} />
-          </ColumnContainer>
-        )
-      )}
-    </FlexRowContainer>
-    <Grid numDashedLine={5} />
-  </ProjectHealthWrapper>
-);
-
-export const WaterfallPercentage = () => (
-  <ProjectHealthWrapper>
-    <FlexRowContainer numCommits={versions.length}>
-      {versions.map(({ version, rolledUpVersions }) =>
-        version ? (
-          <ActiveCommit
-            key={version.id}
-            version={version}
-            chartType={ChartTypes.Absolute}
-            total={versionToGroupedTaskStatsMap[version.id].total}
-            max={max}
-            groupedTaskStats={versionToGroupedTaskStatsMap[version.id].stats}
-            hasTaskFilter={boolean("hasTaskFilter", false)}
-          />
-        ) : (
-          <ColumnContainer key={rolledUpVersions[0].id}>
-            <InactiveCommits rolledUpVersions={rolledUpVersions} />
-          </ColumnContainer>
-        )
-      )}
-    </FlexRowContainer>
-    <Grid numDashedLine={5} />
-  </ProjectHealthWrapper>
+export const ActualWaterfallPage = () => (
+  <CommitsWrapper
+    versions={versions}
+    isLoading={boolean("isLoading", false)}
+    error={null}
+    chartType={ChartTypes.Absolute}
+    hasTaskFilter={boolean("hasTaskFilter", false)}
+    hasFilters={boolean("hasFilters", false)}
+  />
 );
 
 const versions = [
@@ -79,6 +29,7 @@ const versions = [
       message: "EVG-14901 add ssh key to EditSpawnHostModal (#805)",
       revision: "987bf57eb679c6361322c3961b30a10724a9b001",
       order: 929,
+      projectIdentifier: "spruce",
       taskStatusCounts: [
         { status: "system-timed-out", count: 4 },
         { status: "system-unresponsive", count: 3 },
@@ -88,6 +39,7 @@ const versions = [
       buildVariants: [
         {
           displayName: "01. Code Health [code_health]",
+          variant: "code_health",
           tasks: [
             {
               status: TaskStatus.Pending,
@@ -99,6 +51,7 @@ const versions = [
         },
         {
           displayName: "02. Packaging (RPM - RHEL7) [package_rpm]",
+          variant: "package_rpm",
           tasks: [
             {
               status: TaskStatus.WillRun,
@@ -120,6 +73,7 @@ const versions = [
       message: "Triggered From Git Tag 'v2.11.1': v2.11.1",
       revision: "a77bd39ccf515b63327dc2355a8444955043c66a",
       order: 928,
+      projectIdentifier: "spruce",
       taskStatusCounts: [
         { status: "system-failed", count: 6 },
         { status: "pending", count: 2 },
@@ -130,6 +84,7 @@ const versions = [
       buildVariants: [
         {
           displayName: "01. Code Health [code_health]",
+          variant: "code_health",
           tasks: [
             {
               status: TaskStatus.Pending,
@@ -141,6 +96,7 @@ const versions = [
         },
         {
           displayName: "02. Packaging (RPM - RHEL7) [package_rpm]",
+          variant: "package_rpm",
           tasks: [
             {
               status: TaskStatus.Pending,
@@ -163,6 +119,7 @@ const versions = [
         author: "Mohamed Khelif",
         order: 927,
         message: "v2.11.1",
+        projectIdentifier: "spruce",
         revision: "a77bd39ccf515b63327dc2355a8444955043c66a",
       },
     ],
@@ -176,6 +133,7 @@ const versions = [
         "EVG-14799 Correctly visit configure page when no tab indicated (#810)",
       revision: "9c1d1ebc85829d69dde7684fbcce86dd21e5a9ad",
       order: 926,
+      projectIdentifier: "spruce",
       taskStatusCounts: [
         { status: "setup-failed", count: 4 },
         { status: "inactive", count: 3 },
@@ -185,6 +143,7 @@ const versions = [
       buildVariants: [
         {
           displayName: "01. Code Health [code_health]",
+          variant: "code_health",
           tasks: [
             {
               status: TaskStatus.WillRun,
@@ -196,6 +155,7 @@ const versions = [
         },
         {
           displayName: "02. Packaging (RPM - RHEL7) [package_rpm]",
+          variant: "package_rpm",
           tasks: [
             {
               status: TaskStatus.Pending,
@@ -216,6 +176,7 @@ const versions = [
       createTime: new Date("2021-07-13T14:51:30Z"),
       message: "Remove navigation announcement toast (#808)",
       revision: "f7f7f1a3abdb9897dfc02b7a1de9821651b0916e",
+      projectIdentifier: "spruce",
       order: 925,
       taskStatusCounts: [
         { status: "blocked", count: 4 },
@@ -226,6 +187,7 @@ const versions = [
       buildVariants: [
         {
           displayName: "01. Code Health [code_health]",
+          variant: "code_health",
           tasks: [
             {
               status: TaskStatus.WillRun,
@@ -237,6 +199,7 @@ const versions = [
         },
         {
           displayName: "02. Packaging (RPM - RHEL7) [package_rpm]",
+          variant: "package_rpm",
           tasks: [
             {
               status: TaskStatus.Succeeded,
@@ -257,6 +220,7 @@ const versions = [
       createTime: new Date("2021-07-13T14:51:30Z"),
       message: "Triggered From Git Tag 'v2.11.0': v2.11.0",
       revision: "211b3a06e2948a5afa5dbd61c2322037c300629b",
+      projectIdentifier: "spruce",
       order: 924,
       taskStatusCounts: [
         { status: "success", count: 6 },
@@ -268,6 +232,7 @@ const versions = [
       buildVariants: [
         {
           displayName: "01. Code Health [code_health]",
+          variant: "code_health",
           tasks: [
             {
               status: TaskStatus.Failed,
@@ -279,6 +244,7 @@ const versions = [
         },
         {
           displayName: "02. Packaging (RPM - RHEL7) [package_rpm]",
+          variant: "package_rpm",
           tasks: [
             {
               status: TaskStatus.Failed,
@@ -293,6 +259,3 @@ const versions = [
     rolledUpVersions: null,
   },
 ];
-
-const versionToGroupedTaskStatsMap = getAllTaskStatsGroupedByColor(versions);
-const { max } = findMaxGroupedTaskStats(versionToGroupedTaskStatsMap);

--- a/src/pages/commits/ActiveCommits/__snapshots__/ProjectHealth.stories.storyshot
+++ b/src/pages/commits/ActiveCommits/__snapshots__/ProjectHealth.stories.storyshot
@@ -8,10 +8,10 @@ exports[`storybook Storyshots Project Health Page Actual Waterfall Page 1`] = `
     className="css-f6c9ue-FlexRowContainer ech0nhv3"
   >
     <div
-      className="css-6yhz1l-Container e1s1lwa10"
+      className="css-1ry038z-Container e1s1lwa10"
     >
       <div
-        className="css-m6knb7-ColumnContainer e1s1lwa11"
+        className="css-1cagedb-ColumnContainer e1s1lwa11"
       >
         <div
           className="leafygreen-ui-cssveg css-tdhexo-ChartContainer e1tzsy281"
@@ -40,54 +40,60 @@ exports[`storybook Storyshots Project Health Page Actual Waterfall Page 1`] = `
             height="16.666666666666664%"
           />
         </div>
+        <div />
         <div
-          className="css-1qv3l5b-LabelContainer e1cz15301"
-          data-cy="commit-label"
+          className="css-1gkww3q-StickyDiv-StickyContainer e1pdm2sm0"
+          offset={64}
         >
           <div
-            className="css-1l2peoq-LabelText e1cz15300 leafygreen-ui-1mngpnd"
+            className="css-1qv3l5b-LabelContainer e1cz15301"
+            data-cy="commit-label"
           >
-            <a
-              className="css-1bct88o-StyledRouterLink-linkStyles es7lfqt0"
-              href="/version/spruce_987bf57eb679c6361322c3961b30a10724a9b001/tasks"
-              onClick={[Function]}
+            <div
+              className="css-1l2peoq-LabelText e1cz15300 leafygreen-ui-1mngpnd"
             >
-              987bf57
-            </a>
-             
-            7/16/21 3:53 PM
-          </div>
-          <div
-            className="css-1l2peoq-LabelText e1cz15300 leafygreen-ui-1mngpnd"
-          >
-            Jonathan Brill
-             -
-          </div>
-          <div
-            className="css-1l2peoq-LabelText e1cz15300 leafygreen-ui-1mngpnd"
-          >
-            
-            <a
-              className="css-1yjsn23-StyledLink-linkStyles es7lfqt2"
-              href="https://undefined/browse/EVG-14901"
+              <a
+                className="css-1bct88o-StyledRouterLink-linkStyles es7lfqt0"
+                href="/version/spruce_987bf57eb679c6361322c3961b30a10724a9b001/tasks"
+                onClick={[Function]}
+              >
+                987bf57
+              </a>
+               
+              7/16/21 3:53 PM
+            </div>
+            <div
+              className="css-1l2peoq-LabelText e1cz15300 leafygreen-ui-1mngpnd"
             >
-              EVG-14901
-            </a>
-             add ssh key to EditSpawnHos...
+              Jonathan Brill
+               -
+            </div>
+            <div
+              className="css-1l2peoq-LabelText e1cz15300 leafygreen-ui-1mngpnd"
+            >
+              
+              <a
+                className="css-1yjsn23-StyledLink-linkStyles es7lfqt2"
+                href="https://undefined/browse/EVG-14901"
+              >
+                EVG-14901
+              </a>
+               add ssh key to EditSpawnHos...
+            </div>
+            <small
+              className="css-2n0pzr-ButtonText eq9i5u71 leafygreen-ui-1mvgvb8"
+              onBlur={[Function]}
+              onFocus={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+            >
+              more
+            </small>
           </div>
-          <small
-            className="css-2n0pzr-ButtonText eq9i5u71 leafygreen-ui-1mvgvb8"
-            onBlur={[Function]}
-            onFocus={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-          >
-            more
-          </small>
         </div>
       </div>
       <div
-        className="css-m6knb7-ColumnContainer e1s1lwa11"
+        className="css-1cagedb-ColumnContainer e1s1lwa11"
       >
         <div
           className="css-8bv1t4-Container ek3nkvx1"
@@ -190,10 +196,10 @@ exports[`storybook Storyshots Project Health Page Actual Waterfall Page 1`] = `
       </div>
     </div>
     <div
-      className="css-6yhz1l-Container e1s1lwa10"
+      className="css-1ry038z-Container e1s1lwa10"
     >
       <div
-        className="css-m6knb7-ColumnContainer e1s1lwa11"
+        className="css-1cagedb-ColumnContainer e1s1lwa11"
       >
         <div
           className="leafygreen-ui-cssveg css-tdhexo-ChartContainer e1tzsy281"
@@ -228,47 +234,53 @@ exports[`storybook Storyshots Project Health Page Actual Waterfall Page 1`] = `
             height="100%"
           />
         </div>
+        <div />
         <div
-          className="css-1qv3l5b-LabelContainer e1cz15301"
-          data-cy="commit-label"
+          className="css-1gkww3q-StickyDiv-StickyContainer e1pdm2sm0"
+          offset={64}
         >
           <div
-            className="css-1l2peoq-LabelText e1cz15300 leafygreen-ui-1mngpnd"
+            className="css-1qv3l5b-LabelContainer e1cz15301"
+            data-cy="commit-label"
           >
-            <a
-              className="css-1bct88o-StyledRouterLink-linkStyles es7lfqt0"
-              href="/version/spruce_v2.11.1_60eda8722a60ed09bb78a2ff/tasks"
-              onClick={[Function]}
+            <div
+              className="css-1l2peoq-LabelText e1cz15300 leafygreen-ui-1mngpnd"
             >
-              a77bd39
-            </a>
-             
-            7/13/21 2:51 PM
+              <a
+                className="css-1bct88o-StyledRouterLink-linkStyles es7lfqt0"
+                href="/version/spruce_v2.11.1_60eda8722a60ed09bb78a2ff/tasks"
+                onClick={[Function]}
+              >
+                a77bd39
+              </a>
+               
+              7/13/21 2:51 PM
+            </div>
+            <div
+              className="css-1l2peoq-LabelText e1cz15300 leafygreen-ui-1mngpnd"
+            >
+              Mohamed Khelif
+               -
+            </div>
+            <div
+              className="css-1l2peoq-LabelText e1cz15300 leafygreen-ui-1mngpnd"
+            >
+              Triggered From Git Tag 'v2.11.1': v2....
+            </div>
+            <small
+              className="css-2n0pzr-ButtonText eq9i5u71 leafygreen-ui-1mvgvb8"
+              onBlur={[Function]}
+              onFocus={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+            >
+              more
+            </small>
           </div>
-          <div
-            className="css-1l2peoq-LabelText e1cz15300 leafygreen-ui-1mngpnd"
-          >
-            Mohamed Khelif
-             -
-          </div>
-          <div
-            className="css-1l2peoq-LabelText e1cz15300 leafygreen-ui-1mngpnd"
-          >
-            Triggered From Git Tag 'v2.11.1': v2....
-          </div>
-          <small
-            className="css-2n0pzr-ButtonText eq9i5u71 leafygreen-ui-1mvgvb8"
-            onBlur={[Function]}
-            onFocus={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-          >
-            more
-          </small>
         </div>
       </div>
       <div
-        className="css-m6knb7-ColumnContainer e1s1lwa11"
+        className="css-1cagedb-ColumnContainer e1s1lwa11"
       >
         <div
           className="css-8bv1t4-Container ek3nkvx1"
@@ -376,29 +388,35 @@ exports[`storybook Storyshots Project Health Page Actual Waterfall Page 1`] = `
       <div
         className="css-1q62izj-InactiveCommitLine ezzuvrx4"
       />
+      <div />
       <div
-        className="leafygreen-ui-cssveg css-ls8suj-ButtonContainer ezzuvrx5"
-        onClick={[Function]}
-        role="button"
+        className="css-1gkww3q-StickyDiv-StickyContainer e1pdm2sm0"
+        offset={64}
       >
-        <small
-          className="css-t2ltce-ButtonText ezzuvrx2 leafygreen-ui-13bqno6"
-          data-cy="inactive-commits-button"
+        <div
+          className="leafygreen-ui-cssveg css-ls8suj-ButtonContainer ezzuvrx5"
+          onClick={[Function]}
+          role="button"
         >
-          <div
-            className="css-hifh5j-TopText ezzuvrx3"
+          <small
+            className="css-t2ltce-ButtonText ezzuvrx2 leafygreen-ui-13bqno6"
+            data-cy="inactive-commits-button"
           >
-            1
-          </div>
-          Inactive
-        </small>
+            <div
+              className="css-hifh5j-TopText ezzuvrx3"
+            >
+              1
+            </div>
+            Inactive
+          </small>
+        </div>
       </div>
     </div>
     <div
-      className="css-6yhz1l-Container e1s1lwa10"
+      className="css-1ry038z-Container e1s1lwa10"
     >
       <div
-        className="css-m6knb7-ColumnContainer e1s1lwa11"
+        className="css-1cagedb-ColumnContainer e1s1lwa11"
       >
         <div
           className="leafygreen-ui-cssveg css-tdhexo-ChartContainer e1tzsy281"
@@ -421,54 +439,60 @@ exports[`storybook Storyshots Project Health Page Actual Waterfall Page 1`] = `
             height="58.333333333333336%"
           />
         </div>
+        <div />
         <div
-          className="css-1qv3l5b-LabelContainer e1cz15301"
-          data-cy="commit-label"
+          className="css-1gkww3q-StickyDiv-StickyContainer e1pdm2sm0"
+          offset={64}
         >
           <div
-            className="css-1l2peoq-LabelText e1cz15300 leafygreen-ui-1mngpnd"
+            className="css-1qv3l5b-LabelContainer e1cz15301"
+            data-cy="commit-label"
           >
-            <a
-              className="css-1bct88o-StyledRouterLink-linkStyles es7lfqt0"
-              href="/version/spruce_9c1d1ebc85829d69dde7684fbcce86dd21e5a9ad/tasks"
-              onClick={[Function]}
+            <div
+              className="css-1l2peoq-LabelText e1cz15300 leafygreen-ui-1mngpnd"
             >
-              9c1d1eb
-            </a>
-             
-            7/13/21 2:51 PM
-          </div>
-          <div
-            className="css-1l2peoq-LabelText e1cz15300 leafygreen-ui-1mngpnd"
-          >
-            Mohamed Khelif
-             -
-          </div>
-          <div
-            className="css-1l2peoq-LabelText e1cz15300 leafygreen-ui-1mngpnd"
-          >
-            
-            <a
-              className="css-1yjsn23-StyledLink-linkStyles es7lfqt2"
-              href="https://undefined/browse/EVG-14799"
+              <a
+                className="css-1bct88o-StyledRouterLink-linkStyles es7lfqt0"
+                href="/version/spruce_9c1d1ebc85829d69dde7684fbcce86dd21e5a9ad/tasks"
+                onClick={[Function]}
+              >
+                9c1d1eb
+              </a>
+               
+              7/13/21 2:51 PM
+            </div>
+            <div
+              className="css-1l2peoq-LabelText e1cz15300 leafygreen-ui-1mngpnd"
             >
-              EVG-14799
-            </a>
-             Correctly visit configure p...
+              Mohamed Khelif
+               -
+            </div>
+            <div
+              className="css-1l2peoq-LabelText e1cz15300 leafygreen-ui-1mngpnd"
+            >
+              
+              <a
+                className="css-1yjsn23-StyledLink-linkStyles es7lfqt2"
+                href="https://undefined/browse/EVG-14799"
+              >
+                EVG-14799
+              </a>
+               Correctly visit configure p...
+            </div>
+            <small
+              className="css-2n0pzr-ButtonText eq9i5u71 leafygreen-ui-1mvgvb8"
+              onBlur={[Function]}
+              onFocus={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+            >
+              more
+            </small>
           </div>
-          <small
-            className="css-2n0pzr-ButtonText eq9i5u71 leafygreen-ui-1mvgvb8"
-            onBlur={[Function]}
-            onFocus={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-          >
-            more
-          </small>
         </div>
       </div>
       <div
-        className="css-m6knb7-ColumnContainer e1s1lwa11"
+        className="css-1cagedb-ColumnContainer e1s1lwa11"
       >
         <div
           className="css-8bv1t4-Container ek3nkvx1"
@@ -571,10 +595,10 @@ exports[`storybook Storyshots Project Health Page Actual Waterfall Page 1`] = `
       </div>
     </div>
     <div
-      className="css-6yhz1l-Container e1s1lwa10"
+      className="css-1ry038z-Container e1s1lwa10"
     >
       <div
-        className="css-m6knb7-ColumnContainer e1s1lwa11"
+        className="css-1cagedb-ColumnContainer e1s1lwa11"
       >
         <div
           className="leafygreen-ui-cssveg css-tdhexo-ChartContainer e1tzsy281"
@@ -597,47 +621,53 @@ exports[`storybook Storyshots Project Health Page Actual Waterfall Page 1`] = `
             height="58.333333333333336%"
           />
         </div>
+        <div />
         <div
-          className="css-1qv3l5b-LabelContainer e1cz15301"
-          data-cy="commit-label"
+          className="css-1gkww3q-StickyDiv-StickyContainer e1pdm2sm0"
+          offset={64}
         >
           <div
-            className="css-1l2peoq-LabelText e1cz15300 leafygreen-ui-1mngpnd"
+            className="css-1qv3l5b-LabelContainer e1cz15301"
+            data-cy="commit-label"
           >
-            <a
-              className="css-1bct88o-StyledRouterLink-linkStyles es7lfqt0"
-              href="/version/spruce_f7f7f1a3abdb9897dfc02b7a1de9821651b0916e/tasks"
-              onClick={[Function]}
+            <div
+              className="css-1l2peoq-LabelText e1cz15300 leafygreen-ui-1mngpnd"
             >
-              f7f7f1a
-            </a>
-             
-            7/13/21 2:51 PM
+              <a
+                className="css-1bct88o-StyledRouterLink-linkStyles es7lfqt0"
+                href="/version/spruce_f7f7f1a3abdb9897dfc02b7a1de9821651b0916e/tasks"
+                onClick={[Function]}
+              >
+                f7f7f1a
+              </a>
+               
+              7/13/21 2:51 PM
+            </div>
+            <div
+              className="css-1l2peoq-LabelText e1cz15300 leafygreen-ui-1mngpnd"
+            >
+              Sophie Stadler
+               -
+            </div>
+            <div
+              className="css-1l2peoq-LabelText e1cz15300 leafygreen-ui-1mngpnd"
+            >
+              Remove navigation announcement toast ...
+            </div>
+            <small
+              className="css-2n0pzr-ButtonText eq9i5u71 leafygreen-ui-1mvgvb8"
+              onBlur={[Function]}
+              onFocus={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+            >
+              more
+            </small>
           </div>
-          <div
-            className="css-1l2peoq-LabelText e1cz15300 leafygreen-ui-1mngpnd"
-          >
-            Sophie Stadler
-             -
-          </div>
-          <div
-            className="css-1l2peoq-LabelText e1cz15300 leafygreen-ui-1mngpnd"
-          >
-            Remove navigation announcement toast ...
-          </div>
-          <small
-            className="css-2n0pzr-ButtonText eq9i5u71 leafygreen-ui-1mvgvb8"
-            onBlur={[Function]}
-            onFocus={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-          >
-            more
-          </small>
         </div>
       </div>
       <div
-        className="css-m6knb7-ColumnContainer e1s1lwa11"
+        className="css-1cagedb-ColumnContainer e1s1lwa11"
       >
         <div
           className="css-8bv1t4-Container ek3nkvx1"
@@ -740,10 +770,10 @@ exports[`storybook Storyshots Project Health Page Actual Waterfall Page 1`] = `
       </div>
     </div>
     <div
-      className="css-6yhz1l-Container e1s1lwa10"
+      className="css-1ry038z-Container e1s1lwa10"
     >
       <div
-        className="css-m6knb7-ColumnContainer e1s1lwa11"
+        className="css-1cagedb-ColumnContainer e1s1lwa11"
       >
         <div
           className="leafygreen-ui-cssveg css-tdhexo-ChartContainer e1tzsy281"
@@ -778,47 +808,53 @@ exports[`storybook Storyshots Project Health Page Actual Waterfall Page 1`] = `
             height="16.666666666666664%"
           />
         </div>
+        <div />
         <div
-          className="css-1qv3l5b-LabelContainer e1cz15301"
-          data-cy="commit-label"
+          className="css-1gkww3q-StickyDiv-StickyContainer e1pdm2sm0"
+          offset={64}
         >
           <div
-            className="css-1l2peoq-LabelText e1cz15300 leafygreen-ui-1mngpnd"
+            className="css-1qv3l5b-LabelContainer e1cz15301"
+            data-cy="commit-label"
           >
-            <a
-              className="css-1bct88o-StyledRouterLink-linkStyles es7lfqt0"
-              href="/version/spruce_v2.11.0_60ec461532f4172d48288274/tasks"
-              onClick={[Function]}
+            <div
+              className="css-1l2peoq-LabelText e1cz15300 leafygreen-ui-1mngpnd"
             >
-              211b3a0
-            </a>
-             
-            7/13/21 2:51 PM
+              <a
+                className="css-1bct88o-StyledRouterLink-linkStyles es7lfqt0"
+                href="/version/spruce_v2.11.0_60ec461532f4172d48288274/tasks"
+                onClick={[Function]}
+              >
+                211b3a0
+              </a>
+               
+              7/13/21 2:51 PM
+            </div>
+            <div
+              className="css-1l2peoq-LabelText e1cz15300 leafygreen-ui-1mngpnd"
+            >
+              Chaya Malik
+               -
+            </div>
+            <div
+              className="css-1l2peoq-LabelText e1cz15300 leafygreen-ui-1mngpnd"
+            >
+              Triggered From Git Tag 'v2.11.0': v2....
+            </div>
+            <small
+              className="css-2n0pzr-ButtonText eq9i5u71 leafygreen-ui-1mvgvb8"
+              onBlur={[Function]}
+              onFocus={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+            >
+              more
+            </small>
           </div>
-          <div
-            className="css-1l2peoq-LabelText e1cz15300 leafygreen-ui-1mngpnd"
-          >
-            Chaya Malik
-             -
-          </div>
-          <div
-            className="css-1l2peoq-LabelText e1cz15300 leafygreen-ui-1mngpnd"
-          >
-            Triggered From Git Tag 'v2.11.0': v2....
-          </div>
-          <small
-            className="css-2n0pzr-ButtonText eq9i5u71 leafygreen-ui-1mvgvb8"
-            onBlur={[Function]}
-            onFocus={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-          >
-            more
-          </small>
         </div>
       </div>
       <div
-        className="css-m6knb7-ColumnContainer e1s1lwa11"
+        className="css-1cagedb-ColumnContainer e1s1lwa11"
       >
         <div
           className="css-8bv1t4-Container ek3nkvx1"

--- a/src/pages/commits/ActiveCommits/__snapshots__/ProjectHealth.stories.storyshot
+++ b/src/pages/commits/ActiveCommits/__snapshots__/ProjectHealth.stories.storyshot
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`storybook Storyshots Project Health Page Waterfall Absolute 1`] = `
+exports[`storybook Storyshots Project Health Page Actual Waterfall Page 1`] = `
 <div
   className="css-11f0p6-ProjectHealthWrapper ech0nhv2"
 >
@@ -94,7 +94,7 @@ exports[`storybook Storyshots Project Health Page Waterfall Absolute 1`] = `
         >
           <a
             className="css-51km4x-StyledRouterLink-linkStyles-Label ek3nkvx3"
-            href="/variant-history/undefined/undefined"
+            href="/variant-history/spruce/code_health"
             onClick={[Function]}
           >
             01. Code Health [code_health]
@@ -115,7 +115,7 @@ exports[`storybook Storyshots Project Health Page Waterfall Absolute 1`] = `
               >
                 <a
                   data-cy="grouped-task-status-badge"
-                  href="/version/spruce_987bf57eb679c6361322c3961b30a10724a9b001/tasks?statuses=scheduled-umbrella,will-run,pending,unstarted"
+                  href="/version/spruce_987bf57eb679c6361322c3961b30a10724a9b001/tasks?statuses=scheduled-umbrella,will-run,pending,unstarted&variant=%5Ecode_health%24"
                   onClick={[Function]}
                 >
                   <div
@@ -143,7 +143,7 @@ exports[`storybook Storyshots Project Health Page Waterfall Absolute 1`] = `
         >
           <a
             className="css-51km4x-StyledRouterLink-linkStyles-Label ek3nkvx3"
-            href="/variant-history/undefined/undefined"
+            href="/variant-history/spruce/package_rpm"
             onClick={[Function]}
           >
             02. Packaging (RPM - RHEL7) [package_rpm]
@@ -164,7 +164,7 @@ exports[`storybook Storyshots Project Health Page Waterfall Absolute 1`] = `
               >
                 <a
                   data-cy="grouped-task-status-badge"
-                  href="/version/spruce_987bf57eb679c6361322c3961b30a10724a9b001/tasks?statuses=scheduled-umbrella,will-run,pending,unstarted"
+                  href="/version/spruce_987bf57eb679c6361322c3961b30a10724a9b001/tasks?statuses=scheduled-umbrella,will-run,pending,unstarted&variant=%5Epackage_rpm%24"
                   onClick={[Function]}
                 >
                   <div
@@ -275,7 +275,7 @@ exports[`storybook Storyshots Project Health Page Waterfall Absolute 1`] = `
         >
           <a
             className="css-51km4x-StyledRouterLink-linkStyles-Label ek3nkvx3"
-            href="/variant-history/undefined/undefined"
+            href="/variant-history/spruce/code_health"
             onClick={[Function]}
           >
             01. Code Health [code_health]
@@ -296,7 +296,7 @@ exports[`storybook Storyshots Project Health Page Waterfall Absolute 1`] = `
               >
                 <a
                   data-cy="grouped-task-status-badge"
-                  href="/version/spruce_v2.11.1_60eda8722a60ed09bb78a2ff/tasks?statuses=scheduled-umbrella,will-run,pending,unstarted"
+                  href="/version/spruce_v2.11.1_60eda8722a60ed09bb78a2ff/tasks?statuses=scheduled-umbrella,will-run,pending,unstarted&variant=%5Ecode_health%24"
                   onClick={[Function]}
                 >
                   <div
@@ -324,7 +324,7 @@ exports[`storybook Storyshots Project Health Page Waterfall Absolute 1`] = `
         >
           <a
             className="css-51km4x-StyledRouterLink-linkStyles-Label ek3nkvx3"
-            href="/variant-history/undefined/undefined"
+            href="/variant-history/spruce/package_rpm"
             onClick={[Function]}
           >
             02. Packaging (RPM - RHEL7) [package_rpm]
@@ -345,7 +345,7 @@ exports[`storybook Storyshots Project Health Page Waterfall Absolute 1`] = `
               >
                 <a
                   data-cy="grouped-task-status-badge"
-                  href="/version/spruce_v2.11.1_60eda8722a60ed09bb78a2ff/tasks?statuses=scheduled-umbrella,will-run,pending,unstarted"
+                  href="/version/spruce_v2.11.1_60eda8722a60ed09bb78a2ff/tasks?statuses=scheduled-umbrella,will-run,pending,unstarted&variant=%5Epackage_rpm%24"
                   onClick={[Function]}
                 >
                   <div
@@ -371,26 +371,26 @@ exports[`storybook Storyshots Project Health Page Waterfall Absolute 1`] = `
       </div>
     </div>
     <div
-      className="css-b7olip-ColumnContainer ech0nhv1"
+      className="css-ytrjsr-Container ezzuvrx0"
     >
       <div
-        className="css-mh33b0-InactiveCommitLine ezzuvrx3"
+        className="css-1q62izj-InactiveCommitLine ezzuvrx4"
       />
       <div
-        className="leafygreen-ui-cssveg css-ue3t3g-ButtonContainer ezzuvrx4"
+        className="leafygreen-ui-cssveg css-ls8suj-ButtonContainer ezzuvrx5"
         onClick={[Function]}
+        role="button"
       >
         <small
-          className="css-nr1a01-ButtonText ezzuvrx1 leafygreen-ui-13bqno6"
+          className="css-t2ltce-ButtonText ezzuvrx2 leafygreen-ui-13bqno6"
           data-cy="inactive-commits-button"
         >
           <div
-            className="css-hifh5j-TopText ezzuvrx2"
+            className="css-hifh5j-TopText ezzuvrx3"
           >
             1
-             
           </div>
-          inactive
+          Inactive
         </small>
       </div>
     </div>
@@ -475,7 +475,7 @@ exports[`storybook Storyshots Project Health Page Waterfall Absolute 1`] = `
         >
           <a
             className="css-51km4x-StyledRouterLink-linkStyles-Label ek3nkvx3"
-            href="/variant-history/undefined/undefined"
+            href="/variant-history/spruce/code_health"
             onClick={[Function]}
           >
             01. Code Health [code_health]
@@ -496,7 +496,7 @@ exports[`storybook Storyshots Project Health Page Waterfall Absolute 1`] = `
               >
                 <a
                   data-cy="grouped-task-status-badge"
-                  href="/version/spruce_9c1d1ebc85829d69dde7684fbcce86dd21e5a9ad/tasks?statuses=scheduled-umbrella,will-run,pending,unstarted"
+                  href="/version/spruce_9c1d1ebc85829d69dde7684fbcce86dd21e5a9ad/tasks?statuses=scheduled-umbrella,will-run,pending,unstarted&variant=%5Ecode_health%24"
                   onClick={[Function]}
                 >
                   <div
@@ -524,7 +524,7 @@ exports[`storybook Storyshots Project Health Page Waterfall Absolute 1`] = `
         >
           <a
             className="css-51km4x-StyledRouterLink-linkStyles-Label ek3nkvx3"
-            href="/variant-history/undefined/undefined"
+            href="/variant-history/spruce/package_rpm"
             onClick={[Function]}
           >
             02. Packaging (RPM - RHEL7) [package_rpm]
@@ -545,7 +545,7 @@ exports[`storybook Storyshots Project Health Page Waterfall Absolute 1`] = `
               >
                 <a
                   data-cy="grouped-task-status-badge"
-                  href="/version/spruce_9c1d1ebc85829d69dde7684fbcce86dd21e5a9ad/tasks?statuses=scheduled-umbrella,will-run,pending,unstarted"
+                  href="/version/spruce_9c1d1ebc85829d69dde7684fbcce86dd21e5a9ad/tasks?statuses=scheduled-umbrella,will-run,pending,unstarted&variant=%5Epackage_rpm%24"
                   onClick={[Function]}
                 >
                   <div
@@ -644,7 +644,7 @@ exports[`storybook Storyshots Project Health Page Waterfall Absolute 1`] = `
         >
           <a
             className="css-51km4x-StyledRouterLink-linkStyles-Label ek3nkvx3"
-            href="/variant-history/undefined/undefined"
+            href="/variant-history/spruce/code_health"
             onClick={[Function]}
           >
             01. Code Health [code_health]
@@ -665,7 +665,7 @@ exports[`storybook Storyshots Project Health Page Waterfall Absolute 1`] = `
               >
                 <a
                   data-cy="grouped-task-status-badge"
-                  href="/version/spruce_f7f7f1a3abdb9897dfc02b7a1de9821651b0916e/tasks?statuses=scheduled-umbrella,will-run,pending,unstarted"
+                  href="/version/spruce_f7f7f1a3abdb9897dfc02b7a1de9821651b0916e/tasks?statuses=scheduled-umbrella,will-run,pending,unstarted&variant=%5Ecode_health%24"
                   onClick={[Function]}
                 >
                   <div
@@ -693,7 +693,7 @@ exports[`storybook Storyshots Project Health Page Waterfall Absolute 1`] = `
         >
           <a
             className="css-51km4x-StyledRouterLink-linkStyles-Label ek3nkvx3"
-            href="/variant-history/undefined/undefined"
+            href="/variant-history/spruce/package_rpm"
             onClick={[Function]}
           >
             02. Packaging (RPM - RHEL7) [package_rpm]
@@ -714,7 +714,7 @@ exports[`storybook Storyshots Project Health Page Waterfall Absolute 1`] = `
               >
                 <a
                   data-cy="grouped-task-status-badge"
-                  href="/version/spruce_f7f7f1a3abdb9897dfc02b7a1de9821651b0916e/tasks?statuses=success"
+                  href="/version/spruce_f7f7f1a3abdb9897dfc02b7a1de9821651b0916e/tasks?statuses=success&variant=%5Epackage_rpm%24"
                   onClick={[Function]}
                 >
                   <div
@@ -825,7 +825,7 @@ exports[`storybook Storyshots Project Health Page Waterfall Absolute 1`] = `
         >
           <a
             className="css-51km4x-StyledRouterLink-linkStyles-Label ek3nkvx3"
-            href="/variant-history/undefined/undefined"
+            href="/variant-history/spruce/code_health"
             onClick={[Function]}
           >
             01. Code Health [code_health]
@@ -870,945 +870,7 @@ exports[`storybook Storyshots Project Health Page Waterfall Absolute 1`] = `
         >
           <a
             className="css-51km4x-StyledRouterLink-linkStyles-Label ek3nkvx3"
-            href="/variant-history/undefined/undefined"
-            onClick={[Function]}
-          >
-            02. Packaging (RPM - RHEL7) [package_rpm]
-          </a>
-          <div
-            className="css-100ar08-IconContainer ek3nkvx2"
-          >
-            <a
-              aria-disabled={false}
-              aria-label="task icon"
-              className="leafygreen-ui-12hedrr"
-              data-cy="waterfall-task-status-icon"
-              href="/task/code_health"
-              onBlur={[Function]}
-              onClick={[Function]}
-              onFocus={[Function]}
-              onMouseEnter={[Function]}
-              onMouseLeave={[Function]}
-              onMouseOver={[Function]}
-              tabIndex={0}
-            >
-              <div
-                className="leafygreen-ui-xhlipt"
-              >
-                <svg
-                  fill="currentColor"
-                  height={16}
-                  viewBox="0 0 21 21"
-                  width={16}
-                >
-                  <path
-                    d="M17.7783.807588c-.7811-.7810482-2.0474-.7810486-2.8285 0L10.0001 5.75734 5.05035.807588c-.78105-.7810484-2.04738-.7810482-2.82843 0L.80771 2.2218c-.7810481.78105-.7810485 2.04738 0 2.82843l4.94975 4.94975L.80771 14.9497c-.7810474.7811-.7810481 2.0474 0 2.8285l1.41421 1.4142c.78105.781 2.04738.781 2.82843 0l4.94975-4.9498 4.9497 4.9498c.7811.781 2.0474.781 2.8285 0l1.4142-1.4142c.781-.7811.781-2.0474 0-2.8285l-4.9498-4.94972 4.9498-4.94975c.781-.78105.781-2.04738 0-2.82843L17.7783.807588Z"
-                    fill="#CF4A22"
-                  />
-                </svg>
-              </div>
-            </a>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    className="css-1x4jjy8-ColumnContainer e15dc98b2"
-  >
-    <div
-      className="css-oxpn1r-DashedLine e15dc98b1"
-    />
-    <div
-      className="css-oxpn1r-DashedLine e15dc98b1"
-    />
-    <div
-      className="css-oxpn1r-DashedLine e15dc98b1"
-    />
-    <div
-      className="css-oxpn1r-DashedLine e15dc98b1"
-    />
-    <div
-      className="css-oxpn1r-DashedLine e15dc98b1"
-    />
-    <div
-      className="css-1sahvn-SolidLine e15dc98b0"
-    />
-  </div>
-</div>
-`;
-
-exports[`storybook Storyshots Project Health Page Waterfall Percentage 1`] = `
-<div
-  className="css-11f0p6-ProjectHealthWrapper ech0nhv2"
->
-  <div
-    className="css-f6c9ue-FlexRowContainer ech0nhv3"
-  >
-    <div
-      className="css-6yhz1l-Container e1s1lwa10"
-    >
-      <div
-        className="css-m6knb7-ColumnContainer e1s1lwa11"
-      >
-        <div
-          className="leafygreen-ui-cssveg css-tdhexo-ChartContainer e1tzsy281"
-          data-cy="commit-chart-container"
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
-        >
-          <div
-            className="css-6kao1w-Bar e1tzsy280"
-            color="#4F4FBF"
-            data-cy="commit-chart-bar"
-            height="58.333333333333336%"
-          />
-          <div
-            className="css-3gn9ru-Bar e1tzsy280"
-            color="#F1F0FC"
-            data-cy="commit-chart-bar"
-            height="41.66666666666667%"
-          />
-          <div
-            className="css-jnxlqf-Bar e1tzsy280"
-            color="#5D6C74"
-            data-cy="commit-chart-bar"
-            height="16.666666666666664%"
-          />
-        </div>
-        <div
-          className="css-1qv3l5b-LabelContainer e1cz15301"
-          data-cy="commit-label"
-        >
-          <div
-            className="css-1l2peoq-LabelText e1cz15300 leafygreen-ui-1mngpnd"
-          >
-            <a
-              className="css-1bct88o-StyledRouterLink-linkStyles es7lfqt0"
-              href="/version/spruce_987bf57eb679c6361322c3961b30a10724a9b001/tasks"
-              onClick={[Function]}
-            >
-              987bf57
-            </a>
-             
-            7/16/21 3:53 PM
-          </div>
-          <div
-            className="css-1l2peoq-LabelText e1cz15300 leafygreen-ui-1mngpnd"
-          >
-            Jonathan Brill
-             -
-          </div>
-          <div
-            className="css-1l2peoq-LabelText e1cz15300 leafygreen-ui-1mngpnd"
-          >
-            
-            <a
-              className="css-1yjsn23-StyledLink-linkStyles es7lfqt2"
-              href="https://undefined/browse/EVG-14901"
-            >
-              EVG-14901
-            </a>
-             add ssh key to EditSpawnHos...
-          </div>
-          <small
-            className="css-2n0pzr-ButtonText eq9i5u71 leafygreen-ui-1mvgvb8"
-            onBlur={[Function]}
-            onFocus={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-          >
-            more
-          </small>
-        </div>
-      </div>
-      <div
-        className="css-m6knb7-ColumnContainer e1s1lwa11"
-      >
-        <div
-          className="css-8bv1t4-Container ek3nkvx1"
-        >
-          <a
-            className="css-51km4x-StyledRouterLink-linkStyles-Label ek3nkvx3"
-            href="/variant-history/undefined/undefined"
-            onClick={[Function]}
-          >
-            01. Code Health [code_health]
-          </a>
-          <div
-            className="css-100ar08-IconContainer ek3nkvx2"
-          >
-            <div
-              className="css-7w5aph-GroupedTaskStatusBadgeWrapper ek3nkvx0"
-              data-cy="grouped-task-status-badge"
-            >
-              <div
-                className="leafygreen-ui-cssveg"
-                onBlur={[Function]}
-                onFocus={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-              >
-                <a
-                  data-cy="grouped-task-status-badge"
-                  href="/version/spruce_987bf57eb679c6361322c3961b30a10724a9b001/tasks?statuses=scheduled-umbrella,will-run,pending,unstarted"
-                  onClick={[Function]}
-                >
-                  <div
-                    className="css-nup11h-BadgeContainer emc61an4"
-                    fill="#5D6C74"
-                  >
-                    <span
-                      className="css-wtl5ix-Number emc61an2"
-                    >
-                      1
-                    </span>
-                    <span
-                      className="css-oqj204-Status emc61an1"
-                    >
-                      Scheduled
-                    </span>
-                  </div>
-                </a>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          className="css-8bv1t4-Container ek3nkvx1"
-        >
-          <a
-            className="css-51km4x-StyledRouterLink-linkStyles-Label ek3nkvx3"
-            href="/variant-history/undefined/undefined"
-            onClick={[Function]}
-          >
-            02. Packaging (RPM - RHEL7) [package_rpm]
-          </a>
-          <div
-            className="css-100ar08-IconContainer ek3nkvx2"
-          >
-            <div
-              className="css-7w5aph-GroupedTaskStatusBadgeWrapper ek3nkvx0"
-              data-cy="grouped-task-status-badge"
-            >
-              <div
-                className="leafygreen-ui-cssveg"
-                onBlur={[Function]}
-                onFocus={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-              >
-                <a
-                  data-cy="grouped-task-status-badge"
-                  href="/version/spruce_987bf57eb679c6361322c3961b30a10724a9b001/tasks?statuses=scheduled-umbrella,will-run,pending,unstarted"
-                  onClick={[Function]}
-                >
-                  <div
-                    className="css-nup11h-BadgeContainer emc61an4"
-                    fill="#5D6C74"
-                  >
-                    <span
-                      className="css-wtl5ix-Number emc61an2"
-                    >
-                      1
-                    </span>
-                    <span
-                      className="css-oqj204-Status emc61an1"
-                    >
-                      Scheduled
-                    </span>
-                  </div>
-                </a>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="css-6yhz1l-Container e1s1lwa10"
-    >
-      <div
-        className="css-m6knb7-ColumnContainer e1s1lwa11"
-      >
-        <div
-          className="leafygreen-ui-cssveg css-tdhexo-ChartContainer e1tzsy281"
-          data-cy="commit-chart-container"
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
-        >
-          <div
-            className="css-u2pqa3-Bar e1tzsy280"
-            color="#CF4A22"
-            data-cy="commit-chart-bar"
-            height="50%"
-          />
-          <div
-            className="css-1e7si1e-Bar e1tzsy280"
-            color="#4F4FBF"
-            data-cy="commit-chart-bar"
-            height="50%"
-          />
-          <div
-            className="css-16hoxq8-Bar e1tzsy280"
-            color="#89979B"
-            data-cy="commit-chart-bar"
-            height="16.666666666666664%"
-          />
-          <div
-            className="css-1n3fse1-Bar e1tzsy280"
-            color="#5D6C74"
-            data-cy="commit-chart-bar"
-            height="100%"
-          />
-        </div>
-        <div
-          className="css-1qv3l5b-LabelContainer e1cz15301"
-          data-cy="commit-label"
-        >
-          <div
-            className="css-1l2peoq-LabelText e1cz15300 leafygreen-ui-1mngpnd"
-          >
-            <a
-              className="css-1bct88o-StyledRouterLink-linkStyles es7lfqt0"
-              href="/version/spruce_v2.11.1_60eda8722a60ed09bb78a2ff/tasks"
-              onClick={[Function]}
-            >
-              a77bd39
-            </a>
-             
-            7/13/21 2:51 PM
-          </div>
-          <div
-            className="css-1l2peoq-LabelText e1cz15300 leafygreen-ui-1mngpnd"
-          >
-            Mohamed Khelif
-             -
-          </div>
-          <div
-            className="css-1l2peoq-LabelText e1cz15300 leafygreen-ui-1mngpnd"
-          >
-            Triggered From Git Tag 'v2.11.1': v2....
-          </div>
-          <small
-            className="css-2n0pzr-ButtonText eq9i5u71 leafygreen-ui-1mvgvb8"
-            onBlur={[Function]}
-            onFocus={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-          >
-            more
-          </small>
-        </div>
-      </div>
-      <div
-        className="css-m6knb7-ColumnContainer e1s1lwa11"
-      >
-        <div
-          className="css-8bv1t4-Container ek3nkvx1"
-        >
-          <a
-            className="css-51km4x-StyledRouterLink-linkStyles-Label ek3nkvx3"
-            href="/variant-history/undefined/undefined"
-            onClick={[Function]}
-          >
-            01. Code Health [code_health]
-          </a>
-          <div
-            className="css-100ar08-IconContainer ek3nkvx2"
-          >
-            <div
-              className="css-7w5aph-GroupedTaskStatusBadgeWrapper ek3nkvx0"
-              data-cy="grouped-task-status-badge"
-            >
-              <div
-                className="leafygreen-ui-cssveg"
-                onBlur={[Function]}
-                onFocus={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-              >
-                <a
-                  data-cy="grouped-task-status-badge"
-                  href="/version/spruce_v2.11.1_60eda8722a60ed09bb78a2ff/tasks?statuses=scheduled-umbrella,will-run,pending,unstarted"
-                  onClick={[Function]}
-                >
-                  <div
-                    className="css-nup11h-BadgeContainer emc61an4"
-                    fill="#5D6C74"
-                  >
-                    <span
-                      className="css-wtl5ix-Number emc61an2"
-                    >
-                      1
-                    </span>
-                    <span
-                      className="css-oqj204-Status emc61an1"
-                    >
-                      Scheduled
-                    </span>
-                  </div>
-                </a>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          className="css-8bv1t4-Container ek3nkvx1"
-        >
-          <a
-            className="css-51km4x-StyledRouterLink-linkStyles-Label ek3nkvx3"
-            href="/variant-history/undefined/undefined"
-            onClick={[Function]}
-          >
-            02. Packaging (RPM - RHEL7) [package_rpm]
-          </a>
-          <div
-            className="css-100ar08-IconContainer ek3nkvx2"
-          >
-            <div
-              className="css-7w5aph-GroupedTaskStatusBadgeWrapper ek3nkvx0"
-              data-cy="grouped-task-status-badge"
-            >
-              <div
-                className="leafygreen-ui-cssveg"
-                onBlur={[Function]}
-                onFocus={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-              >
-                <a
-                  data-cy="grouped-task-status-badge"
-                  href="/version/spruce_v2.11.1_60eda8722a60ed09bb78a2ff/tasks?statuses=scheduled-umbrella,will-run,pending,unstarted"
-                  onClick={[Function]}
-                >
-                  <div
-                    className="css-nup11h-BadgeContainer emc61an4"
-                    fill="#5D6C74"
-                  >
-                    <span
-                      className="css-wtl5ix-Number emc61an2"
-                    >
-                      1
-                    </span>
-                    <span
-                      className="css-oqj204-Status emc61an1"
-                    >
-                      Scheduled
-                    </span>
-                  </div>
-                </a>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="css-b7olip-ColumnContainer ech0nhv1"
-    >
-      <div
-        className="css-mh33b0-InactiveCommitLine ezzuvrx3"
-      />
-      <div
-        className="leafygreen-ui-cssveg css-ue3t3g-ButtonContainer ezzuvrx4"
-        onClick={[Function]}
-      >
-        <small
-          className="css-nr1a01-ButtonText ezzuvrx1 leafygreen-ui-13bqno6"
-          data-cy="inactive-commits-button"
-        >
-          <div
-            className="css-hifh5j-TopText ezzuvrx2"
-          >
-            1
-             
-          </div>
-          inactive
-        </small>
-      </div>
-    </div>
-    <div
-      className="css-6yhz1l-Container e1s1lwa10"
-    >
-      <div
-        className="css-m6knb7-ColumnContainer e1s1lwa11"
-      >
-        <div
-          className="leafygreen-ui-cssveg css-tdhexo-ChartContainer e1tzsy281"
-          data-cy="commit-chart-container"
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
-        >
-          <div
-            className="css-1x4khp7-Bar e1tzsy280"
-            color="#F1F0FC"
-            data-cy="commit-chart-bar"
-            height="33.33333333333333%"
-          />
-          <div
-            className="css-1q4dzih-Bar e1tzsy280"
-            color="#89979B"
-            data-cy="commit-chart-bar"
-            height="58.333333333333336%"
-          />
-        </div>
-        <div
-          className="css-1qv3l5b-LabelContainer e1cz15301"
-          data-cy="commit-label"
-        >
-          <div
-            className="css-1l2peoq-LabelText e1cz15300 leafygreen-ui-1mngpnd"
-          >
-            <a
-              className="css-1bct88o-StyledRouterLink-linkStyles es7lfqt0"
-              href="/version/spruce_9c1d1ebc85829d69dde7684fbcce86dd21e5a9ad/tasks"
-              onClick={[Function]}
-            >
-              9c1d1eb
-            </a>
-             
-            7/13/21 2:51 PM
-          </div>
-          <div
-            className="css-1l2peoq-LabelText e1cz15300 leafygreen-ui-1mngpnd"
-          >
-            Mohamed Khelif
-             -
-          </div>
-          <div
-            className="css-1l2peoq-LabelText e1cz15300 leafygreen-ui-1mngpnd"
-          >
-            
-            <a
-              className="css-1yjsn23-StyledLink-linkStyles es7lfqt2"
-              href="https://undefined/browse/EVG-14799"
-            >
-              EVG-14799
-            </a>
-             Correctly visit configure p...
-          </div>
-          <small
-            className="css-2n0pzr-ButtonText eq9i5u71 leafygreen-ui-1mvgvb8"
-            onBlur={[Function]}
-            onFocus={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-          >
-            more
-          </small>
-        </div>
-      </div>
-      <div
-        className="css-m6knb7-ColumnContainer e1s1lwa11"
-      >
-        <div
-          className="css-8bv1t4-Container ek3nkvx1"
-        >
-          <a
-            className="css-51km4x-StyledRouterLink-linkStyles-Label ek3nkvx3"
-            href="/variant-history/undefined/undefined"
-            onClick={[Function]}
-          >
-            01. Code Health [code_health]
-          </a>
-          <div
-            className="css-100ar08-IconContainer ek3nkvx2"
-          >
-            <div
-              className="css-7w5aph-GroupedTaskStatusBadgeWrapper ek3nkvx0"
-              data-cy="grouped-task-status-badge"
-            >
-              <div
-                className="leafygreen-ui-cssveg"
-                onBlur={[Function]}
-                onFocus={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-              >
-                <a
-                  data-cy="grouped-task-status-badge"
-                  href="/version/spruce_9c1d1ebc85829d69dde7684fbcce86dd21e5a9ad/tasks?statuses=scheduled-umbrella,will-run,pending,unstarted"
-                  onClick={[Function]}
-                >
-                  <div
-                    className="css-nup11h-BadgeContainer emc61an4"
-                    fill="#5D6C74"
-                  >
-                    <span
-                      className="css-wtl5ix-Number emc61an2"
-                    >
-                      1
-                    </span>
-                    <span
-                      className="css-oqj204-Status emc61an1"
-                    >
-                      Scheduled
-                    </span>
-                  </div>
-                </a>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          className="css-8bv1t4-Container ek3nkvx1"
-        >
-          <a
-            className="css-51km4x-StyledRouterLink-linkStyles-Label ek3nkvx3"
-            href="/variant-history/undefined/undefined"
-            onClick={[Function]}
-          >
-            02. Packaging (RPM - RHEL7) [package_rpm]
-          </a>
-          <div
-            className="css-100ar08-IconContainer ek3nkvx2"
-          >
-            <div
-              className="css-7w5aph-GroupedTaskStatusBadgeWrapper ek3nkvx0"
-              data-cy="grouped-task-status-badge"
-            >
-              <div
-                className="leafygreen-ui-cssveg"
-                onBlur={[Function]}
-                onFocus={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-              >
-                <a
-                  data-cy="grouped-task-status-badge"
-                  href="/version/spruce_9c1d1ebc85829d69dde7684fbcce86dd21e5a9ad/tasks?statuses=scheduled-umbrella,will-run,pending,unstarted"
-                  onClick={[Function]}
-                >
-                  <div
-                    className="css-nup11h-BadgeContainer emc61an4"
-                    fill="#5D6C74"
-                  >
-                    <span
-                      className="css-wtl5ix-Number emc61an2"
-                    >
-                      1
-                    </span>
-                    <span
-                      className="css-oqj204-Status emc61an1"
-                    >
-                      Scheduled
-                    </span>
-                  </div>
-                </a>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="css-6yhz1l-Container e1s1lwa10"
-    >
-      <div
-        className="css-m6knb7-ColumnContainer e1s1lwa11"
-      >
-        <div
-          className="leafygreen-ui-cssveg css-tdhexo-ChartContainer e1tzsy281"
-          data-cy="commit-chart-container"
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
-        >
-          <div
-            className="css-14yldmu-Bar e1tzsy280"
-            color="#CF4A22"
-            data-cy="commit-chart-bar"
-            height="16.666666666666664%"
-          />
-          <div
-            className="css-gebqh9-Bar e1tzsy280"
-            color="#5D6C74"
-            data-cy="commit-chart-bar"
-            height="58.333333333333336%"
-          />
-        </div>
-        <div
-          className="css-1qv3l5b-LabelContainer e1cz15301"
-          data-cy="commit-label"
-        >
-          <div
-            className="css-1l2peoq-LabelText e1cz15300 leafygreen-ui-1mngpnd"
-          >
-            <a
-              className="css-1bct88o-StyledRouterLink-linkStyles es7lfqt0"
-              href="/version/spruce_f7f7f1a3abdb9897dfc02b7a1de9821651b0916e/tasks"
-              onClick={[Function]}
-            >
-              f7f7f1a
-            </a>
-             
-            7/13/21 2:51 PM
-          </div>
-          <div
-            className="css-1l2peoq-LabelText e1cz15300 leafygreen-ui-1mngpnd"
-          >
-            Sophie Stadler
-             -
-          </div>
-          <div
-            className="css-1l2peoq-LabelText e1cz15300 leafygreen-ui-1mngpnd"
-          >
-            Remove navigation announcement toast ...
-          </div>
-          <small
-            className="css-2n0pzr-ButtonText eq9i5u71 leafygreen-ui-1mvgvb8"
-            onBlur={[Function]}
-            onFocus={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-          >
-            more
-          </small>
-        </div>
-      </div>
-      <div
-        className="css-m6knb7-ColumnContainer e1s1lwa11"
-      >
-        <div
-          className="css-8bv1t4-Container ek3nkvx1"
-        >
-          <a
-            className="css-51km4x-StyledRouterLink-linkStyles-Label ek3nkvx3"
-            href="/variant-history/undefined/undefined"
-            onClick={[Function]}
-          >
-            01. Code Health [code_health]
-          </a>
-          <div
-            className="css-100ar08-IconContainer ek3nkvx2"
-          >
-            <div
-              className="css-7w5aph-GroupedTaskStatusBadgeWrapper ek3nkvx0"
-              data-cy="grouped-task-status-badge"
-            >
-              <div
-                className="leafygreen-ui-cssveg"
-                onBlur={[Function]}
-                onFocus={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-              >
-                <a
-                  data-cy="grouped-task-status-badge"
-                  href="/version/spruce_f7f7f1a3abdb9897dfc02b7a1de9821651b0916e/tasks?statuses=scheduled-umbrella,will-run,pending,unstarted"
-                  onClick={[Function]}
-                >
-                  <div
-                    className="css-nup11h-BadgeContainer emc61an4"
-                    fill="#5D6C74"
-                  >
-                    <span
-                      className="css-wtl5ix-Number emc61an2"
-                    >
-                      1
-                    </span>
-                    <span
-                      className="css-oqj204-Status emc61an1"
-                    >
-                      Scheduled
-                    </span>
-                  </div>
-                </a>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          className="css-8bv1t4-Container ek3nkvx1"
-        >
-          <a
-            className="css-51km4x-StyledRouterLink-linkStyles-Label ek3nkvx3"
-            href="/variant-history/undefined/undefined"
-            onClick={[Function]}
-          >
-            02. Packaging (RPM - RHEL7) [package_rpm]
-          </a>
-          <div
-            className="css-100ar08-IconContainer ek3nkvx2"
-          >
-            <div
-              className="css-7w5aph-GroupedTaskStatusBadgeWrapper ek3nkvx0"
-              data-cy="grouped-task-status-badge"
-            >
-              <div
-                className="leafygreen-ui-cssveg"
-                onBlur={[Function]}
-                onFocus={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-              >
-                <a
-                  data-cy="grouped-task-status-badge"
-                  href="/version/spruce_f7f7f1a3abdb9897dfc02b7a1de9821651b0916e/tasks?statuses=success"
-                  onClick={[Function]}
-                >
-                  <div
-                    className="css-q6x9ck-BadgeContainer emc61an4"
-                    fill="#E4F4E4"
-                  >
-                    <span
-                      className="css-wtl5ix-Number emc61an2"
-                    >
-                      1
-                    </span>
-                    <span
-                      className="css-oqj204-Status emc61an1"
-                    >
-                      Succeeded
-                    </span>
-                  </div>
-                </a>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="css-6yhz1l-Container e1s1lwa10"
-    >
-      <div
-        className="css-m6knb7-ColumnContainer e1s1lwa11"
-      >
-        <div
-          className="leafygreen-ui-cssveg css-tdhexo-ChartContainer e1tzsy281"
-          data-cy="commit-chart-container"
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
-        >
-          <div
-            className="css-1pmbxjd-Bar e1tzsy280"
-            color="#13AA52"
-            data-cy="commit-chart-bar"
-            height="50%"
-          />
-          <div
-            className="css-14yldmu-Bar e1tzsy280"
-            color="#CF4A22"
-            data-cy="commit-chart-bar"
-            height="16.666666666666664%"
-          />
-          <div
-            className="css-1kcoqbt-Bar e1tzsy280"
-            color="#FFDD49"
-            data-cy="commit-chart-bar"
-            height="75%"
-          />
-          <div
-            className="css-16hoxq8-Bar e1tzsy280"
-            color="#89979B"
-            data-cy="commit-chart-bar"
-            height="16.666666666666664%"
-          />
-        </div>
-        <div
-          className="css-1qv3l5b-LabelContainer e1cz15301"
-          data-cy="commit-label"
-        >
-          <div
-            className="css-1l2peoq-LabelText e1cz15300 leafygreen-ui-1mngpnd"
-          >
-            <a
-              className="css-1bct88o-StyledRouterLink-linkStyles es7lfqt0"
-              href="/version/spruce_v2.11.0_60ec461532f4172d48288274/tasks"
-              onClick={[Function]}
-            >
-              211b3a0
-            </a>
-             
-            7/13/21 2:51 PM
-          </div>
-          <div
-            className="css-1l2peoq-LabelText e1cz15300 leafygreen-ui-1mngpnd"
-          >
-            Chaya Malik
-             -
-          </div>
-          <div
-            className="css-1l2peoq-LabelText e1cz15300 leafygreen-ui-1mngpnd"
-          >
-            Triggered From Git Tag 'v2.11.0': v2....
-          </div>
-          <small
-            className="css-2n0pzr-ButtonText eq9i5u71 leafygreen-ui-1mvgvb8"
-            onBlur={[Function]}
-            onFocus={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-          >
-            more
-          </small>
-        </div>
-      </div>
-      <div
-        className="css-m6knb7-ColumnContainer e1s1lwa11"
-      >
-        <div
-          className="css-8bv1t4-Container ek3nkvx1"
-        >
-          <a
-            className="css-51km4x-StyledRouterLink-linkStyles-Label ek3nkvx3"
-            href="/variant-history/undefined/undefined"
-            onClick={[Function]}
-          >
-            01. Code Health [code_health]
-          </a>
-          <div
-            className="css-100ar08-IconContainer ek3nkvx2"
-          >
-            <a
-              aria-disabled={false}
-              aria-label="task icon"
-              className="leafygreen-ui-12hedrr"
-              data-cy="waterfall-task-status-icon"
-              href="/task/code_health"
-              onBlur={[Function]}
-              onClick={[Function]}
-              onFocus={[Function]}
-              onMouseEnter={[Function]}
-              onMouseLeave={[Function]}
-              onMouseOver={[Function]}
-              tabIndex={0}
-            >
-              <div
-                className="leafygreen-ui-xhlipt"
-              >
-                <svg
-                  fill="currentColor"
-                  height={16}
-                  viewBox="0 0 21 21"
-                  width={16}
-                >
-                  <path
-                    d="M17.7783.807588c-.7811-.7810482-2.0474-.7810486-2.8285 0L10.0001 5.75734 5.05035.807588c-.78105-.7810484-2.04738-.7810482-2.82843 0L.80771 2.2218c-.7810481.78105-.7810485 2.04738 0 2.82843l4.94975 4.94975L.80771 14.9497c-.7810474.7811-.7810481 2.0474 0 2.8285l1.41421 1.4142c.78105.781 2.04738.781 2.82843 0l4.94975-4.9498 4.9497 4.9498c.7811.781 2.0474.781 2.8285 0l1.4142-1.4142c.781-.7811.781-2.0474 0-2.8285l-4.9498-4.94972 4.9498-4.94975c.781-.78105.781-2.04738 0-2.82843L17.7783.807588Z"
-                    fill="#CF4A22"
-                  />
-                </svg>
-              </div>
-            </a>
-          </div>
-        </div>
-        <div
-          className="css-8bv1t4-Container ek3nkvx1"
-        >
-          <a
-            className="css-51km4x-StyledRouterLink-linkStyles-Label ek3nkvx3"
-            href="/variant-history/undefined/undefined"
+            href="/variant-history/spruce/package_rpm"
             onClick={[Function]}
           >
             02. Packaging (RPM - RHEL7) [package_rpm]
@@ -1872,6 +934,120 @@ exports[`storybook Storyshots Project Health Page Waterfall Percentage 1`] = `
     <div
       className="css-1sahvn-SolidLine e15dc98b0"
     />
+  </div>
+  <div
+    className="css-1isl84h-Container e1d5uzqe2"
+  >
+    <div
+      className="css-r7f5o5-ToggleWrapper e1d5uzqe0"
+    >
+      <label
+        className="leafygreen-ui-ly82bp"
+        htmlFor="chart-toggle"
+      >
+        View Options
+      </label>
+      <div
+        aria-label="chart-select"
+        className="leafygreen-ui-sgfp3 css-1ey7tse-StyledRadioGroup e1d5uzqe1"
+        role="group"
+      >
+        <div
+          className="leafygreen-ui-1s4vgyd"
+        >
+          <label
+            className="leafygreen-ui-17avto4"
+            htmlFor="chart-radio-absolute"
+          >
+            <input
+              aria-checked={true}
+              aria-disabled={false}
+              checked={true}
+              className="leafygreen-ui-x2r5fc"
+              data-cy="cy-chart-absolute-radio"
+              data-leafygreen-ui="input-element"
+              disabled={false}
+              id="chart-radio-absolute"
+              name="chart-select"
+              onChange={[Function]}
+              type="radio"
+              value="absolute"
+            />
+            <div
+              className="leafygreen-ui-5a1vdt"
+              data-leafygreen-ui="radio-input-display-wrapper"
+            >
+              <div
+                className="leafygreen-ui-1y6j5s3"
+                data-leafygreen-ui="radio-input-display"
+                onBlur={[Function]}
+                onFocus={[Function]}
+              />
+              <div
+                className="leafygreen-ui-1cqcpzq"
+                data-leafygreen-ui="interaction-ring"
+              />
+            </div>
+            <div
+              className="leafygreen-ui-3sm8z"
+            >
+              <label
+                className="leafygreen-ui-ly82bp"
+                htmlFor="chart-radio-absolute"
+              >
+                Absolute Number
+              </label>
+            </div>
+          </label>
+        </div>
+        <div
+          className="leafygreen-ui-1s4vgyd"
+        >
+          <label
+            className="leafygreen-ui-17avto4"
+            htmlFor="chart-radio-percent"
+          >
+            <input
+              aria-disabled={false}
+              className="leafygreen-ui-x2r5fc"
+              data-cy="cy-chart-percent-radio"
+              data-leafygreen-ui="input-element"
+              disabled={false}
+              id="chart-radio-percent"
+              name="chart-select"
+              onChange={[Function]}
+              type="radio"
+              value="percentage"
+            />
+            <div
+              className="leafygreen-ui-5a1vdt"
+              data-leafygreen-ui="radio-input-display-wrapper"
+            >
+              <div
+                className="leafygreen-ui-1y6j5s3"
+                data-leafygreen-ui="radio-input-display"
+                onBlur={[Function]}
+                onFocus={[Function]}
+              />
+              <div
+                className="leafygreen-ui-1cqcpzq"
+                data-leafygreen-ui="interaction-ring"
+              />
+            </div>
+            <div
+              className="leafygreen-ui-3sm8z"
+            >
+              <label
+                className="leafygreen-ui-ly82bp"
+                htmlFor="chart-radio-percent"
+              >
+                Percentage
+              </label>
+            </div>
+          </label>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 `;

--- a/src/pages/commits/ActiveCommits/index.tsx
+++ b/src/pages/commits/ActiveCommits/index.tsx
@@ -1,6 +1,9 @@
-import React from "react";
+import { css } from "@emotion/react";
 import styled from "@emotion/styled";
+import { uiColors } from "@leafygreen-ui/palette";
 import CommitChartLabel from "components/CommitChartLabel";
+import { navBarHeight } from "components/Header/Navbar";
+import StickyContainer from "components/StickyContainer";
 import { MainlineCommitsQuery } from "gql/generated/types";
 import { ChartTypes } from "types/commits";
 import { shortenGithash } from "utils/string";
@@ -8,6 +11,7 @@ import { BuildVariantCard } from "./BuildVariantCard";
 import { CommitChart } from "./CommitChart";
 import { ColorCount } from "./utils";
 
+const { white } = uiColors;
 interface Props {
   version: MainlineCommitsQuery["mainlineCommits"]["versions"][0]["version"];
   groupedTaskStats: ColorCount[];
@@ -15,6 +19,7 @@ interface Props {
   total: number;
   chartType: ChartTypes;
   hasTaskFilter: boolean;
+  containerRef?: React.RefObject<HTMLDivElement>;
 }
 
 export const ActiveCommit: React.FC<Props> = ({
@@ -24,22 +29,29 @@ export const ActiveCommit: React.FC<Props> = ({
   total,
   chartType,
   hasTaskFilter,
+  containerRef,
 }) => (
   <Container>
-    <ColumnContainer key={version.id}>
+    <ColumnContainer>
       <CommitChart
         groupedTaskStats={groupedTaskStats}
         total={total}
         max={max}
         chartType={chartType}
       />
-      <CommitChartLabel
-        versionId={version.id}
-        githash={shortenGithash(version.revision)}
-        createTime={version.createTime}
-        author={version.author}
-        message={version.message}
-      />
+      <StickyContainer
+        offset={navBarHeight}
+        styles={stickyStyles}
+        containerRef={containerRef}
+      >
+        <CommitChartLabel
+          versionId={version.id}
+          githash={shortenGithash(version.revision)}
+          createTime={version.createTime}
+          author={version.author}
+          message={version.message}
+        />
+      </StickyContainer>
     </ColumnContainer>
     <ColumnContainer>
       {version.buildVariants.map(({ variant, displayName, tasks }) => (
@@ -62,9 +74,16 @@ const ColumnContainer = styled.div`
   flex-direction: column;
   justify-content: flex-start;
   align-items: flex-start;
-  margin-bottom: 15px;
+  margin-bottom: 16px;
 `;
 
 const Container = styled.div`
-  margin-bottom: 50px;
+  display: flex;
+  flex-direction: column;
+`;
+
+const stickyStyles = css`
+  background-color: ${white};
+  z-index: 1;
+  width: 203.5px;
 `;

--- a/src/pages/commits/CommitsWrapper.tsx
+++ b/src/pages/commits/CommitsWrapper.tsx
@@ -19,6 +19,7 @@ interface Props {
   chartType?: ChartTypes;
   hasTaskFilter: boolean;
   hasFilters: boolean;
+  onChangeChartType: (chartType: ChartTypes) => void;
 }
 
 export const CommitsWrapper: React.FC<Props> = ({
@@ -28,6 +29,7 @@ export const CommitsWrapper: React.FC<Props> = ({
   chartType,
   hasTaskFilter,
   hasFilters,
+  onChangeChartType,
 }) => {
   if (error) {
     return (
@@ -62,17 +64,19 @@ export const CommitsWrapper: React.FC<Props> = ({
                 hasTaskFilter={hasTaskFilter}
               />
             ) : (
-              <ColumnContainer key={rolledUpVersions[0].id}>
-                <InactiveCommits
-                  hasFilters={hasFilters}
-                  rolledUpVersions={rolledUpVersions}
-                />
-              </ColumnContainer>
+              <InactiveCommits
+                key={rolledUpVersions[0].id}
+                hasFilters={hasFilters}
+                rolledUpVersions={rolledUpVersions}
+              />
             )
           )}
         </FlexRowContainer>
         <Grid numDashedLine={5} />
-        <ChartToggle currentChartType={chartType} />
+        <ChartToggle
+          currentChartType={chartType}
+          onChangeChartType={onChangeChartType}
+        />
       </ProjectHealthWrapper>
     );
   }

--- a/src/pages/commits/CommitsWrapper.tsx
+++ b/src/pages/commits/CommitsWrapper.tsx
@@ -10,7 +10,7 @@ import {
   getAllTaskStatsGroupedByColor,
   findMaxGroupedTaskStats,
 } from "./ActiveCommits/utils";
-import { InactiveCommits, InactiveCommitLine } from "./InactiveCommits/index";
+import InactiveCommits from "./InactiveCommits";
 
 interface Props {
   versions: MainlineCommitsQuery["mainlineCommits"]["versions"];
@@ -39,7 +39,7 @@ export const CommitsWrapper: React.FC<Props> = ({
   if (isLoading) {
     return <StyledSkeleton active title={false} paragraph={{ rows: 6 }} />;
   }
-  if (!isLoading && versions?.length !== 0) {
+  if (versions?.length !== 0) {
     const versionToGroupedTaskStatsMap = getAllTaskStatsGroupedByColor(
       versions
     );
@@ -63,7 +63,6 @@ export const CommitsWrapper: React.FC<Props> = ({
               />
             ) : (
               <ColumnContainer key={rolledUpVersions[0].id}>
-                <InactiveCommitLine />
                 <InactiveCommits
                   hasFilters={hasFilters}
                   rolledUpVersions={rolledUpVersions}

--- a/src/pages/commits/CommitsWrapper.tsx
+++ b/src/pages/commits/CommitsWrapper.tsx
@@ -21,6 +21,7 @@ interface Props {
   hasTaskFilter: boolean;
   hasFilters: boolean;
   onChangeChartType: (chartType: ChartTypes) => void;
+  containerRef?: React.RefObject<HTMLDivElement>;
 }
 
 export const CommitsWrapper: React.FC<Props> = ({
@@ -31,6 +32,7 @@ export const CommitsWrapper: React.FC<Props> = ({
   hasTaskFilter,
   hasFilters,
   onChangeChartType,
+  containerRef,
 }) => {
   const versionToGroupedTaskStatsMap = useMemo(() => {
     if (versions) {
@@ -72,12 +74,14 @@ export const CommitsWrapper: React.FC<Props> = ({
                   versionToGroupedTaskStatsMap[version.id].stats
                 }
                 hasTaskFilter={hasTaskFilter}
+                containerRef={containerRef}
               />
             ) : (
               <InactiveCommits
                 key={rolledUpVersions[0].id}
                 hasFilters={hasFilters}
                 rolledUpVersions={rolledUpVersions}
+                containerRef={containerRef}
               />
             )
           )}

--- a/src/pages/commits/CommitsWrapper.tsx
+++ b/src/pages/commits/CommitsWrapper.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { ApolloError } from "@apollo/client";
 import styled from "@emotion/styled";
 import { Skeleton } from "antd";
@@ -31,6 +32,20 @@ export const CommitsWrapper: React.FC<Props> = ({
   hasFilters,
   onChangeChartType,
 }) => {
+  const versionToGroupedTaskStatsMap = useMemo(() => {
+    if (versions) {
+      return getAllTaskStatsGroupedByColor(versions);
+    }
+    return undefined;
+  }, [versions]);
+
+  const maxGroupedTaskStats = useMemo(() => {
+    if (versionToGroupedTaskStatsMap) {
+      return findMaxGroupedTaskStats(versionToGroupedTaskStatsMap);
+    }
+    return undefined;
+  }, [versionToGroupedTaskStatsMap]);
+  const { max } = maxGroupedTaskStats || {};
   if (error) {
     return (
       <ProjectHealthWrapper>
@@ -42,11 +57,6 @@ export const CommitsWrapper: React.FC<Props> = ({
     return <StyledSkeleton active title={false} paragraph={{ rows: 6 }} />;
   }
   if (versions?.length !== 0) {
-    const versionToGroupedTaskStatsMap = getAllTaskStatsGroupedByColor(
-      versions
-    );
-    const { max } = findMaxGroupedTaskStats(versionToGroupedTaskStatsMap);
-
     return (
       <ProjectHealthWrapper>
         <FlexRowContainer numCommits={versions.length}>

--- a/src/pages/commits/InactiveCommits/InactiveCommits.stories.tsx
+++ b/src/pages/commits/InactiveCommits/InactiveCommits.stories.tsx
@@ -1,5 +1,5 @@
 import { BrowserRouter } from "react-router-dom";
-import { InactiveCommits } from ".";
+import InactiveCommits from ".";
 
 export default {
   title: "Inactive Commits",

--- a/src/pages/commits/InactiveCommits/InactiveCommits.test.tsx
+++ b/src/pages/commits/InactiveCommits/InactiveCommits.test.tsx
@@ -1,7 +1,7 @@
 import userEvent from "@testing-library/user-event";
 import { render, waitFor } from "test_utils";
 
-import { InactiveCommits } from ".";
+import InactiveCommits from ".";
 
 const RenderInactiveCommits = (versions) => (
   <InactiveCommits rolledUpVersions={versions} />

--- a/src/pages/commits/InactiveCommits/__snapshots__/InactiveCommits.stories.storyshot
+++ b/src/pages/commits/InactiveCommits/__snapshots__/InactiveCommits.stories.storyshot
@@ -2,20 +2,27 @@
 
 exports[`storybook Storyshots Inactive Commits Story 1`] = `
 <div
-  className="leafygreen-ui-cssveg css-ue3t3g-ButtonContainer ezzuvrx4"
-  onClick={[Function]}
+  className="css-ytrjsr-Container ezzuvrx0"
 >
-  <small
-    className="css-nr1a01-ButtonText ezzuvrx1 leafygreen-ui-13bqno6"
-    data-cy="inactive-commits-button"
+  <div
+    className="css-1q62izj-InactiveCommitLine ezzuvrx4"
+  />
+  <div
+    className="leafygreen-ui-cssveg css-ls8suj-ButtonContainer ezzuvrx5"
+    onClick={[Function]}
+    role="button"
   >
-    <div
-      className="css-hifh5j-TopText ezzuvrx2"
+    <small
+      className="css-t2ltce-ButtonText ezzuvrx2 leafygreen-ui-13bqno6"
+      data-cy="inactive-commits-button"
     >
-      6
-       
-    </div>
-    inactive
-  </small>
+      <div
+        className="css-hifh5j-TopText ezzuvrx3"
+      >
+        6
+      </div>
+      Inactive
+    </small>
+  </div>
 </div>
 `;

--- a/src/pages/commits/InactiveCommits/__snapshots__/InactiveCommits.stories.storyshot
+++ b/src/pages/commits/InactiveCommits/__snapshots__/InactiveCommits.stories.storyshot
@@ -7,22 +7,28 @@ exports[`storybook Storyshots Inactive Commits Story 1`] = `
   <div
     className="css-1q62izj-InactiveCommitLine ezzuvrx4"
   />
+  <div />
   <div
-    className="leafygreen-ui-cssveg css-ls8suj-ButtonContainer ezzuvrx5"
-    onClick={[Function]}
-    role="button"
+    className="css-1gkww3q-StickyDiv-StickyContainer e1pdm2sm0"
+    offset={64}
   >
-    <small
-      className="css-t2ltce-ButtonText ezzuvrx2 leafygreen-ui-13bqno6"
-      data-cy="inactive-commits-button"
+    <div
+      className="leafygreen-ui-cssveg css-ls8suj-ButtonContainer ezzuvrx5"
+      onClick={[Function]}
+      role="button"
     >
-      <div
-        className="css-hifh5j-TopText ezzuvrx3"
+      <small
+        className="css-t2ltce-ButtonText ezzuvrx2 leafygreen-ui-13bqno6"
+        data-cy="inactive-commits-button"
       >
-        6
-      </div>
-      Inactive
-    </small>
+        <div
+          className="css-hifh5j-TopText ezzuvrx3"
+        >
+          6
+        </div>
+        Inactive
+      </small>
+    </div>
   </div>
 </div>
 `;

--- a/src/pages/commits/InactiveCommits/index.tsx
+++ b/src/pages/commits/InactiveCommits/index.tsx
@@ -133,7 +133,7 @@ const ButtonContainer = styled.div`
   justify-content: center;
 `;
 
-export const InactiveCommitLine = styled.div`
+const InactiveCommitLine = styled.div`
   height: ${commitChartHeight}px;
   border: 1px dashed ${gray.light1};
 `;

--- a/src/pages/commits/InactiveCommits/index.tsx
+++ b/src/pages/commits/InactiveCommits/index.tsx
@@ -3,6 +3,7 @@ import { uiColors } from "@leafygreen-ui/palette";
 import Tooltip from "@leafygreen-ui/tooltip";
 import { Body, Disclaimer } from "@leafygreen-ui/typography";
 import { string } from "utils";
+import { commitChartHeight } from "../constants";
 
 const { getDateCopy } = string;
 const { gray } = uiColors;
@@ -15,11 +16,24 @@ type rolledUpVersion = {
   message: string;
   revision?: string;
 };
+
 interface InactiveCommitsProps {
   rolledUpVersions: rolledUpVersion[];
   hasFilters?: boolean;
 }
-export const InactiveCommits: React.FC<InactiveCommitsProps> = ({
+const InactiveCommits: React.FC<InactiveCommitsProps> = ({
+  rolledUpVersions,
+  hasFilters = false,
+}) => (
+  <Container>
+    <InactiveCommitLine />
+    <InactiveCommitButton
+      rolledUpVersions={rolledUpVersions}
+      hasFilters={hasFilters}
+    />
+  </Container>
+);
+const InactiveCommitButton: React.FC<InactiveCommitsProps> = ({
   rolledUpVersions,
   hasFilters = false,
 }) => {
@@ -27,6 +41,7 @@ export const InactiveCommits: React.FC<InactiveCommitsProps> = ({
 
   const shouldSplitCommits = versionCount > MAX_COMMIT_COUNT;
 
+  const tooltipType = hasFilters ? "Unmatching" : "Inactive";
   let returnedCommits = [];
   if (shouldSplitCommits) {
     const hiddenCommitCount = versionCount - MAX_COMMIT_COUNT;
@@ -36,12 +51,12 @@ export const InactiveCommits: React.FC<InactiveCommitsProps> = ({
           {getCommitCopy(v)}
         </CommitText>
       )),
-      <HiddenCommitsWrapper
-        key="hidden_commits"
-        data-cy="hidden-commits"
-      >{`${hiddenCommitCount} more commit${
-        hiddenCommitCount !== 1 ? "s" : ""
-      }`}</HiddenCommitsWrapper>,
+      <HiddenCommitsWrapper key="hidden_commits" data-cy="hidden-commits">
+        <Disclaimer>
+          {hiddenCommitCount}
+          {` more commit${hiddenCommitCount !== 1 ? "s" : ""}`}
+        </Disclaimer>
+      </HiddenCommitsWrapper>,
       ...rolledUpVersions.slice(-3).map((v) => (
         <CommitText key={v.revision} data-cy="commit-text">
           {getCommitCopy(v)}
@@ -64,8 +79,8 @@ export const InactiveCommits: React.FC<InactiveCommitsProps> = ({
       trigger={
         <ButtonContainer>
           <ButtonText data-cy="inactive-commits-button">
-            <TopText>{`${versionCount}`} </TopText>
-            {hasFilters ? "unmatching" : "inactive"}
+            <TopText>{versionCount} </TopText>
+            {tooltipType}
           </ButtonText>
         </ButtonContainer>
       }
@@ -73,9 +88,9 @@ export const InactiveCommits: React.FC<InactiveCommitsProps> = ({
       popoverZIndex={10}
     >
       <TooltipContainer data-cy="inactive-commits-tooltip">
-        <TitleText>
-          {versionCount} {hasFilters ? "Unmatching" : "Inactive"}{" "}
-          {`Commit${versionCount !== 1 ? "s" : ""}`}
+        <TitleText weight="medium">
+          {versionCount} {tooltipType}
+          {` Commit${versionCount !== 1 ? "s" : ""}`}
         </TitleText>
         {returnedCommits}
       </TooltipContainer>
@@ -89,14 +104,15 @@ const getCommitCopy = (v: rolledUpVersion) =>
   } (#${v.order})`;
 
 const CommitText = styled(Body)`
-  padding: 2px 0;
+  padding: 4px 0;
 `;
 const HiddenCommitsWrapper = styled.div`
-  width: 180px;
+  width: 60%;
   border-bottom: 1px solid ${gray.dark2};
   text-align: center;
   padding: 4px 0;
-  margin: 18px 0px 28px 60px;
+  align-self: center;
+  margin: 32px 0;
 `;
 
 const TooltipContainer = styled.div`
@@ -111,15 +127,14 @@ const TooltipContainer = styled.div`
 `;
 
 const ButtonContainer = styled.div`
-  width: 58px;
+  width: 64px;
   cursor: pointer;
   display: flex;
   justify-content: center;
 `;
 
 export const InactiveCommitLine = styled.div`
-  margin-left: 29px;
-  height: 224px;
+  height: ${commitChartHeight}px;
   border: 1px dashed ${gray.light1};
 `;
 
@@ -127,17 +142,22 @@ const TopText = styled.div`
   white-space: nowrap;
 `;
 const ButtonText = styled(Disclaimer)`
-  margin-top: 10px;
+  margin-top: 8px;
   text-align: center;
-  display: table;
   color: ${gray.dark2};
   font-weight: bold;
 `;
 
-const TitleText = styled(Disclaimer)`
-  margin-bottom: 14px;
-  font-weight: bold;
-  font-size: 14px;
+const TitleText = styled(Body)`
+  margin-bottom: 16px;
+`;
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 `;
 
 const MAX_COMMIT_COUNT = 5;
+
+export default InactiveCommits;

--- a/src/pages/commits/InactiveCommits/index.tsx
+++ b/src/pages/commits/InactiveCommits/index.tsx
@@ -5,7 +5,7 @@ import { Body, Disclaimer } from "@leafygreen-ui/typography";
 import { string } from "utils";
 import { commitChartHeight } from "../constants";
 
-const { getDateCopy } = string;
+const { getDateCopy, shortenGithash } = string;
 const { gray } = uiColors;
 
 type rolledUpVersion = {
@@ -77,9 +77,9 @@ const InactiveCommitButton: React.FC<InactiveCommitsProps> = ({
       align="bottom"
       justify="middle"
       trigger={
-        <ButtonContainer>
+        <ButtonContainer role="button">
           <ButtonText data-cy="inactive-commits-button">
-            <TopText>{versionCount} </TopText>
+            <TopText>{versionCount}</TopText>
             {tooltipType}
           </ButtonText>
         </ButtonContainer>
@@ -99,7 +99,7 @@ const InactiveCommitButton: React.FC<InactiveCommitsProps> = ({
 };
 
 const getCommitCopy = (v: rolledUpVersion) =>
-  `${v.revision.slice(0, 5)} ${getDateCopy(v.createTime)} ${v.author} ${
+  `${shortenGithash(v.revision)} ${getDateCopy(v.createTime)} ${v.author} ${
     v.message
   } (#${v.order})`;
 

--- a/src/pages/commits/InactiveCommits/index.tsx
+++ b/src/pages/commits/InactiveCommits/index.tsx
@@ -2,6 +2,8 @@ import styled from "@emotion/styled";
 import { uiColors } from "@leafygreen-ui/palette";
 import Tooltip from "@leafygreen-ui/tooltip";
 import { Body, Disclaimer } from "@leafygreen-ui/typography";
+import { navBarHeight } from "components/Header/Navbar";
+import StickyContainer from "components/StickyContainer";
 import { string } from "utils";
 import { commitChartHeight } from "../constants";
 
@@ -20,17 +22,21 @@ type rolledUpVersion = {
 interface InactiveCommitsProps {
   rolledUpVersions: rolledUpVersion[];
   hasFilters?: boolean;
+  containerRef?: React.RefObject<HTMLDivElement>;
 }
 const InactiveCommits: React.FC<InactiveCommitsProps> = ({
   rolledUpVersions,
   hasFilters = false,
+  containerRef,
 }) => (
   <Container>
     <InactiveCommitLine />
-    <InactiveCommitButton
-      rolledUpVersions={rolledUpVersions}
-      hasFilters={hasFilters}
-    />
+    <StickyContainer containerRef={containerRef} offset={navBarHeight}>
+      <InactiveCommitButton
+        rolledUpVersions={rolledUpVersions}
+        hasFilters={hasFilters}
+      />
+    </StickyContainer>
   </Container>
 );
 const InactiveCommitButton: React.FC<InactiveCommitsProps> = ({

--- a/src/pages/commits/constants.ts
+++ b/src/pages/commits/constants.ts
@@ -1,0 +1,3 @@
+const commitChartHeight = 224;
+
+export { commitChartHeight };


### PR DESCRIPTION
[EVG-16120](https://jira.mongodb.org/browse/EVG-16120)

### Description 
This adds a StickyContainer component that behaves similarly to the `position: sticky;`[ css attribute](https://developer.mozilla.org/en-US/docs/Web/CSS/position)  but is able to position itself independently of its direct parent. 
This was necessary because the "containing block" where this element is positioned is not a scrollable element. The scrollable Element is actually a few layers up ("PageWrapper" component). 

This also updates some sizes in preparation for [EVG-16152 ](https://jira.mongodb.org/browse/EVG-16152)
There is also a refactor of some storybook stories and some components to make it easier to render the project health view in a storybook story. 
 

### Screenshots

https://user-images.githubusercontent.com/4605522/150382824-5dd91f2f-a081-48fc-a000-d87e81d55aa9.mov




