### PR TITLE
EVG-16626 Only call getRepoId if on project settings page

### DIFF
--- a/src/components/projectSelect/index.tsx
+++ b/src/components/projectSelect/index.tsx
@@ -110,7 +110,9 @@ export const ProjectSelect: React.FC<ProjectSelectProps> = ({
           projects={projectGroup.projects}
           name={projectGroup.name}
           onClick={onClick}
-          repoIdentifier={getRepoId(projectGroup.projects)}
+          repoIdentifier={
+            isProjectSettingsPage && getRepoId(projectGroup.projects)
+          }
           canClickOnRepoGroup={
             isProjectSettingsPage && getRepoId(projectGroup.projects) !== ""
           }


### PR DESCRIPTION
[EVG-16626](https://jira.mongodb.org/browse/EVG-16626)

### Description 
This error was pretty noisy during local development on the commits page. It should be suppressed on non project settings pages. 
### Screenshots
![image](https://user-images.githubusercontent.com/4605522/160182358-58358e52-7c78-4ab1-88f0-dc1f10136379.png)

