### PR TITLE
EVG-15533: Default to user's preferred AWS region in SpawnHostModal

### DIFF
--- a/src/pages/preferences/preferencesTabs/ProfileTab.tsx
+++ b/src/pages/preferences/preferencesTabs/ProfileTab.tsx
@@ -120,7 +120,6 @@ export const ProfileTab: React.FC = () => {
               </Option>
             ))}
           </StyledSelect>
-
           <StyledSelect
             label="AWS Region"
             placeholder="Select AWS Region"
@@ -133,7 +132,6 @@ export const ProfileTab: React.FC = () => {
               </Option>
             ))}
           </StyledSelect>
-
           <Button
             data-cy="save-profile-changes-button"
             variant={Variant.Primary}

--- a/src/pages/preferences/preferencesTabs/ProfileTab.tsx
+++ b/src/pages/preferences/preferencesTabs/ProfileTab.tsx
@@ -27,7 +27,7 @@ export const ProfileTab: React.FC = () => {
 
   const { data, loadingComp } = useUserSettingsQuery();
   const { githubUser, timezone, region } = data?.userSettings ?? {};
-  const { lastKnownAs = "" } = githubUser || {};
+  const lastKnownAs = githubUser?.lastKnownAs || "";
 
   const [timezoneField, setTimezoneField] = useState<string>(timezone);
   const [regionField, setRegionField] = useState<string>(region);
@@ -55,9 +55,9 @@ export const ProfileTab: React.FC = () => {
 
   const {
     data: awsRegionData,
-    loading: loadingAWSRegion,
+    loading: awsRegionLoading,
   } = useQuery<AwsRegionsQuery>(GET_AWS_REGIONS);
-  const { awsRegions = [] } = awsRegionData || {};
+  const awsRegions = awsRegionData?.awsRegions || [];
 
   const handleSave = async (e): Promise<void> => {
     e.preventDefault();
@@ -89,63 +89,61 @@ export const ProfileTab: React.FC = () => {
     timezone !== timezoneField ||
     region !== regionField;
 
-  if (loadingComp) {
+  if (loadingComp || awsRegionLoading) {
     return loadingComp;
   }
 
   return (
     <div>
-      {!loadingAWSRegion && (
-        /* @ts-expect-error */
-        <PreferencesCard>
-          <ContentWrapper>
-            <StyledTextInput
-              label="Github Username"
-              onChange={handleFieldUpdate(setGithubUsernameField)}
-              value={githubUsernameField}
-            />
-            <StyledSelect
-              label="Timezone"
-              placeholder="Select timezone"
-              defaultValue={timezoneField}
-              onChange={handleFieldUpdate(setTimezoneField)}
-              data-cy="timezone-field"
-            >
-              {timeZones.map((timeZone) => (
-                <Option
-                  value={timeZone.value}
-                  key={timeZone.value}
-                  data-cy={`${timeZone.str}-option`}
-                >
-                  {timeZone.str}
-                </Option>
-              ))}
-            </StyledSelect>
+      {/* @ts-expect-error */}
+      <PreferencesCard>
+        <ContentWrapper>
+          <StyledTextInput
+            label="Github Username"
+            onChange={handleFieldUpdate(setGithubUsernameField)}
+            value={githubUsernameField}
+          />
+          <StyledSelect
+            label="Timezone"
+            placeholder="Select timezone"
+            defaultValue={timezoneField}
+            onChange={handleFieldUpdate(setTimezoneField)}
+            data-cy="timezone-field"
+          >
+            {timeZones.map((timeZone) => (
+              <Option
+                value={timeZone.value}
+                key={timeZone.value}
+                data-cy={`${timeZone.str}-option`}
+              >
+                {timeZone.str}
+              </Option>
+            ))}
+          </StyledSelect>
 
-            <StyledSelect
-              label="AWS Region"
-              placeholder="Select AWS Region"
-              defaultValue={regionField}
-              onChange={handleFieldUpdate(setRegionField)}
-            >
-              {(awsRegions as any[])?.map((awsRegion) => (
-                <Option value={awsRegion} key={awsRegion}>
-                  {awsRegion}
-                </Option>
-              ))}
-            </StyledSelect>
+          <StyledSelect
+            label="AWS Region"
+            placeholder="Select AWS Region"
+            defaultValue={regionField}
+            onChange={handleFieldUpdate(setRegionField)}
+          >
+            {awsRegions.map((awsRegion) => (
+              <Option value={awsRegion} key={awsRegion}>
+                {awsRegion}
+              </Option>
+            ))}
+          </StyledSelect>
 
-            <Button
-              data-cy="save-profile-changes-button"
-              variant={Variant.Primary}
-              disabled={!hasFieldUpdates || updateLoading}
-              onClick={handleSave}
-            >
-              Save Changes
-            </Button>
-          </ContentWrapper>
-        </PreferencesCard>
-      )}
+          <Button
+            data-cy="save-profile-changes-button"
+            variant={Variant.Primary}
+            disabled={!hasFieldUpdates || updateLoading}
+            onClick={handleSave}
+          >
+            Save Changes
+          </Button>
+        </ContentWrapper>
+      </PreferencesCard>
     </div>
   );
 };

--- a/src/pages/spawn/spawnHost/SpawnHostButton.test.tsx
+++ b/src/pages/spawn/spawnHost/SpawnHostButton.test.tsx
@@ -83,7 +83,7 @@ const userSettingsMock = {
     variables: {},
   },
   result: {
-    data: { region: "eu-west-1" },
+    data: { userSettings: { region: "eu-west-1" } },
   },
 };
 

--- a/src/pages/spawn/spawnHost/SpawnHostButton.test.tsx
+++ b/src/pages/spawn/spawnHost/SpawnHostButton.test.tsx
@@ -8,6 +8,7 @@ import {
   GET_MY_PUBLIC_KEYS,
   GET_MY_VOLUMES,
   GET_USER,
+  GET_USER_SETTINGS,
 } from "gql/queries";
 import { renderWithRouterMatch as render, waitFor } from "test_utils";
 import { SpawnHostButton } from "./SpawnHostButton";
@@ -21,6 +22,7 @@ describe("spawnHostButton", () => {
       <MockedProvider
         mocks={[
           awsRegionsMock,
+          userSettingsMock,
           getDistrosMock,
           getMyPublicKeysMock,
           getUserMock,
@@ -43,6 +45,7 @@ describe("spawnHostButton", () => {
       <MockedProvider
         mocks={[
           awsRegionsMock,
+          userSettingsMock,
           getDistrosMock,
           getMyPublicKeysMock,
           getUserMock,
@@ -71,6 +74,16 @@ const awsRegionsMock = {
     data: {
       awsRegions: ["us-east-1", "us-west-1", "eu-west-1", "ap-southeast-2"],
     },
+  },
+};
+
+const userSettingsMock = {
+  request: {
+    query: GET_USER_SETTINGS,
+    variables: {},
+  },
+  result: {
+    data: { region: "eu-west-1" },
   },
 };
 

--- a/src/pages/spawn/spawnHost/SpawnHostModal.tsx
+++ b/src/pages/spawn/spawnHost/SpawnHostModal.tsx
@@ -155,7 +155,7 @@ export const SpawnHostModal: React.FC<SpawnHostModalProps> = ({
         savePublicKey: false,
       });
     }
-  }, [awsRegions, publicKeys, dispatch]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [awsRegions, userAwsRegion, publicKeys, dispatch]);
 
   const unexpirableCountReached = useDisableSpawnExpirationCheckbox(false);
 

--- a/src/pages/spawn/spawnHost/SpawnHostModal.tsx
+++ b/src/pages/spawn/spawnHost/SpawnHostModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { useQuery, useMutation } from "@apollo/client";
 import styled from "@emotion/styled";
 import Button, { Variant } from "@leafygreen-ui/button";
@@ -23,6 +23,7 @@ import {
   MyHostsQueryVariables,
   SpawnHostMutation,
   SpawnHostMutationVariables,
+  GetUserSettingsQuery,
 } from "gql/generated/types";
 import { SPAWN_HOST } from "gql/mutations";
 import {
@@ -30,6 +31,7 @@ import {
   GET_MY_PUBLIC_KEYS,
   GET_AWS_REGIONS,
   GET_MY_VOLUMES,
+  GET_USER_SETTINGS,
 } from "gql/queries";
 import { useDisableSpawnExpirationCheckbox } from "hooks";
 import { string } from "utils";
@@ -66,6 +68,12 @@ export const SpawnHostModal: React.FC<SpawnHostModalProps> = ({
     AwsRegionsQuery,
     AwsRegionsQueryVariables
   >(GET_AWS_REGIONS);
+
+  // QUERY user settings to get user's preferred aws region
+  const { data: userSettingsData } = useQuery<GetUserSettingsQuery>(
+    GET_USER_SETTINGS
+  );
+  const { region: userAwsRegion } = userSettingsData?.userSettings ?? {};
 
   // QUERY public keys
   const { data: publicKeysData, loading: publicKeyLoading } = useQuery<
@@ -112,7 +120,10 @@ export const SpawnHostModal: React.FC<SpawnHostModalProps> = ({
   useEffect(() => {
     dispatch({ type: "reset" });
     if (awsRegions && awsRegions.length) {
-      dispatch({ type: "editAWSRegion", region: awsRegions[0] });
+      dispatch({
+        type: "editAWSRegion",
+        region: userAwsRegion || awsRegions[0],
+      });
     }
     if (publicKeys && publicKeys.length) {
       dispatch({
@@ -132,7 +143,10 @@ export const SpawnHostModal: React.FC<SpawnHostModalProps> = ({
 
   useEffect(() => {
     if (awsRegions && awsRegions.length) {
-      dispatch({ type: "editAWSRegion", region: awsRegions[0] });
+      dispatch({
+        type: "editAWSRegion",
+        region: userAwsRegion || awsRegions[0],
+      });
     }
     if (publicKeys && publicKeys.length) {
       dispatch({
@@ -141,7 +155,7 @@ export const SpawnHostModal: React.FC<SpawnHostModalProps> = ({
         savePublicKey: false,
       });
     }
-  }, [awsRegions, publicKeys, dispatch]);
+  }, [awsRegions, publicKeys, dispatch]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const unexpirableCountReached = useDisableSpawnExpirationCheckbox(false);
 

--- a/src/pages/task/taskTabs/buildBaronAndAnnotations/BuildBaron.test.tsx
+++ b/src/pages/task/taskTabs/buildBaronAndAnnotations/BuildBaron.test.tsx
@@ -304,14 +304,14 @@ const ticketsTableMocks = [
       query: MOVE_ANNOTATION,
       variables: { taskId, execution, apiIssue, isIssue: true },
     },
-    result: { success: true },
+    result: { data: { moveAnnotationIssue: true } },
   },
   {
     request: {
       query: REMOVE_ANNOTATION,
       variables: { taskId, execution, apiIssue, isIssue: true },
     },
-    result: { success: true },
+    result: { data: { removeAnnotationIssue: true } },
   },
   {
     request: {


### PR DESCRIPTION
[EVG-15533](https://jira.mongodb.org/browse/EVG-15533)

### Description 
This PR makes it so that the "Region" dropdown in the `SpawnHostModal` is pre-filled to the user’s preferred AWS region if it exists. Otherwise, it's just set to the first region in the list of AWS regions.

It also fixes a separate bug where the Profile tab doesn't properly display a user's preferred AWS region. (see video below)

#### Buggy behavior on Profile tab in deployed Spruce (now fixed)
https://user-images.githubusercontent.com/47064971/156423730-ae22c838-49b4-4fb9-bded-d0f47b6f83d7.mov

### Screenshots
https://user-images.githubusercontent.com/47064971/156426305-48d67a20-3b8a-4322-98d1-9d037f3a3b19.mov

### Testing 
- Manually
