### PR TITLE
EVG-16574 Show previous version in version metadata

### DIFF
--- a/src/analytics/version/useVersionAnalytics.ts
+++ b/src/analytics/version/useVersionAnalytics.ts
@@ -46,6 +46,7 @@ type Action =
     }
   | { name: "Toggle Display Task Dropdown"; expanded: boolean }
   | { name: "Click Base Commit Link" }
+  | { name: "Click Previous Version Link" }
   | { name: "Open Schedule Tasks Modal" };
 
 interface V extends Properties {

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -550,6 +550,7 @@ export type Version = {
   /** @deprecated baseVersionId is deprecated, use baseVersion.id instead */
   baseVersionID?: Maybe<Scalars["String"]>;
   baseVersion?: Maybe<Version>;
+  previousVersion?: Maybe<Version>;
   versionTiming?: Maybe<VersionTiming>;
   parameters: Array<Parameter>;
   taskStatuses: Array<Scalars["String"]>;
@@ -4025,8 +4026,8 @@ export type VersionQuery = {
     message: string;
     isPatch: boolean;
     taskCount?: Maybe<number>;
-    baseVersionID?: Maybe<string>;
     projectIdentifier: string;
+    baseVersion?: Maybe<{ id: string }>;
     versionTiming?: Maybe<{
       makespan?: Maybe<number>;
       timeTaken?: Maybe<number>;
@@ -4041,6 +4042,7 @@ export type VersionQuery = {
       moduleOverrides?: Maybe<{ [key: string]: any }>;
       modules?: Maybe<any>;
     }>;
+    previousVersion?: Maybe<{ id: string; revision: string }>;
     patch?: Maybe<{
       id: string;
       patchNumber: number;

--- a/src/gql/queries/get-version.graphql
+++ b/src/gql/queries/get-version.graphql
@@ -15,7 +15,9 @@ query Version($id: String!) {
     isPatch
     taskCount
     project
-    baseVersionID
+    baseVersion {
+      id
+    }
     projectIdentifier
     versionTiming {
       makespan
@@ -33,6 +35,10 @@ query Version($id: String!) {
       isBase
       moduleOverrides
       modules
+    }
+    previousVersion {
+      id
+      revision
     }
     patch {
       id

--- a/src/pages/version/Metadata.tsx
+++ b/src/pages/version/Metadata.tsx
@@ -63,7 +63,7 @@ export const Metadata: React.FC<Props> = ({ loading, version }) => {
           Base commit:{" "}
           <StyledRouterLink
             data-cy="patch-base-commit"
-            to={getVersionRoute(baseVersion.id)}
+            to={getVersionRoute(baseVersion?.id)}
             onClick={() => sendEvent({ name: "Click Base Commit Link" })}
           >
             {revision.slice(0, 10)}


### PR DESCRIPTION
[EVG-16574](https://jira.mongodb.org/browse/EVG-16574)

### Description 
Show previous commit instead of base commit for mainline commits.
These changes will be reflected in the table and the version metadata.
### Screenshots
![image](https://user-images.githubusercontent.com/4605522/160177854-362bfe47-040f-43cf-85a3-481f41040b33.png)
<img width="1413" alt="image" src="https://user-images.githubusercontent.com/4605522/160178086-a52b3d10-fb4f-4a32-9a31-9f4b719cd42e.png">

### Testing 
Spruce tests with evergreen pr changes on top 
https://spruce.mongodb.com/version/623e053f2fbabe3b63973ad3/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC
### Evergreen PR 
https://github.com/evergreen-ci/evergreen/pull/5523