### PR TITLE
EVG-16475: Disable Previous Commits Selector button by default

### DIFF
--- a/src/pages/task/ActionButtons.tsx
+++ b/src/pages/task/ActionButtons.tsx
@@ -260,7 +260,7 @@ export const ActionButtons: React.FC<Props> = ({
   return (
     <>
       <PageButtonRow>
-        {isBeta() && <PreviousCommits taskId={taskId} />}
+        {isBeta() && !isExecutionTask && <PreviousCommits taskId={taskId} />}
         {isBeta() && !isExecutionTask && (
           <Button
             size="small"

--- a/src/pages/task/actionButtons/PreviousCommits.test.tsx
+++ b/src/pages/task/actionButtons/PreviousCommits.test.tsx
@@ -7,10 +7,101 @@ import {
 import { renderWithRouterMatch, waitFor } from "test_utils";
 import { PreviousCommits } from "./PreviousCommits";
 
-describe("previous Commits", () => {
+describe("previous commits", () => {
+  // Patch and mainline commit behavior only have a significant difference when it comes to determining
+  // the base or parent task. Patch gets the base task directly from GET_BASE_VERSION_AND_TASK, while
+  // mainline commits needs to run another query GET_LAST_MAINLINE_COMMIT to get parent task.
+  describe("patch specific", () => {
+    it("the GO button is disabled when there is no base task", async () => {
+      const { getByText } = renderWithRouterMatch(() => (
+        <MockedProvider mocks={[getPatchTaskWithNoBaseTask]}>
+          <PreviousCommits taskId="t1" />
+        </MockedProvider>
+      ));
+      await waitFor(() => {
+        expect(getByText("Go").closest("a")).toHaveAttribute(
+          "aria-disabled",
+          "true"
+        );
+      });
+      // Select won't be disabled because baseVersion exists
+      await waitFor(() => {
+        expect(
+          getByText("Go to base commit").closest("button")
+        ).toHaveAttribute("aria-disabled", "false");
+      });
+    });
+  });
+
+  describe("mainline commits specific", () => {
+    it("the GO button is disabled when getParentTask returns null", async () => {
+      const { getByText } = renderWithRouterMatch(() => (
+        <MockedProvider
+          mocks={[getMainlineTaskWithBaseVersion, getNullParentTask]}
+        >
+          <PreviousCommits taskId="t4" />
+        </MockedProvider>
+      ));
+      await waitFor(() => {
+        expect(getByText("Go").closest("a")).toHaveAttribute(
+          "aria-disabled",
+          "true"
+        );
+      });
+      // Select won't be disabled because baseVersion exists (the baseVersion of a mainline commit is itself).
+      await waitFor(() => {
+        expect(
+          getByText("Go to parent commit").closest("button")
+        ).toHaveAttribute("aria-disabled", "false");
+      });
+    });
+
+    it("the GO button is disabled when getParentTask returns an error", async () => {
+      const { getByText } = renderWithRouterMatch(() => (
+        <MockedProvider
+          mocks={[getMainlineTaskWithBaseVersion, getParentTaskWithError]}
+        >
+          <PreviousCommits taskId="t4" />
+        </MockedProvider>
+      ));
+      await waitFor(() => {
+        expect(getByText("Go").closest("a")).toHaveAttribute(
+          "aria-disabled",
+          "true"
+        );
+      });
+      // Select won't be disabled because baseVersion exists
+      await waitFor(() => {
+        expect(
+          getByText("Go to parent commit").closest("button")
+        ).toHaveAttribute("aria-disabled", "false");
+      });
+    });
+  });
+
+  it("the select & GO button are disabled when no base version exists", async () => {
+    const { getByText } = renderWithRouterMatch(() => (
+      <MockedProvider mocks={[getPatchTaskWithNoBaseVersion]}>
+        <PreviousCommits taskId="t3" />
+      </MockedProvider>
+    ));
+    await waitFor(() => {
+      expect(getByText("Go").closest("a")).toHaveAttribute(
+        "aria-disabled",
+        "true"
+      );
+    });
+    await waitFor(() => {
+      expect(getByText("Go to base commit").closest("button")).toHaveAttribute(
+        "aria-disabled",
+        "true"
+      );
+    });
+  });
+
   it("when base task is passing, all dropdown items generate the same link.", async () => {
     const { getAllByText, getByText } = renderWithRouterMatch(() => (
-      <MockedProvider mocks={[getTaskWithSuccessfulBase]}>
+      <MockedProvider mocks={[getPatchTaskWithSuccessfulBaseTask]}>
         <PreviousCommits taskId="t1" />
       </MockedProvider>
     ));
@@ -41,7 +132,9 @@ describe("previous Commits", () => {
 
   it("when base task is failing, 'Go to base commit' and 'Go to last executed' dropdown items generate the same link and 'Go to last passing version' will be different.", async () => {
     const { getAllByText, getByText } = renderWithRouterMatch(() => (
-      <MockedProvider mocks={[getTaskWithFailingBase, getLastPassingVersion]}>
+      <MockedProvider
+        mocks={[getPatchTaskWithFailingBaseTask, getLastPassingVersion]}
+      >
         <PreviousCommits taskId="t1" />
       </MockedProvider>
     ));
@@ -75,7 +168,7 @@ describe("previous Commits", () => {
     const { getAllByText, getByText } = renderWithRouterMatch(() => (
       <MockedProvider
         mocks={[
-          getTaskWithRunningBase,
+          getPatchTaskWithRunningBaseTask,
           getLastPassingVersion,
           getLastExecutedVersion,
         ]}
@@ -107,267 +200,348 @@ describe("previous Commits", () => {
       );
     });
   });
-
-  it("the select is disabled when no base version exists", async () => {
-    const { getByText } = renderWithRouterMatch(() => (
-      <MockedProvider mocks={[getTaskWithNoBaseVersion]}>
-        <PreviousCommits taskId="t3" />
-      </MockedProvider>
-    ));
-    await waitFor(() => {
-      expect(getByText("Go").closest("a")).toHaveAttribute(
-        "aria-disabled",
-        "true"
-      );
-    });
-    await waitFor(() => {
-      expect(getByText("Go to base commit").closest("button")).toHaveAttribute(
-        "aria-disabled",
-        "true"
-      );
-    });
-  });
-
-  const baseTaskId =
-    "evergreen_lint_lint_agent_f4fe4814088e13b8ef423a73d65a6e0a5579cf93_21_11_29_17_55_27";
-  const baseTaskHref = `/task/${baseTaskId}`;
-  const getTaskWithSuccessfulBase = {
-    request: {
-      query: GET_BASE_VERSION_AND_TASK,
-      variables: {
-        taskId: "t1",
-      },
-    },
-    result: {
-      data: {
-        task: {
-          id:
-            "evergreen_lint_lint_agent_patch_f4fe4814088e13b8ef423a73d65a6e0a5579cf93_61a8edf132f41750ab47bc72_21_12_02_16_01_54",
-          execution: 0,
-          displayName: "lint-agent",
-          buildVariant: "lint",
-          versionMetadata: {
-            baseVersion: {
-              id: "baseVersion",
-              order: 3676,
-              projectIdentifier: "evergreen",
-              __typename: "Version",
-            },
-            isPatch: true,
-            id: "versionMetadataId",
-            __typename: "Version",
-          },
-          baseTask: {
-            id: baseTaskId,
-            execution: 0,
-            status: "success",
-            __typename: "Task",
-          },
-          __typename: "Task",
-        },
-      },
-    },
-  };
-
-  const getTaskWithRunningBase = {
-    request: {
-      query: GET_BASE_VERSION_AND_TASK,
-      variables: {
-        taskId: "t3",
-      },
-    },
-    result: {
-      data: {
-        task: {
-          id:
-            "evergreen_lint_lint_agent_patch_f4fe4814088e13b8ef423a73d65a6e0a5579cf93_61a8edf132f41750ab47bc72_21_12_02_16_01_54",
-          execution: 0,
-          displayName: "lint-agent",
-          buildVariant: "lint",
-          versionMetadata: {
-            baseVersion: {
-              id: "baseVersion",
-              order: 3676,
-              projectIdentifier: "evergreen",
-              __typename: "Version",
-            },
-            isPatch: true,
-            id: "versionMetadataId",
-            __typename: "Version",
-          },
-          baseTask: {
-            id: baseTaskId,
-            execution: 0,
-            status: "started",
-            __typename: "Task",
-          },
-          __typename: "Task",
-        },
-      },
-    },
-  };
-
-  const getTaskWithFailingBase = {
-    request: {
-      query: GET_BASE_VERSION_AND_TASK,
-      variables: {
-        taskId: "t1",
-      },
-    },
-    result: {
-      data: {
-        task: {
-          id:
-            "evergreen_lint_lint_agent_patch_f4fe4814088e13b8ef423a73d65a6e0a5579cf93_61a8edf132f41750ab47bc72_21_12_02_16_01_54",
-          execution: 0,
-          displayName: "lint-agent",
-          buildVariant: "lint",
-          versionMetadata: {
-            baseVersion: {
-              id: "baseVersion",
-              order: 3676,
-              projectIdentifier: "evergreen",
-              __typename: "Version",
-            },
-            isPatch: true,
-            id: "versionMetadataId",
-            __typename: "Version",
-          },
-          baseTask: {
-            id: baseTaskId,
-            execution: 0,
-            status: "failed",
-            __typename: "Task",
-          },
-          __typename: "Task",
-        },
-      },
-    },
-  };
-
-  const getLastPassingVersion = {
-    request: {
-      query: GET_LAST_MAINLINE_COMMIT,
-      variables: {
-        projectIdentifier: "evergreen",
-        skipOrderNumber: 3676,
-        buildVariantOptions: {
-          tasks: ["^lint-agent$"],
-          variants: ["^lint$"],
-          statuses: ["success"],
-        },
-      },
-    },
-    result: {
-      data: {
-        mainlineCommits: {
-          versions: [
-            {
-              version: {
-                id: "evergreen_44110b57c6977bf3557009193628c9389772163f",
-                buildVariants: [
-                  {
-                    tasks: [
-                      {
-                        id: "last_passing_task",
-                        execution: 0,
-                        status: "success",
-                        __typename: "Task",
-                      },
-                    ],
-                    __typename: "GroupedBuildVariant",
-                  },
-                ],
-                __typename: "Version",
-              },
-              __typename: "MainlineCommitVersion",
-            },
-          ],
-          __typename: "MainlineCommits",
-        },
-      },
-    },
-  };
-
-  const getTaskWithNoBaseVersion = {
-    request: {
-      query: GET_BASE_VERSION_AND_TASK,
-      variables: {
-        taskId: "t3",
-      },
-    },
-    result: {
-      data: {
-        task: {
-          id:
-            "evergreen_lint_lint_agent_patch_f4fe4814088e13b8ef423a73d65a6e0a5579cf93_61a8edf132f41750ab47bc72_21_12_02_16_01_54",
-          execution: 0,
-          displayName: "lint-agent",
-          buildVariant: "lint",
-          versionMetadata: {
-            baseVersion: null,
-            id: "versionMetadataId",
-            isPatch: true,
-            __typename: "Version",
-          },
-          baseTask: null,
-          __typename: "Task",
-        },
-      },
-    },
-  };
-
-  const getLastExecutedVersion = {
-    request: {
-      query: GET_LAST_MAINLINE_COMMIT,
-      variables: {
-        projectIdentifier: "evergreen",
-        skipOrderNumber: 3676,
-        buildVariantOptions: {
-          tasks: ["^lint-agent$"],
-          variants: ["^lint$"],
-          statuses: [
-            "failed",
-            "setup-failed",
-            "system-failed",
-            "task-timed-out",
-            "test-timed-out",
-            "known-issue",
-            "system-unresponsive",
-            "system-timed-out",
-            "success",
-          ],
-        },
-      },
-    },
-    result: {
-      data: {
-        mainlineCommits: {
-          versions: [
-            {
-              version: {
-                id: "evergreen_44110b57c6977bf3557009193628c9389772163f",
-                buildVariants: [
-                  {
-                    tasks: [
-                      {
-                        id: "last_executed_task",
-                        execution: 0,
-                        status: "failed",
-                        __typename: "Task",
-                      },
-                    ],
-                    __typename: "GroupedBuildVariant",
-                  },
-                ],
-                __typename: "Version",
-              },
-              __typename: "MainlineCommitVersion",
-            },
-          ],
-          __typename: "MainlineCommits",
-        },
-      },
-    },
-  };
 });
+
+const baseTaskId =
+  "evergreen_lint_lint_agent_f4fe4814088e13b8ef423a73d65a6e0a5579cf93_21_11_29_17_55_27";
+const baseTaskHref = `/task/${baseTaskId}`;
+
+const getPatchTaskWithSuccessfulBaseTask = {
+  request: {
+    query: GET_BASE_VERSION_AND_TASK,
+    variables: {
+      taskId: "t1",
+    },
+  },
+  result: {
+    data: {
+      task: {
+        id:
+          "evergreen_lint_lint_agent_patch_f4fe4814088e13b8ef423a73d65a6e0a5579cf93_61a8edf132f41750ab47bc72_21_12_02_16_01_54",
+        execution: 0,
+        displayName: "lint-agent",
+        buildVariant: "lint",
+        versionMetadata: {
+          baseVersion: {
+            id: "baseVersion",
+            order: 3676,
+            projectIdentifier: "evergreen",
+            __typename: "Version",
+          },
+          isPatch: true,
+          id: "versionMetadataId",
+          __typename: "Version",
+        },
+        baseTask: {
+          id: baseTaskId,
+          execution: 0,
+          status: "success",
+          __typename: "Task",
+        },
+        __typename: "Task",
+      },
+    },
+  },
+};
+
+const getPatchTaskWithRunningBaseTask = {
+  request: {
+    query: GET_BASE_VERSION_AND_TASK,
+    variables: {
+      taskId: "t3",
+    },
+  },
+  result: {
+    data: {
+      task: {
+        id:
+          "evergreen_lint_lint_agent_patch_f4fe4814088e13b8ef423a73d65a6e0a5579cf93_61a8edf132f41750ab47bc72_21_12_02_16_01_54",
+        execution: 0,
+        displayName: "lint-agent",
+        buildVariant: "lint",
+        versionMetadata: {
+          baseVersion: {
+            id: "baseVersion",
+            order: 3676,
+            projectIdentifier: "evergreen",
+            __typename: "Version",
+          },
+          isPatch: true,
+          id: "versionMetadataId",
+          __typename: "Version",
+        },
+        baseTask: {
+          id: baseTaskId,
+          execution: 0,
+          status: "started",
+          __typename: "Task",
+        },
+        __typename: "Task",
+      },
+    },
+  },
+};
+
+const getPatchTaskWithFailingBaseTask = {
+  request: {
+    query: GET_BASE_VERSION_AND_TASK,
+    variables: {
+      taskId: "t1",
+    },
+  },
+  result: {
+    data: {
+      task: {
+        id:
+          "evergreen_lint_lint_agent_patch_f4fe4814088e13b8ef423a73d65a6e0a5579cf93_61a8edf132f41750ab47bc72_21_12_02_16_01_54",
+        execution: 0,
+        displayName: "lint-agent",
+        buildVariant: "lint",
+        versionMetadata: {
+          baseVersion: {
+            id: "baseVersion",
+            order: 3676,
+            projectIdentifier: "evergreen",
+            __typename: "Version",
+          },
+          isPatch: true,
+          id: "versionMetadataId",
+          __typename: "Version",
+        },
+        baseTask: {
+          id: baseTaskId,
+          execution: 0,
+          status: "failed",
+          __typename: "Task",
+        },
+        __typename: "Task",
+      },
+    },
+  },
+};
+
+const getPatchTaskWithNoBaseVersion = {
+  request: {
+    query: GET_BASE_VERSION_AND_TASK,
+    variables: {
+      taskId: "t3",
+    },
+  },
+  result: {
+    data: {
+      task: {
+        id:
+          "evergreen_lint_lint_agent_patch_f4fe4814088e13b8ef423a73d65a6e0a5579cf93_61a8edf132f41750ab47bc72_21_12_02_16_01_54",
+        execution: 0,
+        displayName: "lint-agent",
+        buildVariant: "lint",
+        versionMetadata: {
+          baseVersion: null,
+          id: "versionMetadataId",
+          isPatch: true,
+          __typename: "Version",
+        },
+        baseTask: null,
+        __typename: "Task",
+      },
+    },
+  },
+};
+
+const getLastPassingVersion = {
+  request: {
+    query: GET_LAST_MAINLINE_COMMIT,
+    variables: {
+      projectIdentifier: "evergreen",
+      skipOrderNumber: 3676,
+      buildVariantOptions: {
+        tasks: ["^lint-agent$"],
+        variants: ["^lint$"],
+        statuses: ["success"],
+      },
+    },
+  },
+  result: {
+    data: {
+      mainlineCommits: {
+        versions: [
+          {
+            version: {
+              id: "evergreen_44110b57c6977bf3557009193628c9389772163f",
+              buildVariants: [
+                {
+                  tasks: [
+                    {
+                      id: "last_passing_task",
+                      execution: 0,
+                      status: "success",
+                      __typename: "Task",
+                    },
+                  ],
+                  __typename: "GroupedBuildVariant",
+                },
+              ],
+              __typename: "Version",
+            },
+            __typename: "MainlineCommitVersion",
+          },
+        ],
+        __typename: "MainlineCommits",
+      },
+    },
+  },
+};
+
+const getLastExecutedVersion = {
+  request: {
+    query: GET_LAST_MAINLINE_COMMIT,
+    variables: {
+      projectIdentifier: "evergreen",
+      skipOrderNumber: 3676,
+      buildVariantOptions: {
+        tasks: ["^lint-agent$"],
+        variants: ["^lint$"],
+        statuses: [
+          "failed",
+          "setup-failed",
+          "system-failed",
+          "task-timed-out",
+          "test-timed-out",
+          "known-issue",
+          "system-unresponsive",
+          "system-timed-out",
+          "success",
+        ],
+      },
+    },
+  },
+  result: {
+    data: {
+      mainlineCommits: {
+        versions: [
+          {
+            version: {
+              id: "evergreen_44110b57c6977bf3557009193628c9389772163f",
+              buildVariants: [
+                {
+                  tasks: [
+                    {
+                      id: "last_executed_task",
+                      execution: 0,
+                      status: "failed",
+                      __typename: "Task",
+                    },
+                  ],
+                  __typename: "GroupedBuildVariant",
+                },
+              ],
+              __typename: "Version",
+            },
+            __typename: "MainlineCommitVersion",
+          },
+        ],
+        __typename: "MainlineCommits",
+      },
+    },
+  },
+};
+
+// patch specific
+const getPatchTaskWithNoBaseTask = {
+  request: {
+    query: GET_BASE_VERSION_AND_TASK,
+    variables: {
+      taskId: "t1",
+    },
+  },
+  result: {
+    data: {
+      task: {
+        id:
+          "evergreen_lint_lint_agent_patch_f4fe4814088e13b8ef423a73d65a6e0a5579cf93_61a8edf132f41750ab47bc72_21_12_02_16_01_54",
+        execution: 0,
+        displayName: "lint-agent",
+        buildVariant: "lint",
+        versionMetadata: {
+          baseVersion: {
+            id: "baseVersion",
+            order: 3676,
+            projectIdentifier: "evergreen",
+            __typename: "Version",
+          },
+          isPatch: true,
+          id: "versionMetadataId",
+          __typename: "Version",
+        },
+        baseTask: null,
+        __typename: "Task",
+      },
+    },
+  },
+};
+
+// Mainline commits specific
+const getMainlineTaskWithBaseVersion = {
+  request: {
+    query: GET_BASE_VERSION_AND_TASK,
+    variables: {
+      taskId: "t4",
+    },
+  },
+  result: {
+    data: {
+      task: {
+        id:
+          "evergreen_lint_lint_agent_patch_f4fe4814088e13b8ef423a73d65a6e0a5579cf93_61a8edf132f41750ab47bc72_21_12_02_16_01_54",
+        execution: 0,
+        displayName: "lint-agent",
+        buildVariant: "lint",
+        versionMetadata: {
+          baseVersion: {
+            id: "baseVersion",
+            order: 3676,
+            projectIdentifier: "evergreen",
+            __typename: "Version",
+          },
+          isPatch: false,
+          id: "versionMetadataId",
+          __typename: "Version",
+        },
+        baseTask: null,
+        __typename: "Task",
+      },
+    },
+  },
+};
+
+const getNullParentTask = {
+  request: {
+    query: GET_LAST_MAINLINE_COMMIT,
+    variables: {
+      projectIdentifier: "evergreen",
+      skipOrderNumber: 3676,
+      buildVariantOptions: {
+        tasks: ["^lint-agent$"],
+        variants: ["^lint$"],
+        statuses: ["success"],
+      },
+    },
+  },
+  error: new Error("Matching version not found in 300 most recent versions"),
+};
+
+const getParentTaskWithError = {
+  request: {
+    query: GET_LAST_MAINLINE_COMMIT,
+    variables: {
+      projectIdentifier: "evergreen",
+      skipOrderNumber: 3676,
+      buildVariantOptions: {
+        tasks: ["^lint-agent$"],
+        variants: ["^lint$"],
+        statuses: ["success"],
+      },
+    },
+  },
+  error: new Error("Matching version not found in 300 most recent versions"),
+};

--- a/src/pages/task/actionButtons/PreviousCommits.tsx
+++ b/src/pages/task/actionButtons/PreviousCommits.tsx
@@ -147,7 +147,7 @@ export const PreviousCommits: React.FC<PreviousCommitsProps> = ({ taskId }) => {
     }
   }, [shouldFetchLastExecuted]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  return versionMetadata?.isPatch !== undefined ? (
+  return (
     <PreviousCommitsWrapper>
       <StyledSelect
         size="small"
@@ -158,10 +158,10 @@ export const PreviousCommits: React.FC<PreviousCommitsProps> = ({ taskId }) => {
           dispatch({ type: "setSelectState", selectState: v })
         }
         value={selectState}
-        disabled={!versionMetadata.baseVersion}
+        disabled={!versionMetadata?.baseVersion}
       >
         <Option value={CommitType.Base}>
-          Go to {versionMetadata.isPatch ? "base commit" : "parent commit"}
+          Go to {versionMetadata?.isPatch ? "base commit" : "parent commit"}
         </Option>
         <Option value={CommitType.LastPassing}>
           Go to last passing version
@@ -193,7 +193,7 @@ export const PreviousCommits: React.FC<PreviousCommitsProps> = ({ taskId }) => {
         </div>
       </ConditionalWrapper>
     </PreviousCommitsWrapper>
-  ) : null;
+  );
 };
 
 // The return value from GetLastMainlineCommitQuery has a lot of nested fields that may or may

--- a/src/pages/task/actionButtons/PreviousCommits.tsx
+++ b/src/pages/task/actionButtons/PreviousCommits.tsx
@@ -50,7 +50,7 @@ export const PreviousCommits: React.FC<PreviousCommitsProps> = ({ taskId }) => {
     variables: { taskId },
   });
 
-  const [fetchParentTask] = useLazyQuery<
+  const [fetchParentTask, { loading: parentLoading }] = useLazyQuery<
     GetLastMainlineCommitQuery,
     GetLastMainlineCommitQueryVariables
   >(GET_LAST_MAINLINE_COMMIT, {
@@ -62,7 +62,7 @@ export const PreviousCommits: React.FC<PreviousCommitsProps> = ({ taskId }) => {
     },
   });
 
-  const [fetchLastPassing] = useLazyQuery<
+  const [fetchLastPassing, { loading: passingLoading }] = useLazyQuery<
     GetLastMainlineCommitQuery,
     GetLastMainlineCommitQueryVariables
   >(GET_LAST_MAINLINE_COMMIT, {
@@ -74,7 +74,7 @@ export const PreviousCommits: React.FC<PreviousCommitsProps> = ({ taskId }) => {
     },
   });
 
-  const [fetchLastExecuted] = useLazyQuery<
+  const [fetchLastExecuted, { loading: executedLoading }] = useLazyQuery<
     GetLastMainlineCommitQuery,
     GetLastMainlineCommitQueryVariables
   >(GET_LAST_MAINLINE_COMMIT, {
@@ -94,6 +94,7 @@ export const PreviousCommits: React.FC<PreviousCommitsProps> = ({ taskId }) => {
     tasks: [applyStrictRegex(displayName)],
     variants: [applyStrictRegex(buildVariant)],
   };
+  const loading = parentLoading || passingLoading || executedLoading;
 
   // Hook to determine the parent task. If mainline commit, use fetchParentTask function to get task from
   // previous mainline commit. Otherwise, just extract the base task from the task data.
@@ -181,7 +182,9 @@ export const PreviousCommits: React.FC<PreviousCommitsProps> = ({ taskId }) => {
             trigger={children}
             darkMode
           >
-            There is no version that satisfies this criteria.
+            {loading
+              ? `Fetching...`
+              : `There is no version that satisfies this criteria.`}
           </Tooltip>
         )}
       >

--- a/src/pages/task/actionButtons/reducer.ts
+++ b/src/pages/task/actionButtons/reducer.ts
@@ -18,6 +18,9 @@ interface State {
   hasFetchedLastExecuted: boolean;
 }
 
+// a link cannot be null, so it's common to use # as a substitute.
+const nullLink = "#";
+
 // Note that the state doesn't include a field for shouldFetchParent / hasFetchedParent as the parent task
 // is always fetched on render.
 export const initialState: State = {
@@ -25,8 +28,8 @@ export const initialState: State = {
   lastPassingTask: null,
   lastExecutedTask: null,
   selectState: CommitType.Base,
-  disableButton: false,
-  link: "/",
+  disableButton: true,
+  link: nullLink,
   shouldFetchLastPassing: false,
   hasFetchedLastPassing: false,
   shouldFetchLastExecuted: false,
@@ -159,7 +162,7 @@ export const reducer = (state: State, action: Action): State => {
         selectState: newSelectState,
         link: newLink,
         disableButton:
-          newLink === "/" ||
+          newLink === nullLink ||
           lastPassingTaskDoesNotExist ||
           lastExecutedTaskDoesNotExist,
       };
@@ -219,5 +222,5 @@ const determineNewLink = (
         break;
     }
   }
-  return "/";
+  return nullLink;
 };

--- a/src/pages/task/actionButtons/reducer.ts
+++ b/src/pages/task/actionButtons/reducer.ts
@@ -118,6 +118,8 @@ export const reducer = (state: State, action: Action): State => {
             ...state,
             selectState: newSelectState,
             shouldFetchLastPassing: true,
+            link: nullLink,
+            disableButton: true,
           };
         }
       }
@@ -134,6 +136,8 @@ export const reducer = (state: State, action: Action): State => {
             ...state,
             selectState: newSelectState,
             shouldFetchLastExecuted: true,
+            link: nullLink,
+            disableButton: true,
           };
         }
       }


### PR DESCRIPTION
[EVG-16475](https://jira.mongodb.org/browse/EVG-16475)

### Description 
The Go button for the Previous Commits Selector is currently enabled by default, which is problematic because the user can click on it while a task is still being fetched. The task link is only correct after the task has been fetched, so the button should be disabled by default instead.

This PR also entirely removes the Previous Commits Selector on execution task pages.

### Screenshots
(First tab is task that doesn't exist on parent, second tab is task that exists on parent, and third tab is an execution task.)

https://user-images.githubusercontent.com/47064971/158634949-408c84b8-318f-4891-8205-35177d4fd18c.mov

### Testing 
- Added more tests in `PreviousCommits.test.tsx` for patch specific and mainline commits specific scenarios