### PR TITLE
EVG-16143: Wrap options in SearchableDropdown

### DIFF
--- a/src/components/SearchableDropdown/__snapshots__/SearchableDropdown.stories.storyshot
+++ b/src/components/SearchableDropdown/__snapshots__/SearchableDropdown.stories.storyshot
@@ -11,7 +11,7 @@ exports[`storybook Storyshots Searchable Dropdown Custom Option 1`] = `
     Custom option select
   </label>
   <div
-    className="css-gte0m8-Wrapper e17dnzmx3"
+    className="css-gte0m8-Wrapper e17dnzmx4"
   >
     <div
       className="css-1ry038z-Container e1yw4j304"
@@ -85,7 +85,7 @@ exports[`storybook Storyshots Searchable Dropdown Multiselect 1`] = `
     multi select
   </label>
   <div
-    className="css-gte0m8-Wrapper e17dnzmx3"
+    className="css-gte0m8-Wrapper e17dnzmx4"
   >
     <div
       className="css-1ry038z-Container e1yw4j304"
@@ -159,7 +159,7 @@ exports[`storybook Storyshots Searchable Dropdown Story 1`] = `
     standard select
   </label>
   <div
-    className="css-gte0m8-Wrapper e17dnzmx3"
+    className="css-gte0m8-Wrapper e17dnzmx4"
   >
     <div
       className="css-1ry038z-Container e1yw4j304"

--- a/src/components/SearchableDropdown/index.tsx
+++ b/src/components/SearchableDropdown/index.tsx
@@ -174,9 +174,13 @@ export const SearchableDropdownOption = <T extends {}>({
     data-cy="searchable-dropdown-option"
   >
     <CheckmarkContainer>
-      {isChecked && (
-        <Icon glyph="Checkmark" height={12} width={12} fill={blue.base} />
-      )}
+      <CheckmarkIcon
+        glyph="Checkmark"
+        height={12}
+        width={12}
+        fill={blue.base}
+        checked={isChecked}
+      />
     </CheckmarkContainer>
     {displayName || value}
   </Option>
@@ -193,10 +197,11 @@ const Wrapper = styled.div`
 `;
 
 const Option = styled.div`
-  width: 100%;
   padding: 10px 12px;
   display: flex;
-  flex-direction: row;
+  align-items: start;
+  word-break: break-all; // Safari
+  overflow-wrap: anywhere;
   :hover {
     cursor: pointer;
     background-color: ${gray.light1};
@@ -204,7 +209,11 @@ const Option = styled.div`
 `;
 
 const CheckmarkContainer = styled.div`
-  width: 24px;
+  margin-right: 4px;
+`;
+
+const CheckmarkIcon = styled(Icon)<{ checked: boolean }>`
+  visibility: ${({ checked }) => (checked ? "visible" : "hidden")};
 `;
 
 const Container = styled.div`

--- a/src/pages/TaskQueue.tsx
+++ b/src/pages/TaskQueue.tsx
@@ -83,7 +83,7 @@ export const TaskQueue = () => {
                 <StyledBadge>{`${option?.hostCount} ${
                   option?.hostCount === 1 ? "HOST" : "HOSTS"
                 }`}</StyledBadge>
-                {option?.id}
+                <DistroName> {option?.id} </DistroName>
               </DistroLabel>
             )}
           />
@@ -102,9 +102,13 @@ const SearchableDropdownWrapper = styled.div`
 `;
 const DistroLabel = styled.div`
   display: flex;
+  align-items: center;
   white-space: nowrap;
 `;
-
 const StyledBadge = styled(Badge)`
   margin-right: 8px;
+`;
+const DistroName = styled.div`
+  overflow: hidden;
+  text-overflow: ellipsis;
 `;

--- a/src/pages/commits/projectSelect/__snapshots__/ProjectSelect.stories.storyshot
+++ b/src/pages/commits/projectSelect/__snapshots__/ProjectSelect.stories.storyshot
@@ -11,7 +11,7 @@ exports[`storybook Storyshots ProjectSelect Story 1`] = `
     Project
   </label>
   <div
-    className="css-gte0m8-Wrapper e17dnzmx3"
+    className="css-gte0m8-Wrapper e17dnzmx4"
   >
     <div
       className="css-1ry038z-Container e1yw4j304"

--- a/src/pages/taskHistory/BuildVariantSelector.tsx
+++ b/src/pages/taskHistory/BuildVariantSelector.tsx
@@ -71,6 +71,7 @@ export const BuildVariantSelector: React.FC<BuildVariantSelectorProps> = ({
         searchFunc={handleSearch}
         optionRenderer={(option: BuildVariantTuple, onClick, isChecked) => (
           <SearchableDropdownOption
+            key={`searchable_dropdown_option_${option.buildVariant}`}
             value={option.buildVariant}
             displayName={option.displayName}
             onClick={() => onClick(option.buildVariant)}

--- a/src/pages/taskQueue/DistroOption.tsx
+++ b/src/pages/taskQueue/DistroOption.tsx
@@ -31,15 +31,18 @@ export const DistroOption: React.FC<DistroOptionProps> = ({
 
 const OptionWrapper = styled.div`
   display: flex;
-  padding: 8px;
-  align-items: center;
-  overflow-y: scroll;
+  padding: 10px 12px;
+  align-items: start;
   &:hover {
     cursor: pointer;
     background-color: ${blue.light3};
   }
 `;
 const StyledBadge = styled(Badge)`
+  display: flex;
+  flex-shrink: 0;
+  justify-content: center;
+  width: 90px;
   margin-right: 8px;
 `;
 const DistroName = styled(Disclaimer)`


### PR DESCRIPTION
[EVG-16143](https://jira.mongodb.org/browse/EVG-16143)

### Description 
This PR solves the issue where the options in the `SearchableDropdown` on the Task & Variant History pages would not wrap, causing many of them to be unreadable.

It also fixes some styling in the custom `SearchableDropdown` option used on the Task Queue page.


### Screenshots

#### On Task & Variant History pages:

Before      |  After
:-------------------------:|:-------------------------:
<img width="333" alt="Screen Shot 2022-01-25 at 1 12 25 PM" src="https://user-images.githubusercontent.com/47064971/151034849-56afead9-efaa-4304-8aed-c8fc5f9d7d6a.png"> |  <img width="319" alt="Screen Shot 2022-01-25 at 1 04 56 PM" src="https://user-images.githubusercontent.com/47064971/151034831-918164cb-c633-45a7-8ef7-88a4f8624f02.png">

#### On Task Queue page:

Before      |  After
:-------------------------:|:-------------------------:
<img width="333" alt="Screen Shot 2022-01-25 at 11 43 33 AM" src="https://user-images.githubusercontent.com/47064971/151035268-37c7208d-014f-4381-8673-9c15efcca695.png"> |  <img width="333" alt="Screen Shot 2022-01-25 at 12 22 22 PM" src="https://user-images.githubusercontent.com/47064971/151035275-b5a86fe0-8447-4497-b1f1-29d9c8b0a583.png">

### Testing 
- Just visually

