### PR TITLE
EVG-16384 Remove history buttons on execution tasks

### DIFF
--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -3662,7 +3662,7 @@ export type GetTaskForTestsTableQuery = {
   task?: Maybe<
     {
       displayName: string;
-      projectId: string;
+      projectIdentifier?: Maybe<string>;
       displayTask?: Maybe<{ id: string; execution: number }>;
     } & BaseTaskFragment
   >;

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -3653,6 +3653,21 @@ export type TaskFilesQuery = {
   };
 };
 
+export type GetTaskForTestsTableQueryVariables = Exact<{
+  taskId: Scalars["String"];
+  execution?: Maybe<Scalars["Int"]>;
+}>;
+
+export type GetTaskForTestsTableQuery = {
+  task?: Maybe<
+    {
+      displayName: string;
+      projectId: string;
+      displayTask?: Maybe<{ id: string; execution: number }>;
+    } & BaseTaskFragment
+  >;
+};
+
 export type TaskLogsQueryVariables = Exact<{
   id: Scalars["String"];
   execution?: Maybe<Scalars["Int"]>;

--- a/src/gql/queries/get-task-for-tests-table.graphql
+++ b/src/gql/queries/get-task-for-tests-table.graphql
@@ -8,6 +8,6 @@ query GetTaskForTestsTable($taskId: String!, $execution: Int) {
       execution
     }
     displayName
-    projectId
+    projectIdentifier
   }
 }

--- a/src/gql/queries/get-task-for-tests-table.graphql
+++ b/src/gql/queries/get-task-for-tests-table.graphql
@@ -1,0 +1,13 @@
+#import "../fragments/baseTask.graphql"
+
+query GetTaskForTestsTable($taskId: String!, $execution: Int) {
+  task(taskId: $taskId, execution: $execution) {
+    ...baseTask
+    displayTask {
+      id
+      execution
+    }
+    displayName
+    projectId
+  }
+}

--- a/src/gql/queries/index.ts
+++ b/src/gql/queries/index.ts
@@ -42,6 +42,7 @@ import GET_SPRUCE_CONFIG from "./get-spruce-config.graphql";
 import GET_SYSTEM_LOGS from "./get-system-logs.graphql";
 import GET_TASK_ALL_EXECUTIONS from "./get-task-all-executions.graphql";
 import GET_TASK_FILES from "./get-task-files.graphql";
+import GET_TASKS_FOR_TESTS_TABLE from "./get-task-for-tests-table.graphql";
 import GET_TASK_LOGS from "./get-task-logs.graphql";
 import GET_TASK_NAMES_FOR_BUILD_VARIANT from "./get-task-names-for-build-variant.graphql";
 import GET_TASK_STATUSES from "./get-task-statuses.graphql";
@@ -86,6 +87,7 @@ export {
   GET_TASK_TESTS,
   GET_TASK_TEST_SAMPLE,
   GET_TASK,
+  GET_TASKS_FOR_TESTS_TABLE,
   GET_TASK_ALL_EXECUTIONS,
   GET_TASK_STATUSES,
   GET_TESTS,

--- a/src/pages/Task.tsx
+++ b/src/pages/Task.tsx
@@ -69,6 +69,7 @@ export const Task: React.FC = () => {
     requester,
     canOverrideDependencies,
     project,
+    displayTask,
   } = task ?? {};
   const attributed = annotation?.issues?.length > 0;
 
@@ -119,6 +120,7 @@ export const Task: React.FC = () => {
             canOverrideDependencies={canOverrideDependencies}
             taskName={displayName}
             projectIdentifier={project?.identifier}
+            isExecutionTask={!!displayTask}
           />
         }
       />

--- a/src/pages/task/ActionButtons.tsx
+++ b/src/pages/task/ActionButtons.tsx
@@ -47,6 +47,7 @@ interface Props {
   canUnschedule: boolean;
   canSetPriority: boolean;
   canOverrideDependencies: boolean;
+  isExecutionTask: boolean;
   taskName: string;
   projectIdentifier: string;
 }
@@ -61,6 +62,7 @@ export const ActionButtons: React.FC<Props> = ({
   canOverrideDependencies,
   projectIdentifier,
   taskName,
+  isExecutionTask,
 }) => {
   const dispatchToast = useToastContext();
   const [isVisibleModal, setIsVisibleModal] = useState(false);
@@ -259,7 +261,7 @@ export const ActionButtons: React.FC<Props> = ({
     <>
       <PageButtonRow>
         {isBeta() && <PreviousCommits taskId={taskId} />}
-        {isBeta() && (
+        {isBeta() && !isExecutionTask && (
           <Button
             size="small"
             as={Link}

--- a/src/pages/task/taskTabs/TestsTable.tsx
+++ b/src/pages/task/taskTabs/TestsTable.tsx
@@ -21,10 +21,10 @@ import {
   TestSortCategory,
   TestResult,
   TaskTestResult,
-  GetTaskQuery,
-  GetTaskQueryVariables,
+  GetTaskForTestsTableQuery,
+  GetTaskForTestsTableQueryVariables,
 } from "gql/generated/types";
-import { GET_TASK_TESTS, GET_TASK } from "gql/queries";
+import { GET_TASK_TESTS, GET_TASKS_FOR_TESTS_TABLE } from "gql/queries";
 import {
   useUpdateURLQueryParams,
   useNetworkStatus,
@@ -52,15 +52,14 @@ export const TestsTable: React.FC = () => {
     taskAnalytics.sendEvent({ name: "Filter Tests", filterBy });
   const execution = Number(parsed[RequiredQueryParams.Execution]);
 
-  const { data: taskData } = useQuery<GetTaskQuery, GetTaskQueryVariables>(
-    GET_TASK,
-    {
-      variables: { taskId, execution },
-    }
-  );
+  const { data: taskData } = useQuery<
+    GetTaskForTestsTableQuery,
+    GetTaskForTestsTableQueryVariables
+  >(GET_TASKS_FOR_TESTS_TABLE, {
+    variables: { taskId, execution },
+  });
 
   const { task } = taskData || {};
-  const { displayName, projectId } = task || {};
   const queryVariables = getQueryVariables(search, taskId);
   const { cat, dir, pageNum, limitNum } = queryVariables;
 
@@ -112,10 +111,7 @@ export const TestsTable: React.FC = () => {
       taskAnalytics.sendEvent({ name: "Sort Tests Table", sortBy: sortField }),
     statusSelectorProps,
     testNameInputProps,
-    task: {
-      name: displayName,
-      projectIdentifier: projectId,
-    },
+    task,
   }).map((column) => ({
     ...column,
     ...(column.key === cat && {

--- a/src/pages/task/taskTabs/testsTable/LogsColumn.tsx
+++ b/src/pages/task/taskTabs/testsTable/LogsColumn.tsx
@@ -28,7 +28,7 @@ export const LogsColumn: React.FC<Props> = ({
 }) => {
   const { status, testFile } = testResult;
   const { url: urlHTML, urlRaw, urlLobster } = testResult.logs ?? {};
-  const { projectId, displayName, displayTask } = task ?? {};
+  const { projectIdentifier, displayName, displayTask } = task ?? {};
 
   const filters =
     status === TestStatus.Fail
@@ -95,7 +95,7 @@ export const LogsColumn: React.FC<Props> = ({
           onClick={() => {
             taskAnalytics.sendEvent({ name: "Click See History Button" });
           }}
-          to={getTaskHistoryRoute(projectId, displayName, filters)}
+          to={getTaskHistoryRoute(projectIdentifier, displayName, filters)}
         >
           History
         </Button>

--- a/src/pages/task/taskTabs/testsTable/getColumnsTemplate.tsx
+++ b/src/pages/task/taskTabs/testsTable/getColumnsTemplate.tsx
@@ -7,7 +7,11 @@ import {
 } from "components/Table/Filters";
 import { TreeSelectProps } from "components/TreeSelect";
 import { WordBreak } from "components/Typography";
-import { TestSortCategory, TestResult } from "gql/generated/types";
+import {
+  TestSortCategory,
+  TestResult,
+  GetTaskForTestsTableQuery,
+} from "gql/generated/types";
 import { string } from "utils";
 import { LogsColumn } from "./LogsColumn";
 import { TestStatusBadge } from "./TestStatusBadge";
@@ -23,10 +27,7 @@ interface GetColumnsTemplateParams {
   onColumnHeaderClick?: (sortField) => void;
   statusSelectorProps: TreeSelectProps;
   testNameInputProps: InputFilterProps;
-  task: {
-    name: string;
-    projectIdentifier: string;
-  };
+  task: GetTaskForTestsTableQuery["task"];
 }
 
 export const getColumnsTemplate = ({


### PR DESCRIPTION
[EVG-16384](https://jira.mongodb.org/browse/EVG-16384)

### Description 
Disable history buttons on execution tasks

### Screenshots
Execution task
<img width="1426" alt="image" src="https://user-images.githubusercontent.com/4605522/157284783-7332ed1b-8dad-4ccb-844c-2c1af83887e3.png">
Display task
<img width="1432" alt="image" src="https://user-images.githubusercontent.com/4605522/157284877-42a698b3-8bb6-472c-a8df-c34856618a53.png">
Normal task
<img width="1434" alt="image" src="https://user-images.githubusercontent.com/4605522/157284971-bdb33a19-d567-4610-afb3-eef6779dd6ec.png">


