### PR TITLE
EVG-16464 Only link uppercase jira tickets

### DIFF
--- a/src/utils/string/jiraLinkify.tsx
+++ b/src/utils/string/jiraLinkify.tsx
@@ -6,7 +6,7 @@ export const jiraLinkify = (
   unlinkified: string | React.ReactNodeArray,
   jiraHost: string
 ) =>
-  reactStringReplace(unlinkified, /([A-Z]{1,10}-\d{1,6})/gi, (match, i) => (
+  reactStringReplace(unlinkified, /([A-Z]{1,10}-\d{1,6})/g, (match, i) => (
     <StyledLink key={`${match}${i}`} href={getJiraTicketUrl(jiraHost, match)}>
       {match}
     </StyledLink>


### PR DESCRIPTION
[EVG-16464](https://jira.mongodb.org/browse/EVG-16464)

### Description 
This removes the case insensitivity flag, since all Jira projects are uppercase, and things like "<branch_name>-<branch_number>" were matching, but shouldn't have.

### Testing 
This didn't originally have tests, seems tiny, and uses an existing language feature, so I think is safe to commit without a test.
