### PR TITLE
EVG-16330: Reset search when SearchableDropdown closes

### DIFF
--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -18,6 +18,7 @@ interface DropdownProps {
   children?: React.ReactNode;
   isOpen: boolean;
   setIsOpen: (isOpen: boolean) => void;
+  onClose?: () => void;
 }
 const Dropdown: React.FC<DropdownProps> = ({
   "data-cy": dataCy = "dropdown-button",
@@ -28,12 +29,18 @@ const Dropdown: React.FC<DropdownProps> = ({
   children,
   isOpen,
   setIsOpen,
+  onClose,
 }) => {
   const listMenuRef = useRef(null);
   const menuButtonRef = useRef(null);
 
+  const handleClickOutside = () => {
+    setIsOpen(false);
+    onClose?.(); // call if exists
+  };
+
   // Handle onClickOutside
-  useOnClickOutside([listMenuRef, menuButtonRef], () => setIsOpen(false));
+  useOnClickOutside([listMenuRef, menuButtonRef], handleClickOutside);
 
   return (
     <Container id={id}>

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -29,14 +29,14 @@ const Dropdown: React.FC<DropdownProps> = ({
   children,
   isOpen,
   setIsOpen,
-  onClose,
+  onClose = () => {},
 }) => {
   const listMenuRef = useRef(null);
   const menuButtonRef = useRef(null);
 
   const handleClickOutside = () => {
     setIsOpen(false);
-    onClose?.(); // call if exists
+    onClose();
   };
 
   // Handle onClickOutside

--- a/src/components/SearchableDropdown/SearchableDropdown.test.tsx
+++ b/src/components/SearchableDropdown/SearchableDropdown.test.tsx
@@ -62,28 +62,6 @@ describe("searchableDropdown", () => {
     expect(queryAllByDataCy("searchable-dropdown-option")).toHaveLength(1);
   });
 
-  it("should reset the search input and options after user selects an option", () => {
-    const onChange = jest.fn();
-    const { queryByDataCy, queryAllByDataCy, queryByText } = render(
-      RenderSearchableDropdown({
-        value: "evergreen",
-        onChange,
-        options: ["evergreen", "spruce"],
-      })
-    );
-    // use text input to filter and select an option.
-    userEvent.click(queryByDataCy("searchable-dropdown"));
-    expect(queryAllByDataCy("searchable-dropdown-option")).toHaveLength(2);
-    userEvent.type(queryByDataCy("searchable-dropdown-search-input"), "spru");
-    expect(queryAllByDataCy("searchable-dropdown-option")).toHaveLength(1);
-    userEvent.click(queryByText("spruce"));
-
-    // when reopening the dropdown, the text input should be cleared and all options should be visible.
-    userEvent.click(queryByDataCy("searchable-dropdown"));
-    expect(queryAllByDataCy("searchable-dropdown-option")).toHaveLength(2);
-    expect(queryByDataCy("searchable-dropdown-search-input")).toHaveValue("");
-  });
-
   it("should reset the search input and options after SearchableDropdown closes", () => {
     const onChange = jest.fn();
     const { queryByDataCy, queryAllByDataCy } = render(
@@ -161,6 +139,28 @@ describe("searchableDropdown", () => {
       );
       expect(queryByText("spruce")).toBeInTheDocument();
     });
+
+    it("should reset the search input and options after user selects an option", () => {
+      const onChange = jest.fn();
+      const { queryByDataCy, queryAllByDataCy, queryByText } = render(
+        RenderSearchableDropdown({
+          value: "evergreen",
+          onChange,
+          options: ["evergreen", "spruce"],
+        })
+      );
+      // use text input to filter and select an option.
+      userEvent.click(queryByDataCy("searchable-dropdown"));
+      expect(queryAllByDataCy("searchable-dropdown-option")).toHaveLength(2);
+      userEvent.type(queryByDataCy("searchable-dropdown-search-input"), "spru");
+      expect(queryAllByDataCy("searchable-dropdown-option")).toHaveLength(1);
+      userEvent.click(queryByText("spruce"));
+
+      // when reopening the dropdown, the text input should be cleared and all options should be visible.
+      userEvent.click(queryByDataCy("searchable-dropdown"));
+      expect(queryAllByDataCy("searchable-dropdown-option")).toHaveLength(2);
+      expect(queryByDataCy("searchable-dropdown-search-input")).toHaveValue("");
+    });
   });
 
   describe("when multiselect == true", () => {
@@ -200,6 +200,30 @@ describe("searchableDropdown", () => {
       );
       userEvent.click(queryByText("evergreen"));
       expect(onChange).toHaveBeenCalledWith(["spruce", "evergreen"]);
+    });
+
+    it("should NOT reset the search input and options after user selects an option", () => {
+      const onChange = jest.fn();
+      const { queryByDataCy, queryAllByDataCy, queryByText } = render(
+        RenderSearchableDropdown({
+          value: "evergreen",
+          onChange,
+          options: ["evergreen", "spruce", "sandbox"],
+          allowMultiSelect: true,
+        })
+      );
+      // use text input to filter and select an option.
+      userEvent.click(queryByDataCy("searchable-dropdown"));
+      expect(queryAllByDataCy("searchable-dropdown-option")).toHaveLength(3);
+      userEvent.type(queryByDataCy("searchable-dropdown-search-input"), "s");
+      expect(queryAllByDataCy("searchable-dropdown-option")).toHaveLength(2);
+      userEvent.click(queryByText("spruce"));
+
+      // the dropdown should not be closed and the search state should not be reset.
+      expect(queryByDataCy("searchable-dropdown-search-input")).toHaveValue(
+        "s"
+      );
+      expect(queryAllByDataCy("searchable-dropdown-option")).toHaveLength(2);
     });
   });
 

--- a/src/components/SearchableDropdown/SearchableDropdown.test.tsx
+++ b/src/components/SearchableDropdown/SearchableDropdown.test.tsx
@@ -62,6 +62,50 @@ describe("searchableDropdown", () => {
     expect(queryAllByDataCy("searchable-dropdown-option")).toHaveLength(1);
   });
 
+  it("should reset the search input and options after user selects an option", () => {
+    const onChange = jest.fn();
+    const { queryByDataCy, queryAllByDataCy, queryByText } = render(
+      RenderSearchableDropdown({
+        value: "evergreen",
+        onChange,
+        options: ["evergreen", "spruce"],
+      })
+    );
+    // use text input to filter and select an option.
+    userEvent.click(queryByDataCy("searchable-dropdown"));
+    expect(queryAllByDataCy("searchable-dropdown-option")).toHaveLength(2);
+    userEvent.type(queryByDataCy("searchable-dropdown-search-input"), "spru");
+    expect(queryAllByDataCy("searchable-dropdown-option")).toHaveLength(1);
+    userEvent.click(queryByText("spruce"));
+
+    // when reopening the dropdown, the text input should be cleared and all options should be visible.
+    userEvent.click(queryByDataCy("searchable-dropdown"));
+    expect(queryAllByDataCy("searchable-dropdown-option")).toHaveLength(2);
+    expect(queryByDataCy("searchable-dropdown-search-input")).toHaveValue("");
+  });
+
+  it("should reset the search input and options after SearchableDropdown closes", () => {
+    const onChange = jest.fn();
+    const { queryByDataCy, queryAllByDataCy } = render(
+      RenderSearchableDropdown({
+        value: "evergreen",
+        onChange,
+        options: ["evergreen", "spruce"],
+      })
+    );
+    // use text input to filter and click on document body (which closes the dropdown).
+    userEvent.click(queryByDataCy("searchable-dropdown"));
+    expect(queryAllByDataCy("searchable-dropdown-option")).toHaveLength(2);
+    userEvent.type(queryByDataCy("searchable-dropdown-search-input"), "spru");
+    expect(queryAllByDataCy("searchable-dropdown-option")).toHaveLength(1);
+    userEvent.click(document.body as HTMLElement);
+
+    // when reopening the dropdown, the text input should be cleared and all options should be visible.
+    userEvent.click(queryByDataCy("searchable-dropdown"));
+    expect(queryAllByDataCy("searchable-dropdown-option")).toHaveLength(2);
+    expect(queryByDataCy("searchable-dropdown-search-input")).toHaveValue("");
+  });
+
   it("should use custom search function when passed in", () => {
     const onChange = jest.fn();
     const searchFunc = jest.fn((options, match) =>

--- a/src/components/SearchableDropdown/index.tsx
+++ b/src/components/SearchableDropdown/index.tsx
@@ -74,8 +74,8 @@ const SearchableDropdown = <T extends {}>({
       if (DropdownRef.current) {
         DropdownRef.current.setIsOpen(false);
       }
+      resetSearch();
     }
-    resetSearch();
   };
 
   const option = optionRenderer

--- a/src/components/SearchableDropdown/index.tsx
+++ b/src/components/SearchableDropdown/index.tsx
@@ -53,7 +53,7 @@ const SearchableDropdown = <T extends {}>({
   }, [options]);
 
   // Clear search text input and reset visible options to show every option.
-  const clearSearch = () => {
+  const resetSearch = () => {
     setSearch("");
     setVisibleOptions(options);
   };
@@ -75,7 +75,7 @@ const SearchableDropdown = <T extends {}>({
         DropdownRef.current.setIsOpen(false);
       }
     }
-    clearSearch();
+    resetSearch();
   };
 
   const option = optionRenderer
@@ -145,8 +145,8 @@ const SearchableDropdown = <T extends {}>({
           buttonRenderer={
             buttonRenderer ? () => buttonRenderer(value) : undefined
           }
+          onClose={resetSearch}
           ref={DropdownRef}
-          onClose={clearSearch}
         >
           <TextInput
             data-cy={`${dataCy}-search-input`}

--- a/src/components/SearchableDropdown/index.tsx
+++ b/src/components/SearchableDropdown/index.tsx
@@ -52,6 +52,12 @@ const SearchableDropdown = <T extends {}>({
     }
   }, [options]);
 
+  // Clear search text input and reset visible options to show every option.
+  const clearSearch = () => {
+    setSearch("");
+    setVisibleOptions(options);
+  };
+
   const onClick = (v: T) => {
     if (allowMultiSelect) {
       if (Array.isArray(value)) {
@@ -69,6 +75,7 @@ const SearchableDropdown = <T extends {}>({
         DropdownRef.current.setIsOpen(false);
       }
     }
+    clearSearch();
   };
 
   const option = optionRenderer
@@ -139,6 +146,7 @@ const SearchableDropdown = <T extends {}>({
             buttonRenderer ? () => buttonRenderer(value) : undefined
           }
           ref={DropdownRef}
+          onClose={clearSearch}
         >
           <TextInput
             data-cy={`${dataCy}-search-input`}


### PR DESCRIPTION
[EVG-16330](https://jira.mongodb.org/browse/EVG-16330)

### Description 
This PR adds the functionality to reset the search (i.e. clear the text input and show all available options) for two scenarios:
1. the user closes the `SearchableDropdown` by clicking on an option
2. the user closes the `SearchableDropdown` by clicking outside of it

Note that for the scenario where the user clicks on an option, we only reset the search state if `SearchableDropdown` does NOT allow multiselect. This is because we don't close the dropdown after the user clicks on an option if multiselect is enabled.

### Screenshots
https://user-images.githubusercontent.com/47064971/156393125-05d01188-b9bf-42cd-8fdb-4e6ad92ae113.mov

### Testing 
- Added tests in `SearchableDropdown.test.tsx`
