### PR TITLE
EVG-16436: Add default to repo button

### DIFF
--- a/cypress/integration/projectSettings/project_settings.ts
+++ b/cypress/integration/projectSettings/project_settings.ts
@@ -26,7 +26,7 @@ describe("Repo Settings", () => {
   });
 
   it("Does not show a 'Default to Repo' button on page", () => {
-    cy.dataCy("default-to-repo").should("not.exist");
+    cy.dataCy("default-to-repo-button").should("not.exist");
   });
 
   it("Does not show a 'Move to New Repo' button on page", () => {
@@ -154,7 +154,7 @@ describe("Project Settings when not defaulting to repo", () => {
   });
 
   it("Does not show a 'Default to Repo' button on page", () => {
-    cy.dataCy("default-to-repo").should("not.exist");
+    cy.dataCy("default-to-repo-button").should("not.exist");
   });
 
   it("Shows two radio boxes", () => {
@@ -301,7 +301,7 @@ describe("Project Settings when defaulting to repo", () => {
   });
 
   it("Shows a 'Default to Repo' button on page", () => {
-    cy.dataCy("default-to-repo").should("exist");
+    cy.dataCy("default-to-repo-button").should("exist");
   });
 
   it("Shows a third radio box when rendering a project that inherits from repo", () => {
@@ -408,6 +408,22 @@ describe("Project Settings when defaulting to repo", () => {
     it("Clicking on save button should show a success toast", () => {
       cy.dataCy("save-settings-button").click();
       cy.validateToast("success", "Successfully updated project");
+    });
+
+    it("Defaults to repo", () => {
+      cy.dataCy("default-to-repo-button").click();
+      cy.dataCy("default-to-repo-modal").should("be.visible");
+      cy.dataCy("default-to-repo-modal")
+        .find("button")
+        .contains("Confirm")
+        .parent()
+        .click();
+      cy.validateToast("success");
+    });
+
+    it.only("Again shows the repo's disabled patch definition", () => {
+      cy.dataCy("accordion-toggle").should("exist");
+      cy.dataCy("accordion-toggle").contains("Patch Definition 1");
     });
   });
 

--- a/src/components/ProjectSettingsTabs/Context.tsx
+++ b/src/components/ProjectSettingsTabs/Context.tsx
@@ -56,9 +56,6 @@ const reducer = (state: TabState, action: Action): TabState => {
           }
         : state;
     case "updateForm":
-      if (state[action.tab].formData === action.formData) {
-        return state;
-      }
       return {
         ...state,
         [action.tab]: {

--- a/src/components/ProjectSettingsTabs/DefaultSectionToRepoModal.tsx
+++ b/src/components/ProjectSettingsTabs/DefaultSectionToRepoModal.tsx
@@ -1,0 +1,57 @@
+import { useMutation } from "@apollo/client";
+import { ConfirmationModal } from "components/ConfirmationModal";
+import { useToastContext } from "context/toast";
+import {
+  DefaultSectionToRepoMutation,
+  DefaultSectionToRepoMutationVariables,
+  ProjectSettingsSection,
+} from "gql/generated/types";
+import { DEFAULT_SECTION_TO_REPO } from "gql/mutations";
+
+interface Props {
+  handleClose: () => void;
+  open: boolean;
+  projectId: string;
+  section: ProjectSettingsSection;
+}
+
+export const DefaultSectionToRepoModal = ({
+  handleClose,
+  open,
+  projectId,
+  section,
+}: Props) => {
+  const dispatchToast = useToastContext();
+
+  const [defaultSectionToRepo] = useMutation<
+    DefaultSectionToRepoMutation,
+    DefaultSectionToRepoMutationVariables
+  >(DEFAULT_SECTION_TO_REPO, {
+    variables: { projectId, section },
+    onCompleted() {
+      dispatchToast.success("Successfully defaulted page to repo");
+    },
+    onError(err) {
+      dispatchToast.error(
+        `There was an error defaulting to repo: ${err.message}`
+      );
+    },
+    refetchQueries: ["ProjectSettings", "RepoSettings"],
+  });
+
+  return (
+    <ConfirmationModal
+      buttonText="Confirm"
+      data-cy="default-to-repo-modal"
+      onCancel={handleClose}
+      onConfirm={() => {
+        defaultSectionToRepo();
+        handleClose();
+      }}
+      open={open}
+      title="Are you sure you want to default all settings in this section to the repo settings?"
+    >
+      Settings will continue to be modifiable at the project level.
+    </ConfirmationModal>
+  );
+};

--- a/src/components/ProjectSettingsTabs/GeneralTab/getFormSchema.ts
+++ b/src/components/ProjectSettingsTabs/GeneralTab/getFormSchema.ts
@@ -243,12 +243,22 @@ export const getFormSchema = (
       },
       repositoryInfo: {
         "ui:field": "repoConfigField",
-        "ui:disabled": projectType !== ProjectType.AttachedProject,
+        "ui:disabled": projectType !== ProjectType.Project,
         options: {
           projectId,
           projectType,
           repoName: repoData?.generalConfiguration?.repositoryInfo?.repo,
           repoOwner: repoData?.generalConfiguration?.repositoryInfo?.owner,
+        },
+        owner: {
+          ...placeholderIf(
+            repoData?.generalConfiguration?.repositoryInfo?.owner
+          ),
+        },
+        repo: {
+          ...placeholderIf(
+            repoData?.generalConfiguration?.repositoryInfo?.repo
+          ),
         },
       },
       branch: {

--- a/src/components/ProjectSettingsTabs/GeneralTab/transformers.test.ts
+++ b/src/components/ProjectSettingsTabs/GeneralTab/transformers.test.ts
@@ -40,7 +40,7 @@ const repoForm: FormState = {
     branch: "main",
     other: {
       displayName: "",
-      batchTime: 0,
+      batchTime: null,
       remotePath: "evergreen.yml",
       spawnHostScriptPath: "/test/path",
     },
@@ -112,7 +112,7 @@ const projectForm: FormState = {
     branch: null,
     other: {
       displayName: null,
-      batchTime: 0,
+      batchTime: null,
       remotePath: null,
       spawnHostScriptPath: null,
     },

--- a/src/components/ProjectSettingsTabs/GeneralTab/transformers.ts
+++ b/src/components/ProjectSettingsTabs/GeneralTab/transformers.ts
@@ -29,7 +29,7 @@ export const gqlToForm: GqlToFormFunction<FormState> = (
       branch: projectRef.branch,
       other: {
         displayName: projectRef.displayName,
-        batchTime: projectRef.batchTime,
+        batchTime: projectRef.batchTime || null,
         remotePath: projectRef.remotePath,
         spawnHostScriptPath: projectRef.spawnHostScriptPath,
       },
@@ -88,7 +88,7 @@ export const formToGql: FormToGqlFunction = (
     repo: generalConfiguration.repositoryInfo.repo,
     branch: generalConfiguration.branch,
     displayName: generalConfiguration.other.displayName,
-    batchTime: generalConfiguration.other.batchTime,
+    batchTime: generalConfiguration.other.batchTime ?? 0,
     remotePath: generalConfiguration.other.remotePath,
     spawnHostScriptPath: generalConfiguration.other.spawnHostScriptPath,
     dispatchingDisabled: projectFlags.dispatchingDisabled,

--- a/src/components/ProjectSettingsTabs/Header.tsx
+++ b/src/components/ProjectSettingsTabs/Header.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { useMutation } from "@apollo/client";
 import styled from "@emotion/styled";
 import { H2, Disclaimer } from "@leafygreen-ui/typography";
@@ -18,6 +19,7 @@ import {
 } from "gql/mutations";
 import { getTabTitle } from "pages/projectSettings/getTabTitle";
 import { useProjectSettingsContext } from "./Context";
+import { DefaultSectionToRepoModal } from "./DefaultSectionToRepoModal";
 import { formToGqlMap } from "./transformers";
 import { WritableTabRoutes } from "./types";
 import { ProjectType } from "./utils";
@@ -41,6 +43,8 @@ export const Header: React.FC<Props> = ({
   const { title, subtitle } = getTabTitle(tab);
   const { getTab, saveTab } = useProjectSettingsContext();
   const { formData, hasChanges, hasError } = getTab(tab);
+
+  const [defaultModalOpen, setDefaultModalOpen] = useState(false);
 
   const [saveProjectSection] = useMutation<
     SaveProjectSettingsForSectionMutation,
@@ -109,7 +113,20 @@ export const Header: React.FC<Props> = ({
           </Button>
         )}
         {projectType === ProjectType.AttachedProject && (
-          <Button data-cy="default-to-repo">Default to Repo on Page</Button>
+          <>
+            <Button
+              onClick={() => setDefaultModalOpen(true)}
+              data-cy="default-to-repo-button"
+            >
+              Default to Repo on Page
+            </Button>
+            <DefaultSectionToRepoModal
+              handleClose={() => setDefaultModalOpen(false)}
+              open={defaultModalOpen}
+              projectId={id}
+              section={mapRouteToSection[tab]}
+            />
+          </>
         )}
       </ButtonRow>
     </Container>

--- a/src/components/SpruceForm/LeafyGreenWidgets.tsx
+++ b/src/components/SpruceForm/LeafyGreenWidgets.tsx
@@ -57,7 +57,9 @@ export const LeafyGreenTextInput: React.FC<WidgetProps> = ({
           disabled={disabled || (readonlyAsDisabled && readonly)}
           onChange={({ target }) =>
             onChange(
-              target.value === "" && emptyValue ? emptyValue : target.value
+              target.value === "" && emptyValue !== undefined
+                ? emptyValue
+                : target.value
             )
           }
           aria-label={label}

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -228,6 +228,7 @@ export type Mutation = {
   attachProjectToNewRepo: Project;
   saveProjectSettingsForSection: ProjectSettings;
   saveRepoSettingsForSection: RepoSettings;
+  defaultSectionToRepo?: Maybe<Scalars["String"]>;
   attachProjectToRepo: Project;
   detachProjectFromRepo: Project;
   forceRepotrackerRun: Scalars["Boolean"];
@@ -300,6 +301,11 @@ export type MutationSaveProjectSettingsForSectionArgs = {
 
 export type MutationSaveRepoSettingsForSectionArgs = {
   repoSettings?: Maybe<RepoSettingsInput>;
+  section: ProjectSettingsSection;
+};
+
+export type MutationDefaultSectionToRepoArgs = {
+  projectId: Scalars["String"];
   section: ProjectSettingsSection;
 };
 
@@ -2467,6 +2473,15 @@ export type CreatePublicKeyMutationVariables = Exact<{
 
 export type CreatePublicKeyMutation = {
   createPublicKey: Array<{ key: string; name: string }>;
+};
+
+export type DefaultSectionToRepoMutationVariables = Exact<{
+  projectId: Scalars["String"];
+  section: ProjectSettingsSection;
+}>;
+
+export type DefaultSectionToRepoMutation = {
+  defaultSectionToRepo?: Maybe<string>;
 };
 
 export type DetachProjectFromRepoMutationVariables = Exact<{

--- a/src/gql/mutations/default-section-to-repo.graphql
+++ b/src/gql/mutations/default-section-to-repo.graphql
@@ -1,0 +1,6 @@
+mutation DefaultSectionToRepo(
+  $projectId: String!
+  $section: ProjectSettingsSection!
+) {
+  defaultSectionToRepo(projectId: $projectId, section: $section)
+}

--- a/src/gql/mutations/index.ts
+++ b/src/gql/mutations/index.ts
@@ -5,6 +5,7 @@ import ATTACH_PROJECT_TO_REPO from "./attach-project-to-repo.graphql";
 import ATTACH_VOLUME from "./attach-volume.graphql";
 import CLEAR_MY_SUBSCRIPTIONS from "./clear-my-subscriptions.graphql";
 import CREATE_PUBLIC_KEY from "./create-public-key.graphql";
+import DEFAULT_SECTION_TO_REPO from "./default-section-to-repo.graphql";
 import DETACH_PROJECT_FROM_REPO from "./detach-project-from-repo.graphql";
 import DETACH_VOLUME from "./detach-volume.graphql";
 import EDIT_ANNOTATION_NOTE from "./edit-annotation-note.graphql";
@@ -49,6 +50,7 @@ export {
   ATTACH_VOLUME,
   CLEAR_MY_SUBSCRIPTIONS,
   CREATE_PUBLIC_KEY,
+  DEFAULT_SECTION_TO_REPO,
   DETACH_PROJECT_FROM_REPO,
   DETACH_VOLUME,
   EDIT_ANNOTATION_NOTE,


### PR DESCRIPTION
EVG-16436

### Description 
- Call `defaultSectionToRepo` resolver when "Default Page to Repo" button is clicked

### Screenshots
<img width="1475" alt="image" src="https://user-images.githubusercontent.com/9298431/156441772-623bb600-f189-46b2-b4a7-d83b68f47c0e.png">

### Testing 
- Added integration tests

### Evergreen PR 
 https://github.com/evergreen-ci/evergreen/pull/5443