### PR TITLE
EVG-16085: Prevent text from overlapping on Commits page

### DIFF
--- a/src/pages/commits/CommitsWrapper.tsx
+++ b/src/pages/commits/CommitsWrapper.tsx
@@ -153,6 +153,15 @@ const AbsoluteContainer = styled.div`
 
 const CommitWrapper = styled.div<{ width: number }>`
   width: ${({ width }) => width}px;
+  min-width: ${({ width }) => width * 0.75}px;
+  margin: 0px 8px;
+
+  &:first-child {
+    margin-left: 0px;
+  }
+  &:last-child {
+    margin-right: 0px;
+  }
 `;
 
 const ChartWrapper = styled.div`


### PR DESCRIPTION
[EVG-16085](https://jira.mongodb.org/browse/EVG-16085)

### Description 
Currently, when you view the `/commits` page with a small screen you will see a few visual bugs (see image): 
1. "Unmatching" text will overlap with commits text
2. Text in the sticky headers will overflow and overlap the task results below
<p align="center">
<img width="500" alt="Screen Shot 2022-02-04 at 11 54 29 AM" src="https://user-images.githubusercontent.com/47064971/152571996-f1a233fd-2a79-4a0a-a28d-a5f95a780eb3.png">
</p>

I modified some CSS to prevent this from happening. Most importantly, I gave the `CommitWrapper` a `min-width` because right now it shrinks proportionately to the screen size which causes the overflow to get worse.

### Screenshots
<p align="center">
<img width="600" alt="Screen Shot 2022-02-04 at 12 17 34 PM" src="https://user-images.githubusercontent.com/47064971/152574166-0111fe37-d6e0-4d45-8a90-1661bc615654.png">
</p>

### Testing 
- Visually
