### PR TITLE
EVG-16534: Modify usePolling to work with lazy queries

### DIFF
--- a/src/hooks/tests/usePolling.test.tsx
+++ b/src/hooks/tests/usePolling.test.tsx
@@ -31,6 +31,19 @@ describe("usePolling", () => {
     expect(result.current).toBe(true);
   });
 
+  it("usePolling should be able to be initialized with an initialPollingState", async () => {
+    const startPolling = undefined;
+    const stopPolling = undefined;
+    const { result, waitForNextUpdate } = renderHook(
+      () => usePolling(startPolling, stopPolling, false),
+      {
+        wrapper: Provider,
+      }
+    );
+    await waitForNextUpdate();
+    expect(result.current).toBe(false);
+  });
+
   describe("stopPolling", () => {
     it("usePolling should stop polling when user's browser is offline", async () => {
       const startPolling = jest.fn();

--- a/src/hooks/usePolling.ts
+++ b/src/hooks/usePolling.ts
@@ -7,7 +7,8 @@ import { usePageVisibility } from "./usePageVisibility";
 type usePollingType = {
   (
     startPolling: (pollInterval?: number) => void,
-    stopPolling: () => void
+    stopPolling: () => void,
+    initialPollingState?: boolean
   ): boolean;
 };
 
@@ -19,10 +20,14 @@ type usePollingType = {
  * @param stopPolling - Function from useQuery that is called when offline or not visible
  * @returns boolean - true if polling, false if not polling
  */
-export const usePolling: usePollingType = (startPolling, stopPolling) => {
+export const usePolling: usePollingType = (
+  startPolling,
+  stopPolling,
+  initialPollingState = true
+) => {
   const { sendEvent } = usePollingAnalytics();
 
-  const [isPolling, setIsPolling] = useState(true);
+  const [isPolling, setIsPolling] = useState(initialPollingState);
   const isOnline = useNetworkStatus();
   const isVisible = usePageVisibility();
 

--- a/src/hooks/usePolling.ts
+++ b/src/hooks/usePolling.ts
@@ -27,21 +27,21 @@ export const usePolling: usePollingType = (startPolling, stopPolling) => {
   const isVisible = usePageVisibility();
 
   // If offline and polling, stop polling.
-  if (!isOnline && isPolling) {
+  if (!isOnline && isPolling && stopPolling) {
     sendEvent({ name: "Tab Not Active", status: "offline" });
     setIsPolling(false);
     stopPolling();
   }
 
   // If not visible and polling, stop polling.
-  if (!isVisible && isPolling) {
+  if (!isVisible && isPolling && stopPolling) {
     sendEvent({ name: "Tab Not Active", status: "hidden" });
     setIsPolling(false);
     stopPolling();
   }
 
   // If online and visible and not polling, start polling.
-  if (isOnline && isVisible && !isPolling) {
+  if (isOnline && isVisible && !isPolling && startPolling) {
     sendEvent({ name: "Tab Active" });
     setIsPolling(true);
     startPolling(pollInterval);

--- a/src/pages/Version.tsx
+++ b/src/pages/Version.tsx
@@ -107,7 +107,7 @@ export const VersionPage: React.FC = () => {
       setIsLoadingData(false);
     },
   });
-  usePolling(startPolling, stopPolling);
+  usePolling(startPolling, stopPolling, false);
 
   // Decide where to redirect the user based off of whether or not the patch has been activated
   // If this patch is activated and not on the commit queue we can safely fetch the associated version

--- a/src/pages/spawn/spawnHost/SpawnHostActionButton.tsx
+++ b/src/pages/spawn/spawnHost/SpawnHostActionButton.tsx
@@ -40,7 +40,7 @@ export const SpawnHostActionButton: React.FC<{ host: MyHost }> = ({ host }) => {
       );
     },
   });
-  usePolling(startPolling, stopPolling);
+  usePolling(startPolling, stopPolling, false);
   // Stop polling when we get updated host data
   useEffect(() => {
     if (stopPolling) {

--- a/src/pages/task/taskTabs/buildBaronAndAnnotations/BBFileTicket.tsx
+++ b/src/pages/task/taskTabs/buildBaronAndAnnotations/BBFileTicket.tsx
@@ -43,7 +43,7 @@ export const FileTicket: React.FC<FileTicketProps> = ({
       );
     },
   });
-  usePolling(startPolling, stopPolling);
+  usePolling(startPolling, stopPolling, false);
 
   // Stop polling when we get updated created ticket data
   useEffect(() => {


### PR DESCRIPTION
[EVG-16534](https://jira.mongodb.org/browse/EVG-16534)

### Description 
It's possible for `startPolling` and `stopPolling` to be undefined when using `useLazyQuery`. We should check that these functions are defined before calling them in the hook.

### Screenshots
- No visible changes
