### PR TITLE
EVG-16356 Fix task grouping with build variant filter applied

### DIFF
--- a/src/pages/commits/utils.test.ts
+++ b/src/pages/commits/utils.test.ts
@@ -413,6 +413,27 @@ describe("getMainlineCommitsQueryVariables", () => {
         statuses: [TaskStatus.Succeeded],
       });
     });
+    it("should only return failing tasks when a variant filter is applied with no other filters", () => {
+      expect(
+        getMainlineCommitsQueryVariables({
+          mainlineCommitOptions: {
+            projectID: "projectID",
+            limit: 5,
+            skipOrderNumber: 0,
+          },
+          filterState: {
+            statuses: [],
+            tasks: [],
+            variants: ["variant1"],
+            requesters: [],
+          },
+        }).buildVariantOptionsForTaskIcons
+      ).toStrictEqual({
+        tasks: [],
+        variants: ["variant1"],
+        statuses: FAILED_STATUSES,
+      });
+    });
   });
 
   describe("buildVariantOptionsForGroupedTasks", () => {

--- a/src/pages/commits/utils.ts
+++ b/src/pages/commits/utils.ts
@@ -89,6 +89,8 @@ const generateBuildVariantOptionsForTaskIconsFromState = (
           FAILED_STATUSES
         );
       }
+    } else {
+      statusesToShow = FAILED_STATUSES;
     }
   } else {
     statusesToShow = FAILED_STATUSES;

--- a/src/pages/commits/utils.ts
+++ b/src/pages/commits/utils.ts
@@ -71,26 +71,19 @@ const generateBuildVariantOptionsForTaskIconsFromState = (
   state: CommitsPageReducerState
 ): MainlineCommitsQueryVariables["buildVariantOptions"] => {
   const { filterState } = state;
-  const { hasTasks, hasFilters, hasStatuses } = getFilterStatus(filterState);
+  const { hasTasks, hasStatuses } = getFilterStatus(filterState);
 
   let shouldShowTaskIcons = true;
   let statusesToShow = [];
-  if (hasFilters) {
-    if (hasTasks) {
-      statusesToShow = filterState.statuses;
-    } else if (hasStatuses) {
-      const onlyHasNonFailingStatuses =
-        arrayIntersection(filterState.statuses, FAILED_STATUSES).length === 0;
-      if (onlyHasNonFailingStatuses) {
-        shouldShowTaskIcons = false;
-      } else {
-        statusesToShow = arrayIntersection(
-          filterState.statuses,
-          FAILED_STATUSES
-        );
-      }
+  if (hasTasks) {
+    statusesToShow = filterState.statuses;
+  } else if (hasStatuses) {
+    const onlyHasNonFailingStatuses =
+      arrayIntersection(filterState.statuses, FAILED_STATUSES).length === 0;
+    if (onlyHasNonFailingStatuses) {
+      shouldShowTaskIcons = false;
     } else {
-      statusesToShow = FAILED_STATUSES;
+      statusesToShow = arrayIntersection(filterState.statuses, FAILED_STATUSES);
     }
   } else {
     statusesToShow = FAILED_STATUSES;


### PR DESCRIPTION
[EVG-16356](https://jira.mongodb.org/browse/EVG-16356)

### Description 
Noticed a edge case where a lone variant filter would cause the task status icons to appear. 
### Screenshots
Before:
<img width="1438" alt="image" src="https://user-images.githubusercontent.com/4605522/156630851-88273002-e229-4fd6-a8e4-6227d379c4c3.png">

After:
<img width="1439" alt="image" src="https://user-images.githubusercontent.com/4605522/156630785-f751e373-b24d-4d80-bf85-4a9fc29158a2.png">

### Testing 
Wrote tests for this edge case and tested

