### PR TITLE
EVG-15804: Update task counter after reconfiguring patch

### DIFF
--- a/src/pages/Version.tsx
+++ b/src/pages/Version.tsx
@@ -98,6 +98,8 @@ export const VersionPage: React.FC = () => {
   ] = useLazyQuery<VersionQuery, VersionQueryVariables>(GET_VERSION, {
     variables: { id },
     pollInterval,
+    fetchPolicy: "network-only",
+    nextFetchPolicy: "cache-and-network",
     onError: (e) => {
       dispatchToast.error(
         `There was an error loading the version: ${e.message}`


### PR DESCRIPTION
[EVG-15804](https://jira.mongodb.org/browse/EVG-15804)

### Description 
This PR modifies the `fetchPolicy` when fetching `Version`s. `Version` contains the `taskCount` reflected on the UI, so it needs to be refetched when a patch has been reconfigured.

### Screenshots
https://user-images.githubusercontent.com/47064971/153438703-922d11c1-0b41-42bb-9d55-58e905818fca.mov

(The old behavior is that the second number wouldn't update — so this patch would say `6/5 tasks` after reconfiguring, which didn't make sense.)

### Testing 
- Manually
