### PR TITLE
EVG-15835 Use lg icons for table selectors

### DIFF
--- a/src/components/Table/Filters.tsx
+++ b/src/components/Table/Filters.tsx
@@ -36,7 +36,7 @@ export const InputFilter: React.FC<InputFilterProps> = ({
 
   useEffect(() => {
     if (visible && inputEl?.current) {
-      // timeout prevents race conditon with antd table animation
+      // timeout prevents race condition with antd table animation
       const timer = setTimeout(() => {
         inputEl.current.focus();
       }, 100);

--- a/src/components/Table/Filters.tsx
+++ b/src/components/Table/Filters.tsx
@@ -13,7 +13,7 @@ import {
 } from "components/TreeSelect";
 import { fontSize } from "constants/tokens";
 
-const { black } = uiColors;
+const { focus } = uiColors;
 
 export interface InputFilterProps {
   "data-cy"?: string;
@@ -24,14 +24,14 @@ export interface InputFilterProps {
   visible?: boolean;
 }
 
-export const InputFilter: React.FC<InputFilterProps> = ({
+export const InputFilter = ({
   placeholder,
   value,
   onChange,
   onFilter,
   "data-cy": dataCy,
   visible,
-}) => {
+}: InputFilterProps) => {
   const inputEl = useRef(null);
 
   useEffect(() => {
@@ -85,7 +85,7 @@ export const getColumnSearchFilterProps = ({
     <StyledFilterWrapper>
       <Icon
         glyph="MagnifyingGlass"
-        fill={value.length > 0 && black}
+        fill={value.length > 0 && focus}
         data-cy={dataCy}
       />
     </StyledFilterWrapper>
@@ -108,7 +108,7 @@ export const getColumnTreeSelectFilterProps = ({
   ),
   filterIcon: () => (
     <StyledFilterWrapper>
-      <Icon glyph="Filter" fill={state.length > 0 && black} data-cy={dataCy} />
+      <Icon glyph="Filter" fill={state.length > 0 && focus} data-cy={dataCy} />
     </StyledFilterWrapper>
   ),
 });
@@ -120,12 +120,12 @@ export interface CheckboxFilterProps {
   onChange: (e: React.ChangeEvent<HTMLInputElement>, key: string) => void;
 }
 
-export const CheckboxFilter: React.FC<CheckboxFilterProps> = ({
+export const CheckboxFilter = ({
   statuses,
   value,
   onChange,
   dataCy,
-}) => (
+}: CheckboxFilterProps) => (
   <FilterWrapper data-cy={`${dataCy}-wrapper`}>
     <CheckboxGroup value={value} data={statuses} onChange={onChange} />
   </FilterWrapper>
@@ -147,7 +147,7 @@ export const getColumnCheckboxFilterProps = ({
   ),
   filterIcon: () => (
     <StyledFilterWrapper>
-      <Icon glyph="Filter" fill={value.length > 0 && black} data-cy={dataCy} />
+      <Icon glyph="Filter" fill={value.length > 0 && focus} data-cy={dataCy} />
     </StyledFilterWrapper>
   ),
 });

--- a/src/components/Table/Filters.tsx
+++ b/src/components/Table/Filters.tsx
@@ -158,10 +158,7 @@ const FilterWrapper = styled.div`
   font-weight: normal; // need to set this as side effect of getPopupContainer
 `;
 
-interface StyledOutlinedProps {
-  active?: boolean;
-}
-const StyledFilterWrapper = styled.div<StyledOutlinedProps>`
+const StyledFilterWrapper = styled.div`
   display: flex;
   align-items: center;
   height: 100%;

--- a/src/components/Table/Filters.tsx
+++ b/src/components/Table/Filters.tsx
@@ -1,10 +1,10 @@
-import React, { useEffect, useRef } from "react";
-import { FilterOutlined, SearchOutlined } from "@ant-design/icons";
+import { useEffect, useRef } from "react";
 import styled from "@emotion/styled";
 import { uiColors } from "@leafygreen-ui/palette";
 import TextInput from "@leafygreen-ui/text-input";
 import { FilterDropdownProps } from "antd/es/table/interface";
 import { CheckboxGroup } from "components/Checkbox";
+import Icon from "components/Icon";
 import { tableInputContainerCSS } from "components/styles/Table";
 import {
   TreeDataEntry,
@@ -13,7 +13,8 @@ import {
 } from "components/TreeSelect";
 import { fontSize } from "constants/tokens";
 
-const { focus } = uiColors;
+const { black } = uiColors;
+
 export interface InputFilterProps {
   "data-cy"?: string;
   placeholder: string;
@@ -81,9 +82,13 @@ export const getColumnSearchFilterProps = ({
     />
   ),
   filterIcon: () => (
-    <StyledSearchWrapper active={!!value}>
-      <SearchOutlined data-cy={dataCy} />
-    </StyledSearchWrapper>
+    <StyledFilterWrapper>
+      <Icon
+        glyph="MagnifyingGlass"
+        fill={value.length > 0 && black}
+        data-cy={dataCy}
+      />
+    </StyledFilterWrapper>
   ),
 });
 
@@ -102,8 +107,8 @@ export const getColumnTreeSelectFilterProps = ({
     />
   ),
   filterIcon: () => (
-    <StyledFilterWrapper active={!!state.length}>
-      <FilterOutlined data-cy={dataCy} />
+    <StyledFilterWrapper>
+      <Icon glyph="Filter" fill={state.length > 0 && black} data-cy={dataCy} />
     </StyledFilterWrapper>
   ),
 });
@@ -141,8 +146,8 @@ export const getColumnCheckboxFilterProps = ({
     />
   ),
   filterIcon: () => (
-    <StyledFilterWrapper active={!!value.length}>
-      <FilterOutlined data-cy={dataCy} />
+    <StyledFilterWrapper>
+      <Icon glyph="Filter" fill={value.length > 0 && black} data-cy={dataCy} />
     </StyledFilterWrapper>
   ),
 });
@@ -157,10 +162,10 @@ interface StyledOutlinedProps {
   active?: boolean;
 }
 const StyledFilterWrapper = styled.div<StyledOutlinedProps>`
+  display: flex;
+  align-items: center;
+  height: 100%;
+  width: 100%;
+  justify-content: center;
   font-size: ${fontSize.l};
-  ${({ active }) => active && `color: ${focus}`}
-`;
-const StyledSearchWrapper = styled.div<StyledOutlinedProps>`
-  font-size: ${fontSize.l};
-  ${({ active }) => active && `color: ${focus}`}
 `;


### PR DESCRIPTION
[EVG-15835](https://jira.mongodb.org/browse/EVG-15835)

### Description 
Replaced Antd table icons with LG Icons and updated their active colors to make it more visible that there are filters applied. 

### Screenshots
<img width="1109" alt="image" src="https://user-images.githubusercontent.com/4605522/161067144-becadbdd-b491-4551-a317-e700eb0cde59.png">


