### PR TITLE
EVG-16284 EVG-16378 Fix typo and clear babel cache 

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "analyze": "source-map-explorer 'build/static/js/*.js' --html | sed 1d > build/source_map.html",
-    "build": "REACT_APP_GIT_SHA=`git rev-parse HEAD` node scripts/build.js build",
+    "build": "REACT_APP_GIT_SHA=`git rev-parse HEAD` && rm -rf ./node_modules/.cache/babel-loader && node scripts/build.js build",
     "build-storybook": "build-storybook -s public",
     "build:prod": "env-cmd -e prod -r env/.cmdrc.json yarn build",
     "build:staging": "env-cmd -e staging -r env/.cmdrc.json yarn build",

--- a/src/pages/spawn/spawnHost/SpawnHostActionButton.tsx
+++ b/src/pages/spawn/spawnHost/SpawnHostActionButton.tsx
@@ -83,7 +83,7 @@ export const SpawnHostActionButton: React.FC<{ host: MyHost }> = ({ host }) => {
   if (host.noExpiration && host.distro?.isVirtualWorkStation) {
     checkboxLabel = `${copyPrefix} a workstation and unexpirable.`;
   } else if (host.noExpiration) {
-    checkboxLabel = `${copyPrefix} is unexpirable.`;
+    checkboxLabel = `${copyPrefix} unexpirable.`;
   } else if (host.distro?.isVirtualWorkStation) {
     checkboxLabel = `${copyPrefix} a virtual workstation.`;
   }


### PR DESCRIPTION
[EVG-16284](https://jira.mongodb.org/browse/EVG-16284)
[EVG-16378](https://jira.mongodb.org/browse/EVG-16378)

### Description 
Fix typo and clear the babel cache before builds
Clearing the babel cache will prevent it from using cached data such as outdated graphql queries when ever we build a prod build. 



