### PR TITLE
EVG-15974: Trim filter badge text

### DIFF
--- a/src/components/FilterBadges/FilterBadge.tsx
+++ b/src/components/FilterBadges/FilterBadge.tsx
@@ -6,19 +6,24 @@ import { ConditionalWrapper } from "components/ConditionalWrapper";
 import Icon from "components/Icon";
 import { string } from "utils";
 
-const maxBadgeLength = 25;
 const { trimStringFromMiddle } = string;
-
 const { gray } = uiColors;
+
+const tooltipInModalZIndex = 100; // necessary due to SeeMoreModal
 
 interface FilterBadgeProps {
   badge: {
     key: string;
     value: string;
   };
+  maxBadgeLength?: number;
   onClose: () => void;
 }
-export const FilterBadge: React.FC<FilterBadgeProps> = ({ badge, onClose }) => {
+export const FilterBadge: React.FC<FilterBadgeProps> = ({
+  badge,
+  maxBadgeLength = 25,
+  onClose,
+}) => {
   const trimmedBadgeName = trimStringFromMiddle(badge.value, maxBadgeLength);
 
   return (
@@ -28,7 +33,7 @@ export const FilterBadge: React.FC<FilterBadgeProps> = ({ badge, onClose }) => {
         <StyledTooltip
           align="top"
           justify="middle"
-          popoverZIndex={10 /* use tooltipIndex when it's merged */}
+          popoverZIndex={tooltipInModalZIndex}
           trigger={children}
           triggerEvent="hover"
         >

--- a/src/components/FilterBadges/FilterBadge.tsx
+++ b/src/components/FilterBadges/FilterBadge.tsx
@@ -22,31 +22,30 @@ export const FilterBadge: React.FC<FilterBadgeProps> = ({ badge, onClose }) => {
   const trimmedBadgeName = trimStringFromMiddle(badge.value, maxBadgeLength);
 
   return (
-    <PaddedBadge
-      key={`filter_badge_${badge.key}_${badge.value}`}
-      data-cy="filter-badge"
+    <ConditionalWrapper
+      condition={trimmedBadgeName !== badge.value}
+      wrapper={(children) => (
+        <StyledTooltip
+          align="top"
+          justify="middle"
+          popoverZIndex={10 /* use tooltipIndex when it's merged */}
+          trigger={children}
+          triggerEvent="hover"
+        >
+          {badge.value}
+        </StyledTooltip>
+      )}
     >
-      <ConditionalWrapper
-        condition={trimmedBadgeName !== badge.value}
-        wrapper={(children) => (
-          <StyledTooltip
-            align="top"
-            justify="middle"
-            popoverZIndex={10 /* use tooltipIndex when it's merged */}
-            trigger={children}
-            triggerEvent="hover"
-          >
-            {badge.value}
-          </StyledTooltip>
-        )}
+      <PaddedBadge
+        key={`filter_badge_${badge.key}_${badge.value}`}
+        data-cy="filter-badge"
       >
         <BadgeContent>
           {badge.key} : {trimmedBadgeName}
         </BadgeContent>
-      </ConditionalWrapper>
-
-      <ClickableIcon data-cy="close-badge" glyph="X" onClick={onClose} />
-    </PaddedBadge>
+        <ClickableIcon data-cy="close-badge" glyph="X" onClick={onClose} />
+      </PaddedBadge>
+    </ConditionalWrapper>
   );
 };
 
@@ -66,16 +65,19 @@ const PaddedBadge = styled(Badge)`
   margin-right: 16px;
   margin-bottom: 24px;
   padding: 0px 24px 0px 16px; // the difference in padding is to offset the "X" button visually
+  :hover {
+    cursor: default;
+  }
 `;
 
 const BadgeContent = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 100%;
 `;
 
 // @ts-expect-error
+// Reduce Tooltip padding because the default Tooltip is invasive when trying to interact with other UI elements
 const StyledTooltip = styled(Tooltip)`
   padding: 4px 8px;
 `;

--- a/src/components/FilterBadges/FilterBadge.tsx
+++ b/src/components/FilterBadges/FilterBadge.tsx
@@ -9,7 +9,7 @@ import { string } from "utils";
 const { trimStringFromMiddle } = string;
 const { gray } = uiColors;
 
-const tooltipInModalZIndex = 100; // necessary due to SeeMoreModal
+const tooltipInModalZIndex = 50; // necessary due to SeeMoreModal, which has zIndex 40
 const maxBadgeLength = 25;
 
 interface FilterBadgeProps {
@@ -20,9 +20,10 @@ interface FilterBadgeProps {
   onClose: () => void;
 }
 export const FilterBadge: React.FC<FilterBadgeProps> = ({ badge, onClose }) => {
+  // the trimmed name needs to account for the label
   const trimmedBadgeName = trimStringFromMiddle(
     badge.value,
-    maxBadgeLength - (badge.key.length + 2) // subtract "KEY :" length
+    maxBadgeLength - badge.key.length
   );
 
   return (

--- a/src/components/FilterBadges/FilterBadge.tsx
+++ b/src/components/FilterBadges/FilterBadge.tsx
@@ -1,7 +1,13 @@
 import styled from "@emotion/styled";
 import Badge from "@leafygreen-ui/badge";
 import { uiColors } from "@leafygreen-ui/palette";
+import Tooltip from "@leafygreen-ui/tooltip";
+import { ConditionalWrapper } from "components/ConditionalWrapper";
 import Icon from "components/Icon";
+import { string } from "utils";
+
+const maxBadgeLength = 25;
+const { trimStringFromMiddle } = string;
 
 const { gray } = uiColors;
 
@@ -12,33 +18,54 @@ interface FilterBadgeProps {
   };
   onClose: () => void;
 }
-export const FilterBadge: React.FC<FilterBadgeProps> = ({ badge, onClose }) => (
-  <PaddedBadge
-    key={`filter_badge_${badge.key}_${badge.value}`}
-    data-cy="filter-badge"
-  >
-    <BadgeContent>
-      {badge.key} : {badge.value}
+export const FilterBadge: React.FC<FilterBadgeProps> = ({ badge, onClose }) => {
+  const trimmedBadgeName = trimStringFromMiddle(badge.value, maxBadgeLength);
+
+  return (
+    <PaddedBadge
+      key={`filter_badge_${badge.key}_${badge.value}`}
+      data-cy="filter-badge"
+    >
+      <ConditionalWrapper
+        condition={trimmedBadgeName !== badge.value}
+        wrapper={(children) => (
+          <StyledTooltip
+            align="top"
+            justify="middle"
+            popoverZIndex={10 /* use tooltipIndex when it's merged */}
+            trigger={children}
+            triggerEvent="hover"
+          >
+            {badge.value}
+          </StyledTooltip>
+        )}
+      >
+        <BadgeContent>
+          {badge.key} : {trimmedBadgeName}
+        </BadgeContent>
+      </ConditionalWrapper>
+
       <ClickableIcon data-cy="close-badge" glyph="X" onClick={onClose} />
-    </BadgeContent>
-  </PaddedBadge>
-);
+    </PaddedBadge>
+  );
+};
 
 const ClickableIcon = styled(Icon)`
   position: absolute;
-  right: 0%;
+  right: 4px;
   :hover {
     cursor: pointer;
     color: ${gray.light1};
   }
 `;
 const PaddedBadge = styled(Badge)`
+  position: relative;
   :nth-of-type {
     margin-left: 16px;
   }
   margin-right: 16px;
   margin-bottom: 24px;
-  width: 260px;
+  padding: 0px 24px 0px 16px; // the difference in padding is to offset the "X" button visually
 `;
 
 const BadgeContent = styled.div`
@@ -46,5 +73,9 @@ const BadgeContent = styled.div`
   justify-content: center;
   align-items: center;
   width: 100%;
-  position: relative;
+`;
+
+// @ts-expect-error
+const StyledTooltip = styled(Tooltip)`
+  padding: 4px 8px;
 `;

--- a/src/components/FilterBadges/FilterBadge.tsx
+++ b/src/components/FilterBadges/FilterBadge.tsx
@@ -10,21 +10,20 @@ const { trimStringFromMiddle } = string;
 const { gray } = uiColors;
 
 const tooltipInModalZIndex = 100; // necessary due to SeeMoreModal
+const maxBadgeLength = 25;
 
 interface FilterBadgeProps {
   badge: {
     key: string;
     value: string;
   };
-  maxBadgeLength?: number;
   onClose: () => void;
 }
-export const FilterBadge: React.FC<FilterBadgeProps> = ({
-  badge,
-  maxBadgeLength = 25,
-  onClose,
-}) => {
-  const trimmedBadgeName = trimStringFromMiddle(badge.value, maxBadgeLength);
+export const FilterBadge: React.FC<FilterBadgeProps> = ({ badge, onClose }) => {
+  const trimmedBadgeName = trimStringFromMiddle(
+    badge.value,
+    maxBadgeLength - (badge.key.length + 2) // subtract "KEY :" length
+  );
 
   return (
     <ConditionalWrapper
@@ -64,6 +63,7 @@ const ClickableIcon = styled(Icon)`
 `;
 const PaddedBadge = styled(Badge)`
   position: relative;
+  width: 260px;
   :nth-of-type {
     margin-left: 16px;
   }
@@ -79,6 +79,7 @@ const BadgeContent = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
+  width: 100%;
 `;
 
 // @ts-expect-error

--- a/src/components/FilterBadges/FilterBadge.tsx
+++ b/src/components/FilterBadges/FilterBadge.tsx
@@ -62,14 +62,14 @@ const ClickableIcon = styled(Icon)`
   }
 `;
 const PaddedBadge = styled(Badge)`
-  position: relative;
-  width: 260px;
   :nth-of-type {
     margin-left: 16px;
   }
   margin-right: 16px;
   margin-bottom: 24px;
-  padding: 0px 24px 0px 16px; // the difference in padding is to offset the "X" button visually
+  width: 260px;
+
+  position: relative;
   :hover {
     cursor: default;
   }

--- a/src/components/FilterBadges/FilterBadges.test.tsx
+++ b/src/components/FilterBadges/FilterBadges.test.tsx
@@ -1,4 +1,8 @@
-import { renderWithRouterMatch as render, fireEvent } from "test_utils";
+import {
+  renderWithRouterMatch as render,
+  fireEvent,
+  waitFor,
+} from "test_utils";
 import { ProjectFilterOptions } from "types/commits";
 import { FilterBadges } from ".";
 
@@ -121,7 +125,7 @@ describe("filterBadges", () => {
     expect(queryByText("see 1 more")).toBeInTheDocument();
   });
 
-  it("should truncate a badge name if it's too long", () => {
+  it("should truncate a badge name if it's too long, with hover showing full name", async () => {
     const longVariantName = "long_long_long_long_long_long_build_variant_name";
     const { queryAllByDataCy, queryByText } = render(Content, {
       route: `/commits/evergreen?buildVariants=${longVariantName}`,
@@ -130,6 +134,8 @@ describe("filterBadges", () => {
 
     expect(queryByText(longVariantName)).not.toBeInTheDocument();
     fireEvent.mouseEnter(queryAllByDataCy("filter-badge")[0]);
-    expect(queryByText(longVariantName)).toBeVisible();
+    await waitFor(() => {
+      expect(queryByText(longVariantName)).toBeVisible();
+    });
   });
 });

--- a/src/components/FilterBadges/FilterBadges.test.tsx
+++ b/src/components/FilterBadges/FilterBadges.test.tsx
@@ -127,13 +127,13 @@ describe("filterBadges", () => {
 
   it("should truncate a badge name if it's too long, with hover showing full name", async () => {
     const longVariantName = "long_long_long_long_long_long_build_variant_name";
-    const { queryAllByDataCy, queryByText } = render(Content, {
+    const { queryByDataCy, queryByText } = render(Content, {
       route: `/commits/evergreen?buildVariants=${longVariantName}`,
       path: "/commits/:projectId",
     });
 
     expect(queryByText(longVariantName)).not.toBeInTheDocument();
-    fireEvent.mouseEnter(queryAllByDataCy("filter-badge")[0]);
+    fireEvent.mouseEnter(queryByDataCy("filter-badge"));
     await waitFor(() => {
       expect(queryByText(longVariantName)).toBeVisible();
     });

--- a/src/components/FilterBadges/FilterBadges.test.tsx
+++ b/src/components/FilterBadges/FilterBadges.test.tsx
@@ -120,4 +120,16 @@ describe("filterBadges", () => {
 
     expect(queryByText("see 1 more")).toBeInTheDocument();
   });
+
+  it("should truncate a badge name if it's too long", () => {
+    const longVariantName = "long_long_long_long_long_long_build_variant_name";
+    const { queryAllByDataCy, queryByText } = render(Content, {
+      route: `/commits/evergreen?buildVariants=${longVariantName}`,
+      path: "/commits/:projectId",
+    });
+
+    expect(queryByText(longVariantName)).not.toBeInTheDocument();
+    fireEvent.mouseEnter(queryAllByDataCy("filter-badge")[0]);
+    expect(queryByText(longVariantName)).toBeVisible();
+  });
 });

--- a/src/components/FilterBadges/__snapshots__/FilterBadges.stories.storyshot
+++ b/src/components/FilterBadges/__snapshots__/FilterBadges.stories.storyshot
@@ -17,7 +17,7 @@ exports[`storybook Storyshots FilterBadges Default 1`] = `
     >
       buildVariants
        : 
-      ! Ent… Tidy
+      ! Ente…g Tidy
     </div>
     <svg
       aria-label="X Icon"
@@ -52,7 +52,7 @@ exports[`storybook Storyshots FilterBadges Default 1`] = `
     >
       buildVariants
        : 
-      ! Ent…ndows
+      ! Ente…indows
     </div>
     <svg
       aria-label="X Icon"
@@ -87,7 +87,7 @@ exports[`storybook Storyshots FilterBadges Default 1`] = `
     >
       buildVariants
        : 
-      Enter…bled)
+      Enterp…abled)
     </div>
     <svg
       aria-label="X Icon"

--- a/src/components/FilterBadges/__snapshots__/FilterBadges.stories.storyshot
+++ b/src/components/FilterBadges/__snapshots__/FilterBadges.stories.storyshot
@@ -5,69 +5,7 @@ exports[`storybook Storyshots FilterBadges Default 1`] = `
   className="css-19f1xe2-Container e3qndfh0"
 >
   <div
-    className="css-h29ynq-PaddedBadge e1vs77ku2 leafygreen-ui-13xc3rv"
-    data-cy="filter-badge"
-  >
-    <div
-      className="css-1fqgdhu-BadgeContent e1vs77ku1"
-    >
-      buildVariants
-       : 
-      ! Enterprise Clang Tidy
-    </div>
-    <svg
-      aria-label="X Icon"
-      className="css-4ijbt0-ClickableIcon e1vs77ku3"
-      data-cy="close-badge"
-      fill="none"
-      height={16}
-      onClick={[Function]}
-      role="img"
-      viewBox="0 0 16 16"
-      width={16}
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        clipRule="evenodd"
-        d="M12.203 3.404a1 1 0 00-1.414 0L8.314 5.879 5.839 3.404a1 1 0 00-1.414 0l-.707.707a1 1 0 000 1.414L6.192 8l-2.474 2.475a1 1 0 000 1.414l.707.707a1 1 0 001.414 0l2.475-2.475 2.475 2.475a1 1 0 001.414 0l.707-.707a1 1 0 000-1.414L10.435 8l2.475-2.475a1 1 0 000-1.414l-.707-.707z"
-        fill="currentColor"
-        fillRule="evenodd"
-      />
-    </svg>
-  </div>
-  <div
-    className="css-h29ynq-PaddedBadge e1vs77ku2 leafygreen-ui-13xc3rv"
-    data-cy="filter-badge"
-  >
-    <div
-      className="css-1fqgdhu-BadgeContent e1vs77ku1"
-    >
-      buildVariants
-       : 
-      ! Enterprise Windows
-    </div>
-    <svg
-      aria-label="X Icon"
-      className="css-4ijbt0-ClickableIcon e1vs77ku3"
-      data-cy="close-badge"
-      fill="none"
-      height={16}
-      onClick={[Function]}
-      role="img"
-      viewBox="0 0 16 16"
-      width={16}
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        clipRule="evenodd"
-        d="M12.203 3.404a1 1 0 00-1.414 0L8.314 5.879 5.839 3.404a1 1 0 00-1.414 0l-.707.707a1 1 0 000 1.414L6.192 8l-2.474 2.475a1 1 0 000 1.414l.707.707a1 1 0 001.414 0l2.475-2.475 2.475 2.475a1 1 0 001.414 0l.707-.707a1 1 0 000-1.414L10.435 8l2.475-2.475a1 1 0 000-1.414l-.707-.707z"
-        fill="currentColor"
-        fillRule="evenodd"
-      />
-    </svg>
-  </div>
-  <div
-    className="css-h29ynq-PaddedBadge e1vs77ku2 leafygreen-ui-187420t"
+    className="css-1f49uy4-PaddedBadge e1vs77ku2 leafygreen-ui-187420t"
     data-cy="filter-badge"
     onBlur={[Function]}
     onFocus={[Function]}
@@ -75,11 +13,81 @@ exports[`storybook Storyshots FilterBadges Default 1`] = `
     onMouseLeave={[Function]}
   >
     <div
-      className="css-1fqgdhu-BadgeContent e1vs77ku1"
+      className="css-1i7u60d-BadgeContent e1vs77ku1"
     >
       buildVariants
        : 
-      Enterprise RH…ds disabled)
+      ! Ent… Tidy
+    </div>
+    <svg
+      aria-label="X Icon"
+      className="css-4ijbt0-ClickableIcon e1vs77ku3"
+      data-cy="close-badge"
+      fill="none"
+      height={16}
+      onClick={[Function]}
+      role="img"
+      viewBox="0 0 16 16"
+      width={16}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        clipRule="evenodd"
+        d="M12.203 3.404a1 1 0 00-1.414 0L8.314 5.879 5.839 3.404a1 1 0 00-1.414 0l-.707.707a1 1 0 000 1.414L6.192 8l-2.474 2.475a1 1 0 000 1.414l.707.707a1 1 0 001.414 0l2.475-2.475 2.475 2.475a1 1 0 001.414 0l.707-.707a1 1 0 000-1.414L10.435 8l2.475-2.475a1 1 0 000-1.414l-.707-.707z"
+        fill="currentColor"
+        fillRule="evenodd"
+      />
+    </svg>
+  </div>
+  <div
+    className="css-1f49uy4-PaddedBadge e1vs77ku2 leafygreen-ui-187420t"
+    data-cy="filter-badge"
+    onBlur={[Function]}
+    onFocus={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+  >
+    <div
+      className="css-1i7u60d-BadgeContent e1vs77ku1"
+    >
+      buildVariants
+       : 
+      ! Ent…ndows
+    </div>
+    <svg
+      aria-label="X Icon"
+      className="css-4ijbt0-ClickableIcon e1vs77ku3"
+      data-cy="close-badge"
+      fill="none"
+      height={16}
+      onClick={[Function]}
+      role="img"
+      viewBox="0 0 16 16"
+      width={16}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        clipRule="evenodd"
+        d="M12.203 3.404a1 1 0 00-1.414 0L8.314 5.879 5.839 3.404a1 1 0 00-1.414 0l-.707.707a1 1 0 000 1.414L6.192 8l-2.474 2.475a1 1 0 000 1.414l.707.707a1 1 0 001.414 0l2.475-2.475 2.475 2.475a1 1 0 001.414 0l.707-.707a1 1 0 000-1.414L10.435 8l2.475-2.475a1 1 0 000-1.414l-.707-.707z"
+        fill="currentColor"
+        fillRule="evenodd"
+      />
+    </svg>
+  </div>
+  <div
+    className="css-1f49uy4-PaddedBadge e1vs77ku2 leafygreen-ui-187420t"
+    data-cy="filter-badge"
+    onBlur={[Function]}
+    onFocus={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+  >
+    <div
+      className="css-1i7u60d-BadgeContent e1vs77ku1"
+    >
+      buildVariants
+       : 
+      Enter…bled)
     </div>
     <svg
       aria-label="X Icon"

--- a/src/components/FilterBadges/__snapshots__/FilterBadges.stories.storyshot
+++ b/src/components/FilterBadges/__snapshots__/FilterBadges.stories.storyshot
@@ -5,11 +5,11 @@ exports[`storybook Storyshots FilterBadges Default 1`] = `
   className="css-19f1xe2-Container e3qndfh0"
 >
   <div
-    className="css-1mc9e8m-PaddedBadge e1vs77ku2 leafygreen-ui-13xc3rv"
+    className="css-h29ynq-PaddedBadge e1vs77ku2 leafygreen-ui-13xc3rv"
     data-cy="filter-badge"
   >
     <div
-      className="css-1i7u60d-BadgeContent e1vs77ku1"
+      className="css-1fqgdhu-BadgeContent e1vs77ku1"
     >
       buildVariants
        : 
@@ -36,11 +36,11 @@ exports[`storybook Storyshots FilterBadges Default 1`] = `
     </svg>
   </div>
   <div
-    className="css-1mc9e8m-PaddedBadge e1vs77ku2 leafygreen-ui-13xc3rv"
+    className="css-h29ynq-PaddedBadge e1vs77ku2 leafygreen-ui-13xc3rv"
     data-cy="filter-badge"
   >
     <div
-      className="css-1i7u60d-BadgeContent e1vs77ku1"
+      className="css-1fqgdhu-BadgeContent e1vs77ku1"
     >
       buildVariants
        : 
@@ -67,15 +67,15 @@ exports[`storybook Storyshots FilterBadges Default 1`] = `
     </svg>
   </div>
   <div
-    className="css-1mc9e8m-PaddedBadge e1vs77ku2 leafygreen-ui-13xc3rv"
+    className="css-h29ynq-PaddedBadge e1vs77ku2 leafygreen-ui-187420t"
     data-cy="filter-badge"
+    onBlur={[Function]}
+    onFocus={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <div
-      className="leafygreen-ui-cssveg css-1i7u60d-BadgeContent e1vs77ku1"
-      onBlur={[Function]}
-      onFocus={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
+      className="css-1fqgdhu-BadgeContent e1vs77ku1"
     >
       buildVariants
        : 

--- a/src/components/FilterBadges/__snapshots__/FilterBadges.stories.storyshot
+++ b/src/components/FilterBadges/__snapshots__/FilterBadges.stories.storyshot
@@ -5,97 +5,101 @@ exports[`storybook Storyshots FilterBadges Default 1`] = `
   className="css-19f1xe2-Container e3qndfh0"
 >
   <div
-    className="css-ks018z-PaddedBadge e1vs77ku1 leafygreen-ui-13xc3rv"
+    className="css-1mc9e8m-PaddedBadge e1vs77ku2 leafygreen-ui-13xc3rv"
     data-cy="filter-badge"
   >
     <div
-      className="css-d7bq0k-BadgeContent e1vs77ku0"
+      className="css-1i7u60d-BadgeContent e1vs77ku1"
     >
       buildVariants
        : 
       ! Enterprise Clang Tidy
-      <svg
-        aria-label="X Icon"
-        className="css-1qoqp9c-ClickableIcon e1vs77ku2"
-        data-cy="close-badge"
-        fill="none"
-        height={16}
-        onClick={[Function]}
-        role="img"
-        viewBox="0 0 16 16"
-        width={16}
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          clipRule="evenodd"
-          d="M12.203 3.404a1 1 0 00-1.414 0L8.314 5.879 5.839 3.404a1 1 0 00-1.414 0l-.707.707a1 1 0 000 1.414L6.192 8l-2.474 2.475a1 1 0 000 1.414l.707.707a1 1 0 001.414 0l2.475-2.475 2.475 2.475a1 1 0 001.414 0l.707-.707a1 1 0 000-1.414L10.435 8l2.475-2.475a1 1 0 000-1.414l-.707-.707z"
-          fill="currentColor"
-          fillRule="evenodd"
-        />
-      </svg>
     </div>
+    <svg
+      aria-label="X Icon"
+      className="css-4ijbt0-ClickableIcon e1vs77ku3"
+      data-cy="close-badge"
+      fill="none"
+      height={16}
+      onClick={[Function]}
+      role="img"
+      viewBox="0 0 16 16"
+      width={16}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        clipRule="evenodd"
+        d="M12.203 3.404a1 1 0 00-1.414 0L8.314 5.879 5.839 3.404a1 1 0 00-1.414 0l-.707.707a1 1 0 000 1.414L6.192 8l-2.474 2.475a1 1 0 000 1.414l.707.707a1 1 0 001.414 0l2.475-2.475 2.475 2.475a1 1 0 001.414 0l.707-.707a1 1 0 000-1.414L10.435 8l2.475-2.475a1 1 0 000-1.414l-.707-.707z"
+        fill="currentColor"
+        fillRule="evenodd"
+      />
+    </svg>
   </div>
   <div
-    className="css-ks018z-PaddedBadge e1vs77ku1 leafygreen-ui-13xc3rv"
+    className="css-1mc9e8m-PaddedBadge e1vs77ku2 leafygreen-ui-13xc3rv"
     data-cy="filter-badge"
   >
     <div
-      className="css-d7bq0k-BadgeContent e1vs77ku0"
+      className="css-1i7u60d-BadgeContent e1vs77ku1"
     >
       buildVariants
        : 
       ! Enterprise Windows
-      <svg
-        aria-label="X Icon"
-        className="css-1qoqp9c-ClickableIcon e1vs77ku2"
-        data-cy="close-badge"
-        fill="none"
-        height={16}
-        onClick={[Function]}
-        role="img"
-        viewBox="0 0 16 16"
-        width={16}
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          clipRule="evenodd"
-          d="M12.203 3.404a1 1 0 00-1.414 0L8.314 5.879 5.839 3.404a1 1 0 00-1.414 0l-.707.707a1 1 0 000 1.414L6.192 8l-2.474 2.475a1 1 0 000 1.414l.707.707a1 1 0 001.414 0l2.475-2.475 2.475 2.475a1 1 0 001.414 0l.707-.707a1 1 0 000-1.414L10.435 8l2.475-2.475a1 1 0 000-1.414l-.707-.707z"
-          fill="currentColor"
-          fillRule="evenodd"
-        />
-      </svg>
     </div>
+    <svg
+      aria-label="X Icon"
+      className="css-4ijbt0-ClickableIcon e1vs77ku3"
+      data-cy="close-badge"
+      fill="none"
+      height={16}
+      onClick={[Function]}
+      role="img"
+      viewBox="0 0 16 16"
+      width={16}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        clipRule="evenodd"
+        d="M12.203 3.404a1 1 0 00-1.414 0L8.314 5.879 5.839 3.404a1 1 0 00-1.414 0l-.707.707a1 1 0 000 1.414L6.192 8l-2.474 2.475a1 1 0 000 1.414l.707.707a1 1 0 001.414 0l2.475-2.475 2.475 2.475a1 1 0 001.414 0l.707-.707a1 1 0 000-1.414L10.435 8l2.475-2.475a1 1 0 000-1.414l-.707-.707z"
+        fill="currentColor"
+        fillRule="evenodd"
+      />
+    </svg>
   </div>
   <div
-    className="css-ks018z-PaddedBadge e1vs77ku1 leafygreen-ui-13xc3rv"
+    className="css-1mc9e8m-PaddedBadge e1vs77ku2 leafygreen-ui-13xc3rv"
     data-cy="filter-badge"
   >
     <div
-      className="css-d7bq0k-BadgeContent e1vs77ku0"
+      className="leafygreen-ui-cssveg css-1i7u60d-BadgeContent e1vs77ku1"
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
     >
       buildVariants
        : 
-      Enterprise RHEL 8.0 (Lock Free Reads disabled)
-      <svg
-        aria-label="X Icon"
-        className="css-1qoqp9c-ClickableIcon e1vs77ku2"
-        data-cy="close-badge"
-        fill="none"
-        height={16}
-        onClick={[Function]}
-        role="img"
-        viewBox="0 0 16 16"
-        width={16}
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          clipRule="evenodd"
-          d="M12.203 3.404a1 1 0 00-1.414 0L8.314 5.879 5.839 3.404a1 1 0 00-1.414 0l-.707.707a1 1 0 000 1.414L6.192 8l-2.474 2.475a1 1 0 000 1.414l.707.707a1 1 0 001.414 0l2.475-2.475 2.475 2.475a1 1 0 001.414 0l.707-.707a1 1 0 000-1.414L10.435 8l2.475-2.475a1 1 0 000-1.414l-.707-.707z"
-          fill="currentColor"
-          fillRule="evenodd"
-        />
-      </svg>
+      Enterprise RH…ds disabled)
     </div>
+    <svg
+      aria-label="X Icon"
+      className="css-4ijbt0-ClickableIcon e1vs77ku3"
+      data-cy="close-badge"
+      fill="none"
+      height={16}
+      onClick={[Function]}
+      role="img"
+      viewBox="0 0 16 16"
+      width={16}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        clipRule="evenodd"
+        d="M12.203 3.404a1 1 0 00-1.414 0L8.314 5.879 5.839 3.404a1 1 0 00-1.414 0l-.707.707a1 1 0 000 1.414L6.192 8l-2.474 2.475a1 1 0 000 1.414l.707.707a1 1 0 001.414 0l2.475-2.475 2.475 2.475a1 1 0 001.414 0l.707-.707a1 1 0 000-1.414L10.435 8l2.475-2.475a1 1 0 000-1.414l-.707-.707z"
+        fill="currentColor"
+        fillRule="evenodd"
+      />
+    </svg>
   </div>
   <button
     aria-disabled={false}

--- a/src/components/FilterBadges/__snapshots__/FilterBadges.stories.storyshot
+++ b/src/components/FilterBadges/__snapshots__/FilterBadges.stories.storyshot
@@ -5,7 +5,7 @@ exports[`storybook Storyshots FilterBadges Default 1`] = `
   className="css-19f1xe2-Container e3qndfh0"
 >
   <div
-    className="css-1f49uy4-PaddedBadge e1vs77ku2 leafygreen-ui-187420t"
+    className="css-lhiqu7-PaddedBadge e1vs77ku2 leafygreen-ui-187420t"
     data-cy="filter-badge"
     onBlur={[Function]}
     onFocus={[Function]}
@@ -40,7 +40,7 @@ exports[`storybook Storyshots FilterBadges Default 1`] = `
     </svg>
   </div>
   <div
-    className="css-1f49uy4-PaddedBadge e1vs77ku2 leafygreen-ui-187420t"
+    className="css-lhiqu7-PaddedBadge e1vs77ku2 leafygreen-ui-187420t"
     data-cy="filter-badge"
     onBlur={[Function]}
     onFocus={[Function]}
@@ -75,7 +75,7 @@ exports[`storybook Storyshots FilterBadges Default 1`] = `
     </svg>
   </div>
   <div
-    className="css-1f49uy4-PaddedBadge e1vs77ku2 leafygreen-ui-187420t"
+    className="css-lhiqu7-PaddedBadge e1vs77ku2 leafygreen-ui-187420t"
     data-cy="filter-badge"
     onBlur={[Function]}
     onFocus={[Function]}


### PR DESCRIPTION
[EVG-15974](https://jira.mongodb.org/browse/EVG-15974)

### Description 
Currently, there is a visual bug where long text in filter badges will overflow.

This PR trims text so that it fits within the fixed filter badge width (`260px`). If the text in a filter badge has been trimmed, a tooltip displaying the full text will appear when hovering over it; otherwise, no tooltip appears.

### Screenshots
https://user-images.githubusercontent.com/47064971/150845010-55a23272-d857-4e9a-a45a-16a4d1533854.mov


### Testing 
- Added test in `FilterBadges.test.tsx`
