### PR TITLE
EVG-15529: Block users from spawning host from task if public key is missing

### DIFF
--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -531,6 +531,7 @@ export type Version = {
   activated?: Maybe<Scalars["Boolean"]>;
   taskStatusCounts?: Maybe<Array<StatusCount>>;
   buildVariants?: Maybe<Array<Maybe<GroupedBuildVariant>>>;
+  buildVariantStats?: Maybe<Array<GroupedTaskStatusCount>>;
   isPatch: Scalars["Boolean"];
   patch?: Maybe<Patch>;
   childVersions?: Maybe<Array<Maybe<Version>>>;
@@ -553,6 +554,10 @@ export type VersionBuildVariantsArgs = {
   options?: Maybe<BuildVariantOptions>;
 };
 
+export type VersionBuildVariantStatsArgs = {
+  options?: Maybe<BuildVariantOptions>;
+};
+
 export type Manifest = {
   id: Scalars["String"];
   revision: Scalars["String"];
@@ -571,6 +576,12 @@ export type VersionTiming = {
 export type StatusCount = {
   status: Scalars["String"];
   count: Scalars["Int"];
+};
+
+export type GroupedTaskStatusCount = {
+  variant: Scalars["String"];
+  displayName: Scalars["String"];
+  statusCounts: Array<StatusCount>;
 };
 
 export type BuildVariantOptions = {

--- a/src/pages/spawn/spawnHost/SpawnHostModal.tsx
+++ b/src/pages/spawn/spawnHost/SpawnHostModal.tsx
@@ -108,6 +108,7 @@ export const SpawnHostModal: React.FC<SpawnHostModalProps> = ({
   const awsRegions = awsData?.awsRegions;
   const volumes = volumesData?.myVolumes ?? [];
 
+  // When the modal is opened, reset to the "default" state of the Modal contents.
   useEffect(() => {
     dispatch({ type: "reset" });
     if (awsRegions && awsRegions.length) {
@@ -130,10 +131,10 @@ export const SpawnHostModal: React.FC<SpawnHostModalProps> = ({
   }, [visible]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
-    if (awsRegions) {
+    if (awsRegions && awsRegions.length) {
       dispatch({ type: "editAWSRegion", region: awsRegions[0] });
     }
-    if (publicKeys) {
+    if (publicKeys && publicKeys.length) {
       dispatch({
         type: "editPublicKey",
         publicKey: publicKeys[0],


### PR DESCRIPTION
[EVG-15529](https://jira.mongodb.org/browse/EVG-15529)

### Description 
Normally, users cannot spawn a host until they provide a public key (the intended behavior). However, spawning a host from a task will ignore this requirement and allow users to spawn a host without a public key, which leads to an error. This PR fixes this bug.

The error was occurring because `GetMyPublicKeysQuery` always returns an array but we were always setting the `publicKey` to `publicKeys[0]`, even if the array had no length.

### Screenshots
https://user-images.githubusercontent.com/47064971/153950728-57c96d68-e7c3-4c7a-bcc0-bf4b2b1a58a1.mov

### Testing 
- Manually
