### PR TITLE
EVG-16355 Fix build variant panel styling

### DIFF
--- a/src/pages/version/BuildVariants.tsx
+++ b/src/pages/version/BuildVariants.tsx
@@ -6,7 +6,7 @@ import { useVersionAnalytics } from "analytics";
 import { GroupedTaskStatusBadge } from "components/GroupedTaskStatusBadge";
 import { StyledRouterLink, SiderCard } from "components/styles";
 import { Divider } from "components/styles/Divider";
-import { H3 } from "components/Typography";
+import { H3, wordBreakCss } from "components/Typography";
 import { pollInterval } from "constants/index";
 import { getVersionRoute } from "constants/routes";
 import { size } from "constants/tokens";
@@ -49,6 +49,7 @@ export const BuildVariants: React.FC = () => {
               data-cy="patch-build-variant"
             >
               <StyledRouterLink
+                css={wordBreakCss}
                 to={`${getVersionRoute(id, {
                   page: 0,
                   variant: applyStrictRegex(variant),

--- a/src/pages/version/BuildVariants.tsx
+++ b/src/pages/version/BuildVariants.tsx
@@ -44,7 +44,7 @@ export const BuildVariants: React.FC = () => {
         {loading && <Skeleton active title={false} paragraph={{ rows: 4 }} />}
         {version?.buildVariantStats?.map(
           ({ displayName, statusCounts, variant }) => (
-            <BuildVariant
+            <div
               key={`buildVariant_${displayName}_${variant}`}
               data-cy="patch-build-variant"
             >
@@ -66,7 +66,7 @@ export const BuildVariants: React.FC = () => {
                 statusCounts={statusCounts}
                 versionId={id}
               />
-            </BuildVariant>
+            </div>
           )
         )}
       </SiderCard>
@@ -112,13 +112,12 @@ const VariantTaskGroup: React.FC<VariantTaskGroupProps> = ({
   );
 };
 
-const BuildVariant = styled.div`
-  margin-bottom: ${size.xs};
-`;
 const VariantTasks = styled.div`
   display: flex;
   flex-wrap: wrap;
+  margin-top: ${size.xs};
   > * {
     margin-right: ${size.xs};
+    margin-bottom: ${size.xs};
   }
 `;


### PR DESCRIPTION
[EVG-16355](https://jira.mongodb.org/browse/EVG-16355)

### Description 
Fixes styling bug introduced #1093 
### Screenshots
Before: 
<img width="273" alt="image" src="https://user-images.githubusercontent.com/4605522/154527679-4b29fd45-7a9e-4bb1-9909-ebe6d75a4440.png">
After:
![image](https://user-images.githubusercontent.com/4605522/154527735-4b2c35d7-f940-4c1b-9adf-2ea297f15050.png)


