### PR TITLE
EVG-14849: Add Project Patches link in Navbar dropdown

### DIFF
--- a/cypress/integration/nav_bar.ts
+++ b/cypress/integration/nav_bar.ts
@@ -50,14 +50,14 @@ describe("Nav Bar", () => {
       .should("have.attr", "href")
       .and("include", LEGACY_URLS.distros);
   });
-  it("Nav Dropdown should link to patches page of most recent project if cookie exists", () => {
+  it.skip("Nav Dropdown should link to patches page of most recent project if cookie exists", () => {
     cy.setCookie("mci-project-cookie", "spruce");
     cy.visit(SPRUCE_URLS.userPatches);
     cy.dataCy("auxiliary-dropdown-link").click();
     cy.dataCy("auxiliary-dropdown-project-patches").click();
     cy.location("pathname").should("eq", "/project/spruce/patches");
   });
-  it("Nav Dropdown should link to patches page of default project in SpruceConfig if cookie does not exist", () => {
+  it.skip("Nav Dropdown should link to patches page of default project in SpruceConfig if cookie does not exist", () => {
     cy.clearCookie("mci-project-cookie");
     cy.visit(SPRUCE_URLS.userPatches);
     cy.dataCy("auxiliary-dropdown-link").click();

--- a/cypress/integration/nav_bar.ts
+++ b/cypress/integration/nav_bar.ts
@@ -51,15 +51,15 @@ describe("Nav Bar", () => {
       .and("include", LEGACY_URLS.distros);
   });
   it("Nav Dropdown should link to patches page of most recent project if cookie exists", () => {
-    cy.visit("/");
     cy.setCookie("mci-project-cookie", "spruce");
+    cy.visit(SPRUCE_URLS.userPatches);
     cy.dataCy("auxiliary-dropdown-link").first().click();
     cy.dataCy("auxiliary-dropdown-project-patches").first().click();
     cy.location("pathname").should("eq", "/project/spruce/patches");
   });
   it("Nav Dropdown should link to patches page of default project in SpruceConfig if cookie does not exist", () => {
-    cy.visit("/");
     cy.clearCookie("mci-project-cookie");
+    cy.visit(SPRUCE_URLS.userPatches);
     cy.dataCy("auxiliary-dropdown-link").first().click();
     cy.dataCy("auxiliary-dropdown-project-patches").first().click();
     cy.location("pathname").should("eq", "/project/evergreen/patches");

--- a/cypress/integration/nav_bar.ts
+++ b/cypress/integration/nav_bar.ts
@@ -53,15 +53,15 @@ describe("Nav Bar", () => {
   it("Nav Dropdown should link to patches page of most recent project if cookie exists", () => {
     cy.setCookie("mci-project-cookie", "spruce");
     cy.visit(SPRUCE_URLS.userPatches);
-    cy.dataCy("auxiliary-dropdown-link").first().click();
-    cy.dataCy("auxiliary-dropdown-project-patches").first().click();
+    cy.dataCy("auxiliary-dropdown-link").click();
+    cy.dataCy("auxiliary-dropdown-project-patches").click();
     cy.location("pathname").should("eq", "/project/spruce/patches");
   });
   it("Nav Dropdown should link to patches page of default project in SpruceConfig if cookie does not exist", () => {
     cy.clearCookie("mci-project-cookie");
     cy.visit(SPRUCE_URLS.userPatches);
-    cy.dataCy("auxiliary-dropdown-link").first().click();
-    cy.dataCy("auxiliary-dropdown-project-patches").first().click();
+    cy.dataCy("auxiliary-dropdown-link").click();
+    cy.dataCy("auxiliary-dropdown-project-patches").click();
     cy.location("pathname").should("eq", "/project/evergreen/patches");
   });
 });

--- a/cypress/integration/nav_bar.ts
+++ b/cypress/integration/nav_bar.ts
@@ -38,7 +38,7 @@ describe("Nav Bar", () => {
       .should("have.attr", "href")
       .and("include", LEGACY_URLS.userPatches);
   });
-  it("Visiting a page with no legacy equivelant should not display a nav link", () => {
+  it("Visiting a page with no legacy equivalent should not display a nav link", () => {
     cy.visit(SPRUCE_URLS.cli);
     cy.dataCy("legacy-ui-link").should("not.exist");
   });
@@ -49,5 +49,19 @@ describe("Nav Bar", () => {
     cy.dataCy("legacy_route")
       .should("have.attr", "href")
       .and("include", LEGACY_URLS.distros);
+  });
+  it("Nav Dropdown should link to patches page of most recent project if cookie exists", () => {
+    cy.visit("/");
+    cy.setCookie("mci-project-cookie", "spruce");
+    cy.dataCy("auxiliary-dropdown-link").first().click();
+    cy.dataCy("auxiliary-dropdown-project-patches").first().click();
+    cy.location("pathname").should("eq", "/project/spruce/patches");
+  });
+  it("Nav Dropdown should link to patches page of default project in SpruceConfig if cookie does not exist", () => {
+    cy.visit("/");
+    cy.clearCookie("mci-project-cookie");
+    cy.dataCy("auxiliary-dropdown-link").first().click();
+    cy.dataCy("auxiliary-dropdown-project-patches").first().click();
+    cy.location("pathname").should("eq", "/project/evergreen/patches");
   });
 });

--- a/src/components/Dropdown/__snapshots__/Dropdown.stories.storyshot
+++ b/src/components/Dropdown/__snapshots__/Dropdown.stories.storyshot
@@ -9,7 +9,6 @@ exports[`storybook Storyshots Dropdown Custom Button Render 1`] = `
     className="leafygreen-ui-26sqyb css-mbqq81-StyledButton e1yw4j302"
     data-cy="dropdown-button"
     disabled={false}
-    id="searchable-dropdown"
     onClick={[Function]}
     type="button"
   >
@@ -66,7 +65,6 @@ exports[`storybook Storyshots Dropdown Story 1`] = `
     className="leafygreen-ui-26sqyb css-mbqq81-StyledButton e1yw4j302"
     data-cy="dropdown-button"
     disabled={false}
-    id="searchable-dropdown"
     onClick={[Function]}
     type="button"
   >

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -10,6 +10,7 @@ const { gray, white } = uiColors;
 
 interface DropdownProps {
   ["data-cy"]?: string;
+  id?: string;
   disabled?: boolean;
   buttonRenderer?: () => React.ReactNode;
   buttonText?: string;
@@ -19,6 +20,7 @@ interface DropdownProps {
 }
 const Dropdown: React.FC<DropdownProps> = ({
   "data-cy": dataCy = "dropdown-button",
+  id,
   disabled = false,
   buttonText,
   buttonRenderer,
@@ -33,7 +35,7 @@ const Dropdown: React.FC<DropdownProps> = ({
   useOnClickOutside([listMenuRef, menuButtonRef], () => setIsOpen(false));
 
   return (
-    <Container>
+    <Container id={id}>
       <StyledButton
         ref={menuButtonRef}
         onClick={() => setIsOpen(!isOpen)}

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -38,7 +38,6 @@ const Dropdown: React.FC<DropdownProps> = ({
         ref={menuButtonRef}
         onClick={() => setIsOpen(!isOpen)}
         data-cy={dataCy}
-        id="searchable-dropdown"
         disabled={disabled}
         rightGlyph={<Icon glyph={isOpen ? "ChevronUp" : "ChevronDown"} />}
       >

--- a/src/components/Header/AuxiliaryDropdown.tsx
+++ b/src/components/Header/AuxiliaryDropdown.tsx
@@ -1,5 +1,10 @@
+import { useQuery } from "@apollo/client";
+import Cookies from "js-cookie";
+import { CURRENT_PROJECT } from "constants/cookies";
 import { legacyRoutes } from "constants/externalResources";
-import { routes } from "constants/routes";
+import { routes, getProjectPatchesRoute } from "constants/routes";
+import { GetSpruceConfigQuery } from "gql/generated/types";
+import { GET_SPRUCE_CONFIG } from "gql/queries";
 import { environmentalVariables } from "utils";
 import { Dropdown } from "./Dropdown";
 
@@ -7,6 +12,14 @@ const { getUiUrl } = environmentalVariables;
 
 export const AuxiliaryDropdown = () => {
   const uiURL = getUiUrl();
+  const projectCookie = Cookies.get(CURRENT_PROJECT);
+
+  const { data } = useQuery<GetSpruceConfigQuery>(GET_SPRUCE_CONFIG, {
+    skip: !!projectCookie,
+  });
+
+  const mostRecentProject =
+    projectCookie || data?.spruceConfig?.ui?.defaultProject;
 
   const menuItems = [
     {
@@ -22,6 +35,11 @@ export const AuxiliaryDropdown = () => {
       "data-cy": "legacy_route",
       href: `${uiURL}${legacyRoutes.projects}`,
       text: "Projects",
+    },
+    {
+      "data-cy": "auxiliary-dropdown-project-patches",
+      to: getProjectPatchesRoute(mostRecentProject),
+      text: "Project Patches",
     },
   ];
 

--- a/src/components/Header/AuxiliaryDropdown.tsx
+++ b/src/components/Header/AuxiliaryDropdown.tsx
@@ -6,6 +6,7 @@ import { routes, getProjectPatchesRoute } from "constants/routes";
 import { GetSpruceConfigQuery } from "gql/generated/types";
 import { GET_SPRUCE_CONFIG } from "gql/queries";
 import { environmentalVariables } from "utils";
+import { isBeta } from "utils/environmentalVariables";
 import { Dropdown } from "./Dropdown";
 
 const { getUiUrl } = environmentalVariables;
@@ -17,9 +18,15 @@ export const AuxiliaryDropdown = () => {
   const { data } = useQuery<GetSpruceConfigQuery>(GET_SPRUCE_CONFIG, {
     skip: !!projectCookie,
   });
-
   const mostRecentProject =
     projectCookie || data?.spruceConfig?.ui?.defaultProject;
+
+  // At the moment, this link is only included in Spruce beta.
+  const projectPatchesLink = {
+    "data-cy": "auxiliary-dropdown-project-patches",
+    to: getProjectPatchesRoute(mostRecentProject),
+    text: "Project Patches",
+  };
 
   const menuItems = [
     {
@@ -36,11 +43,7 @@ export const AuxiliaryDropdown = () => {
       href: `${uiURL}${legacyRoutes.projects}`,
       text: "Projects",
     },
-    {
-      "data-cy": "auxiliary-dropdown-project-patches",
-      to: getProjectPatchesRoute(mostRecentProject),
-      text: "Project Patches",
-    },
+    ...(isBeta() ? [projectPatchesLink] : []),
   ];
 
   return (

--- a/src/components/SearchableDropdown/SearchableDropdown.stories.tsx
+++ b/src/components/SearchableDropdown/SearchableDropdown.stories.tsx
@@ -57,7 +57,11 @@ export const CustomOption = () => {
       options={options}
       allowMultiSelect
       optionRenderer={(option, onClick, isChecked) => (
-        <button onClick={() => onClick(option.value)} type="button">
+        <button
+          onClick={() => onClick(option.value)}
+          type="button"
+          key={option.value}
+        >
           {isChecked(option.value) && `✔️`}
           {option.label}
         </button>

--- a/src/components/SearchableDropdown/__snapshots__/SearchableDropdown.stories.storyshot
+++ b/src/components/SearchableDropdown/__snapshots__/SearchableDropdown.stories.storyshot
@@ -5,8 +5,8 @@ exports[`storybook Storyshots Searchable Dropdown Custom Option 1`] = `
   className="css-1ry038z-Container e17dnzmx0"
 >
   <label
-    className="leafygreen-ui-ly82bp"
-    htmlFor="searchable-dropdown"
+    className="css-c0hrp-InputLabel e1xf068s2"
+    htmlFor="searchable-dropdown-Custom option select"
   >
     Custom option select
   </label>
@@ -15,6 +15,7 @@ exports[`storybook Storyshots Searchable Dropdown Custom Option 1`] = `
   >
     <div
       className="css-1ry038z-Container e1yw4j304"
+      id="searchable-dropdown-Custom option select"
     >
       <button
         aria-disabled={false}
@@ -78,8 +79,8 @@ exports[`storybook Storyshots Searchable Dropdown Multiselect 1`] = `
   className="css-1ry038z-Container e17dnzmx0"
 >
   <label
-    className="leafygreen-ui-ly82bp"
-    htmlFor="searchable-dropdown"
+    className="css-c0hrp-InputLabel e1xf068s2"
+    htmlFor="searchable-dropdown-multi select"
   >
     multi select
   </label>
@@ -88,6 +89,7 @@ exports[`storybook Storyshots Searchable Dropdown Multiselect 1`] = `
   >
     <div
       className="css-1ry038z-Container e1yw4j304"
+      id="searchable-dropdown-multi select"
     >
       <button
         aria-disabled={false}
@@ -151,8 +153,8 @@ exports[`storybook Storyshots Searchable Dropdown Story 1`] = `
   className="css-1ry038z-Container e17dnzmx0"
 >
   <label
-    className="leafygreen-ui-ly82bp"
-    htmlFor="searchable-dropdown"
+    className="css-c0hrp-InputLabel e1xf068s2"
+    htmlFor="searchable-dropdown-standard select"
   >
     standard select
   </label>
@@ -161,6 +163,7 @@ exports[`storybook Storyshots Searchable Dropdown Story 1`] = `
   >
     <div
       className="css-1ry038z-Container e1yw4j304"
+      id="searchable-dropdown-standard select"
     >
       <button
         aria-disabled={false}

--- a/src/components/SearchableDropdown/__snapshots__/SearchableDropdown.stories.storyshot
+++ b/src/components/SearchableDropdown/__snapshots__/SearchableDropdown.stories.storyshot
@@ -21,7 +21,6 @@ exports[`storybook Storyshots Searchable Dropdown Custom Option 1`] = `
         className="leafygreen-ui-26sqyb css-mbqq81-StyledButton e1yw4j302"
         data-cy="searchable-dropdown"
         disabled={false}
-        id="searchable-dropdown"
         onClick={[Function]}
         type="button"
       >
@@ -95,7 +94,6 @@ exports[`storybook Storyshots Searchable Dropdown Multiselect 1`] = `
         className="leafygreen-ui-26sqyb css-mbqq81-StyledButton e1yw4j302"
         data-cy="searchable-dropdown"
         disabled={false}
-        id="searchable-dropdown"
         onClick={[Function]}
         type="button"
       >
@@ -169,7 +167,6 @@ exports[`storybook Storyshots Searchable Dropdown Story 1`] = `
         className="leafygreen-ui-26sqyb css-mbqq81-StyledButton e1yw4j302"
         data-cy="searchable-dropdown"
         disabled={false}
-        id="searchable-dropdown"
         onClick={[Function]}
         type="button"
       >

--- a/src/components/SearchableDropdown/index.tsx
+++ b/src/components/SearchableDropdown/index.tsx
@@ -1,9 +1,9 @@
 import { useState, PropsWithChildren, useRef, useEffect, useMemo } from "react";
 import styled from "@emotion/styled";
 import { uiColors } from "@leafygreen-ui/palette";
-import { Label } from "@leafygreen-ui/typography";
 import Dropdown from "components/Dropdown";
 import Icon from "components/Icon";
+import { InputLabel } from "components/styles";
 import TextInput from "components/TextInputWithGlyph";
 import { toggleArray } from "utils/array";
 
@@ -127,9 +127,10 @@ const SearchableDropdown = <T extends {}>({
 
   return (
     <Container>
-      <Label htmlFor="searchable-dropdown">{label}</Label>
+      <InputLabel htmlFor={`searchable-dropdown-${label}`}>{label}</InputLabel>
       <Wrapper>
         <Dropdown
+          id={`searchable-dropdown-${label}`}
           data-cy={dataCy}
           disabled={disabled}
           buttonText={buttonText}

--- a/src/pages/commits/projectSelect/__snapshots__/ProjectSelect.stories.storyshot
+++ b/src/pages/commits/projectSelect/__snapshots__/ProjectSelect.stories.storyshot
@@ -21,7 +21,6 @@ exports[`storybook Storyshots ProjectSelect Story 1`] = `
         className="leafygreen-ui-117l5vj css-mbqq81-StyledButton e1yw4j302"
         data-cy="project-select"
         disabled={true}
-        id="searchable-dropdown"
         onClick={[Function]}
         type="button"
       >

--- a/src/pages/commits/projectSelect/__snapshots__/ProjectSelect.stories.storyshot
+++ b/src/pages/commits/projectSelect/__snapshots__/ProjectSelect.stories.storyshot
@@ -5,8 +5,8 @@ exports[`storybook Storyshots ProjectSelect Story 1`] = `
   className="css-1ry038z-Container e17dnzmx0"
 >
   <label
-    className="leafygreen-ui-ly82bp"
-    htmlFor="searchable-dropdown"
+    className="css-c0hrp-InputLabel e1xf068s2"
+    htmlFor="searchable-dropdown-Project"
   >
     Project
   </label>
@@ -15,6 +15,7 @@ exports[`storybook Storyshots ProjectSelect Story 1`] = `
   >
     <div
       className="css-1ry038z-Container e1yw4j304"
+      id="searchable-dropdown-Project"
     >
       <button
         aria-disabled={true}


### PR DESCRIPTION
[EVG-14849](https://jira.mongodb.org/browse/EVG-14849)

### Description 
This PR adds a `Project Patches` link in the navbar dropdown based on a user's most recently selected project. 

Information about a user's most recently selected project is stored in the cookie `mci-project-cookie`. If a user does not have this cookie, then this link defaults to `mongodb-mongo-master` (alternatively `evergreen` if running entirely locally).

### Screenshots
https://user-images.githubusercontent.com/47064971/151207754-9a26309f-c385-4bc9-b0f2-f57b146e4947.mov

### Testing 
- Added tests in `nav_bar.ts` (e2e)

