### PR TITLE
EVG-16332: Send analytics events for text input filters

### DIFF
--- a/src/hooks/useFilterInputChangeHandler.ts
+++ b/src/hooks/useFilterInputChangeHandler.ts
@@ -18,22 +18,23 @@ export const useFilterInputChangeHandler = ({
   sendAnalyticsEvent = () => undefined,
 }: FilterHookParams): FilterHookResult<string> => {
   const { search } = useLocation();
+  const { [urlParam]: rawValue } = parseQueryString(search);
+  const urlValue = (rawValue || "").toString();
+
   const updateQueryParams = useUpdateURLQueryParams();
   const updateQueryParamWithDebounce = useMemo(
     () => debounce(updateQueryParams, 250),
     [updateQueryParams]
   );
-  const { [urlParam]: rawValue } = parseQueryString(search);
-  const urlValue = (rawValue || "").toString();
 
   const [inputValue, setInputValue] = useState(urlValue);
+  const page = resetPage && { page: "0" };
+
   useEffect(() => {
     if (!urlValue && inputValue) {
       setInputValue("");
     }
   }, [urlValue]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  const page = resetPage && { page: "0" };
 
   const updateUrl = (newValue: string) => {
     updateQueryParams({
@@ -51,7 +52,10 @@ export const useFilterInputChangeHandler = ({
     sendAnalyticsEvent(urlParam);
   };
 
-  const submitInputValue = () => updateUrl(inputValue);
+  const submitInputValue = () => {
+    updateUrl(inputValue);
+    sendAnalyticsEvent(urlParam);
+  };
 
   const reset = () => {
     setInputValue("");


### PR DESCRIPTION
[EVG-16332](https://jira.mongodb.org/browse/EVG-16332)

### Description 
Somewhere along the line, we stopped sending analytics events for text inputs filters (e.g. `taskName`, `variant`) on the `Task` and `Test` tables. This PR adds that line of code back (+ moves a few things around just for organization sake).

### Screenshots

<img width="1596" alt="Screen Shot 2022-03-08 at 5 03 35 PM" src="https://user-images.githubusercontent.com/47064971/157335050-d6ba77a5-e378-4346-8780-64a56097502d.png">


### Testing 
- Manually checked the console 
