### PR TITLE
EVG-16302 Deprecate unused Graphql fields 

### DIFF
--- a/cypress/integration/version/unscheduled_patch/configure_patch.ts
+++ b/cypress/integration/version/unscheduled_patch/configure_patch.ts
@@ -442,8 +442,7 @@ describe("Configure Patch Page", () => {
       });
     });
 
-    // Skip until EVG-15085 is completed, since the patch trigger alias data is currently being overwritten
-    describe.skip("Selecting a trigger alias", () => {
+    describe("Selecting a trigger alias", () => {
       before(() => {
         cy.dataCy("trigger-alias-list-item")
           .contains("logkeeper-alias")

--- a/cypress/integration/version/unscheduled_patch/configure_patch.ts
+++ b/cypress/integration/version/unscheduled_patch/configure_patch.ts
@@ -536,7 +536,7 @@ describe("Configure Patch Page", () => {
 
     it("Shows error toast if unsuccessful and keeps data", () => {
       const val = "hello world";
-      cy.dataCy(`patch-name-input`).as("patchNameInput").clear().type(val);
+      cy.dataCy(`patch-name-input`).clear().type(val);
       cy.dataCy("task-checkbox").first().check({ force: true });
       // TODO: Replace this with cy.intercept() once we upgrade to > Cypress 6.0.0
       cy.route2("/graphql/query", (req) => {
@@ -568,105 +568,6 @@ const mockedErrorConfigureResponse = {
 };
 
 const mockedSuccessfulConfigureResponse = {
-  data: {
-    schedulePatch: {
-      id: unactivatedPatchId,
-      activated: true,
-      __typename: "Patch",
-    },
-    patchTasks: {
-      count: 3,
-      tasks: [
-        {
-          id:
-            "mci_osx_dist_patch_c12773e028910390ab4fda66e4b1745cfdc9ee65_5ea99425b23736089a09a98f_20_04_29_14_53_16",
-          status: "success",
-          baseStatus: "success",
-          displayName: "dist",
-          buildVariant: "osx",
-          __typename: "TaskResult",
-        },
-        {
-          id:
-            "mci_osx_test_auth_patch_c12773e028910390ab4fda66e4b1745cfdc9ee65_5ea99425b23736089a09a98f_20_04_29_14_53_16",
-          status: "success",
-          baseStatus: "success",
-          displayName: "test-auth",
-          buildVariant: "osx",
-          __typename: "TaskResult",
-        },
-        {
-          id:
-            "mci_osx_test_graphql_patch_c12773e028910390ab4fda66e4b1745cfdc9ee65_5ea99425b23736089a09a98f_20_04_29_14_53_16",
-          status: "success",
-          baseStatus: "success",
-          displayName: "test-graphql",
-          buildVariant: "osx",
-          __typename: "TaskResult",
-        },
-      ],
-      __typename: "PatchTasks",
-    },
-    patchBuildVariants: [
-      {
-        variant: "osx",
-        tasks: [
-          {
-            id:
-              "mci_osx_dist_patch_c12773e028910390ab4fda66e4b1745cfdc9ee65_5ea99425b23736089a09a98f_20_04_29_14_53_16",
-            name: "dist",
-            status: "success",
-            __typename: "Task",
-          },
-          {
-            id:
-              "mci_osx_test_auth_patch_c12773e028910390ab4fda66e4b1745cfdc9ee65_5ea99425b23736089a09a98f_20_04_29_14_53_16",
-            name: "test-auth",
-            status: "success",
-            __typename: "Task",
-          },
-          {
-            id:
-              "mci_osx_test_graphql_patch_c12773e028910390ab4fda66e4b1745cfdc9ee65_5ea99425b23736089a09a98f_20_04_29_14_53_16",
-            name: "test-graphql",
-            status: "success",
-            __typename: "Task",
-          },
-        ],
-        __typename: "GroupedBuildVariant",
-      },
-    ],
-    patch: {
-      id: unactivatedPatchId,
-      description: "whoaaaaaa mama!!!",
-      projectID: "mci",
-      githash: "c12773e028910390ab4fda66e4b1745cfdc9ee65",
-      patchNumber: 6,
-      author: "trey.granderson",
-      version: "5ea99425b23736089a09a98f",
-      status: "succeeded",
-      activated: true,
-      alias: "",
-      taskCount: 3,
-      duration: {
-        makespan: "18m31s",
-        timeTaken: null,
-        __typename: "PatchDuration",
-      },
-      time: {
-        started: "April 29, 2020, 11:09AM",
-        submittedAt: "April 29, 2020, 10:50AM",
-        finished: "April 29, 2020, 11:27AM",
-        __typename: "PatchTime",
-      },
-      variantsTasks: [
-        {
-          name: "osx",
-          tasks: ["test-graphql", "test-auth", "dist"],
-          __typename: "VariantTask",
-        },
-      ],
-      __typename: "Patch",
-    },
-  },
+  data: {},
+  errors: null,
 };

--- a/src/components/PatchesPage/patchCard/DropdownMenu.tsx
+++ b/src/components/PatchesPage/patchCard/DropdownMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { ButtonDropdown } from "components/ButtonDropdown";
 import { LinkToReconfigurePage } from "components/LinkToReconfigurePage";
 import {
@@ -17,14 +17,14 @@ interface Props {
   childPatches: Partial<Patch>[];
   hasVersion: boolean;
 }
-export const DropdownMenu: React.FC<Props> = ({
+export const DropdownMenu = ({
   patchId,
   childPatches,
   canEnqueueToCommitQueue,
   isPatchOnCommitQueue,
   patchDescription,
   hasVersion,
-}) => {
+}: Props): JSX.Element => {
   const restartModalVisibilityControl = useState(false);
   const enqueueModalVisibilityControl = useState(false);
   const dropdownItems = [
@@ -67,4 +67,4 @@ export const DropdownMenu: React.FC<Props> = ({
   );
 };
 
-const refetchQueries = ["PatchBuildVariants"];
+const refetchQueries = ["Version"];

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -34,8 +34,6 @@ export type Query = {
   taskFiles: TaskFiles;
   user: User;
   taskLogs: TaskLogs;
-  /** @deprecated Use version.buildVariants instead */
-  patchBuildVariants: Array<GroupedBuildVariant>;
   commitQueue: CommitQueue;
   userSettings?: Maybe<UserSettings>;
   spruceConfig?: Maybe<SpruceConfig>;
@@ -131,10 +129,6 @@ export type QueryUserArgs = {
 export type QueryTaskLogsArgs = {
   taskId: Scalars["String"];
   execution?: Maybe<Scalars["Int"]>;
-};
-
-export type QueryPatchBuildVariantsArgs = {
-  patchId: Scalars["String"];
 };
 
 export type QueryCommitQueueArgs = {
@@ -236,13 +230,9 @@ export type Mutation = {
   schedulePatchTasks?: Maybe<Scalars["String"]>;
   unschedulePatchTasks?: Maybe<Scalars["String"]>;
   restartVersions?: Maybe<Array<Version>>;
-  /** @deprecated restartPatch deprecated, Use restartVersions instead */
-  restartPatch?: Maybe<Scalars["String"]>;
   scheduleUndispatchedBaseTasks?: Maybe<Array<Task>>;
   enqueuePatch: Patch;
   setPatchPriority?: Maybe<Scalars["String"]>;
-  /** @deprecated scheduleTask deprecated, Use scheduleTasks instead */
-  scheduleTask: Task;
   scheduleTasks: Array<Task>;
   unscheduleTask: Task;
   abortTask: Task;
@@ -341,12 +331,6 @@ export type MutationRestartVersionsArgs = {
   versionsToRestart: Array<VersionToRestart>;
 };
 
-export type MutationRestartPatchArgs = {
-  patchId: Scalars["String"];
-  abort: Scalars["Boolean"];
-  taskIds: Array<Scalars["String"]>;
-};
-
 export type MutationScheduleUndispatchedBaseTasksArgs = {
   patchId: Scalars["String"];
 };
@@ -359,10 +343,6 @@ export type MutationEnqueuePatchArgs = {
 export type MutationSetPatchPriorityArgs = {
   patchId: Scalars["String"];
   priority: Scalars["Int"];
-};
-
-export type MutationScheduleTaskArgs = {
-  taskId: Scalars["String"];
 };
 
 export type MutationScheduleTasksArgs = {
@@ -2771,9 +2751,9 @@ export type SchedulePatchMutationVariables = Exact<{
 
 export type SchedulePatchMutation = {
   schedulePatch: {
-    version: string;
     tasks: Array<string>;
     variants: Array<string>;
+    versionFull?: Maybe<{ id: string }>;
   } & BasePatchFragment;
 };
 
@@ -3628,7 +3608,6 @@ export type PatchQuery = {
     projectIdentifier: string;
     githash: string;
     patchNumber: number;
-    version: string;
     taskCount?: Maybe<number>;
     baseVersionID?: Maybe<string>;
     canEnqueueToCommitQueue: boolean;
@@ -3642,6 +3621,7 @@ export type PatchQuery = {
         status: string;
       }>
     >;
+    versionFull?: Maybe<{ id: string }>;
     duration?: Maybe<{ makespan?: Maybe<string>; timeTaken?: Maybe<string> }>;
     time?: Maybe<{
       started?: Maybe<string>;
@@ -3865,7 +3845,6 @@ export type GetTaskQuery = {
       canOverrideDependencies: boolean;
       startTime?: Maybe<Date>;
       timeTaken?: Maybe<number>;
-      version: string;
       totalTestCount: number;
       failedTestCount: number;
       spawnHostLink?: Maybe<string>;

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -527,8 +527,6 @@ export type Version = {
   patch?: Maybe<Patch>;
   childVersions?: Maybe<Array<Maybe<Version>>>;
   taskCount?: Maybe<Scalars["Int"]>;
-  /** @deprecated baseVersionId is deprecated, use baseVersion.id instead */
-  baseVersionID?: Maybe<Scalars["String"]>;
   baseVersion?: Maybe<Version>;
   previousVersion?: Maybe<Version>;
   versionTiming?: Maybe<VersionTiming>;
@@ -1176,8 +1174,6 @@ export type Patch = {
   patchNumber: Scalars["Int"];
   author: Scalars["String"];
   authorDisplayName: Scalars["String"];
-  /** @deprecated version is deprecated, use versionFull.id instead */
-  version: Scalars["String"];
   versionFull?: Maybe<Version>;
   status: Scalars["String"];
   variants: Array<Scalars["String"]>;
@@ -1317,8 +1313,6 @@ export type TestResult = {
   status: Scalars["String"];
   baseStatus?: Maybe<Scalars["String"]>;
   testFile: Scalars["String"];
-  /** @deprecated displayTestName deprecated, use testFile instead (EVG-15379) */
-  displayTestName?: Maybe<Scalars["String"]>;
   logs: TestLog;
   exitCode?: Maybe<Scalars["Int"]>;
   startTime?: Maybe<Scalars["Time"]>;
@@ -1341,18 +1335,11 @@ export type Dependency = {
   requiredStatus: RequiredStatus;
   buildVariant: Scalars["String"];
   taskId: Scalars["String"];
-  /** @deprecated uiLink is deprecated and should not be used */
-  uiLink: Scalars["String"];
 };
 
 export type PatchMetadata = {
   author: Scalars["String"];
   patchID: Scalars["String"];
-};
-
-export type BaseTaskMetadata = {
-  baseTaskDuration?: Maybe<Scalars["Duration"]>;
-  baseTaskLink: Scalars["String"];
 };
 
 export type AbortInfo = {
@@ -1374,8 +1361,6 @@ export type Task = {
   annotation?: Maybe<Annotation>;
   baseTask?: Maybe<Task>;
   baseStatus?: Maybe<Scalars["String"]>;
-  /** @deprecated baseTaskMetadata is deprecated. Use baseTask instead */
-  baseTaskMetadata?: Maybe<BaseTaskMetadata>;
   blocked: Scalars["Boolean"];
   buildId: Scalars["String"];
   buildVariant: Scalars["String"];
@@ -3888,7 +3873,6 @@ export type GetTaskQuery = {
           buildVariantDisplayName?: Maybe<string>;
         }>
       >;
-      baseTaskMetadata?: Maybe<{ baseTaskDuration?: Maybe<number> }>;
       displayTask?: Maybe<{
         id: string;
         execution: number;

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -1032,8 +1032,6 @@ export type TaskQueueItem = {
 
 export type TaskQueueDistro = {
   id: Scalars["ID"];
-  /** @deprecated queueCount is deprecated, use taskCount instead */
-  queueCount: Scalars["Int"];
   taskCount: Scalars["Int"];
   hostCount: Scalars["Int"];
 };
@@ -1186,6 +1184,7 @@ export type Patch = {
   duration?: Maybe<PatchDuration>;
   time?: Maybe<PatchTime>;
   taskCount?: Maybe<Scalars["Int"]>;
+  /** @deprecated Use versionFull.baseVersion.id instead */
   baseVersionID?: Maybe<Scalars["String"]>;
   parameters: Array<Parameter>;
   moduleCodeChanges: Array<ModuleCodeChange>;
@@ -1337,11 +1336,6 @@ export type Dependency = {
   taskId: Scalars["String"];
 };
 
-export type PatchMetadata = {
-  author: Scalars["String"];
-  patchID: Scalars["String"];
-};
-
 export type AbortInfo = {
   user: Scalars["String"];
   taskID: Scalars["String"];
@@ -1397,15 +1391,11 @@ export type Task = {
   logs: TaskLogLinks;
   minQueuePosition: Scalars["Int"];
   patch?: Maybe<Patch>;
-  /** @deprecated patchMetadata is deprecated. Use versionMetadata instead. */
-  patchMetadata: PatchMetadata;
   patchNumber?: Maybe<Scalars["Int"]>;
   priority?: Maybe<Scalars["Int"]>;
   project?: Maybe<Project>;
   projectId: Scalars["String"];
   projectIdentifier?: Maybe<Scalars["String"]>;
-  /** @deprecated reliesOn is deprecated. Use dependsOn instead. */
-  reliesOn: Array<Dependency>;
   dependsOn?: Maybe<Array<Dependency>>;
   canOverrideDependencies: Scalars["Boolean"];
   requester: Scalars["String"];
@@ -1419,8 +1409,6 @@ export type Task = {
   taskGroupMaxHosts?: Maybe<Scalars["Int"]>;
   timeTaken?: Maybe<Scalars["Duration"]>;
   totalTestCount: Scalars["Int"];
-  /** @deprecated version is deprecated. Use versionMetadata instead. */
-  version: Scalars["String"];
   versionMetadata: Version;
   order: Scalars["Int"];
 };

--- a/src/gql/mutations/schedule-patch.graphql
+++ b/src/gql/mutations/schedule-patch.graphql
@@ -1,10 +1,12 @@
 #import "../fragments/basePatch.graphql"
 
-  mutation SchedulePatch($patchId: String!, $configure: PatchConfigure!) {
-    schedulePatch(patchId: $patchId, configure: $configure) {
-      ...basePatch
-      version
-      tasks
-      variants
+mutation SchedulePatch($patchId: String!, $configure: PatchConfigure!) {
+  schedulePatch(patchId: $patchId, configure: $configure) {
+    ...basePatch
+    versionFull {
+      id
     }
+    tasks
+    variants
   }
+}

--- a/src/gql/queries/get-patch.graphql
+++ b/src/gql/queries/get-patch.graphql
@@ -15,7 +15,9 @@ query Patch($id: String!) {
     projectIdentifier
     githash
     patchNumber
-    version
+    versionFull {
+      id
+    }
     taskCount
     baseVersionID
     duration {

--- a/src/gql/queries/get-task.graphql
+++ b/src/gql/queries/get-task.graphql
@@ -76,7 +76,6 @@ query GetTask($taskId: String!, $execution: Int) {
     }
     startTime
     timeTaken
-    version
     totalTestCount
     failedTestCount
     spawnHostLink

--- a/src/gql/queries/get-task.graphql
+++ b/src/gql/queries/get-task.graphql
@@ -32,9 +32,6 @@ query GetTask($taskId: String!, $execution: Int) {
       buildVariant
       buildVariantDisplayName
     }
-    baseTaskMetadata {
-      baseTaskDuration
-    }
     displayTask {
       id
       execution

--- a/src/hooks/tests/useVersionStatusSelect.test.ts
+++ b/src/hooks/tests/useVersionStatusSelect.test.ts
@@ -28,14 +28,14 @@ const allTrue = {
 describe("useVersionStatusSelect", () => {
   it("should have no tasks and no valid statuses selected by default", () => {
     const { result } = renderHook(() =>
-      useVersionTaskStatusSelect(patchBuildVariants, versionId, childVersion)
+      useVersionTaskStatusSelect(groupedBuildVariants, versionId, childVersion)
     );
     expect(result.current.selectedTasks[versionId]).toStrictEqual(allFalse);
   });
 
   it("should select all tasks that match the patch status filter when the base status filter is empty", () => {
     const { result } = renderHook(() =>
-      useVersionTaskStatusSelect(patchBuildVariants, versionId, childVersion)
+      useVersionTaskStatusSelect(groupedBuildVariants, versionId, childVersion)
     );
     act(() => {
       result.current.setVersionStatusFilterTerm({
@@ -52,7 +52,7 @@ describe("useVersionStatusSelect", () => {
 
   it("should select all tasks that match the base status filter when the patch status filter is empty", () => {
     const { result } = renderHook(() =>
-      useVersionTaskStatusSelect(patchBuildVariants, versionId, childVersion)
+      useVersionTaskStatusSelect(groupedBuildVariants, versionId, childVersion)
     );
     act(() => {
       result.current.setVersionStatusFilterTerm({});
@@ -70,7 +70,7 @@ describe("useVersionStatusSelect", () => {
 
   it("should select all tasks that match the patch status filter and base status filter when both filters have active filter terms.", () => {
     const { result } = renderHook(() =>
-      useVersionTaskStatusSelect(patchBuildVariants, versionId, childVersion)
+      useVersionTaskStatusSelect(groupedBuildVariants, versionId, childVersion)
     );
     act(() => {
       result.current.setVersionStatusFilterTerm({
@@ -92,7 +92,7 @@ describe("useVersionStatusSelect", () => {
 
   it("tasks with undefined base statuses do not match with any base status filter state.", () => {
     const { result } = renderHook(() =>
-      useVersionTaskStatusSelect(patchBuildVariants, versionId, childVersion)
+      useVersionTaskStatusSelect(groupedBuildVariants, versionId, childVersion)
     );
     act(() => {
       result.current.setVersionStatusFilterTerm({
@@ -113,7 +113,7 @@ describe("useVersionStatusSelect", () => {
 
   it("should deselect all tasks with statuses that do not match any patch status filter terms.", () => {
     const { result } = renderHook(() =>
-      useVersionTaskStatusSelect(patchBuildVariants, versionId, childVersion)
+      useVersionTaskStatusSelect(groupedBuildVariants, versionId, childVersion)
     );
     act(() => {
       result.current.setVersionStatusFilterTerm({
@@ -135,7 +135,7 @@ describe("useVersionStatusSelect", () => {
 
   it("selecting multiple patch statuses should select all tasks with a matching status", () => {
     const { result } = renderHook(() =>
-      useVersionTaskStatusSelect(patchBuildVariants, versionId, childVersion)
+      useVersionTaskStatusSelect(groupedBuildVariants, versionId, childVersion)
     );
     act(() => {
       result.current.setVersionStatusFilterTerm({
@@ -150,7 +150,7 @@ describe("useVersionStatusSelect", () => {
 
   it("selecting an individual task should work", () => {
     const { result } = renderHook(() =>
-      useVersionTaskStatusSelect(patchBuildVariants, versionId, childVersion)
+      useVersionTaskStatusSelect(groupedBuildVariants, versionId, childVersion)
     );
     act(() => {
       result.current.toggleSelectedTask({
@@ -165,7 +165,7 @@ describe("useVersionStatusSelect", () => {
 
   it("deselecting an individual task should work if it was selected by valid statuses", () => {
     const { result } = renderHook(() =>
-      useVersionTaskStatusSelect(patchBuildVariants, versionId, childVersion)
+      useVersionTaskStatusSelect(groupedBuildVariants, versionId, childVersion)
     );
     act(() => {
       result.current.setVersionStatusFilterTerm({
@@ -190,7 +190,7 @@ describe("useVersionStatusSelect", () => {
 
   it("batch toggling tasks will set them all to checked when they are orignially unchecked", () => {
     const { result } = renderHook(() =>
-      useVersionTaskStatusSelect(patchBuildVariants, versionId, childVersion)
+      useVersionTaskStatusSelect(groupedBuildVariants, versionId, childVersion)
     );
     waitFor(() =>
       expect(result.current.selectedTasks).toStrictEqual({ ...allFalse })
@@ -207,7 +207,7 @@ describe("useVersionStatusSelect", () => {
 
   it("batch toggling tasks will set them all to checked when some and not all are originally checked.", () => {
     const { result } = renderHook(() =>
-      useVersionTaskStatusSelect(patchBuildVariants, versionId, childVersion)
+      useVersionTaskStatusSelect(groupedBuildVariants, versionId, childVersion)
     );
     waitFor(() =>
       expect(result.current.selectedTasks).toStrictEqual({ ...allFalse })
@@ -235,7 +235,7 @@ describe("useVersionStatusSelect", () => {
 
   it("batch toggling tasks will set them all to unchecked when they are all originally checked.", () => {
     const { result } = renderHook(() =>
-      useVersionTaskStatusSelect(patchBuildVariants, versionId, childVersion)
+      useVersionTaskStatusSelect(groupedBuildVariants, versionId, childVersion)
     );
     waitFor(() =>
       expect(result.current.selectedTasks).toStrictEqual({ ...allTrue })
@@ -251,7 +251,7 @@ describe("useVersionStatusSelect", () => {
   });
 });
 
-const patchBuildVariants = [
+const groupedBuildVariants = [
   {
     variant: "lint",
     displayName: "Lint",
@@ -332,7 +332,7 @@ const childVersion = [
   {
     id: "childVersionId",
     projectIdentifier: "childProjectIdentifier",
-    buildVariants: patchBuildVariants,
+    buildVariants: groupedBuildVariants,
   },
 ];
 

--- a/src/pages/configurePatch/ConfigurePatchCore.tsx
+++ b/src/pages/configurePatch/ConfigurePatchCore.tsx
@@ -94,7 +94,7 @@ export const ConfigurePatchCore: React.FC<Props> = ({ patch }) => {
     onCompleted(data) {
       const { schedulePatch: scheduledPatch } = data;
       dispatchToast.success("Successfully scheduled the patch");
-      history.push(getVersionRoute(scheduledPatch.id));
+      history.push(getVersionRoute(scheduledPatch.versionFull.id));
     },
     onError(err) {
       dispatchToast.error(

--- a/src/pages/task/metadata/taskData.js
+++ b/src/pages/task/metadata/taskData.js
@@ -20,7 +20,7 @@ export const taskQuery = {
     hostId: "i-0e0e62799806e037d",
     hostLink: "https://evergreen.mongodb.com/host/i-0e0e62799806e037d",
     versionMetadata: {
-      __typename: "PatchMetadata",
+      __typename: "Version",
       author: "mohamed.khelif",
       id:
         "spruce_ubuntu1604_e0ece5ad52ad01630bdf29f55b9382a26d6256b3_20_08_26_19_20_41",


### PR DESCRIPTION
[EVG-16302](https://jira.mongodb.org/browse/EVG-16302)

### Description 
Removes most of the fields that had the deprecated directive and are no longer used. 


### Testing 
Spruce patch with evergreen changes as a module.
https://spruce.mongodb.com/version/624cb4691e2d1702fdc5ed34/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

### Evergreen PR 
https://github.com/evergreen-ci/evergreen/pull/5550