### PR TITLE
EVG-16675: Fix e2e test

### DIFF
--- a/src/pages/projectSettings/tabs/GeneralTab/transformers.test.ts
+++ b/src/pages/projectSettings/tabs/GeneralTab/transformers.test.ts
@@ -112,6 +112,7 @@ const projectForm: FormState = {
     branch: null,
     other: {
       displayName: null,
+      identifier: "project",
       batchTime: null,
       remotePath: null,
       spawnHostScriptPath: null,
@@ -157,6 +158,7 @@ const projectResult: Pick<ProjectSettingsInput, "projectRef"> = {
     repo: "evergreen",
     branch: null,
     displayName: null,
+    identifier: "project",
     batchTime: 0,
     remotePath: null,
     spawnHostScriptPath: null,

--- a/src/pages/projectSettings/tabs/GeneralTab/transformers.ts
+++ b/src/pages/projectSettings/tabs/GeneralTab/transformers.ts
@@ -91,7 +91,9 @@ export const formToGql: FormToGqlFunction = (
     repo: generalConfiguration.repositoryInfo.repo,
     branch: generalConfiguration.branch,
     displayName: generalConfiguration.other.displayName,
-    identifier: generalConfiguration.other.identifier,
+    ...(generalConfiguration.other.identifier && {
+      identifier: generalConfiguration.other.identifier,
+    }),
     batchTime: generalConfiguration.other.batchTime ?? 0,
     remotePath: generalConfiguration.other.remotePath,
     spawnHostScriptPath: generalConfiguration.other.spawnHostScriptPath,

--- a/src/pages/projectSettings/tabs/GeneralTab/transformers.ts
+++ b/src/pages/projectSettings/tabs/GeneralTab/transformers.ts
@@ -29,6 +29,9 @@ export const gqlToForm: GqlToFormFunction<FormState> = (
       branch: projectRef.branch,
       other: {
         displayName: projectRef.displayName,
+        ...("identifier" in projectRef && {
+          identifier: projectRef?.identifier,
+        }),
         batchTime: projectRef.batchTime || null,
         remotePath: projectRef.remotePath,
         spawnHostScriptPath: projectRef.spawnHostScriptPath,
@@ -88,6 +91,7 @@ export const formToGql: FormToGqlFunction = (
     repo: generalConfiguration.repositoryInfo.repo,
     branch: generalConfiguration.branch,
     displayName: generalConfiguration.other.displayName,
+    identifier: generalConfiguration.other.identifier,
     batchTime: generalConfiguration.other.batchTime ?? 0,
     remotePath: generalConfiguration.other.remotePath,
     spawnHostScriptPath: generalConfiguration.other.spawnHostScriptPath,

--- a/src/pages/projectSettings/tabs/GeneralTab/types.ts
+++ b/src/pages/projectSettings/tabs/GeneralTab/types.ts
@@ -10,6 +10,7 @@ export interface FormState {
     branch: string;
     other: {
       displayName: string;
+      identifier?: string;
       batchTime: number;
       remotePath: string;
       spawnHostScriptPath: string;


### PR DESCRIPTION
EVG-16675

### Description 
- Fix e2e test: include `identifier` in calls to save project so that it is not overwritten to an empty string.
