### PR TITLE
EVG-13250: Disable all options except Reconfigure for unfinalized patch

### DIFF
--- a/src/analytics/patch/usePatchAnalytics.ts
+++ b/src/analytics/patch/usePatchAnalytics.ts
@@ -55,9 +55,12 @@ interface P extends Properties {
 }
 interface PatchAnalytics extends Analytics<Action> {}
 
-export const usePatchAnalytics = (): PatchAnalytics => {
+export const usePatchAnalytics = (patchId?: string): PatchAnalytics => {
   const userId = useGetUserQuery();
-  const { id } = useParams<{ id: string }>();
+  const { id: idFromURL } = useParams<{ id: string }>();
+
+  const id = patchId || idFromURL;
+
   const { data: eventData } = useQuery<PatchQuery, PatchQueryVariables>(
     GET_PATCH,
     {

--- a/src/analytics/version/useVersionAnalytics.ts
+++ b/src/analytics/version/useVersionAnalytics.ts
@@ -55,9 +55,12 @@ interface V extends Properties {
 }
 interface VersionAnalytics extends Analytics<Action> {}
 
-export const useVersionAnalytics = (): VersionAnalytics => {
+export const useVersionAnalytics = (versionId?: string): VersionAnalytics => {
   const userId = useGetUserQuery();
-  const { id } = useParams<{ id: string }>();
+  const { id: idFromURL } = useParams<{ id: string }>();
+
+  const id = versionId || idFromURL;
+
   const { data: eventData } = useQuery<VersionQuery, VersionQueryVariables>(
     GET_VERSION,
     {

--- a/src/components/LinkToReconfigurePage.tsx
+++ b/src/components/LinkToReconfigurePage.tsx
@@ -1,14 +1,17 @@
 import React from "react";
 import { useHistory } from "react-router-dom";
-import { useVersionAnalytics } from "analytics";
+import { useVersionAnalytics, usePatchAnalytics } from "analytics";
 import { DropdownItem } from "components/ButtonDropdown";
 import { getPatchRoute } from "constants/routes";
 
 export const LinkToReconfigurePage: React.FC<{
   patchId: string;
   disabled?: boolean;
-}> = ({ patchId, disabled }) => {
-  const { sendEvent } = useVersionAnalytics();
+  hasVersion?: boolean;
+}> = ({ patchId, disabled, hasVersion = true }) => {
+  const { sendEvent } = (hasVersion ? useVersionAnalytics : usePatchAnalytics)(
+    patchId
+  );
 
   const router = useHistory();
 

--- a/src/components/PatchActionButtons/ScheduleTasks.tsx
+++ b/src/components/PatchActionButtons/ScheduleTasks.tsx
@@ -15,7 +15,7 @@ export const ScheduleTasks: React.FC<ScheduleTasksProps> = ({
   disabled = false,
 }) => {
   const [open, setOpen] = useState(false);
-  const { sendEvent } = useVersionAnalytics();
+  const { sendEvent } = useVersionAnalytics(versionId);
   const props = {
     onClick: () => {
       sendEvent({ name: "Open Schedule Tasks Modal" });
@@ -29,7 +29,9 @@ export const ScheduleTasks: React.FC<ScheduleTasksProps> = ({
       Schedule
     </Button>
   ) : (
-    <DropdownItem {...props}>Schedule</DropdownItem>
+    <DropdownItem disabled={disabled} {...props}>
+      Schedule
+    </DropdownItem>
   );
   return (
     <>

--- a/src/components/PatchActionButtons/UnscheduleTasks.tsx
+++ b/src/components/PatchActionButtons/UnscheduleTasks.tsx
@@ -46,7 +46,7 @@ export const UnscheduleTasks: React.FC<props> = ({
     refetchQueries,
   });
 
-  const { sendEvent } = useVersionAnalytics();
+  const { sendEvent } = useVersionAnalytics(patchId);
 
   return (
     <Popconfirm

--- a/src/components/PatchesPage/PatchCard.tsx
+++ b/src/components/PatchesPage/PatchCard.tsx
@@ -105,6 +105,7 @@ export const PatchCard: React.FC<Props> = ({
           canEnqueueToCommitQueue={canEnqueueToCommitQueue}
           isPatchOnCommitQueue={isPatchOnCommitQueue}
           patchDescription={description}
+          hasVersion={!!versionId}
         />
       </Right>
     </CardWrapper>

--- a/src/components/PatchesPage/patchCard/DropdownMenu.tsx
+++ b/src/components/PatchesPage/patchCard/DropdownMenu.tsx
@@ -15,6 +15,7 @@ interface Props {
   isPatchOnCommitQueue: boolean;
   patchDescription: string;
   childPatches: Partial<Patch>[];
+  hasVersion: boolean;
 }
 export const DropdownMenu: React.FC<Props> = ({
   patchId,
@@ -22,6 +23,7 @@ export const DropdownMenu: React.FC<Props> = ({
   canEnqueueToCommitQueue,
   isPatchOnCommitQueue,
   patchDescription,
+  hasVersion,
 }) => {
   const restartModalVisibilityControl = useState(false);
   const enqueueModalVisibilityControl = useState(false);
@@ -30,12 +32,14 @@ export const DropdownMenu: React.FC<Props> = ({
       key="reconfigure"
       patchId={patchId}
       disabled={isPatchOnCommitQueue}
+      hasVersion={hasVersion}
     />,
-    <ScheduleTasks key="schedule" versionId={patchId} />,
+    <ScheduleTasks key="schedule" versionId={patchId} disabled={!hasVersion} />,
     <UnscheduleTasks
       key="unschedule"
       patchId={patchId}
       refetchQueries={refetchQueries}
+      disabled={!hasVersion}
     />,
     <RestartPatch
       visibilityControl={restartModalVisibilityControl}
@@ -43,13 +47,14 @@ export const DropdownMenu: React.FC<Props> = ({
       patchId={patchId}
       childPatches={childPatches}
       refetchQueries={refetchQueries}
+      disabled={!hasVersion}
     />,
     <EnqueuePatch
       visibilityControl={enqueueModalVisibilityControl}
       key="enqueue"
       patchId={patchId}
       commitMessage={patchDescription}
-      disabled={!canEnqueueToCommitQueue}
+      disabled={!canEnqueueToCommitQueue || !hasVersion}
       refetchQueries={refetchQueries}
     />,
   ];

--- a/src/components/VersionRestartModal/VersionRestartModal.tsx
+++ b/src/components/VersionRestartModal/VersionRestartModal.tsx
@@ -89,7 +89,7 @@ const VersionRestartModal: React.FC<Props> = ({
     setBaseStatusFilterTerm({ [childVersionId]: selectedFilters });
   };
 
-  const { sendEvent } = useVersionAnalytics();
+  const { sendEvent } = useVersionAnalytics(versionId);
 
   const handlePatchRestart = async (e): Promise<void> => {
     e.preventDefault();

--- a/src/pages/version/EnqueueModal.tsx
+++ b/src/pages/version/EnqueueModal.tsx
@@ -40,7 +40,7 @@ export const EnqueuePatchModal: React.FC<EnqueueProps> = ({
     refetchQueries,
   });
 
-  const patchAnalytics = useVersionAnalytics();
+  const { sendEvent } = useVersionAnalytics(patchId);
   const [commitMessageValue, setCommitMessageValue] = useState<string>(
     commitMessage || ""
   );
@@ -64,7 +64,7 @@ export const EnqueuePatchModal: React.FC<EnqueueProps> = ({
             enqueuePatch({
               variables: { patchId, commitMessage: commitMessageValue },
             });
-            patchAnalytics.sendEvent({ name: "Enqueue" });
+            sendEvent({ name: "Enqueue" });
           }}
           variant="primary"
         >


### PR DESCRIPTION
[EVG-13250](https://jira.mongodb.org/browse/EVG-13250)

### Description 
This PR disables the options to `Schedule Tasks` / `Unschedule All Tasks` / `Restart` / `Add to Commit Queue` for an unfinalized patch.

#### Analytics Changes
This PR also addresses some issues with `usePatchAnalytics` that I missed earlier. I was wondering why I would get this error in Bugsnag whenever I interacted with an action button dropdown on the My Patches page:
<p align="center">
<img width="500" alt="Screen Shot 2022-02-07 at 12 40 55 PM" src="https://user-images.githubusercontent.com/47064971/152842402-d53bb1c0-2655-4751-a605-08f99b33a2cb.png">
</p>

It's because `usePatchAnalytics` and `useVersionAnalytics` always try to grab the `patchID`/`versionID` from the URL, which isn't always possible. For example, if you're on the My Patches page, it'll assume that your username is the `patchID`/`versionID`, causing the error above.

For this reason I slightly altered the analytics functions to take in an optional parameter for `patchID` or `versionID`.

### Screenshots
<img width="1281" alt="Screen Shot 2022-02-04 at 2 34 21 PM" src="https://user-images.githubusercontent.com/47064971/152843015-ab743b18-1922-434e-9749-2de799b66aa6.png">

### Testing 
- Manually checking the console for errors

