### PR TITLE
EVG-16512: Improve form performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@leafygreen-ui/toggle": "7.0.4",
     "@leafygreen-ui/tooltip": "6.3.1",
     "@leafygreen-ui/typography": "8.1.0",
-    "@rjsf/core": "3.2.1",
+    "@rjsf/core": "4.1.0",
     "ansi_up": "5.0.0",
     "antd": "4.12.1",
     "axios": "0.21.2",

--- a/src/components/ProjectSettingsTabs/GeneralTab/Fields/RepoConfigField.tsx
+++ b/src/components/ProjectSettingsTabs/GeneralTab/Fields/RepoConfigField.tsx
@@ -259,16 +259,13 @@ const moveRepoForm = {
         minLength: 1,
       },
     },
-    required: ["owner", "repo"],
   },
   uiSchema: {
     owner: {
       "ui:data-cy": "new-owner-input",
-      "ui:showErrors": false,
     },
     repo: {
       "ui:data-cy": "new-repo-input",
-      "ui:showErrors": false,
     },
   },
 };

--- a/src/components/ProjectSettingsTabs/utils/alias.ts
+++ b/src/components/ProjectSettingsTabs/utils/alias.ts
@@ -197,7 +197,6 @@ const baseProps = {
     },
     uiSchema: {
       "ui:data-cy": "git-tag-input",
-      "ui:showErrors": false,
     },
   },
   remotePath: {
@@ -210,7 +209,6 @@ const baseProps = {
     uiSchema: {
       "ui:data-cy": "remote-path-input",
       "ui:sectionId": "remote-path-field",
-      "ui:showErrors": false,
     },
   },
   task: {
@@ -224,7 +222,6 @@ const baseProps = {
       "ui:data-cy": "task-input",
       "ui:placeholder": "Golang Regex",
       "ui:sectionId": "task-regex-field",
-      "ui:showErrors": false,
     },
   },
   taskTags: {
@@ -234,6 +231,7 @@ const baseProps = {
       items: {
         type: "string" as "string",
         title: "Task Tag",
+        default: "",
         minLength: 1,
       },
     },
@@ -247,7 +245,6 @@ const baseProps = {
       items: {
         "ui:ariaLabelledBy": "variant-input-control",
         "ui:data-cy": "task-tags-input",
-        "ui:showErrors": false,
       },
     },
   },
@@ -262,7 +259,6 @@ const baseProps = {
       "ui:data-cy": "variant-input",
       "ui:placeholder": "Golang Regex",
       "ui:sectionId": "variant-regex-field",
-      "ui:showErrors": false,
     },
   },
   variantTags: {
@@ -287,7 +283,6 @@ const baseProps = {
       items: {
         "ui:ariaLabelledBy": "variant-input-control",
         "ui:data-cy": "variant-tags-input",
-        "ui:showErrors": false,
       },
     },
   },

--- a/src/components/SpruceForm/LeafyGreenWidgets.tsx
+++ b/src/components/SpruceForm/LeafyGreenWidgets.tsx
@@ -35,16 +35,13 @@ export const LeafyGreenTextInput: React.FC<WidgetProps> = ({
     description,
     "data-cy": dataCy,
     emptyValue,
-    showErrors = true,
     optional,
   } = options;
   const hasError = !!rawErrors?.length;
-  const errorProps = showErrors
-    ? {
-        errorMessage: hasError ? rawErrors.join(", ") : null,
-        state: hasError ? "error" : "none",
-      }
-    : {};
+  const errorProps = {
+    errorMessage: hasError ? rawErrors.join(", ") : null,
+    state: hasError ? "error" : "none",
+  };
   const { readonlyAsDisabled = true } = formContext;
   return (
     <ElementWrapper>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3077,10 +3077,10 @@
     prop-types "^15.6.1"
     react-lifecycles-compat "^3.0.4"
 
-"@rjsf/core@3.2.1":
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/@rjsf/core/-/core-3.2.1.tgz#8a7b24c9a6f01f0ecb093fdfc777172c12b1b009"
-  integrity sha512-dk8ihvxFbcuIwU7G+HiJbFgwyIvaumPt5g5zfnuC26mwTUPlaDGFXKK2yITp8tJ3+hcwS5zEXtAN9wUkfuM4jA==
+"@rjsf/core@4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@rjsf/core/-/core-4.1.0.tgz#43714518b339b26f9a2b11223625069642cb3397"
+  integrity sha512-rLtBJzqqFUUYx3c0bycqBYiQePug9keKrwISAd6bZ5xghHNgbXGI8rMtDbwpYoF4sQPiPCO+zlfpUOusK5vsVw==
   dependencies:
     "@types/json-schema" "^7.0.7"
     ajv "^6.7.0"


### PR DESCRIPTION
EVG-16512

### Description 
- Update RJSF to improve project settings form performance, particularly on GitHub/Commit Queue page. This made such a difference that I didn't look into any other approaches, but we can revisit if things start to get sluggish again.
- Remove `showErrors` option for two reasons:
  1. The [`transformErrors` function](https://github.com/evergreen-ci/spruce/blob/000302e68d2106b7c6ebdae83789a5d2816a9e20/src/components/SpruceForm/errors.ts#L3) supresses all of the errors that needed this option  
  2. RJSF added a `hideError` option, so we should use the supported way if we need this in the future

### Testing 
- Manual testing