### PR TITLE
EVG-16545: Highlight matching task icons on Project Health page

### DIFF
--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -550,6 +550,7 @@ export type Version = {
   /** @deprecated baseVersionId is deprecated, use baseVersion.id instead */
   baseVersionID?: Maybe<Scalars["String"]>;
   baseVersion?: Maybe<Version>;
+  previousVersion?: Maybe<Version>;
   versionTiming?: Maybe<VersionTiming>;
   parameters: Array<Parameter>;
   taskStatuses: Array<Scalars["String"]>;

--- a/src/pages/Commits.tsx
+++ b/src/pages/Commits.tsx
@@ -21,6 +21,7 @@ import {
 } from "gql/generated/types";
 import { GET_MAINLINE_COMMITS, GET_SPRUCE_CONFIG } from "gql/queries";
 import { usePageTitle, usePolling } from "hooks";
+import { CommitsProvider } from "pages/commits/CommitsContext";
 import { ProjectFilterOptions, MainlineCommitQueryParams } from "types/commits";
 import { array, queryString } from "utils";
 import { CommitsWrapper } from "./commits/CommitsWrapper";
@@ -140,13 +141,15 @@ export const Commits = () => {
             nextPageOrderNumber={nextPageOrderNumber}
           />
         </PaginationWrapper>
-        <CommitsWrapper
-          versions={versions}
-          error={error}
-          isLoading={loading || !projectId}
-          hasTaskFilter={hasTasks}
-          hasFilters={hasFilters}
-        />
+        <CommitsProvider>
+          <CommitsWrapper
+            versions={versions}
+            error={error}
+            isLoading={loading || !projectId}
+            hasTaskFilter={hasTasks}
+            hasFilters={hasFilters}
+          />
+        </CommitsProvider>
       </PageContainer>
     </PageWrapper>
   );

--- a/src/pages/commits/ActiveCommits/BuildVariantCard.tsx
+++ b/src/pages/commits/ActiveCommits/BuildVariantCard.tsx
@@ -42,7 +42,7 @@ export const BuildVariantCard: React.FC<Props> = ({
           variant={variant}
         />
       )}
-      {tasks && <RenderTaskIcons tasks={tasks} />}
+      {tasks && <RenderTaskIcons tasks={tasks} variant={variant} />}
     </>
   );
   return (
@@ -62,9 +62,10 @@ export const BuildVariantCard: React.FC<Props> = ({
 
 interface RenderTaskIconsProps {
   tasks: taskList;
+  variant: string;
 }
 
-const RenderTaskIcons: React.FC<RenderTaskIconsProps> = ({ tasks }) =>
+const RenderTaskIcons: React.FC<RenderTaskIconsProps> = ({ tasks, variant }) =>
   tasks.length ? (
     <IconContainer>
       {tasks.map(({ id, status, displayName, timeTaken }) => (
@@ -74,6 +75,7 @@ const RenderTaskIcons: React.FC<RenderTaskIconsProps> = ({ tasks }) =>
           status={status}
           displayName={displayName}
           timeTaken={timeTaken}
+          identifier={variant.concat(displayName)}
         />
       ))}
     </IconContainer>

--- a/src/pages/commits/ActiveCommits/BuildVariantCard.tsx
+++ b/src/pages/commits/ActiveCommits/BuildVariantCard.tsx
@@ -75,7 +75,7 @@ const RenderTaskIcons: React.FC<RenderTaskIconsProps> = ({ tasks, variant }) =>
           status={status}
           displayName={displayName}
           timeTaken={timeTaken}
-          identifier={variant.concat(displayName)}
+          identifier={variant.concat(`-${displayName}`)}
         />
       ))}
     </IconContainer>

--- a/src/pages/commits/ActiveCommits/ProjectHealth.stories.tsx
+++ b/src/pages/commits/ActiveCommits/ProjectHealth.stories.tsx
@@ -1,12 +1,22 @@
 import { withKnobs, boolean, number } from "@storybook/addon-knobs";
-import StoryRouter from "storybook-react-router";
+import { MemoryRouter } from "react-router-dom";
 import { CommitVersion, Commit } from "types/commits";
 import { TaskStatus } from "types/task";
+import { CommitsProvider } from "../CommitsContext";
 import { CommitsWrapper } from "../CommitsWrapper";
 
 export default {
   title: "Project Health Page",
-  decorators: [StoryRouter(), withKnobs],
+  decorators: [
+    (Story) => (
+      <MemoryRouter>
+        <CommitsProvider>
+          <Story />
+        </CommitsProvider>
+      </MemoryRouter>
+    ),
+    withKnobs,
+  ],
   component: CommitsWrapper,
 };
 

--- a/src/pages/commits/ActiveCommits/__snapshots__/ProjectHealth.stories.storyshot
+++ b/src/pages/commits/ActiveCommits/__snapshots__/ProjectHealth.stories.storyshot
@@ -635,9 +635,8 @@ exports[`storybook Storyshots Project Health Page Actual Waterfall Page 1`] = `
             className="css-100ar08-IconContainer ek3nkvx1"
           >
             <a
-              aria-disabled={false}
               aria-label="pending icon"
-              className="leafygreen-ui-12hedrr"
+              className="leafygreen-ui-cssveg css-1a4l4zc-StyledRouterLink-linkStyles-IconWrapper enafhlo1"
               data-cy="waterfall-task-status-icon"
               href="/task/code_health"
               onBlur={[Function]}
@@ -645,30 +644,25 @@ exports[`storybook Storyshots Project Health Page Actual Waterfall Page 1`] = `
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              onMouseOver={[Function]}
-              tabIndex={0}
             >
-              <div
-                className="leafygreen-ui-xhlipt"
+              <svg
+                aria-label="Calendar Icon"
+                className="leafygreen-ui-foqtcf css-5k80id-StyledTaskStatusIcon enafhlo0"
+                fill="none"
+                height={16}
+                highlight={true}
+                role="img"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  aria-label="Calendar Icon"
-                  className="leafygreen-ui-foqtcf"
-                  fill="none"
-                  height={16}
-                  role="img"
-                  viewBox="0 0 16 16"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clipRule="evenodd"
-                    d="M5 2a1 1 0 012 0v1a1 1 0 01-2 0V2zm5 1H8a2 2 0 11-4 0 2 2 0 00-2 2v7a2 2 0 002 2h10a2 2 0 002-2V5a2 2 0 00-2-2 2 2 0 11-4 0zm1 0a1 1 0 102 0V2a1 1 0 10-2 0v1zm2 4h-3v3h3V7z"
-                    fill="currentColor"
-                    fillRule="evenodd"
-                  />
-                </svg>
-              </div>
+                <path
+                  clipRule="evenodd"
+                  d="M5 2a1 1 0 012 0v1a1 1 0 01-2 0V2zm5 1H8a2 2 0 11-4 0 2 2 0 00-2 2v7a2 2 0 002 2h10a2 2 0 002-2V5a2 2 0 00-2-2 2 2 0 11-4 0zm1 0a1 1 0 102 0V2a1 1 0 10-2 0v1zm2 4h-3v3h3V7z"
+                  fill="currentColor"
+                  fillRule="evenodd"
+                />
+              </svg>
             </a>
           </div>
         </div>
@@ -687,9 +681,8 @@ exports[`storybook Storyshots Project Health Page Actual Waterfall Page 1`] = `
             className="css-100ar08-IconContainer ek3nkvx1"
           >
             <a
-              aria-disabled={false}
               aria-label="will-run icon"
-              className="leafygreen-ui-12hedrr"
+              className="leafygreen-ui-cssveg css-1a4l4zc-StyledRouterLink-linkStyles-IconWrapper enafhlo1"
               data-cy="waterfall-task-status-icon"
               href="/task/code_health"
               onBlur={[Function]}
@@ -697,30 +690,25 @@ exports[`storybook Storyshots Project Health Page Actual Waterfall Page 1`] = `
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              onMouseOver={[Function]}
-              tabIndex={0}
             >
-              <div
-                className="leafygreen-ui-xhlipt"
+              <svg
+                aria-label="Calendar Icon"
+                className="leafygreen-ui-foqtcf css-5k80id-StyledTaskStatusIcon enafhlo0"
+                fill="none"
+                height={16}
+                highlight={true}
+                role="img"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  aria-label="Calendar Icon"
-                  className="leafygreen-ui-foqtcf"
-                  fill="none"
-                  height={16}
-                  role="img"
-                  viewBox="0 0 16 16"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clipRule="evenodd"
-                    d="M5 2a1 1 0 012 0v1a1 1 0 01-2 0V2zm5 1H8a2 2 0 11-4 0 2 2 0 00-2 2v7a2 2 0 002 2h10a2 2 0 002-2V5a2 2 0 00-2-2 2 2 0 11-4 0zm1 0a1 1 0 102 0V2a1 1 0 10-2 0v1zm2 4h-3v3h3V7z"
-                    fill="currentColor"
-                    fillRule="evenodd"
-                  />
-                </svg>
-              </div>
+                <path
+                  clipRule="evenodd"
+                  d="M5 2a1 1 0 012 0v1a1 1 0 01-2 0V2zm5 1H8a2 2 0 11-4 0 2 2 0 00-2 2v7a2 2 0 002 2h10a2 2 0 002-2V5a2 2 0 00-2-2 2 2 0 11-4 0zm1 0a1 1 0 102 0V2a1 1 0 10-2 0v1zm2 4h-3v3h3V7z"
+                  fill="currentColor"
+                  fillRule="evenodd"
+                />
+              </svg>
             </a>
           </div>
         </div>
@@ -748,9 +736,8 @@ exports[`storybook Storyshots Project Health Page Actual Waterfall Page 1`] = `
             className="css-100ar08-IconContainer ek3nkvx1"
           >
             <a
-              aria-disabled={false}
               aria-label="pending icon"
-              className="leafygreen-ui-12hedrr"
+              className="leafygreen-ui-cssveg css-1a4l4zc-StyledRouterLink-linkStyles-IconWrapper enafhlo1"
               data-cy="waterfall-task-status-icon"
               href="/task/code_health"
               onBlur={[Function]}
@@ -758,30 +745,25 @@ exports[`storybook Storyshots Project Health Page Actual Waterfall Page 1`] = `
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              onMouseOver={[Function]}
-              tabIndex={0}
             >
-              <div
-                className="leafygreen-ui-xhlipt"
+              <svg
+                aria-label="Calendar Icon"
+                className="leafygreen-ui-foqtcf css-5k80id-StyledTaskStatusIcon enafhlo0"
+                fill="none"
+                height={16}
+                highlight={true}
+                role="img"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  aria-label="Calendar Icon"
-                  className="leafygreen-ui-foqtcf"
-                  fill="none"
-                  height={16}
-                  role="img"
-                  viewBox="0 0 16 16"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clipRule="evenodd"
-                    d="M5 2a1 1 0 012 0v1a1 1 0 01-2 0V2zm5 1H8a2 2 0 11-4 0 2 2 0 00-2 2v7a2 2 0 002 2h10a2 2 0 002-2V5a2 2 0 00-2-2 2 2 0 11-4 0zm1 0a1 1 0 102 0V2a1 1 0 10-2 0v1zm2 4h-3v3h3V7z"
-                    fill="currentColor"
-                    fillRule="evenodd"
-                  />
-                </svg>
-              </div>
+                <path
+                  clipRule="evenodd"
+                  d="M5 2a1 1 0 012 0v1a1 1 0 01-2 0V2zm5 1H8a2 2 0 11-4 0 2 2 0 00-2 2v7a2 2 0 002 2h10a2 2 0 002-2V5a2 2 0 00-2-2 2 2 0 11-4 0zm1 0a1 1 0 102 0V2a1 1 0 10-2 0v1zm2 4h-3v3h3V7z"
+                  fill="currentColor"
+                  fillRule="evenodd"
+                />
+              </svg>
             </a>
           </div>
         </div>
@@ -800,9 +782,8 @@ exports[`storybook Storyshots Project Health Page Actual Waterfall Page 1`] = `
             className="css-100ar08-IconContainer ek3nkvx1"
           >
             <a
-              aria-disabled={false}
               aria-label="pending icon"
-              className="leafygreen-ui-12hedrr"
+              className="leafygreen-ui-cssveg css-1a4l4zc-StyledRouterLink-linkStyles-IconWrapper enafhlo1"
               data-cy="waterfall-task-status-icon"
               href="/task/code_health"
               onBlur={[Function]}
@@ -810,30 +791,25 @@ exports[`storybook Storyshots Project Health Page Actual Waterfall Page 1`] = `
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              onMouseOver={[Function]}
-              tabIndex={0}
             >
-              <div
-                className="leafygreen-ui-xhlipt"
+              <svg
+                aria-label="Calendar Icon"
+                className="leafygreen-ui-foqtcf css-5k80id-StyledTaskStatusIcon enafhlo0"
+                fill="none"
+                height={16}
+                highlight={true}
+                role="img"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  aria-label="Calendar Icon"
-                  className="leafygreen-ui-foqtcf"
-                  fill="none"
-                  height={16}
-                  role="img"
-                  viewBox="0 0 16 16"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clipRule="evenodd"
-                    d="M5 2a1 1 0 012 0v1a1 1 0 01-2 0V2zm5 1H8a2 2 0 11-4 0 2 2 0 00-2 2v7a2 2 0 002 2h10a2 2 0 002-2V5a2 2 0 00-2-2 2 2 0 11-4 0zm1 0a1 1 0 102 0V2a1 1 0 10-2 0v1zm2 4h-3v3h3V7z"
-                    fill="currentColor"
-                    fillRule="evenodd"
-                  />
-                </svg>
-              </div>
+                <path
+                  clipRule="evenodd"
+                  d="M5 2a1 1 0 012 0v1a1 1 0 01-2 0V2zm5 1H8a2 2 0 11-4 0 2 2 0 00-2 2v7a2 2 0 002 2h10a2 2 0 002-2V5a2 2 0 00-2-2 2 2 0 11-4 0zm1 0a1 1 0 102 0V2a1 1 0 10-2 0v1zm2 4h-3v3h3V7z"
+                  fill="currentColor"
+                  fillRule="evenodd"
+                />
+              </svg>
             </a>
           </div>
         </div>
@@ -865,9 +841,8 @@ exports[`storybook Storyshots Project Health Page Actual Waterfall Page 1`] = `
             className="css-100ar08-IconContainer ek3nkvx1"
           >
             <a
-              aria-disabled={false}
               aria-label="will-run icon"
-              className="leafygreen-ui-12hedrr"
+              className="leafygreen-ui-cssveg css-1a4l4zc-StyledRouterLink-linkStyles-IconWrapper enafhlo1"
               data-cy="waterfall-task-status-icon"
               href="/task/code_health"
               onBlur={[Function]}
@@ -875,30 +850,25 @@ exports[`storybook Storyshots Project Health Page Actual Waterfall Page 1`] = `
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              onMouseOver={[Function]}
-              tabIndex={0}
             >
-              <div
-                className="leafygreen-ui-xhlipt"
+              <svg
+                aria-label="Calendar Icon"
+                className="leafygreen-ui-foqtcf css-5k80id-StyledTaskStatusIcon enafhlo0"
+                fill="none"
+                height={16}
+                highlight={true}
+                role="img"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  aria-label="Calendar Icon"
-                  className="leafygreen-ui-foqtcf"
-                  fill="none"
-                  height={16}
-                  role="img"
-                  viewBox="0 0 16 16"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clipRule="evenodd"
-                    d="M5 2a1 1 0 012 0v1a1 1 0 01-2 0V2zm5 1H8a2 2 0 11-4 0 2 2 0 00-2 2v7a2 2 0 002 2h10a2 2 0 002-2V5a2 2 0 00-2-2 2 2 0 11-4 0zm1 0a1 1 0 102 0V2a1 1 0 10-2 0v1zm2 4h-3v3h3V7z"
-                    fill="currentColor"
-                    fillRule="evenodd"
-                  />
-                </svg>
-              </div>
+                <path
+                  clipRule="evenodd"
+                  d="M5 2a1 1 0 012 0v1a1 1 0 01-2 0V2zm5 1H8a2 2 0 11-4 0 2 2 0 00-2 2v7a2 2 0 002 2h10a2 2 0 002-2V5a2 2 0 00-2-2 2 2 0 11-4 0zm1 0a1 1 0 102 0V2a1 1 0 10-2 0v1zm2 4h-3v3h3V7z"
+                  fill="currentColor"
+                  fillRule="evenodd"
+                />
+              </svg>
             </a>
           </div>
         </div>
@@ -917,9 +887,8 @@ exports[`storybook Storyshots Project Health Page Actual Waterfall Page 1`] = `
             className="css-100ar08-IconContainer ek3nkvx1"
           >
             <a
-              aria-disabled={false}
               aria-label="pending icon"
-              className="leafygreen-ui-12hedrr"
+              className="leafygreen-ui-cssveg css-1a4l4zc-StyledRouterLink-linkStyles-IconWrapper enafhlo1"
               data-cy="waterfall-task-status-icon"
               href="/task/code_health"
               onBlur={[Function]}
@@ -927,30 +896,25 @@ exports[`storybook Storyshots Project Health Page Actual Waterfall Page 1`] = `
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              onMouseOver={[Function]}
-              tabIndex={0}
             >
-              <div
-                className="leafygreen-ui-xhlipt"
+              <svg
+                aria-label="Calendar Icon"
+                className="leafygreen-ui-foqtcf css-5k80id-StyledTaskStatusIcon enafhlo0"
+                fill="none"
+                height={16}
+                highlight={true}
+                role="img"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  aria-label="Calendar Icon"
-                  className="leafygreen-ui-foqtcf"
-                  fill="none"
-                  height={16}
-                  role="img"
-                  viewBox="0 0 16 16"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clipRule="evenodd"
-                    d="M5 2a1 1 0 012 0v1a1 1 0 01-2 0V2zm5 1H8a2 2 0 11-4 0 2 2 0 00-2 2v7a2 2 0 002 2h10a2 2 0 002-2V5a2 2 0 00-2-2 2 2 0 11-4 0zm1 0a1 1 0 102 0V2a1 1 0 10-2 0v1zm2 4h-3v3h3V7z"
-                    fill="currentColor"
-                    fillRule="evenodd"
-                  />
-                </svg>
-              </div>
+                <path
+                  clipRule="evenodd"
+                  d="M5 2a1 1 0 012 0v1a1 1 0 01-2 0V2zm5 1H8a2 2 0 11-4 0 2 2 0 00-2 2v7a2 2 0 002 2h10a2 2 0 002-2V5a2 2 0 00-2-2 2 2 0 11-4 0zm1 0a1 1 0 102 0V2a1 1 0 10-2 0v1zm2 4h-3v3h3V7z"
+                  fill="currentColor"
+                  fillRule="evenodd"
+                />
+              </svg>
             </a>
           </div>
         </div>
@@ -978,9 +942,8 @@ exports[`storybook Storyshots Project Health Page Actual Waterfall Page 1`] = `
             className="css-100ar08-IconContainer ek3nkvx1"
           >
             <a
-              aria-disabled={false}
               aria-label="will-run icon"
-              className="leafygreen-ui-12hedrr"
+              className="leafygreen-ui-cssveg css-1a4l4zc-StyledRouterLink-linkStyles-IconWrapper enafhlo1"
               data-cy="waterfall-task-status-icon"
               href="/task/code_health"
               onBlur={[Function]}
@@ -988,30 +951,25 @@ exports[`storybook Storyshots Project Health Page Actual Waterfall Page 1`] = `
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              onMouseOver={[Function]}
-              tabIndex={0}
             >
-              <div
-                className="leafygreen-ui-xhlipt"
+              <svg
+                aria-label="Calendar Icon"
+                className="leafygreen-ui-foqtcf css-5k80id-StyledTaskStatusIcon enafhlo0"
+                fill="none"
+                height={16}
+                highlight={true}
+                role="img"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  aria-label="Calendar Icon"
-                  className="leafygreen-ui-foqtcf"
-                  fill="none"
-                  height={16}
-                  role="img"
-                  viewBox="0 0 16 16"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clipRule="evenodd"
-                    d="M5 2a1 1 0 012 0v1a1 1 0 01-2 0V2zm5 1H8a2 2 0 11-4 0 2 2 0 00-2 2v7a2 2 0 002 2h10a2 2 0 002-2V5a2 2 0 00-2-2 2 2 0 11-4 0zm1 0a1 1 0 102 0V2a1 1 0 10-2 0v1zm2 4h-3v3h3V7z"
-                    fill="currentColor"
-                    fillRule="evenodd"
-                  />
-                </svg>
-              </div>
+                <path
+                  clipRule="evenodd"
+                  d="M5 2a1 1 0 012 0v1a1 1 0 01-2 0V2zm5 1H8a2 2 0 11-4 0 2 2 0 00-2 2v7a2 2 0 002 2h10a2 2 0 002-2V5a2 2 0 00-2-2 2 2 0 11-4 0zm1 0a1 1 0 102 0V2a1 1 0 10-2 0v1zm2 4h-3v3h3V7z"
+                  fill="currentColor"
+                  fillRule="evenodd"
+                />
+              </svg>
             </a>
           </div>
         </div>
@@ -1030,9 +988,8 @@ exports[`storybook Storyshots Project Health Page Actual Waterfall Page 1`] = `
             className="css-100ar08-IconContainer ek3nkvx1"
           >
             <a
-              aria-disabled={false}
               aria-label="success icon"
-              className="leafygreen-ui-12hedrr"
+              className="leafygreen-ui-cssveg css-1a4l4zc-StyledRouterLink-linkStyles-IconWrapper enafhlo1"
               data-cy="waterfall-task-status-icon"
               href="/task/code_health"
               onBlur={[Function]}
@@ -1040,30 +997,25 @@ exports[`storybook Storyshots Project Health Page Actual Waterfall Page 1`] = `
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              onMouseOver={[Function]}
-              tabIndex={0}
             >
-              <div
-                className="leafygreen-ui-xhlipt"
+              <svg
+                aria-label="Checkmark Icon"
+                className="leafygreen-ui-ifwzrn css-5k80id-StyledTaskStatusIcon enafhlo0"
+                fill="none"
+                height={16}
+                highlight={true}
+                role="img"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  aria-label="Checkmark Icon"
-                  className="leafygreen-ui-ifwzrn"
-                  fill="none"
-                  height={16}
-                  role="img"
-                  viewBox="0 0 16 16"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clipRule="evenodd"
-                    d="M6.306 9.05l5.455-5.455a1 1 0 011.414 0l.707.707a1 1 0 010 1.414l-7.067 7.068a1 1 0 01-1.5-.098l-3.049-3.97a1 1 0 01.184-1.402l.595-.457a1.25 1.25 0 011.753.23L6.306 9.05z"
-                    fill="currentColor"
-                    fillRule="evenodd"
-                  />
-                </svg>
-              </div>
+                <path
+                  clipRule="evenodd"
+                  d="M6.306 9.05l5.455-5.455a1 1 0 011.414 0l.707.707a1 1 0 010 1.414l-7.067 7.068a1 1 0 01-1.5-.098l-3.049-3.97a1 1 0 01.184-1.402l.595-.457a1.25 1.25 0 011.753.23L6.306 9.05z"
+                  fill="currentColor"
+                  fillRule="evenodd"
+                />
+              </svg>
             </a>
           </div>
         </div>
@@ -1091,9 +1043,8 @@ exports[`storybook Storyshots Project Health Page Actual Waterfall Page 1`] = `
             className="css-100ar08-IconContainer ek3nkvx1"
           >
             <a
-              aria-disabled={false}
               aria-label="failed icon"
-              className="leafygreen-ui-12hedrr"
+              className="leafygreen-ui-cssveg css-1a4l4zc-StyledRouterLink-linkStyles-IconWrapper enafhlo1"
               data-cy="waterfall-task-status-icon"
               href="/task/code_health"
               onBlur={[Function]}
@@ -1101,25 +1052,20 @@ exports[`storybook Storyshots Project Health Page Actual Waterfall Page 1`] = `
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              onMouseOver={[Function]}
-              tabIndex={0}
             >
-              <div
-                className="leafygreen-ui-xhlipt"
+              <svg
+                aria-label="Failure Icon"
+                className="css-5k80id-StyledTaskStatusIcon enafhlo0"
+                fill="currentColor"
+                height={16}
+                viewBox="0 0 21 21"
+                width={16}
               >
-                <svg
-                  aria-label="Failure Icon"
-                  fill="currentColor"
-                  height={16}
-                  viewBox="0 0 21 21"
-                  width={16}
-                >
-                  <path
-                    d="M17.7783.807588c-.7811-.7810482-2.0474-.7810486-2.8285 0L10.0001 5.75734 5.05035.807588c-.78105-.7810484-2.04738-.7810482-2.82843 0L.80771 2.2218c-.7810481.78105-.7810485 2.04738 0 2.82843l4.94975 4.94975L.80771 14.9497c-.7810474.7811-.7810481 2.0474 0 2.8285l1.41421 1.4142c.78105.781 2.04738.781 2.82843 0l4.94975-4.9498 4.9497 4.9498c.7811.781 2.0474.781 2.8285 0l1.4142-1.4142c.781-.7811.781-2.0474 0-2.8285l-4.9498-4.94972 4.9498-4.94975c.781-.78105.781-2.04738 0-2.82843L17.7783.807588Z"
-                    fill="#CF4A22"
-                  />
-                </svg>
-              </div>
+                <path
+                  d="M17.7783.807588c-.7811-.7810482-2.0474-.7810486-2.8285 0L10.0001 5.75734 5.05035.807588c-.78105-.7810484-2.04738-.7810482-2.82843 0L.80771 2.2218c-.7810481.78105-.7810485 2.04738 0 2.82843l4.94975 4.94975L.80771 14.9497c-.7810474.7811-.7810481 2.0474 0 2.8285l1.41421 1.4142c.78105.781 2.04738.781 2.82843 0l4.94975-4.9498 4.9497 4.9498c.7811.781 2.0474.781 2.8285 0l1.4142-1.4142c.781-.7811.781-2.0474 0-2.8285l-4.9498-4.94972 4.9498-4.94975c.781-.78105.781-2.04738 0-2.82843L17.7783.807588Z"
+                  fill="#CF4A22"
+                />
+              </svg>
             </a>
           </div>
         </div>
@@ -1138,9 +1084,8 @@ exports[`storybook Storyshots Project Health Page Actual Waterfall Page 1`] = `
             className="css-100ar08-IconContainer ek3nkvx1"
           >
             <a
-              aria-disabled={false}
               aria-label="failed icon"
-              className="leafygreen-ui-12hedrr"
+              className="leafygreen-ui-cssveg css-1a4l4zc-StyledRouterLink-linkStyles-IconWrapper enafhlo1"
               data-cy="waterfall-task-status-icon"
               href="/task/code_health"
               onBlur={[Function]}
@@ -1148,25 +1093,20 @@ exports[`storybook Storyshots Project Health Page Actual Waterfall Page 1`] = `
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-              onMouseOver={[Function]}
-              tabIndex={0}
             >
-              <div
-                className="leafygreen-ui-xhlipt"
+              <svg
+                aria-label="Failure Icon"
+                className="css-5k80id-StyledTaskStatusIcon enafhlo0"
+                fill="currentColor"
+                height={16}
+                viewBox="0 0 21 21"
+                width={16}
               >
-                <svg
-                  aria-label="Failure Icon"
-                  fill="currentColor"
-                  height={16}
-                  viewBox="0 0 21 21"
-                  width={16}
-                >
-                  <path
-                    d="M17.7783.807588c-.7811-.7810482-2.0474-.7810486-2.8285 0L10.0001 5.75734 5.05035.807588c-.78105-.7810484-2.04738-.7810482-2.82843 0L.80771 2.2218c-.7810481.78105-.7810485 2.04738 0 2.82843l4.94975 4.94975L.80771 14.9497c-.7810474.7811-.7810481 2.0474 0 2.8285l1.41421 1.4142c.78105.781 2.04738.781 2.82843 0l4.94975-4.9498 4.9497 4.9498c.7811.781 2.0474.781 2.8285 0l1.4142-1.4142c.781-.7811.781-2.0474 0-2.8285l-4.9498-4.94972 4.9498-4.94975c.781-.78105.781-2.04738 0-2.82843L17.7783.807588Z"
-                    fill="#CF4A22"
-                  />
-                </svg>
-              </div>
+                <path
+                  d="M17.7783.807588c-.7811-.7810482-2.0474-.7810486-2.8285 0L10.0001 5.75734 5.05035.807588c-.78105-.7810484-2.04738-.7810482-2.82843 0L.80771 2.2218c-.7810481.78105-.7810485 2.04738 0 2.82843l4.94975 4.94975L.80771 14.9497c-.7810474.7811-.7810481 2.0474 0 2.8285l1.41421 1.4142c.78105.781 2.04738.781 2.82843 0l4.94975-4.9498 4.9497 4.9498c.7811.781 2.0474.781 2.8285 0l1.4142-1.4142c.781-.7811.781-2.0474 0-2.8285l-4.9498-4.94972 4.9498-4.94975c.781-.78105.781-2.04738 0-2.82843L17.7783.807588Z"
+                  fill="#CF4A22"
+                />
+              </svg>
             </a>
           </div>
         </div>

--- a/src/pages/commits/ActiveCommits/buildVariantCard/WaterfallTaskStatusIcon.stories.tsx
+++ b/src/pages/commits/ActiveCommits/buildVariantCard/WaterfallTaskStatusIcon.stories.tsx
@@ -1,10 +1,22 @@
 import { MockedProvider } from "@apollo/client/testing";
 import { MemoryRouter } from "react-router-dom";
 import { GET_FAILED_TASK_STATUS_ICON_TOOLTIP } from "gql/queries";
+import { CommitsProvider } from "../../CommitsContext";
 import { WaterfallTaskStatusIcon } from "./WaterfallTaskStatusIcon";
 
 export default {
   title: "WaterfallTaskStatusIcon",
+  decorators: [
+    (Story) => (
+      <MemoryRouter>
+        <MockedProvider mocks={[getTooltipQueryMock]} addTypename={false}>
+          <CommitsProvider>
+            <Story />
+          </CommitsProvider>
+        </MockedProvider>
+      </MemoryRouter>
+    ),
+  ],
   component: WaterfallTaskStatusIcon,
 };
 
@@ -12,22 +24,15 @@ const props = {
   displayName: "multiversion",
   timeTaken: 2754729,
   taskId: "task",
+  identifier: "ubuntu1604-multiversion",
 };
 
 export const FailedIcon = () => (
-  <MemoryRouter>
-    <MockedProvider mocks={[getTooltipQueryMock]} addTypename={false}>
-      <WaterfallTaskStatusIcon {...props} status="failed" />
-    </MockedProvider>
-  </MemoryRouter>
+  <WaterfallTaskStatusIcon {...props} status="failed" />
 );
 
 export const SuccessIcon = () => (
-  <MemoryRouter>
-    <MockedProvider mocks={[getTooltipQueryMock]} addTypename={false}>
-      <WaterfallTaskStatusIcon {...props} status="success" />
-    </MockedProvider>
-  </MemoryRouter>
+  <WaterfallTaskStatusIcon {...props} status="success" />
 );
 
 const getTooltipQueryMock = {

--- a/src/pages/commits/ActiveCommits/buildVariantCard/WaterfallTaskStatusIcon.test.tsx
+++ b/src/pages/commits/ActiveCommits/buildVariantCard/WaterfallTaskStatusIcon.test.tsx
@@ -1,6 +1,6 @@
-import { MockedProvider } from "@apollo/client/testing";
 import userEvent from "@testing-library/user-event";
 import { GET_FAILED_TASK_STATUS_ICON_TOOLTIP } from "gql/queries";
+import { ProviderWrapper } from "pages/commits/test-utils";
 import { renderWithRouterMatch as render, waitFor } from "test_utils";
 import { WaterfallTaskStatusIcon } from "./WaterfallTaskStatusIcon";
 
@@ -8,17 +8,21 @@ const props = {
   displayName: "multiversion",
   timeTaken: 2754729,
   taskId: "task",
+  identifier: "ubuntu1604-multiversion",
 };
 
 const Content = (status: string) => () => (
-  <MockedProvider mocks={[getTooltipQueryMock]} addTypename={false}>
-    <WaterfallTaskStatusIcon {...props} status={status} />
-  </MockedProvider>
+  <WaterfallTaskStatusIcon {...props} status={status} />
 );
 describe("waterfallTaskStatusIcon", () => {
   it("tooltip should contain task name, duration, list of failing test names and additonal test count", async () => {
     const { queryByDataCy, queryByText } = render(Content("failed"), {
       route: "/commits/evergreen",
+      wrapper: ({ children }) =>
+        ProviderWrapper({
+          children,
+          mocks: [getTooltipQueryMock],
+        }),
     });
     userEvent.hover(queryByDataCy("waterfall-task-status-icon"));
     await waitFor(() => {
@@ -41,6 +45,11 @@ describe("waterfallTaskStatusIcon", () => {
   it("icon should link to task page", async () => {
     const { queryByDataCy } = render(Content("failed"), {
       route: "/commits/evergreen",
+      wrapper: ({ children }) =>
+        ProviderWrapper({
+          children,
+          mocks: [getTooltipQueryMock],
+        }),
     });
     await waitFor(() => {
       expect(queryByDataCy("waterfall-task-status-icon")).toBeInTheDocument();

--- a/src/pages/commits/ActiveCommits/buildVariantCard/WaterfallTaskStatusIcon.tsx
+++ b/src/pages/commits/ActiveCommits/buildVariantCard/WaterfallTaskStatusIcon.tsx
@@ -48,6 +48,7 @@ export const WaterfallTaskStatusIcon: React.FC<WaterfallTaskStatusIconProps> = (
       loadData();
     }
   };
+
   const onUnhover = () => {
     setTaskIcon(null);
   };
@@ -67,11 +68,9 @@ export const WaterfallTaskStatusIcon: React.FC<WaterfallTaskStatusIconProps> = (
           to={getTaskRoute(taskId)}
           data-cy="waterfall-task-status-icon"
         >
-          <StyledTaskStatusIcon
-            status={status}
-            size={16}
-            highlight={shouldHighlight}
-          />
+          <TaskStatusIconWrapper highlight={shouldHighlight}>
+            <TaskStatusIcon status={status} size={16} />
+          </TaskStatusIconWrapper>
         </IconWrapper>
       }
       triggerEvent="hover"
@@ -112,6 +111,6 @@ const IconWrapper = styled(StyledRouterLink)`
   border-radius: 50%;
   cursor: pointer;
 `;
-const StyledTaskStatusIcon = styled(TaskStatusIcon)<{ highlight: boolean }>`
+const TaskStatusIconWrapper = styled.div<{ highlight: boolean }>`
   opacity: ${({ highlight }) => (highlight ? 1 : 0.25)};
 `;

--- a/src/pages/commits/ActiveCommits/buildVariantCard/__snapshots__/WaterfallTaskStatusIcon.stories.storyshot
+++ b/src/pages/commits/ActiveCommits/buildVariantCard/__snapshots__/WaterfallTaskStatusIcon.stories.storyshot
@@ -2,9 +2,8 @@
 
 exports[`storybook Storyshots WaterfallTaskStatusIcon Failed Icon 1`] = `
 <a
-  aria-disabled={false}
   aria-label="failed icon"
-  className="leafygreen-ui-12hedrr"
+  className="leafygreen-ui-cssveg css-1a4l4zc-StyledRouterLink-linkStyles-IconWrapper enafhlo1"
   data-cy="waterfall-task-status-icon"
   href="/task/task"
   onBlur={[Function]}
@@ -12,33 +11,27 @@ exports[`storybook Storyshots WaterfallTaskStatusIcon Failed Icon 1`] = `
   onFocus={[Function]}
   onMouseEnter={[Function]}
   onMouseLeave={[Function]}
-  onMouseOver={[Function]}
-  tabIndex={0}
 >
-  <div
-    className="leafygreen-ui-xhlipt"
+  <svg
+    aria-label="Failure Icon"
+    className="css-5k80id-StyledTaskStatusIcon enafhlo0"
+    fill="currentColor"
+    height={16}
+    viewBox="0 0 21 21"
+    width={16}
   >
-    <svg
-      aria-label="Failure Icon"
-      fill="currentColor"
-      height={16}
-      viewBox="0 0 21 21"
-      width={16}
-    >
-      <path
-        d="M17.7783.807588c-.7811-.7810482-2.0474-.7810486-2.8285 0L10.0001 5.75734 5.05035.807588c-.78105-.7810484-2.04738-.7810482-2.82843 0L.80771 2.2218c-.7810481.78105-.7810485 2.04738 0 2.82843l4.94975 4.94975L.80771 14.9497c-.7810474.7811-.7810481 2.0474 0 2.8285l1.41421 1.4142c.78105.781 2.04738.781 2.82843 0l4.94975-4.9498 4.9497 4.9498c.7811.781 2.0474.781 2.8285 0l1.4142-1.4142c.781-.7811.781-2.0474 0-2.8285l-4.9498-4.94972 4.9498-4.94975c.781-.78105.781-2.04738 0-2.82843L17.7783.807588Z"
-        fill="#CF4A22"
-      />
-    </svg>
-  </div>
+    <path
+      d="M17.7783.807588c-.7811-.7810482-2.0474-.7810486-2.8285 0L10.0001 5.75734 5.05035.807588c-.78105-.7810484-2.04738-.7810482-2.82843 0L.80771 2.2218c-.7810481.78105-.7810485 2.04738 0 2.82843l4.94975 4.94975L.80771 14.9497c-.7810474.7811-.7810481 2.0474 0 2.8285l1.41421 1.4142c.78105.781 2.04738.781 2.82843 0l4.94975-4.9498 4.9497 4.9498c.7811.781 2.0474.781 2.8285 0l1.4142-1.4142c.781-.7811.781-2.0474 0-2.8285l-4.9498-4.94972 4.9498-4.94975c.781-.78105.781-2.04738 0-2.82843L17.7783.807588Z"
+      fill="#CF4A22"
+    />
+  </svg>
 </a>
 `;
 
 exports[`storybook Storyshots WaterfallTaskStatusIcon Success Icon 1`] = `
 <a
-  aria-disabled={false}
   aria-label="success icon"
-  className="leafygreen-ui-12hedrr"
+  className="leafygreen-ui-cssveg css-1a4l4zc-StyledRouterLink-linkStyles-IconWrapper enafhlo1"
   data-cy="waterfall-task-status-icon"
   href="/task/task"
   onBlur={[Function]}
@@ -46,29 +39,24 @@ exports[`storybook Storyshots WaterfallTaskStatusIcon Success Icon 1`] = `
   onFocus={[Function]}
   onMouseEnter={[Function]}
   onMouseLeave={[Function]}
-  onMouseOver={[Function]}
-  tabIndex={0}
 >
-  <div
-    className="leafygreen-ui-xhlipt"
+  <svg
+    aria-label="Checkmark Icon"
+    className="leafygreen-ui-ifwzrn css-5k80id-StyledTaskStatusIcon enafhlo0"
+    fill="none"
+    height={16}
+    highlight={true}
+    role="img"
+    viewBox="0 0 16 16"
+    width={16}
+    xmlns="http://www.w3.org/2000/svg"
   >
-    <svg
-      aria-label="Checkmark Icon"
-      className="leafygreen-ui-ifwzrn"
-      fill="none"
-      height={16}
-      role="img"
-      viewBox="0 0 16 16"
-      width={16}
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        clipRule="evenodd"
-        d="M6.306 9.05l5.455-5.455a1 1 0 011.414 0l.707.707a1 1 0 010 1.414l-7.067 7.068a1 1 0 01-1.5-.098l-3.049-3.97a1 1 0 01.184-1.402l.595-.457a1.25 1.25 0 011.753.23L6.306 9.05z"
-        fill="currentColor"
-        fillRule="evenodd"
-      />
-    </svg>
-  </div>
+    <path
+      clipRule="evenodd"
+      d="M6.306 9.05l5.455-5.455a1 1 0 011.414 0l.707.707a1 1 0 010 1.414l-7.067 7.068a1 1 0 01-1.5-.098l-3.049-3.97a1 1 0 01.184-1.402l.595-.457a1.25 1.25 0 011.753.23L6.306 9.05z"
+      fill="currentColor"
+      fillRule="evenodd"
+    />
+  </svg>
 </a>
 `;

--- a/src/pages/commits/CommitsContext.test.tsx
+++ b/src/pages/commits/CommitsContext.test.tsx
@@ -1,0 +1,22 @@
+import { renderHook, act } from "@testing-library/react-hooks";
+import { CommitsProvider, useCommits } from "./CommitsContext";
+
+const wrapper = ({ children }) => <CommitsProvider>{children}</CommitsProvider>;
+
+describe("historyTableContext", () => {
+  it("initializes with the default state", () => {
+    const { result } = renderHook(() => useCommits(), { wrapper });
+    expect(result.current).toStrictEqual({
+      hoveredTaskIcon: null,
+      setTaskIcon: expect.any(Function),
+    });
+  });
+  it("should properly update the selectedTaskIcon", () => {
+    const { result } = renderHook(() => useCommits(), { wrapper });
+    const hoverTask = "ubuntu-1604check_codegen";
+    act(() => {
+      result.current.setTaskIcon(hoverTask);
+    });
+    expect(result.current.hoveredTaskIcon).toBe(hoverTask);
+  });
+});

--- a/src/pages/commits/CommitsContext.tsx
+++ b/src/pages/commits/CommitsContext.tsx
@@ -1,0 +1,72 @@
+import { useContext, createContext, useReducer, useMemo } from "react";
+
+// REDUCER ---- move to another file if it gets too big
+export interface CommitsReducerState {
+  hoveredTaskIcon: string;
+}
+
+type Action = { type: "setTaskIcon"; taskIcon: string };
+
+const reducer = (state: CommitsReducerState, action: Action) => {
+  switch (action.type) {
+    case "setTaskIcon":
+      return {
+        ...state,
+        hoveredTaskIcon: action.taskIcon,
+      };
+    default:
+      throw new Error(`Unknown reducer action ${action}`);
+  }
+};
+
+// CONTEXT ---- uses reducer
+interface CommitsState {
+  hoveredTaskIcon: string;
+  setTaskIcon: (taskIcon: string) => void;
+}
+
+const CommitsDispatchContext = createContext<any | null>(null);
+
+interface CommitsProviderProps {
+  children: React.ReactNode;
+  initialState?: CommitsReducerState;
+}
+const CommitsProvider: React.FC<CommitsProviderProps> = ({
+  children,
+  initialState = {
+    hoveredTaskIcon: null,
+  },
+}) => {
+  const [{ hoveredTaskIcon }, dispatch] = useReducer(reducer, {
+    ...initialState,
+  });
+
+  // If you need any other functions write them here.
+
+  const commitsState: CommitsState = useMemo(
+    () => ({
+      hoveredTaskIcon,
+      setTaskIcon: (taskIcon: string) =>
+        dispatch({ type: "setTaskIcon", taskIcon }),
+    }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [hoveredTaskIcon]
+  );
+  return (
+    <CommitsDispatchContext.Provider value={commitsState}>
+      {children}
+    </CommitsDispatchContext.Provider>
+  );
+};
+
+const useCommits = (): CommitsState => {
+  const context = useContext(CommitsDispatchContext);
+  if (context === undefined) {
+    throw new Error(
+      "useActiveCommits must be used within a ActiveCommitsProvider"
+    );
+  }
+  return context;
+};
+
+export { CommitsProvider, useCommits };

--- a/src/pages/commits/CommitsContext.tsx
+++ b/src/pages/commits/CommitsContext.tsx
@@ -1,6 +1,6 @@
 import { useContext, createContext, useReducer, useMemo } from "react";
 
-// REDUCER ---- move to another file if it gets too big
+// REDUCER
 export interface CommitsReducerState {
   hoveredTaskIcon: string;
 }
@@ -19,7 +19,7 @@ const reducer = (state: CommitsReducerState, action: Action) => {
   }
 };
 
-// CONTEXT ---- uses reducer
+// CONTEXT
 interface CommitsState {
   hoveredTaskIcon: string;
   setTaskIcon: (taskIcon: string) => void;
@@ -40,8 +40,6 @@ const CommitsProvider: React.FC<CommitsProviderProps> = ({
   const [{ hoveredTaskIcon }, dispatch] = useReducer(reducer, {
     ...initialState,
   });
-
-  // If you need any other functions write them here.
 
   const commitsState: CommitsState = useMemo(
     () => ({

--- a/src/pages/commits/CommitsContext.tsx
+++ b/src/pages/commits/CommitsContext.tsx
@@ -1,4 +1,5 @@
 import { useContext, createContext, useReducer, useMemo } from "react";
+import debounce from "lodash.debounce";
 
 // REDUCER
 export interface CommitsReducerState {
@@ -41,15 +42,21 @@ const CommitsProvider: React.FC<CommitsProviderProps> = ({
     ...initialState,
   });
 
+  // It's possible for hundreds of hoverable icons to be visible. We should debounce so that
+  // we don't trigger the task highlight on every hover event.
+  const debounceSetTaskIcon = debounce((taskIcon) => {
+    dispatch({ type: "setTaskIcon", taskIcon });
+  }, 200);
+
   const commitsState: CommitsState = useMemo(
     () => ({
       hoveredTaskIcon,
-      setTaskIcon: (taskIcon: string) =>
-        dispatch({ type: "setTaskIcon", taskIcon }),
+      setTaskIcon: (taskIcon: string) => debounceSetTaskIcon(taskIcon),
     }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [hoveredTaskIcon]
   );
+
   return (
     <CommitsDispatchContext.Provider value={commitsState}>
       {children}

--- a/src/pages/commits/test-utils.tsx
+++ b/src/pages/commits/test-utils.tsx
@@ -1,0 +1,24 @@
+import { MockedProvider, MockedProviderProps } from "@apollo/client/testing";
+import { CommitsProvider, CommitsReducerState } from "./CommitsContext";
+
+const initialState: CommitsReducerState = {
+  hoveredTaskIcon: null,
+};
+
+interface ProviderProps {
+  mocks?: MockedProviderProps["mocks"];
+  state?: Partial<CommitsReducerState>;
+}
+const ProviderWrapper: React.FC<ProviderProps> = ({
+  children,
+  state = {},
+  mocks = [],
+}) => (
+  <MockedProvider mocks={mocks}>
+    <CommitsProvider initialState={{ ...initialState, ...state }}>
+      {children}
+    </CommitsProvider>
+  </MockedProvider>
+);
+
+export { ProviderWrapper };


### PR DESCRIPTION
[EVG-16545](https://jira.mongodb.org/browse/EVG-16545)

### Description 
This PR makes is so that hovering over task icons will highlight matching task icons on the Project Health page.

### Screenshots

https://user-images.githubusercontent.com/47064971/160472916-d4dc1f9d-f609-41be-a477-7579daa14f53.mov



### Testing 
- Added `CommitsContext.test.tsx`
- Modified `storybook` files and `test` files to pass with Context changes (storybook also reflects the highlighting icons  change)
- Wrote a very crude implementation of the build variants ordering (not included in this PR) but seemed to work with the Context stuff so I think it should be okay... 😶‍🌫️