### PR TITLE
EVG-16208: Update GraphQL Schema

### DIFF
--- a/src/components/ProjectSettingsTabs/GithubCommitQueueTab/GithubCommitQueueTab.tsx
+++ b/src/components/ProjectSettingsTabs/GithubCommitQueueTab/GithubCommitQueueTab.tsx
@@ -26,7 +26,7 @@ const getInitialFormState = (
 };
 
 export const GithubCommitQueueTab: React.FC<TabProps> = ({
-  gitHubWebhooksEnabled,
+  githubWebhooksEnabled,
   projectData,
   projectType,
   repoData,
@@ -48,18 +48,18 @@ export const GithubCommitQueueTab: React.FC<TabProps> = ({
       getFormSchema(
         identifier,
         projectType,
-        gitHubWebhooksEnabled,
+        githubWebhooksEnabled,
         formData,
         projectType === ProjectType.AttachedProject ? repoData : null
       ),
-    [formData, gitHubWebhooksEnabled, identifier, projectType, repoData]
+    [formData, githubWebhooksEnabled, identifier, projectType, repoData]
   );
 
   if (!formData) return null;
 
   return (
     <>
-      {!gitHubWebhooksEnabled && (
+      {!githubWebhooksEnabled && (
         <Banner data-cy="disabled-webhook-banner" variant="warning">
           GitHub features are disabled because webhooks are not enabled.
           Webhooks are enabled after saving with a repository and branch.
@@ -71,7 +71,7 @@ export const GithubCommitQueueTab: React.FC<TabProps> = ({
         onChange={onChange}
         schema={schema}
         uiSchema={uiSchema}
-        disabled={isProduction() && !gitHubWebhooksEnabled} // TODO: Remove once EVG-16208 is fixed
+        disabled={isProduction() && !githubWebhooksEnabled} // TODO: Remove once EVG-16208 is fixed
       />
     </>
   );

--- a/src/components/ProjectSettingsTabs/GithubCommitQueueTab/getFormSchema.tsx
+++ b/src/components/ProjectSettingsTabs/GithubCommitQueueTab/getFormSchema.tsx
@@ -19,7 +19,7 @@ const { insertIf, overrideRadioBox, placeholderIf, radioBoxOptions } = form;
 export const getFormSchema = (
   identifier: string,
   projectType: ProjectType,
-  gitHubWebhooksEnabled: boolean,
+  githubWebhooksEnabled: boolean,
   formData: FormState,
   repoData?: FormState
 ): {
@@ -46,11 +46,11 @@ export const getFormSchema = (
           type: "object" as "object",
           title: "GitHub",
           properties: {
-            gitHubWebhooksEnabled: {
+            githubWebhooksEnabled: {
               type: "null",
               title: "GitHub Webhooks",
               description: `GitHub webhooks ${
-                gitHubWebhooksEnabled ? "are" : "are not"
+                githubWebhooksEnabled ? "are" : "are not"
               } enabled.`,
             },
             prTestingEnabledTitle: {

--- a/src/components/ProjectSettingsTabs/GithubCommitQueueTab/types.ts
+++ b/src/components/ProjectSettingsTabs/GithubCommitQueueTab/types.ts
@@ -65,7 +65,7 @@ export interface FormState {
 }
 
 export type TabProps = {
-  gitHubWebhooksEnabled: boolean;
+  githubWebhooksEnabled: boolean;
   projectData?: FormState;
   projectType: ProjectType;
   repoData?: FormState;

--- a/src/components/ProjectSettingsTabs/testData.ts
+++ b/src/components/ProjectSettingsTabs/testData.ts
@@ -1,7 +1,7 @@
 import { ProjectSettingsQuery, RepoSettingsQuery } from "gql/generated/types";
 
 const projectBase: ProjectSettingsQuery["projectSettings"] = {
-  gitHubWebhooksEnabled: true,
+  githubWebhooksEnabled: true,
 
   projectRef: {
     id: "project",
@@ -108,7 +108,7 @@ const projectBase: ProjectSettingsQuery["projectSettings"] = {
 };
 
 const repoBase: RepoSettingsQuery["repoSettings"] = {
-  gitHubWebhooksEnabled: true,
+  githubWebhooksEnabled: true,
 
   projectRef: {
     id: "123",

--- a/src/gql/fragments/projectSettings/githubCommitQueue.graphql
+++ b/src/gql/fragments/projectSettings/githubCommitQueue.graphql
@@ -1,5 +1,5 @@
 fragment projectGithubCommitQueue on ProjectSettings {
-  gitHubWebhooksEnabled
+  githubWebhooksEnabled
 
   projectRef {
     prTestingEnabled
@@ -18,7 +18,7 @@ fragment projectGithubCommitQueue on ProjectSettings {
 }
 
 fragment repoGithubCommitQueue on RepoSettings {
-  gitHubWebhooksEnabled
+  githubWebhooksEnabled
 
   projectRef {
     prTestingEnabled

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -1482,7 +1482,7 @@ export type GithubProjectConflicts = {
 };
 
 export type ProjectSettings = {
-  gitHubWebhooksEnabled: Scalars["Boolean"];
+  githubWebhooksEnabled: Scalars["Boolean"];
   projectRef?: Maybe<Project>;
   vars?: Maybe<ProjectVars>;
   aliases?: Maybe<Array<ProjectAlias>>;
@@ -1490,7 +1490,7 @@ export type ProjectSettings = {
 };
 
 export type RepoSettings = {
-  gitHubWebhooksEnabled: Scalars["Boolean"];
+  githubWebhooksEnabled: Scalars["Boolean"];
   projectRef?: Maybe<RepoRef>;
   vars?: Maybe<ProjectVars>;
   aliases?: Maybe<Array<ProjectAlias>>;
@@ -2285,7 +2285,7 @@ export type RepoGeneralSettingsFragment = {
 };
 
 export type ProjectGithubCommitQueueFragment = {
-  gitHubWebhooksEnabled: boolean;
+  githubWebhooksEnabled: boolean;
   projectRef?: Maybe<{
     prTestingEnabled?: Maybe<boolean>;
     githubChecksEnabled?: Maybe<boolean>;
@@ -2303,7 +2303,7 @@ export type ProjectGithubCommitQueueFragment = {
 };
 
 export type RepoGithubCommitQueueFragment = {
-  gitHubWebhooksEnabled: boolean;
+  githubWebhooksEnabled: boolean;
   projectRef?: Maybe<{
     prTestingEnabled: boolean;
     githubChecksEnabled: boolean;

--- a/src/pages/projectSettings/Tabs.tsx
+++ b/src/pages/projectSettings/Tabs.tsx
@@ -113,9 +113,9 @@ export const ProjectSettingsTabs: React.FC<Props> = ({
         render={(props) => (
           <GithubCommitQueueTab
             {...props}
-            gitHubWebhooksEnabled={
-              projectData?.gitHubWebhooksEnabled ||
-              repoData?.gitHubWebhooksEnabled
+            githubWebhooksEnabled={
+              projectData?.githubWebhooksEnabled ||
+              repoData?.githubWebhooksEnabled
             }
             projectData={
               tabData[ProjectSettingsTabRoutes.GithubCommitQueue].projectData


### PR DESCRIPTION
Addresses changes made in EVG-16208

### Description 
- https://github.com/evergreen-ci/evergreen/pull/5495 renamed `gitHubWebhooksEnabled` to `githubWebhooksEnabled`. Reflect these changes which should fix broken e2e tests

### Evergreen PR 
https://github.com/evergreen-ci/evergreen/pull/5495