### PR TITLE
EVG-16173 Escape regex characters on history table links

### DIFF
--- a/src/pages/task/taskTabs/testsTable/LogsColumn.tsx
+++ b/src/pages/task/taskTabs/testsTable/LogsColumn.tsx
@@ -5,8 +5,10 @@ import { Analytics } from "analytics/addPageAction";
 import { getTaskHistoryRoute } from "constants/routes";
 import { TestResult } from "gql/generated/types";
 import { TestStatus } from "types/test";
+import { string } from "utils";
 import { isBeta } from "utils/environmentalVariables";
 
+const { escapeRegex } = string;
 interface Props {
   taskAnalytics: Analytics<
     | { name: "Click Logs Lobster Button" }
@@ -33,7 +35,7 @@ export const LogsColumn: React.FC<Props> = ({
   let filters;
   if (status === TestStatus.Fail) {
     filters = {
-      failingTests: [testFile],
+      failingTests: [escapeRegex(testFile)],
     };
   }
   return (

--- a/src/utils/string/index.ts
+++ b/src/utils/string/index.ts
@@ -163,6 +163,14 @@ export const sortFunctionDate = (a, b, key) => {
 export const applyStrictRegex = (str: string) => `^${str}$`;
 
 /**
+ *
+ * @param str - A string that may contain regex operators.
+ * @return {string} A regex that matches on the input.
+ */
+export const escapeRegex = (str: string) =>
+  str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+/**
  * @param str - A string that represents a githash
  * @return {string} A shortenend version of the input string.
  */


### PR DESCRIPTION
[EVG-16173](https://jira.mongodb.org/browse/EVG-16173)

### Description 
Since the history table applies a regex search and the tests table often has test names with characters that can be mistaken for regex we need to escape them before using them in the history table otherwise we won't be able to match on them. 

