### PR TITLE
EVG-16470 Fix crashes when we fail to load column headers

### DIFF
--- a/src/pages/TaskHistory.tsx
+++ b/src/pages/TaskHistory.tsx
@@ -24,12 +24,13 @@ import {
 } from "gql/queries";
 import { usePageTitle } from "hooks";
 import { TestStatus } from "types/history";
-import { array, string } from "utils";
+import { array, string, errorReporting } from "utils";
 import { parseQueryString } from "utils/queryString";
 import { BuildVariantSelector } from "./taskHistory/BuildVariantSelector";
 import ColumnHeaders from "./taskHistory/ColumnHeaders";
 import TaskHistoryRow from "./taskHistory/TaskHistoryRow";
 
+const { reportError } = errorReporting;
 const { applyStrictRegex } = string;
 const { toArray } = array;
 const { HistoryTableProvider, useHistoryTable } = context;
@@ -71,7 +72,10 @@ const TaskHistoryContents: React.FC = () => {
     },
     onCompleted: ({ buildVariantsForTaskName }) => {
       if (!buildVariantsForTaskName) {
-        dispatchToast.error(`No build variants found for task ${taskName}`);
+        reportError(
+          new Error("No build variants found for task name")
+        ).severe();
+        dispatchToast.error(`No build variants found for task: ${taskName}`);
       }
     },
   });

--- a/src/pages/TaskHistory.tsx
+++ b/src/pages/TaskHistory.tsx
@@ -11,6 +11,7 @@ import HistoryTable, {
 import { HistoryTableTestSearch } from "components/HistoryTable/HistoryTableTestSearch/HistoryTableTestSearch";
 import { PageWrapper } from "components/styles";
 import { size } from "constants/tokens";
+import { useToastContext } from "context/toast";
 import {
   MainlineCommitsForHistoryQuery,
   MainlineCommitsForHistoryQueryVariables,
@@ -38,7 +39,7 @@ const TaskHistoryContents: React.FC = () => {
     projectId: string;
     taskName: string;
   }>();
-
+  const dispatchToast = useToastContext();
   usePageTitle(`Task History | ${projectId} | ${taskName}`);
   const [nextPageOrderNumber, setNextPageOrderNumber] = useState(null);
   const variables = {
@@ -67,6 +68,11 @@ const TaskHistoryContents: React.FC = () => {
     variables: {
       projectId,
       taskName,
+    },
+    onCompleted: ({ buildVariantsForTaskName }) => {
+      if (!buildVariantsForTaskName) {
+        dispatchToast.error(`No build variants found for task ${taskName}`);
+      }
     },
   });
 

--- a/src/pages/VariantHistory.tsx
+++ b/src/pages/VariantHistory.tsx
@@ -24,11 +24,12 @@ import {
 } from "gql/queries";
 import { usePageTitle } from "hooks";
 import { TestStatus } from "types/history";
-import { queryString, string, array } from "utils";
+import { queryString, string, array, errorReporting } from "utils";
 import ColumnHeaders from "./variantHistory/ColumnHeaders";
 import { TaskSelector } from "./variantHistory/TaskSelector";
 import VariantHistoryRow from "./variantHistory/VariantHistoryRow";
 
+const { reportError } = errorReporting;
 const { HistoryTableProvider, useHistoryTable } = context;
 const { toArray } = array;
 const { parseQueryString } = queryString;
@@ -71,6 +72,9 @@ export const VariantHistoryContents: React.FC = () => {
     },
     onCompleted: ({ taskNamesForBuildVariant }) => {
       if (!taskNamesForBuildVariant) {
+        reportError(
+          new Error("No task names found for build variant")
+        ).severe();
         dispatchToast.error(`No tasks found for buildVariant: ${variantName}}`);
       }
     },

--- a/src/pages/VariantHistory.tsx
+++ b/src/pages/VariantHistory.tsx
@@ -11,6 +11,7 @@ import HistoryTable, {
 import { HistoryTableTestSearch } from "components/HistoryTable/HistoryTableTestSearch/HistoryTableTestSearch";
 import { PageWrapper } from "components/styles";
 import { size } from "constants/tokens";
+import { useToastContext } from "context/toast";
 import {
   MainlineCommitsForHistoryQuery,
   MainlineCommitsForHistoryQueryVariables,
@@ -38,7 +39,7 @@ export const VariantHistoryContents: React.FC = () => {
     projectId: string;
     variantName: string;
   }>();
-
+  const dispatchToast = useToastContext();
   usePageTitle(`Variant History | ${projectId} | ${variantName}`);
   const [nextPageOrderNumber, setNextPageOrderNumber] = useState(null);
   const variables = {
@@ -67,6 +68,11 @@ export const VariantHistoryContents: React.FC = () => {
     variables: {
       projectId,
       buildVariant: variantName,
+    },
+    onCompleted: ({ taskNamesForBuildVariant }) => {
+      if (!taskNamesForBuildVariant) {
+        dispatchToast.error(`No tasks found for buildVariant: ${variantName}}`);
+      }
     },
   });
 

--- a/src/utils/array/index.ts
+++ b/src/utils/array/index.ts
@@ -42,7 +42,7 @@ export const convertArrayToObject = <T = { [key: string]: any }>(
   key: keyof T
 ): { [key: string]: T } => {
   const initialValue = {};
-  if (array === undefined) {
+  if (!Array.isArray(array)) {
     return initialValue;
   }
   return array.reduce((obj, item) => {
@@ -84,7 +84,7 @@ export const mapStringArrayToObject = <T>(
   array: string[],
   v: T
 ): { [key: string]: T } => {
-  if (array === undefined) {
+  if (!Array.isArray(array)) {
     return {};
   }
   return array.reduce((prev, curr) => {
@@ -101,7 +101,7 @@ export const toArray = <T>(value: T | T[]): T[] => {
   if (Array.isArray(value)) {
     return value;
   }
-  return value === undefined ? [] : [value];
+  return value === undefined || value === null ? [] : [value];
 };
 
 /** arrayIntersection takes in two arrays and returns the intersecting elements of the two arrays


### PR DESCRIPTION
[EVG-16470](https://jira.mongodb.org/browse/EVG-16470)

### Description 
Fix crashes that occurred when trying to load the history pages for tasks that have no prior commits with the same name.
Add some error reporting when we encounter this scenario. We have removed all links to these pages in https://jira.mongodb.org/browse/EVG-16384  

