### PR TITLE
EVG-16258: Add requireSigned field

### DIFF
--- a/cypress/integration/projectSettings/project_settings.ts
+++ b/cypress/integration/projectSettings/project_settings.ts
@@ -56,11 +56,12 @@ describe("Repo Settings", () => {
         cy.dataCy("cq-card").children().should("have.length", count);
       };
 
-      countCQFields(4);
+      countCQFields(5);
       cy.dataCy("cq-enabled-radio-box").children().eq(1).click();
-      countCQFields(1);
+      countCQFields(2);
+      cy.dataCy("cq-card").children().eq(1).should("be.empty");
       cy.dataCy("cq-enabled-radio-box").children().first().click();
-      countCQFields(4);
+      countCQFields(5);
     });
 
     it("Presents three options for merge method", () => {

--- a/src/components/ProjectSettingsTabs/GithubCommitQueueTab/getFormSchema.ts
+++ b/src/components/ProjectSettingsTabs/GithubCommitQueueTab/getFormSchema.ts
@@ -355,6 +355,7 @@ export const getFormSchema = (
       },
       requireSigned: {
         "ui:widget": widgets.RadioBoxWidget,
+        ...(formData?.commitQueue?.enabled === false && { "ui:hide": true }),
       },
       message: {
         "ui:description": "Shown in commit queue CLI commands & web UI",

--- a/src/components/ProjectSettingsTabs/GithubCommitQueueTab/getFormSchema.ts
+++ b/src/components/ProjectSettingsTabs/GithubCommitQueueTab/getFormSchema.ts
@@ -194,6 +194,14 @@ export const getFormSchema = (
               repoData?.commitQueue?.enabled
             ),
           },
+          requireSigned: {
+            type: ["boolean", "null"],
+            title: "Require Signed Commits on Pull Request Merges",
+            oneOf: radioBoxOptions(
+              ["Enabled", "Disabled"],
+              repoData?.commitQueue?.requireSigned
+            ),
+          },
           message: {
             type: "string" as "string",
             title: "Commit Queue Message",
@@ -344,6 +352,9 @@ export const getFormSchema = (
         "ui:showLabel": false,
         "ui:widget": widgets.RadioBoxWidget,
         "ui:data-cy": "cq-enabled-radio-box",
+      },
+      requireSigned: {
+        "ui:widget": widgets.RadioBoxWidget,
       },
       message: {
         "ui:description": "Shown in commit queue CLI commands & web UI",

--- a/src/components/ProjectSettingsTabs/GithubCommitQueueTab/transformers.test.ts
+++ b/src/components/ProjectSettingsTabs/GithubCommitQueueTab/transformers.test.ts
@@ -64,6 +64,7 @@ const projectForm: FormState = {
   },
   commitQueue: {
     enabled: null,
+    requireSigned: null,
     mergeMethod: "",
     message: "",
     patchDefinitions: {
@@ -94,6 +95,7 @@ const projectResult: Pick<ProjectSettingsInput, "projectRef" | "aliases"> = {
     gitTagAuthorizedTeams: [],
     commitQueue: {
       enabled: null,
+      requireSigned: null,
       mergeMethod: "",
       message: "",
     },
@@ -157,6 +159,7 @@ const repoForm: FormState = {
   },
   commitQueue: {
     enabled: true,
+    requireSigned: true,
     mergeMethod: "squash",
     message: "Commit Queue Message",
     patchDefinitions: {
@@ -176,6 +179,7 @@ const repoResult: Pick<RepoSettingsInput, "projectRef" | "aliases"> = {
     gitTagAuthorizedTeams: [],
     commitQueue: {
       enabled: true,
+      requireSigned: true,
       mergeMethod: "squash",
       message: "Commit Queue Message",
     },
@@ -256,6 +260,7 @@ const mergedForm: FormState = {
   },
   commitQueue: {
     enabled: null,
+    requireSigned: null,
     mergeMethod: "",
     message: "",
     patchDefinitions: {

--- a/src/components/ProjectSettingsTabs/GithubCommitQueueTab/transformers.ts
+++ b/src/components/ProjectSettingsTabs/GithubCommitQueueTab/transformers.ts
@@ -89,6 +89,7 @@ export const gqlToForm: GqlToFormFunction = (data): FormState => {
     },
     commitQueue: {
       enabled: projectRef.commitQueue.enabled,
+      requireSigned: projectRef.commitQueue.requireSigned,
       message: projectRef.commitQueue.message,
       mergeMethod: projectRef.commitQueue.mergeMethod,
       patchDefinitions: {
@@ -126,7 +127,13 @@ export const formToGql: FormToGqlFunction = (
       users: { gitTagAuthorizedUsers, gitTagAuthorizedUsersOverride },
       teams: { gitTagAuthorizedTeams, gitTagAuthorizedTeamsOverride },
     },
-    commitQueue: { enabled, message, mergeMethod, patchDefinitions },
+    commitQueue: {
+      enabled,
+      requireSigned,
+      message,
+      mergeMethod,
+      patchDefinitions,
+    },
   }: FormState,
   id
 ) => {
@@ -145,6 +152,7 @@ export const formToGql: FormToGqlFunction = (
       [],
     commitQueue: {
       enabled,
+      requireSigned,
       message,
       mergeMethod,
     },

--- a/src/components/ProjectSettingsTabs/GithubCommitQueueTab/types.ts
+++ b/src/components/ProjectSettingsTabs/GithubCommitQueueTab/types.ts
@@ -49,6 +49,7 @@ export interface FormState {
   };
   commitQueue: {
     enabled: boolean | null;
+    requireSigned: boolean | null;
     mergeMethod: string;
     message: string;
     patchDefinitions: {

--- a/src/components/ProjectSettingsTabs/testData.ts
+++ b/src/components/ProjectSettingsTabs/testData.ts
@@ -40,6 +40,7 @@ export const projectBase: ProjectSettingsQuery["projectSettings"] = {
     gitTagAuthorizedTeams: [],
     commitQueue: {
       enabled: null,
+      requireSigned: null,
       mergeMethod: "",
       message: "",
     },
@@ -121,6 +122,7 @@ const repoBase: RepoSettingsQuery["repoSettings"] = {
     gitTagAuthorizedTeams: [],
     commitQueue: {
       enabled: true,
+      requireSigned: true,
       mergeMethod: "squash",
       message: "Commit Queue Message",
     },

--- a/src/components/SpruceForm/LeafyGreenWidgets.tsx
+++ b/src/components/SpruceForm/LeafyGreenWidgets.tsx
@@ -203,12 +203,19 @@ export const LeafyGreenRadioBox: React.FC<WidgetProps> = ({
   value,
   onChange,
   disabled,
+  uiSchema,
 }) => {
   const { description, enumOptions, "data-cy": dataCy, showLabel } = options;
   if (!Array.isArray(enumOptions)) {
     console.error(
       "enumOptions must be an array passed into LeafyGreen Radio Box"
     );
+    return null;
+  }
+
+  // Workaround because {ui:widget: hidden} does not play nicely with this widget
+  const hide = uiSchema["ui:hide"] ?? false;
+  if (hide) {
     return null;
   }
 

--- a/src/gql/fragments/projectSettings/githubCommitQueue.graphql
+++ b/src/gql/fragments/projectSettings/githubCommitQueue.graphql
@@ -10,6 +10,7 @@ fragment projectGithubCommitQueue on ProjectSettings {
     gitTagAuthorizedTeams
     commitQueue {
       enabled
+      requireSigned
       mergeMethod
       message
     }
@@ -28,6 +29,7 @@ fragment repoGithubCommitQueue on RepoSettings {
     gitTagAuthorizedTeams
     commitQueue {
       enabled
+      requireSigned
       mergeMethod
       message
     }

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -875,6 +875,7 @@ export type PeriodicBuildInput = {
 
 export type CommitQueueParamsInput = {
   enabled?: Maybe<Scalars["Boolean"]>;
+  requireSigned?: Maybe<Scalars["Boolean"]>;
   mergeMethod?: Maybe<Scalars["String"]>;
   message?: Maybe<Scalars["String"]>;
 };
@@ -1682,12 +1683,14 @@ export type PeriodicBuild = {
 
 export type CommitQueueParams = {
   enabled?: Maybe<Scalars["Boolean"]>;
+  requireSigned?: Maybe<Scalars["Boolean"]>;
   mergeMethod: Scalars["String"];
   message: Scalars["String"];
 };
 
 export type RepoCommitQueueParams = {
   enabled: Scalars["Boolean"];
+  requireSigned: Scalars["Boolean"];
   mergeMethod: Scalars["String"];
   message: Scalars["String"];
 };
@@ -2260,6 +2263,7 @@ export type ProjectGithubCommitQueueFragment = {
     gitTagAuthorizedTeams?: Maybe<Array<string>>;
     commitQueue: {
       enabled?: Maybe<boolean>;
+      requireSigned?: Maybe<boolean>;
       mergeMethod: string;
       message: string;
     };
@@ -2275,7 +2279,12 @@ export type RepoGithubCommitQueueFragment = {
     gitTagVersionsEnabled: boolean;
     gitTagAuthorizedUsers?: Maybe<Array<string>>;
     gitTagAuthorizedTeams?: Maybe<Array<string>>;
-    commitQueue: { enabled: boolean; mergeMethod: string; message: string };
+    commitQueue: {
+      enabled: boolean;
+      requireSigned: boolean;
+      mergeMethod: string;
+      message: string;
+    };
   }>;
 };
 


### PR DESCRIPTION
EVG-16258

### Description 
- Add field for commit queue's `requireSigned` field

### Screenshots
Project attached to repo view:
<img width="694" alt="image" src="https://user-images.githubusercontent.com/9298431/153281694-5f16bd7d-ca2b-4c4a-9e43-6403b66207f7.png">

Repo/non-attached project view:
<img width="700" alt="image" src="https://user-images.githubusercontent.com/9298431/153281754-bd135236-fcc0-4d07-ac9a-fd0a67afde1b.png">

### Testing 
- Manual testing, update unit test
- To preview locally when running a dev server using the latest main branch of evergreen:
  - http://localhost:3000/project/evergreen/settings/github-commitqueue to view a project that inherits from a repo
  - http://localhost:3000/project/spruce/settings/github-commitqueue to view a project that does not inherit from a repo
  - http://localhost:3000/project/602d70a2b2373672ee493184/settings/github-commitqueue to view a repository's settings