### PR TITLE
EVG-16681 Update React.FC to be React.VFC

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,7 +18,7 @@ const globalStyles = css`
   }
 `;
 
-const App: React.FC = () => (
+const App: React.VFC = () => (
   <ErrorBoundary>
     <ContextProviders>
       <Router>

--- a/src/components/Accordion/index.tsx
+++ b/src/components/Accordion/index.tsx
@@ -15,7 +15,7 @@ interface AccordionProps {
   useIndent?: boolean;
   children: React.ReactNode;
 }
-export const Accordion: React.FC<AccordionProps> = ({
+export const Accordion: React.VFC<AccordionProps> = ({
   title,
   toggledTitle,
   children,

--- a/src/components/Accordion/index.tsx
+++ b/src/components/Accordion/index.tsx
@@ -8,17 +8,17 @@ interface AccordionProps {
   toggledTitle?: React.ReactNode;
   toggleFromBottom?: boolean;
   showCaret?: boolean;
-  contents: React.ReactNode;
   allowToggleFromTitle?: boolean;
   defaultOpen?: boolean;
   titleTag?: React.VFC;
   onToggle?: () => void;
   useIndent?: boolean;
+  children: React.ReactNode;
 }
-export const Accordion: React.VFC<AccordionProps> = ({
+export const Accordion: React.FC<AccordionProps> = ({
   title,
   toggledTitle,
-  contents,
+  children,
   toggleFromBottom = false,
   showCaret = true,
   allowToggleFromTitle = true,
@@ -42,7 +42,7 @@ export const Accordion: React.VFC<AccordionProps> = ({
     <>
       {toggleFromBottom && (
         <AnimatedAccordion hide={!isAccordionDisplayed}>
-          {contents}
+          {children}
         </AnimatedAccordion>
       )}
       <Row>
@@ -60,7 +60,7 @@ export const Accordion: React.VFC<AccordionProps> = ({
       {!toggleFromBottom && (
         <AnimatedAccordion hide={!isAccordionDisplayed}>
           <ContentsContainer indent={showCaret && useIndent}>
-            {contents}
+            {children}
           </ContentsContainer>
         </AnimatedAccordion>
       )}

--- a/src/components/Accordion/index.tsx
+++ b/src/components/Accordion/index.tsx
@@ -11,11 +11,11 @@ interface AccordionProps {
   contents: React.ReactNode;
   allowToggleFromTitle?: boolean;
   defaultOpen?: boolean;
-  titleTag?: React.FC;
+  titleTag?: React.VFC;
   onToggle?: () => void;
   useIndent?: boolean;
 }
-export const Accordion: React.FC<AccordionProps> = ({
+export const Accordion: React.VFC<AccordionProps> = ({
   title,
   toggledTitle,
   contents,

--- a/src/components/Breadcrumb/index.tsx
+++ b/src/components/Breadcrumb/index.tsx
@@ -30,7 +30,7 @@ interface Props {
   };
 }
 
-export const BreadCrumb: React.FC<Props> = ({
+export const BreadCrumb: React.VFC<Props> = ({
   taskName,
   patchNumber,
   versionMetadata,
@@ -72,7 +72,7 @@ interface PatchBreadcrumbProps {
   patchNumber?: number;
   isTask: boolean;
 }
-const PatchBreadcrumb: React.FC<PatchBreadcrumbProps> = ({
+const PatchBreadcrumb: React.VFC<PatchBreadcrumbProps> = ({
   patchAuthor,
   analytics,
   versionId,
@@ -137,7 +137,7 @@ interface VersionBreadcrumbProps {
   isTask: boolean;
   analytics: BreadcrumbAnalytics;
 }
-const VersionBreadcrumb: React.FC<VersionBreadcrumbProps> = ({
+const VersionBreadcrumb: React.VFC<VersionBreadcrumbProps> = ({
   versionMetadata,
   analytics,
   isTask,

--- a/src/components/ButtonDropdown.tsx
+++ b/src/components/ButtonDropdown.tsx
@@ -14,7 +14,7 @@ export const ButtonDropdown: React.VFC<Props> = ({
   loading = false,
   dropdownItems,
   "data-cy": dataCy = "ellipsis-btn",
-}: Props) => (
+}) => (
   <Menu
     trigger={
       <Button

--- a/src/components/ButtonDropdown.tsx
+++ b/src/components/ButtonDropdown.tsx
@@ -9,7 +9,7 @@ interface Props {
   "data-cy"?: string;
 }
 
-export const ButtonDropdown: React.FC<Props> = ({
+export const ButtonDropdown: React.VFC<Props> = ({
   disabled = false,
   loading = false,
   dropdownItems,

--- a/src/components/Checkbox/CheckboxGroup.tsx
+++ b/src/components/Checkbox/CheckboxGroup.tsx
@@ -10,7 +10,7 @@ interface CheckboxesProps {
   onChange: (e: React.ChangeEvent<HTMLInputElement>, key: string) => void;
 }
 
-export const CheckboxGroup: React.FC<CheckboxesProps> = ({
+export const CheckboxGroup: React.VFC<CheckboxesProps> = ({
   data,
   value,
   onChange = () => undefined,

--- a/src/components/CodeChanges/CodeChanges.tsx
+++ b/src/components/CodeChanges/CodeChanges.tsx
@@ -19,7 +19,7 @@ import { commits } from "utils";
 
 const { bucketByCommit } = commits;
 
-export const CodeChanges: React.FC = () => {
+export const CodeChanges: React.VFC = () => {
   const { id } = useParams<{ id: string }>();
   const { data, loading, error } = useQuery<
     CodeChangesQuery,

--- a/src/components/CodeChangesBadge.tsx
+++ b/src/components/CodeChangesBadge.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import styled from "@emotion/styled";
 import Badge from "@leafygreen-ui/badge";
 import { uiColors } from "@leafygreen-ui/palette";
@@ -9,7 +8,10 @@ interface Props {
   deletions: number;
 }
 
-export const CodeChangesBadge: React.FC<Props> = ({ additions, deletions }) => (
+export const CodeChangesBadge: React.VFC<Props> = ({
+  additions,
+  deletions,
+}) => (
   <Badge>
     <FileDiffText type="+" value={additions} />
     <FileDiffText type="-" value={deletions} />
@@ -21,7 +23,7 @@ interface FileDiffTextProps {
   value: number;
 }
 
-export const FileDiffText: React.FC<FileDiffTextProps> = ({ value, type }) => {
+export const FileDiffText: React.VFC<FileDiffTextProps> = ({ value, type }) => {
   const hasValue = value > 0;
   return (
     <FileDiffTextContainer hasValue={hasValue} type={type}>

--- a/src/components/CodeChangesTable/index.tsx
+++ b/src/components/CodeChangesTable/index.tsx
@@ -9,7 +9,7 @@ interface CodeChangesTableProps {
   fileDiffs: FileDiffsFragment[];
   showHeader?: boolean;
 }
-export const CodeChangesTable: React.FC<CodeChangesTableProps> = ({
+export const CodeChangesTable: React.VFC<CodeChangesTableProps> = ({
   fileDiffs,
   showHeader = true,
 }) => (

--- a/src/components/CommitChartLabel/index.tsx
+++ b/src/components/CommitChartLabel/index.tsx
@@ -26,7 +26,7 @@ interface Props {
   versionId: string;
 }
 
-const CommitChartLabel: React.FC<Props> = ({
+const CommitChartLabel: React.VFC<Props> = ({
   githash,
   createTime,
   author,

--- a/src/components/ConditionalWrapper/index.tsx
+++ b/src/components/ConditionalWrapper/index.tsx
@@ -6,7 +6,7 @@ interface ConditionalWrapperProps {
   altWrapper?: (children: any) => JSX.Element;
   children: JSX.Element;
 }
-export const ConditionalWrapper: React.FC<ConditionalWrapperProps> = ({
+export const ConditionalWrapper: React.VFC<ConditionalWrapperProps> = ({
   condition,
   wrapper,
   altWrapper,

--- a/src/components/Content/index.tsx
+++ b/src/components/Content/index.tsx
@@ -36,7 +36,7 @@ import { UserPatches } from "pages/UserPatches";
 import { VariantHistory } from "pages/VariantHistory";
 import { VersionPage } from "pages/Version";
 
-export const Content: React.FC = () => {
+export const Content: React.VFC = () => {
   const { isAuthenticated } = useAuthStateContext();
 
   // this top-level query is required for authentication to work

--- a/src/components/DisplayModal.tsx
+++ b/src/components/DisplayModal.tsx
@@ -15,7 +15,7 @@ interface DisplayModalProps {
   children: React.ReactNode;
 }
 
-export const DisplayModal: React.FC<DisplayModalProps> = ({
+export const DisplayModal: React.VFC<DisplayModalProps> = ({
   children,
   "data-cy": dataCy,
   open,

--- a/src/components/DisplayModal.tsx
+++ b/src/components/DisplayModal.tsx
@@ -12,6 +12,7 @@ interface DisplayModalProps {
   ) => void | React.Dispatch<React.SetStateAction<boolean>>;
   size?: ModalSize;
   title?: string;
+  children: React.ReactNode;
 }
 
 export const DisplayModal: React.FC<DisplayModalProps> = ({

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -20,7 +20,7 @@ interface DropdownProps {
   setIsOpen: (isOpen: boolean) => void;
   onClose?: () => void;
 }
-const Dropdown: React.FC<DropdownProps> = ({
+const Dropdown: React.VFC<DropdownProps> = ({
   "data-cy": dataCy = "dropdown-button",
   id,
   disabled = false,

--- a/src/components/EditableTagField/TagRow.tsx
+++ b/src/components/EditableTagField/TagRow.tsx
@@ -20,7 +20,7 @@ interface TagRowProps {
   isNewTag?: boolean;
   buttonText: string;
 }
-export const TagRow: React.FC<TagRowProps> = ({
+export const TagRow: React.VFC<TagRowProps> = ({
   tag,
   onDelete,
   onUpdateTag,

--- a/src/components/EditableTagField/__snapshots__/EditableTagField.stories.storyshot
+++ b/src/components/EditableTagField/__snapshots__/EditableTagField.stories.storyshot
@@ -295,11 +295,6 @@ exports[`storybook Storyshots Editable Tags Field Editable Tag Field View 1`] = 
         className="leafygreen-ui-26sqyb"
         data-cy="add-tag-button"
         disabled={false}
-        glyph={
-          <Icon
-            glyph="Plus"
-          />
-        }
         onClick={[Function]}
         type="button"
       >
@@ -309,6 +304,24 @@ exports[`storybook Storyshots Editable Tags Field Editable Tag Field View 1`] = 
         <div
           className="leafygreen-ui-ie0uqp"
         >
+          <svg
+            alt=""
+            aria-hidden={true}
+            className="leafygreen-ui-1my2s1b"
+            fill="none"
+            height={16}
+            role="presentation"
+            viewBox="0 0 16 16"
+            width={16}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clipRule="evenodd"
+              d="M7.5 2a1 1 0 00-1 1v3.5H3a1 1 0 00-1 1v1a1 1 0 001 1h3.5V13a1 1 0 001 1h1a1 1 0 001-1V9.5H13a1 1 0 001-1v-1a1 1 0 00-1-1H9.5V3a1 1 0 00-1-1h-1z"
+              fill="currentColor"
+              fillRule="evenodd"
+            />
+          </svg>
           Add Tag
         </div>
       </button>

--- a/src/components/EditableTagField/index.tsx
+++ b/src/components/EditableTagField/index.tsx
@@ -16,7 +16,7 @@ type EditableTagFieldProps = {
   id?: string;
 };
 
-export const EditableTagField: React.FC<EditableTagFieldProps> = ({
+export const EditableTagField: React.VFC<EditableTagFieldProps> = ({
   onChange,
   inputTags,
   visible,

--- a/src/components/ErrorBoundary/index.tsx
+++ b/src/components/ErrorBoundary/index.tsx
@@ -68,7 +68,9 @@ const initializeBugsnag = () => {
   }
 };
 
-const ErrorBoundary: React.FC = ({ children }) => {
+const ErrorBoundary: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
   // In some cases we do not want to enable bugsnag (ex: testing environments).
   // In these cases we will return a fallback element
   const ErrorBoundaryComp = getBoundary();

--- a/src/components/ErrorBoundary/index.tsx
+++ b/src/components/ErrorBoundary/index.tsx
@@ -68,7 +68,7 @@ const initializeBugsnag = () => {
   }
 };
 
-const ErrorBoundary: React.FC<{ children: React.ReactNode }> = ({
+const ErrorBoundary: React.VFC<{ children: React.ReactNode }> = ({
   children,
 }) => {
   // In some cases we do not want to enable bugsnag (ex: testing environments).

--- a/src/components/ExpandedText/index.tsx
+++ b/src/components/ExpandedText/index.tsx
@@ -13,7 +13,7 @@ interface ExpandedTextProps {
   ["data-cy"]?: string;
 }
 
-const ExpandedText: React.FC<ExpandedTextProps> = ({
+const ExpandedText: React.VFC<ExpandedTextProps> = ({
   message,
   triggerEvent = TriggerEvent.Hover,
   popoverZIndex = zIndex.popover,

--- a/src/components/Feedback/index.tsx
+++ b/src/components/Feedback/index.tsx
@@ -13,7 +13,7 @@ import { GET_SPRUCE_CONFIG } from "gql/queries";
 
 const { green } = uiColors;
 
-export const Feedback: React.FC = () => {
+export const Feedback: React.VFC = () => {
   const { data } = useQuery<GetSpruceConfigQuery>(GET_SPRUCE_CONFIG);
 
   const userVoiceUrl = data?.spruceConfig?.ui?.userVoice;

--- a/src/components/FilterBadges/FilterBadge.tsx
+++ b/src/components/FilterBadges/FilterBadge.tsx
@@ -21,7 +21,10 @@ interface FilterBadgeProps {
   };
   onClose: () => void;
 }
-export const FilterBadge: React.FC<FilterBadgeProps> = ({ badge, onClose }) => {
+export const FilterBadge: React.VFC<FilterBadgeProps> = ({
+  badge,
+  onClose,
+}) => {
   // the trimmed name needs to account for the label
   const trimmedBadgeName = trimStringFromMiddle(
     badge.value,

--- a/src/components/FilterBadges/SeeMoreModal.tsx
+++ b/src/components/FilterBadges/SeeMoreModal.tsx
@@ -15,7 +15,7 @@ interface SeeMoreModalProps {
   onRemoveBadge: (key: string, value: string) => void;
   onClearAll: () => void;
 }
-export const SeeMoreModal: React.FC<SeeMoreModalProps> = ({
+export const SeeMoreModal: React.VFC<SeeMoreModalProps> = ({
   badges,
   notVisibleCount,
   onRemoveBadge,

--- a/src/components/FilterBadges/index.tsx
+++ b/src/components/FilterBadges/index.tsx
@@ -12,7 +12,7 @@ const { parseQueryString } = queryString;
 interface FilterBadgesProps {
   queryParamsToDisplay: Set<string>;
 }
-export const FilterBadges: React.FC<FilterBadgesProps> = ({
+export const FilterBadges: React.VFC<FilterBadgesProps> = ({
   queryParamsToDisplay,
 }) => {
   const updateQueryParams = useUpdateURLQueryParams();

--- a/src/components/FilterInputControls/index.tsx
+++ b/src/components/FilterInputControls/index.tsx
@@ -8,7 +8,7 @@ interface Props {
   submitButtonCopy?: string;
 }
 
-export const FilterInputControls: React.FC<Props> = ({
+export const FilterInputControls: React.VFC<Props> = ({
   onClickSubmit,
   onClickReset,
   submitButtonCopy = "Filter",

--- a/src/components/GroupedTaskStatusBadge/index.tsx
+++ b/src/components/GroupedTaskStatusBadge/index.tsx
@@ -21,7 +21,7 @@ interface Props {
   variant?: string;
 }
 
-export const GroupedTaskStatusBadge: React.FC<Props> = ({
+export const GroupedTaskStatusBadge: React.VFC<Props> = ({
   count,
   status,
   onClick = () => undefined,

--- a/src/components/Header/NavDropdown.tsx
+++ b/src/components/Header/NavDropdown.tsx
@@ -7,7 +7,7 @@ import { Link } from "react-router-dom";
 
 const { white } = uiColors;
 
-const DropdownMenuIcon: React.FC<{ open: boolean }> = ({ open }) => (
+const DropdownMenuIcon: React.VFC<{ open: boolean }> = ({ open }) => (
   <Icon glyph={open ? "CaretUp" : "CaretDown"} role="presentation" />
 );
 
@@ -23,7 +23,7 @@ interface DropdownItemType extends MenuItemType {
   closeMenu: () => void;
 }
 
-const DropdownItem: React.FC<DropdownItemType> = ({
+const DropdownItem: React.VFC<DropdownItemType> = ({
   "data-cy": itemDataCy,
   closeMenu,
   href,
@@ -47,7 +47,7 @@ interface DropdownProps {
   title: string;
 }
 
-export const Dropdown: React.FC<DropdownProps> = ({
+export const Dropdown: React.VFC<DropdownProps> = ({
   dataCy,
   menuItems,
   title,

--- a/src/components/Header/Navbar.tsx
+++ b/src/components/Header/Navbar.tsx
@@ -21,7 +21,7 @@ const { getUiUrl, isBeta } = environmentalVariables;
 
 const { white, blue, gray } = uiColors;
 
-export const Navbar: React.FC = () => {
+export const Navbar: React.VFC = () => {
   const { isAuthenticated } = useAuthStateContext();
   const legacyURL = useLegacyUIURL();
   const { sendEvent } = useNavbarAnalytics();

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -6,7 +6,7 @@ import {
 } from "components/Banners";
 import { Navbar } from "./Navbar";
 
-export const Header: React.FC = () => (
+export const Header: React.VFC = () => (
   <StyledHeader>
     <Navbar />
     <ConnectivityBanner />

--- a/src/components/HistoryTable/Cell/Cell.tsx
+++ b/src/components/HistoryTable/Cell/Cell.tsx
@@ -24,7 +24,7 @@ interface TaskCellProps {
   label?: string;
   loading?: boolean;
 }
-const TaskCell: React.FC<TaskCellProps> = ({
+const TaskCell: React.VFC<TaskCellProps> = ({
   task,
   inactive,
   failingTests,
@@ -53,7 +53,7 @@ const EmptyCell = () => (
 interface LoadingCellProps {
   isHeader?: boolean;
 }
-const LoadingCell: React.FC<LoadingCellProps> = ({ isHeader = false }) => (
+const LoadingCell: React.VFC<LoadingCellProps> = ({ isHeader = false }) => (
   <>
     {isHeader ? (
       <HeaderCell data-cy="loading-header-cell">
@@ -72,7 +72,7 @@ interface ColumnHeaderCellProps {
   trimmedDisplayName: string;
   fullDisplayName: string;
 }
-const ColumnHeaderCell: React.FC<ColumnHeaderCellProps> = ({
+const ColumnHeaderCell: React.VFC<ColumnHeaderCellProps> = ({
   link,
   trimmedDisplayName,
   fullDisplayName,

--- a/src/components/HistoryTable/ColumnPaginationButtons.tsx
+++ b/src/components/HistoryTable/ColumnPaginationButtons.tsx
@@ -5,7 +5,7 @@ import Icon from "components/Icon";
 import { size } from "constants/tokens";
 import { useHistoryTable } from "./HistoryTableContext";
 
-const ColumnPaginationButtons: React.FC = () => {
+const ColumnPaginationButtons: React.VFC = () => {
   const {
     nextPage,
     previousPage,

--- a/src/components/HistoryTable/HistoryTable.stories.tsx
+++ b/src/components/HistoryTable/HistoryTable.stories.tsx
@@ -37,7 +37,7 @@ export const VariantHistoryTable = () => (
 interface HistoryTableWrapperProps {
   type?: "variant" | "task";
 }
-const HistoryTableWrapper: React.FC<HistoryTableWrapperProps> = ({ type }) => {
+const HistoryTableWrapper: React.VFC<HistoryTableWrapperProps> = ({ type }) => {
   const { addColumns } = useHistoryTable();
   const [commitData, setCommitData] = useState(mainlineCommitData);
   useEffect(() => {

--- a/src/components/HistoryTable/HistoryTable.tsx
+++ b/src/components/HistoryTable/HistoryTable.tsx
@@ -14,11 +14,11 @@ interface HistoryTableProps {
   recentlyFetchedCommits: MainlineCommitsForHistoryQuery["mainlineCommits"];
   children: ComponentType<ListChildComponentProps<any>>;
 }
-const HistoryTable = ({
+const HistoryTable: React.VFC<HistoryTableProps> = ({
   loadMoreItems,
   recentlyFetchedCommits,
   children,
-}: HistoryTableProps) => {
+}) => {
   const {
     getItemHeight,
     fetchNewCommit,

--- a/src/components/HistoryTable/HistoryTableContext.tsx
+++ b/src/components/HistoryTable/HistoryTableContext.tsx
@@ -48,7 +48,7 @@ interface HistoryTableProviderProps {
   initialState?: HistoryTableReducerState;
 }
 
-const HistoryTableProvider: React.FC<HistoryTableProviderProps> = ({
+const HistoryTableProvider: React.VFC<HistoryTableProviderProps> = ({
   children,
   initialState = {
     loadedCommits: [],

--- a/src/components/HistoryTable/HistoryTableIcon/index.tsx
+++ b/src/components/HistoryTable/HistoryTableIcon/index.tsx
@@ -16,7 +16,7 @@ interface HistoryTableIconProps {
   onClick?: () => void;
 }
 
-export const HistoryTableIcon: React.FC<HistoryTableIconProps> = ({
+export const HistoryTableIcon: React.VFC<HistoryTableIconProps> = ({
   status,
   label,
   failingTests = [],

--- a/src/components/HistoryTable/HistoryTableRow/DateSeparator.tsx
+++ b/src/components/HistoryTable/HistoryTableRow/DateSeparator.tsx
@@ -12,7 +12,7 @@ interface DateSeparatorProps {
   date: Date;
 }
 
-export const DateSeparator: React.FC<DateSeparatorProps> = ({
+export const DateSeparator: React.VFC<DateSeparatorProps> = ({
   style,
   date,
 }) => {

--- a/src/components/HistoryTable/HistoryTableRow/FoldedCommit.tsx
+++ b/src/components/HistoryTable/HistoryTableRow/FoldedCommit.tsx
@@ -26,7 +26,7 @@ interface FoldedCommitProps {
   style?: CSSProperties;
   selected: boolean;
 }
-export const FoldedCommit = memo(
+export const FoldedCommit = memo<FoldedCommitProps>(
   ({
     index,
     rolledUpCommits,
@@ -34,7 +34,7 @@ export const FoldedCommit = memo(
     numVisibleCols,
     style,
     selected,
-  }: FoldedCommitProps) => {
+  }) => {
     const { height } = style;
 
     // The virtualized table will unmount the row when it is scrolled out of view but it will cache its height in memory.

--- a/src/components/HistoryTable/HistoryTableRow/FoldedCommit.tsx
+++ b/src/components/HistoryTable/HistoryTableRow/FoldedCommit.tsx
@@ -70,11 +70,12 @@ export const FoldedCommit = memo(
           title={`Expand ${numCommits} inactive`}
           toggledTitle={`Collapse ${numCommits} inactive`}
           titleTag={AccordionTitle}
-          contents={commits}
           onToggle={() => toggleRowSize(index, numCommits)}
           useIndent={false}
           defaultOpen={defaultOpen}
-        />
+        >
+          {commits}
+        </Accordion>
       </Column>
     );
   },

--- a/src/components/HistoryTable/HistoryTableRow/LoadingRow.tsx
+++ b/src/components/HistoryTable/HistoryTableRow/LoadingRow.tsx
@@ -4,7 +4,7 @@ import { LoadingCell, LabelCellContainer } from "../Cell/Cell";
 interface LoadingRowProps {
   numVisibleCols: number;
 }
-export const LoadingRow: React.FC<LoadingRowProps> = ({ numVisibleCols }) => (
+export const LoadingRow: React.VFC<LoadingRowProps> = ({ numVisibleCols }) => (
   <>
     <LabelCellContainer>
       <Skeleton active title={false} paragraph={{ rows: 3 }} />

--- a/src/components/HistoryTable/HistoryTableRow/Row.tsx
+++ b/src/components/HistoryTable/HistoryTableRow/Row.tsx
@@ -13,7 +13,7 @@ interface RowProps extends ListChildComponentProps {
   numVisibleCols: number;
   selected: boolean;
 }
-const Row: React.FC<RowProps> = ({
+const Row: React.VFC<RowProps> = ({
   columns,
   numVisibleCols,
   index,

--- a/src/components/HistoryTable/hooks/test-utils.tsx
+++ b/src/components/HistoryTable/hooks/test-utils.tsx
@@ -22,7 +22,7 @@ interface ProviderProps {
   state?: Partial<HistoryTableReducerState>;
   children: React.ReactNode;
 }
-const ProviderWrapper: React.FC<ProviderProps> = ({
+const ProviderWrapper: React.VFC<ProviderProps> = ({
   children,
   state = {},
   mocks = [],

--- a/src/components/HistoryTable/hooks/test-utils.tsx
+++ b/src/components/HistoryTable/hooks/test-utils.tsx
@@ -20,6 +20,7 @@ const initialState: HistoryTableReducerState = {
 interface ProviderProps {
   mocks?: MockedProviderProps["mocks"];
   state?: Partial<HistoryTableReducerState>;
+  children: React.ReactNode;
 }
 const ProviderWrapper: React.FC<ProviderProps> = ({
   children,

--- a/src/components/HostStatusBadge.tsx
+++ b/src/components/HostStatusBadge.tsx
@@ -11,7 +11,7 @@ interface Props {
   status: HostStatus;
 }
 
-export const HostStatusBadge: React.FC<Props> = ({ status }) => (
+export const HostStatusBadge: React.VFC<Props> = ({ status }) => (
   <HostStatusWrapper>
     <StyledBadge variant={statusToBadgeVariant[status]}>
       {hostStatusToCopy[status]}

--- a/src/components/Hosts/HostPopover.tsx
+++ b/src/components/Hosts/HostPopover.tsx
@@ -15,7 +15,7 @@ interface Props {
   "data-cy"?: string;
 }
 
-export const HostPopover: React.FC<Props> = ({
+export const HostPopover: React.VFC<Props> = ({
   buttonText,
   titleText,
   loading,

--- a/src/components/Hosts/Reprovision.tsx
+++ b/src/components/Hosts/Reprovision.tsx
@@ -20,7 +20,7 @@ interface Props {
   reprovisionTooltipMessage: string;
 }
 
-export const Reprovision: React.FC<Props> = ({
+export const Reprovision: React.VFC<Props> = ({
   selectedHostIds,
   hostUrl,
   isSingleHost,

--- a/src/components/Hosts/RestartJasper.tsx
+++ b/src/components/Hosts/RestartJasper.tsx
@@ -20,7 +20,7 @@ interface Props {
   jasperTooltipMessage: string;
 }
 
-export const RestartJasper: React.FC<Props> = ({
+export const RestartJasper: React.VFC<Props> = ({
   selectedHostIds,
   hostUrl,
   isSingleHost,

--- a/src/components/Hosts/UpdateStatusModal.tsx
+++ b/src/components/Hosts/UpdateStatusModal.tsx
@@ -26,7 +26,7 @@ interface Props {
   isSingleHost?: boolean;
 }
 
-export const UpdateStatusModal: React.FC<Props> = ({
+export const UpdateStatusModal: React.VFC<Props> = ({
   visible,
   "data-cy": dataCy,
   hostIds,

--- a/src/components/IconTooltip.tsx
+++ b/src/components/IconTooltip.tsx
@@ -12,7 +12,7 @@ interface IconTooltipProps {
   color?: string;
 }
 
-export const IconTooltip: React.FC<IconTooltipProps> = ({
+export const IconTooltip: React.VFC<IconTooltipProps> = ({
   tooltipText,
   iconType,
   color = black,

--- a/src/components/LinkToReconfigurePage.tsx
+++ b/src/components/LinkToReconfigurePage.tsx
@@ -4,7 +4,7 @@ import { useVersionAnalytics, usePatchAnalytics } from "analytics";
 import { DropdownItem } from "components/ButtonDropdown";
 import { getPatchRoute } from "constants/routes";
 
-export const LinkToReconfigurePage: React.FC<{
+export const LinkToReconfigurePage: React.VFC<{
   patchId: string;
   disabled?: boolean;
   hasVersion?: boolean;

--- a/src/components/Loading/FullPageLoad.tsx
+++ b/src/components/Loading/FullPageLoad.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from "@emotion/styled";
 
-export const FullPageLoad: React.FC = () => (
+export const FullPageLoad: React.VFC = () => (
   <FullPage>
     <div>LOADING...</div>
   </FullPage>

--- a/src/components/Loading/PatchAndTaskFullPageLoad.tsx
+++ b/src/components/Loading/PatchAndTaskFullPageLoad.tsx
@@ -9,7 +9,7 @@ import {
 } from "components/styles";
 import { H2 } from "components/Typography";
 
-export const PatchAndTaskFullPageLoad: React.FC = () => (
+export const PatchAndTaskFullPageLoad: React.VFC = () => (
   <PageWrapper>
     <H2>
       <Skeleton active paragraph={{ rows: 0 }} />

--- a/src/components/MetadataCard.tsx
+++ b/src/components/MetadataCard.tsx
@@ -10,9 +10,10 @@ interface Props {
   title: string;
   error: ApolloError;
   loading?: boolean;
+  children: React.ReactNode;
 }
 
-export const MetadataCard: React.FC<Props> = ({
+export const MetadataCard: React.VFC<Props> = ({
   title,
   children,
   error,

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -15,6 +15,7 @@ interface ModalProps {
   visible: boolean;
   onCancel: (e?: React.MouseEvent<HTMLElement, MouseEvent>) => void;
   onOk?: () => void;
+  children: React.ReactNode;
 }
 
 export const Modal: React.FC<ModalProps> = ({

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -18,7 +18,7 @@ interface ModalProps {
   children: React.ReactNode;
 }
 
-export const Modal: React.FC<ModalProps> = ({
+export const Modal: React.VFC<ModalProps> = ({
   footer,
   title,
   onCancel,

--- a/src/components/NotificationModal/RegexSelectorInput.tsx
+++ b/src/components/NotificationModal/RegexSelectorInput.tsx
@@ -24,7 +24,7 @@ export interface RegexSelectorProps {
   selectedOption: string;
 }
 
-export const RegexSelectorInput: React.FC<RegexSelectorProps> = ({
+export const RegexSelectorInput: React.VFC<RegexSelectorProps> = ({
   disabledDropdownOptions,
   dropdownOptions,
   onChangeRegexValue,

--- a/src/components/NotificationModal/index.tsx
+++ b/src/components/NotificationModal/index.tsx
@@ -37,7 +37,7 @@ interface NotificationModalProps extends UseNotificationModalProps {
   type: "task" | "version";
 }
 
-export const NotificationModal: React.FC<NotificationModalProps> = ({
+export const NotificationModal: React.VFC<NotificationModalProps> = ({
   visible,
   onCancel,
   subscriptionMethodDropdownOptions,

--- a/src/components/PageSizeSelector.tsx
+++ b/src/components/PageSizeSelector.tsx
@@ -17,7 +17,7 @@ interface Props {
   useLeafygreen?: boolean;
 }
 
-export const PageSizeSelector: React.FC<Props> = ({
+export const PageSizeSelector: React.VFC<Props> = ({
   value,
   "data-cy": dataCy,
   onClick,

--- a/src/components/PageTitle.tsx
+++ b/src/components/PageTitle.tsx
@@ -19,7 +19,7 @@ interface TitleTypographyProps {
   children: React.ReactNode | string;
 }
 
-const TitleTypography: React.FC<TitleTypographyProps> = ({
+const TitleTypography: React.VFC<TitleTypographyProps> = ({
   children,
   size,
 }) => {

--- a/src/components/PageTitle.tsx
+++ b/src/components/PageTitle.tsx
@@ -16,6 +16,7 @@ interface Props {
 
 interface TitleTypographyProps {
   size: Size;
+  children: React.ReactNode | string;
 }
 
 const TitleTypography: React.FC<TitleTypographyProps> = ({
@@ -30,7 +31,7 @@ const TitleTypography: React.FC<TitleTypographyProps> = ({
   }
 };
 
-export const PageTitle: React.FC<Props> = ({
+export const PageTitle: React.VFC<Props> = ({
   loading,
   hasData,
   title,

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -17,7 +17,7 @@ interface Props {
   useLeafygreen?: boolean;
 }
 
-export const Pagination: React.FC<Props> = ({
+export const Pagination: React.VFC<Props> = ({
   value,
   totalResults,
   numPages,

--- a/src/components/PatchActionButtons/AddNotification.tsx
+++ b/src/components/PatchActionButtons/AddNotification.tsx
@@ -9,7 +9,7 @@ interface Props {
   setParentLoading?: (loading: boolean) => void; // used to toggle loading state of parent
 }
 
-export const AddNotification: React.FC<Props> = ({ patchId }) => {
+export const AddNotification: React.VFC<Props> = ({ patchId }) => {
   const [isVisibleModal, setIsVisibleModal] = useState(false);
   const { sendEvent } = useVersionAnalytics(patchId);
 

--- a/src/components/PatchActionButtons/DisableTasks.tsx
+++ b/src/components/PatchActionButtons/DisableTasks.tsx
@@ -11,7 +11,7 @@ interface Props {
   patchId: string;
   refetchQueries: string[];
 }
-export const DisableTasks: React.FC<Props> = ({ patchId, refetchQueries }) => {
+export const DisableTasks: React.VFC<Props> = ({ patchId, refetchQueries }) => {
   const dispatchToast = useToastContext();
   const [disablePatch] = useMutation<
     SetPatchPriorityMutation,

--- a/src/components/PatchActionButtons/EnqueuePatch.tsx
+++ b/src/components/PatchActionButtons/EnqueuePatch.tsx
@@ -10,7 +10,7 @@ interface EnqueuePatchProps {
   visibilityControl?: [boolean, React.Dispatch<React.SetStateAction<boolean>>];
 }
 
-export const EnqueuePatch: React.FC<EnqueuePatchProps> = ({
+export const EnqueuePatch: React.VFC<EnqueuePatchProps> = ({
   patchId,
   commitMessage,
   disabled,

--- a/src/components/PatchActionButtons/RestartPatch.tsx
+++ b/src/components/PatchActionButtons/RestartPatch.tsx
@@ -12,7 +12,7 @@ interface RestartPatchProps {
   visibilityControl?: [boolean, React.Dispatch<React.SetStateAction<boolean>>];
   childPatches: Partial<Patch>[];
 }
-export const RestartPatch: React.FC<RestartPatchProps> = ({
+export const RestartPatch: React.VFC<RestartPatchProps> = ({
   isButton,
   disabled = false,
   patchId,

--- a/src/components/PatchActionButtons/ScheduleTasks.tsx
+++ b/src/components/PatchActionButtons/ScheduleTasks.tsx
@@ -9,7 +9,7 @@ interface ScheduleTasksProps {
   isButton?: boolean;
   disabled?: boolean;
 }
-export const ScheduleTasks: React.FC<ScheduleTasksProps> = ({
+export const ScheduleTasks: React.VFC<ScheduleTasksProps> = ({
   versionId,
   isButton,
   disabled = false,

--- a/src/components/PatchActionButtons/SetPatchPriority.tsx
+++ b/src/components/PatchActionButtons/SetPatchPriority.tsx
@@ -19,7 +19,7 @@ interface SetPriorityProps {
   refetchQueries: string[];
 }
 
-export const SetPatchPriority: React.FC<SetPriorityProps> = ({
+export const SetPatchPriority: React.VFC<SetPriorityProps> = ({
   patchId,
   disabled,
   refetchQueries,

--- a/src/components/PatchActionButtons/UnscheduleTasks.tsx
+++ b/src/components/PatchActionButtons/UnscheduleTasks.tsx
@@ -19,7 +19,7 @@ interface props {
   refetchQueries: string[];
   disabled?: boolean;
 }
-export const UnscheduleTasks: React.FC<props> = ({
+export const UnscheduleTasks: React.VFC<props> = ({
   patchId,
   refetchQueries,
   disabled,

--- a/src/components/PatchActionButtons/addNotification/PatchNotificationModal.tsx
+++ b/src/components/PatchActionButtons/addNotification/PatchNotificationModal.tsx
@@ -30,7 +30,7 @@ interface ModalProps {
   onCancel: () => void;
 }
 
-export const PatchNotificationModal: React.FC<ModalProps> = ({
+export const PatchNotificationModal: React.VFC<ModalProps> = ({
   visible,
   onCancel,
 }) => {

--- a/src/components/PatchStatusBadge.tsx
+++ b/src/components/PatchStatusBadge.tsx
@@ -8,7 +8,7 @@ interface Props {
   status: string;
 }
 
-export const PatchStatusBadge: React.FC<Props> = ({ status }) => (
+export const PatchStatusBadge: React.VFC<Props> = ({ status }) => (
   <StyledBadge variant={statusToBadgeVariant[status as PatchStatus]}>
     {patchStatusToCopy[status as PatchStatus]}
   </StyledBadge>

--- a/src/components/PatchesPage/ListArea.tsx
+++ b/src/components/PatchesPage/ListArea.tsx
@@ -5,7 +5,7 @@ import { Analytics } from "analytics/addPageAction";
 import { PatchesPagePatchesFragment } from "gql/generated/types";
 import { PatchCard } from "./PatchCard";
 
-export const ListArea: React.FC<{
+export const ListArea: React.VFC<{
   analyticsObject?: Analytics<
     | { name: "Click Patch Link" }
     | {

--- a/src/components/PatchesPage/PatchCard.tsx
+++ b/src/components/PatchesPage/PatchCard.tsx
@@ -33,7 +33,7 @@ interface Props extends PatchProps {
   >;
 }
 
-export const PatchCard: React.FC<Props> = ({
+export const PatchCard: React.VFC<Props> = ({
   id,
   childPatches,
   description,

--- a/src/components/PatchesPage/StatusSelector.tsx
+++ b/src/components/PatchesPage/StatusSelector.tsx
@@ -8,7 +8,7 @@ import {
   ALL_PATCH_STATUS,
 } from "types/patch";
 
-export const StatusSelector: React.FC = () => {
+export const StatusSelector: React.VFC = () => {
   const {
     inputValue: statusVal,
     setAndSubmitInputValue: statusValOnChange,

--- a/src/components/PatchesPage/index.tsx
+++ b/src/components/PatchesPage/index.tsx
@@ -43,7 +43,7 @@ interface Props {
   pageType: "project" | "user";
 }
 
-export const PatchesPage: React.FC<Props> = ({
+export const PatchesPage: React.VFC<Props> = ({
   analyticsObject,
   pageTitle,
   patches,

--- a/src/components/PatchesPage/patchCard/DropdownMenu.tsx
+++ b/src/components/PatchesPage/patchCard/DropdownMenu.tsx
@@ -17,7 +17,7 @@ interface Props {
   childPatches: Partial<Patch>[];
   hasVersion: boolean;
 }
-export const DropdownMenu: React.FC<Props> = ({
+export const DropdownMenu: React.VFC<Props> = ({
   patchId,
   childPatches,
   canEnqueueToCommitQueue,

--- a/src/components/PerfPlugin/TrendChartsPlugin.tsx
+++ b/src/components/PerfPlugin/TrendChartsPlugin.tsx
@@ -8,7 +8,7 @@ interface Props {
   taskId: string;
 }
 
-const TrendChartsPlugin: React.FC<Props> = ({ taskId }) => (
+const TrendChartsPlugin: React.VFC<Props> = ({ taskId }) => (
   <StyledIframe
     src={`${getSignalProcessingUrl()}/task/${taskId}/performanceData`}
     title="Task Performance Data"

--- a/src/components/Popconfirm/index.tsx
+++ b/src/components/Popconfirm/index.tsx
@@ -4,9 +4,11 @@ import Checkbox from "@leafygreen-ui/checkbox";
 import { Popconfirm as AntPopconfirm } from "antd";
 import { size } from "constants/tokens";
 
-export const Popconfirm: React.FC<
-  React.ComponentProps<typeof AntPopconfirm>
-> = ({ children, ...props }) => (
+interface Props extends React.ComponentProps<typeof AntPopconfirm> {
+  children: React.ReactNode;
+}
+
+export const Popconfirm: React.FC<Props> = ({ children, ...props }) => (
   // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
   <span
     onClick={(e) => {
@@ -21,6 +23,7 @@ interface PopconfirmWithCheckboxProps {
   onConfirm: (e: React.MouseEvent) => void;
   title: string;
   checkboxLabel?: string;
+  children: React.ReactNode;
 }
 
 export const PopconfirmWithCheckbox: React.FC<PopconfirmWithCheckboxProps> = ({

--- a/src/components/Popconfirm/index.tsx
+++ b/src/components/Popconfirm/index.tsx
@@ -8,7 +8,7 @@ interface Props extends React.ComponentProps<typeof AntPopconfirm> {
   children: React.ReactNode;
 }
 
-export const Popconfirm: React.FC<Props> = ({ children, ...props }) => (
+export const Popconfirm: React.VFC<Props> = ({ children, ...props }) => (
   // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
   <span
     onClick={(e) => {
@@ -26,7 +26,7 @@ interface PopconfirmWithCheckboxProps {
   children: React.ReactNode;
 }
 
-export const PopconfirmWithCheckbox: React.FC<PopconfirmWithCheckboxProps> = ({
+export const PopconfirmWithCheckbox: React.VFC<PopconfirmWithCheckboxProps> = ({
   checkboxLabel, // truthiness determines if checkbox is rendered
   children,
   onConfirm,

--- a/src/components/ProjectSettingsRedirect.tsx
+++ b/src/components/ProjectSettingsRedirect.tsx
@@ -10,7 +10,7 @@ import {
 } from "gql/generated/types";
 import { GET_VIEWABLE_PROJECTS } from "gql/queries";
 
-export const ProjectSettingsRedirect: React.FC = () => {
+export const ProjectSettingsRedirect: React.VFC = () => {
   const { data } = useQuery<
     GetViewableProjectRefsQuery,
     GetViewableProjectRefsQueryVariables

--- a/src/components/ResultCountLabel.tsx
+++ b/src/components/ResultCountLabel.tsx
@@ -10,7 +10,7 @@ interface Props {
   dataCyDenominator?: string;
   label: string;
 }
-export const ResultCountLabel: React.FC<Props> = ({
+export const ResultCountLabel: React.VFC<Props> = ({
   numerator,
   denominator,
   dataCyNumerator,

--- a/src/components/ScheduleTasksModal/index.tsx
+++ b/src/components/ScheduleTasksModal/index.tsx
@@ -137,7 +137,8 @@ export const ScheduleTasksModal: React.VFC<ScheduleTasksModalProps> = ({
                           }}
                         />
                       }
-                      contents={tasks.map(({ id, displayName }) => (
+                    >
+                      {tasks.map(({ id, displayName }) => (
                         <Checkbox
                           key={id}
                           data-cy={`${buildVariant}-${displayName}-task-checkbox`}
@@ -154,7 +155,7 @@ export const ScheduleTasksModal: React.VFC<ScheduleTasksModalProps> = ({
                           }}
                         />
                       ))}
-                    />
+                    </Accordion>
                   </AccordionWrapper>
                 );
               }

--- a/src/components/ScheduleTasksModal/index.tsx
+++ b/src/components/ScheduleTasksModal/index.tsx
@@ -22,7 +22,7 @@ interface ScheduleTasksModalProps {
   setOpen: (open: boolean) => void;
   versionId: string;
 }
-export const ScheduleTasksModal: React.FC<ScheduleTasksModalProps> = ({
+export const ScheduleTasksModal: React.VFC<ScheduleTasksModalProps> = ({
   open,
   setOpen,
   versionId,

--- a/src/components/Spawn/DetailsCard.tsx
+++ b/src/components/Spawn/DetailsCard.tsx
@@ -19,7 +19,7 @@ interface CardItem {
   value: JSX.Element;
 }
 
-const CardField: React.FC<CardItem> = ({ label, value }) =>
+const CardField: React.VFC<CardItem> = ({ label, value }) =>
   value !== undefined && (
     <FieldContainer>
       <FieldName>{label}</FieldName>
@@ -42,7 +42,7 @@ const CardContainer = styled(SiderCard)`
   padding: ${size.s} ${size.l};
 ` as typeof SiderCard;
 
-export const DetailsCard: React.FC<DetailsCardProps> = ({
+export const DetailsCard: React.VFC<DetailsCardProps> = ({
   type,
   "data-cy": dataCy,
   fieldMaps,

--- a/src/components/Spawn/ExpirationField.tsx
+++ b/src/components/Spawn/ExpirationField.tsx
@@ -29,7 +29,7 @@ interface ExpirationFieldProps {
   targetItem?: MyHost | MyVolume;
 }
 
-export const ExpirationField: React.FC<ExpirationFieldProps> = ({
+export const ExpirationField: React.VFC<ExpirationFieldProps> = ({
   onChange,
   data,
   isVolume,

--- a/src/components/Spawn/Layout.tsx
+++ b/src/components/Spawn/Layout.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import styled from "@emotion/styled";
-import Button from "@leafygreen-ui/button";
+import { ExtendableBox } from "@leafygreen-ui/box";
+import Button, { ButtonProps } from "@leafygreen-ui/button";
 import { Body, H2 } from "@leafygreen-ui/typography";
 import { Table } from "antd";
 import Badge from "components/Badge";
@@ -22,18 +23,25 @@ export const StyledBadge = styled(Badge)`
   margin: 0 ${size.xs};
 `;
 
-export const PlusButton = ({ children, ...props }) => (
-  <Button {...{ ...props, glyph: <Icon glyph="Plus" /> }} as="button">
-    {children}
-  </Button>
-);
+export const PlusButton: ExtendableBox<
+  ButtonProps & { ref?: React.Ref<any> },
+  "button"
+> = React.forwardRef(({ leftGlyph, ...rest }: ButtonProps, forwardRef) => (
+  <Button
+    ref={forwardRef}
+    {...{ ...rest, leftGlyph: <Icon glyph="Plus" /> }}
+    as="button"
+  />
+));
 
 const TableContainer = styled.div`
   overflow-x: scroll;
   width: 100%;
 `;
 
-export const SpawnTable = (props: React.ComponentProps<typeof Table>) => (
+export const SpawnTable: React.VFC<React.ComponentProps<typeof Table>> = (
+  props
+) => (
   <TableContainer>
     <Table
       {...{

--- a/src/components/Spawn/RegionSelector.tsx
+++ b/src/components/Spawn/RegionSelector.tsx
@@ -11,7 +11,7 @@ interface Props {
   awsRegions: string[];
 }
 
-export const RegionSelector: React.FC<Props> = ({
+export const RegionSelector: React.VFC<Props> = ({
   onChange,
   selectedRegion,
   awsRegions,

--- a/src/components/SpruceForm/Container.tsx
+++ b/src/components/SpruceForm/Container.tsx
@@ -7,6 +7,7 @@ interface ContainerProps {
   title?: string;
   id?: string;
   "data-cy"?: string;
+  children: React.ReactNode;
 }
 
 export const SpruceFormContainer: React.FC<ContainerProps> = ({

--- a/src/components/SpruceForm/Container.tsx
+++ b/src/components/SpruceForm/Container.tsx
@@ -10,7 +10,7 @@ interface ContainerProps {
   children: React.ReactNode;
 }
 
-export const SpruceFormContainer: React.FC<ContainerProps> = ({
+export const SpruceFormContainer: React.VFC<ContainerProps> = ({
   children,
   "data-cy": dataCy,
   id,

--- a/src/components/SpruceForm/CustomFields.tsx
+++ b/src/components/SpruceForm/CustomFields.tsx
@@ -5,7 +5,7 @@ import { size } from "constants/tokens";
 
 type TitleFieldProps = Pick<FieldProps, "id" | "title" | "uiSchema">;
 
-export const TitleField: React.FC<TitleFieldProps> = ({
+export const TitleField: React.VFC<TitleFieldProps> = ({
   id,
   title,
   uiSchema,

--- a/src/components/SpruceForm/FieldTemplates.tsx
+++ b/src/components/SpruceForm/FieldTemplates.tsx
@@ -28,7 +28,7 @@ const getIndex = (id: string): number => {
 };
 
 // Custom field template that does not render fields' titles, as this is handled by LeafyGreen widgets
-export const DefaultFieldTemplate: React.FC<FieldTemplateProps> = ({
+export const DefaultFieldTemplate: React.VFC<FieldTemplateProps> = ({
   classNames,
   children,
   description,
@@ -66,7 +66,7 @@ const DefaultFieldContainer = styled.div<{ border?: "top" | "bottom" }>`
     `border-${border}: 1px solid ${gray.light1}; padding-${border}: ${size.s};`}
 `;
 
-const ArrayItem: React.FC<
+const ArrayItem: React.VFC<
   {
     border: boolean;
     title: string;
@@ -175,7 +175,7 @@ const ArrayItemRow = styled.div<{ border: boolean; index: number }>`
   }
 `;
 
-export const ArrayFieldTemplate: React.FC<ArrayFieldTemplateProps> = ({
+export const ArrayFieldTemplate: React.VFC<ArrayFieldTemplateProps> = ({
   canAdd,
   DescriptionField,
   disabled,
@@ -268,7 +268,7 @@ const DeleteButtonWrapper = styled(ElementWrapper)`
     topAlignDelete ? "0px" : "20px"};
 `;
 
-export const CardFieldTemplate: React.FC<ObjectFieldTemplateProps> = ({
+export const CardFieldTemplate: React.VFC<ObjectFieldTemplateProps> = ({
   idSchema,
   properties,
   title,
@@ -283,7 +283,7 @@ export const CardFieldTemplate: React.FC<ObjectFieldTemplateProps> = ({
   </SpruceFormContainer>
 );
 
-export const AccordionFieldTemplate: React.FC<ObjectFieldTemplateProps> = ({
+export const AccordionFieldTemplate: React.VFC<ObjectFieldTemplateProps> = ({
   disabled,
   idSchema,
   properties,

--- a/src/components/SpruceForm/FieldTemplates.tsx
+++ b/src/components/SpruceForm/FieldTemplates.tsx
@@ -304,8 +304,9 @@ export const AccordionFieldTemplate: React.VFC<ObjectFieldTemplateProps> = ({
         numberedTitle ? `${numberedTitle} ${index + 1}` : displayTitle || title
       }
       titleTag={AccordionTitle}
-      contents={properties.map(({ content }) => content)}
-    />
+    >
+      {properties.map(({ content }) => content)}
+    </Accordion>
   );
 };
 

--- a/src/components/SpruceForm/LeafyGreenWidgets.tsx
+++ b/src/components/SpruceForm/LeafyGreenWidgets.tsx
@@ -21,7 +21,7 @@ import ElementWrapper from "./ElementWrapper";
 const { reportError } = errorReporting;
 const { red } = uiColors;
 
-export const LeafyGreenTextInput: React.FC<WidgetProps> = ({
+export const LeafyGreenTextInput: React.VFC<WidgetProps> = ({
   value,
   label,
   placeholder,
@@ -73,7 +73,7 @@ export const LeafyGreenTextInput: React.FC<WidgetProps> = ({
   );
 };
 
-export const LeafyGreenCheckBox: React.FC<WidgetProps> = ({
+export const LeafyGreenCheckBox: React.VFC<WidgetProps> = ({
   value,
   label,
   onChange,
@@ -119,7 +119,7 @@ const IconContainer = styled.span`
   vertical-align: text-top;
 `;
 
-export const LeafyGreenSelect: React.FC<WidgetProps> = ({
+export const LeafyGreenSelect: React.VFC<WidgetProps> = ({
   disabled,
   label,
   options,
@@ -181,7 +181,7 @@ export const LeafyGreenSelect: React.FC<WidgetProps> = ({
   );
 };
 
-export const LeafyGreenRadio: React.FC<WidgetProps> = ({
+export const LeafyGreenRadio: React.VFC<WidgetProps> = ({
   label,
   options,
   value,
@@ -214,7 +214,7 @@ export const LeafyGreenRadio: React.FC<WidgetProps> = ({
   );
 };
 
-export const LeafyGreenRadioBox: React.FC<WidgetProps> = ({
+export const LeafyGreenRadioBox: React.VFC<WidgetProps> = ({
   id,
   label,
   options,
@@ -294,7 +294,7 @@ const StyledRadioBox = styled(RadioBox)`
   line-height: 1.25;
 `;
 
-export const LeafyGreenTextArea: React.FC<WidgetProps> = ({
+export const LeafyGreenTextArea: React.VFC<WidgetProps> = ({
   label,
   disabled,
   value,
@@ -321,7 +321,7 @@ export const LeafyGreenTextArea: React.FC<WidgetProps> = ({
   );
 };
 
-export const LeafyGreenSegmentedControl: React.FC<WidgetProps> = ({
+export const LeafyGreenSegmentedControl: React.VFC<WidgetProps> = ({
   disabled,
   label,
   onChange,

--- a/src/components/SpruceForm/index.tsx
+++ b/src/components/SpruceForm/index.tsx
@@ -13,7 +13,7 @@ export type SpruceFormProps = Pick<
 > &
   Partial<FormProps<any>>;
 
-export const SpruceForm: React.FC<SpruceFormProps> = ({
+export const SpruceForm: React.VFC<SpruceFormProps> = ({
   schema,
   onChange,
   uiSchema,

--- a/src/components/TabLabelWithBadge.tsx
+++ b/src/components/TabLabelWithBadge.tsx
@@ -7,7 +7,7 @@ interface Props {
   badgeVariant: Variant;
   dataCyBadge?: string;
 }
-export const TabLabelWithBadge: React.FC<Props> = ({
+export const TabLabelWithBadge: React.VFC<Props> = ({
   tabLabel,
   badgeText,
   badgeVariant,

--- a/src/components/Table/TasksTable.tsx
+++ b/src/components/Table/TasksTable.tsx
@@ -47,7 +47,7 @@ interface TasksTableProps {
   variantInputProps?: InputFilterProps;
 }
 
-export const TasksTable: React.FC<TasksTableProps> = ({
+export const TasksTable: React.VFC<TasksTableProps> = ({
   baseStatusSelectorProps,
   taskNameInputProps,
   onClickTaskLink = () => {},
@@ -269,7 +269,7 @@ interface TaskLinkProps {
   taskName: string;
   onClick: (taskId: string) => void;
 }
-const TaskLink: React.FC<TaskLinkProps> = ({ taskId, taskName, onClick }) => (
+const TaskLink: React.VFC<TaskLinkProps> = ({ taskId, taskName, onClick }) => (
   <StyledRouterLink onClick={() => onClick(taskId)} to={getTaskRoute(taskId)}>
     <WordBreak>{taskName}</WordBreak>
   </StyledRouterLink>

--- a/src/components/TableSearchPopover.tsx
+++ b/src/components/TableSearchPopover.tsx
@@ -14,7 +14,7 @@ interface TableSearchPopoverProps {
   onConfirm: (search: string) => void;
 }
 
-export const TableSearchPopover: React.FC<TableSearchPopoverProps> = ({
+export const TableSearchPopover: React.VFC<TableSearchPopoverProps> = ({
   onConfirm,
 }) => {
   const [active, setActive] = useState(false);

--- a/src/components/TaskStatusBadge/index.tsx
+++ b/src/components/TaskStatusBadge/index.tsx
@@ -30,7 +30,7 @@ const StyledBadge = styled(Badge)<BadgeColorProps>`
 interface TaskStatusBadgeProps {
   status: string;
 }
-const TaskStatusBadge: React.FC<TaskStatusBadgeProps> = ({ status }) => {
+const TaskStatusBadge: React.VFC<TaskStatusBadgeProps> = ({ status }) => {
   let displayStatus = getStatusBadgeCopy(status);
 
   if (taskStatusToCopy[status] === undefined) {

--- a/src/components/TaskStatusFilters/index.tsx
+++ b/src/components/TaskStatusFilters/index.tsx
@@ -13,7 +13,7 @@ interface Props {
   filterWidth?: string;
 }
 
-export const TaskStatusFilters: React.FC<Props> = ({
+export const TaskStatusFilters: React.VFC<Props> = ({
   onChangeBaseStatusFilter,
   onChangeStatusFilter,
   versionId,

--- a/src/components/TaskStatusIcon/index.tsx
+++ b/src/components/TaskStatusIcon/index.tsx
@@ -14,7 +14,7 @@ interface TaskStatusIconProps
   size?: number;
 }
 
-export const TaskStatusIcon: React.FC<TaskStatusIconProps> = ({
+export const TaskStatusIcon: React.VFC<TaskStatusIconProps> = ({
   status,
   size = 16,
   ...rest

--- a/src/components/TaskStatusIconLegend/index.tsx
+++ b/src/components/TaskStatusIconLegend/index.tsx
@@ -25,7 +25,7 @@ export const LegendContent = () => (
   </Container>
 );
 
-export const TaskStatusIconLegend: React.FC = () => {
+export const TaskStatusIconLegend: React.VFC = () => {
   const [isActive, setIsActive] = useState(false);
 
   return (

--- a/src/components/TextInputWithGlyph/index.tsx
+++ b/src/components/TextInputWithGlyph/index.tsx
@@ -5,7 +5,7 @@ import Icon from "components/Icon";
 type TextInputWithGlyphProps = {
   glyph: string;
 } & React.ComponentProps<typeof TextInput>;
-const TextInputWithGlyph: React.FC<TextInputWithGlyphProps> = (props) => {
+const TextInputWithGlyph: React.VFC<TextInputWithGlyphProps> = (props) => {
   const { glyph, ...rest } = props;
   return (
     <TextInputWrapper>

--- a/src/components/TreeSelect/TreeSelect.tsx
+++ b/src/components/TreeSelect/TreeSelect.tsx
@@ -319,7 +319,7 @@ const getAllValues = (tData: TreeDataEntry[]): string[] =>
 
 const getCheckboxWrapper = (
   level: number
-): React.FC<{ children: React.ReactNode }> => styled.div`
+): React.VFC<{ children: React.ReactNode }> => styled.div`
   padding-left: ${level}em;
   padding-top: ${size.xxs};
   padding-bottom: ${size.xxs};

--- a/src/components/TreeSelect/TreeSelect.tsx
+++ b/src/components/TreeSelect/TreeSelect.tsx
@@ -32,7 +32,7 @@ export interface TreeDataEntry extends TreeDataChildEntry {
   children?: TreeDataChildEntry[];
 }
 
-export const TreeSelect: React.FC<TreeSelectProps> = ({
+export const TreeSelect: React.VFC<TreeSelectProps> = ({
   isDropdown = false,
   isVisible = true,
   hasStyling = true,
@@ -317,7 +317,9 @@ const getAllValues = (tData: TreeDataEntry[]): string[] =>
     return accum.concat([currNode.value]).concat(childrenValues);
   }, []);
 
-const getCheckboxWrapper = (level: number): React.FC => styled.div`
+const getCheckboxWrapper = (
+  level: number
+): React.FC<{ children: React.ReactNode }> => styled.div`
   padding-left: ${level}em;
   padding-top: ${size.xxs};
   padding-bottom: ${size.xxs};

--- a/src/components/TupleSelect/index.tsx
+++ b/src/components/TupleSelect/index.tsx
@@ -19,7 +19,7 @@ type option = {
 interface TupleSelectProps {
   options: option[];
 }
-export const TupleSelect: React.FC<TupleSelectProps> = ({ options }) => {
+export const TupleSelect: React.VFC<TupleSelectProps> = ({ options }) => {
   const [input, setInput] = useState("");
   const [selected, setSelected] = useState(options[0].value);
   const updateQueryParams = useUpdateURLQueryParams();

--- a/src/components/UserPatchesRedirect.tsx
+++ b/src/components/UserPatchesRedirect.tsx
@@ -1,7 +1,7 @@
 import { useParams, Redirect } from "react-router-dom";
 import { getUserPatchesRoute } from "constants/routes";
 
-export const UserPatchesRedirect: React.FC = () => {
+export const UserPatchesRedirect: React.VFC = () => {
   const { id } = useParams<{ id: string }>();
   return <Redirect to={getUserPatchesRoute(id)} />;
 };

--- a/src/components/VariantGroupedTaskStatusBadges/index.tsx
+++ b/src/components/VariantGroupedTaskStatusBadges/index.tsx
@@ -10,7 +10,7 @@ interface Props {
   versionId: string;
   onClick?: (statuses: string[]) => () => void;
 }
-const VariantGroupedTaskStatusBadges: React.FC<Props> = ({
+const VariantGroupedTaskStatusBadges: React.VFC<Props> = ({
   variant,
   statusCounts,
   versionId,

--- a/src/components/VersionRestartModal/BuildVariantAccordian.tsx
+++ b/src/components/VersionRestartModal/BuildVariantAccordian.tsx
@@ -50,18 +50,14 @@ export const BuildVariantAccordian: React.VFC<BuildVariantAccordianProps> = ({
   );
   return (
     <AccordionWrapper data-cy="variant-accordion">
-      <Accordion
-        title={variantTitle}
-        titleTag={FlexContainer}
-        contents={
-          <TaskStatusCheckboxContainer
-            versionId={versionId}
-            tasks={tasks}
-            selectedTasks={selectedTasks}
-            toggleSelectedTask={toggleSelectedTask}
-          />
-        }
-      />
+      <Accordion title={variantTitle} titleTag={FlexContainer}>
+        <TaskStatusCheckboxContainer
+          versionId={versionId}
+          tasks={tasks}
+          selectedTasks={selectedTasks}
+          toggleSelectedTask={toggleSelectedTask}
+        />
+      </Accordion>
     </AccordionWrapper>
   );
 };

--- a/src/components/VersionRestartModal/BuildVariantAccordian.tsx
+++ b/src/components/VersionRestartModal/BuildVariantAccordian.tsx
@@ -20,7 +20,7 @@ interface BuildVariantAccordianProps {
     taskIds: { [versionId: string]: string } | { [versionId: string]: string[] }
   ) => void;
 }
-export const BuildVariantAccordian: React.FC<BuildVariantAccordianProps> = ({
+export const BuildVariantAccordian: React.VFC<BuildVariantAccordianProps> = ({
   versionId,
   tasks,
   displayName,

--- a/src/components/VersionRestartModal/TaskStatusCheckbox.tsx
+++ b/src/components/VersionRestartModal/TaskStatusCheckbox.tsx
@@ -13,7 +13,7 @@ interface TaskStatusCheckboxProps {
   style: React.CSSProperties; // passed in by react-window to handle list virtualization
 }
 
-const CheckboxComponent: React.FC<TaskStatusCheckboxProps> = ({
+const CheckboxComponent: React.VFC<TaskStatusCheckboxProps> = ({
   taskId,
   status,
   baseStatus,

--- a/src/components/VersionRestartModal/TaskStatusCheckboxContainer.tsx
+++ b/src/components/VersionRestartModal/TaskStatusCheckboxContainer.tsx
@@ -14,7 +14,7 @@ interface TaskStatusCheckboxContainerProps {
   selectedTasks: selectedStrings;
   toggleSelectedTask: (taskIds: { [patchId: string]: string }) => void;
 }
-export const TaskStatusCheckboxContainer: React.FC<TaskStatusCheckboxContainerProps> = ({
+export const TaskStatusCheckboxContainer: React.VFC<TaskStatusCheckboxContainerProps> = ({
   versionId,
   tasks,
   selectedTasks,

--- a/src/components/VersionRestartModal/VersionRestartModal.tsx
+++ b/src/components/VersionRestartModal/VersionRestartModal.tsx
@@ -171,20 +171,19 @@ const VersionRestartModal: React.VFC<Props> = ({
                       {v?.projectIdentifier ? v?.projectIdentifier : v?.project}
                     </BoldTextStyle>
                   }
-                  contents={
-                    <TitleContainer>
-                      <VersionTasks
-                        version={v}
-                        selectedTasks={selectedTasks}
-                        setBaseStatusFilterTerm={setVersionBaseStatus(v?.id)}
-                        setVersionStatusFilterTerm={setVersionStatus(v?.id)}
-                        toggleSelectedTask={toggleSelectedTask}
-                        baseStatusFilterTerm={baseStatusFilterTerm[v.id]}
-                        versionStatusFilterTerm={versionStatusFilterTerm[v.id]}
-                      />
-                    </TitleContainer>
-                  }
-                />
+                >
+                  <TitleContainer>
+                    <VersionTasks
+                      version={v}
+                      selectedTasks={selectedTasks}
+                      setBaseStatusFilterTerm={setVersionBaseStatus(v?.id)}
+                      setVersionStatusFilterTerm={setVersionStatus(v?.id)}
+                      toggleSelectedTask={toggleSelectedTask}
+                      baseStatusFilterTerm={baseStatusFilterTerm[v.id]}
+                      versionStatusFilterTerm={versionStatusFilterTerm[v.id]}
+                    />
+                  </TitleContainer>
+                </Accordion>
               ))}
               <br />
             </div>

--- a/src/components/VersionRestartModal/VersionRestartModal.tsx
+++ b/src/components/VersionRestartModal/VersionRestartModal.tsx
@@ -38,7 +38,7 @@ interface Props {
   refetchQueries: string[];
   childPatches: Partial<Patch>[];
 }
-const VersionRestartModal: React.FC<Props> = ({
+const VersionRestartModal: React.VFC<Props> = ({
   visible,
   onOk,
   onCancel,
@@ -219,7 +219,7 @@ interface VersionTasksProps {
   versionStatusFilterTerm: string[];
 }
 
-const VersionTasks: React.FC<VersionTasksProps> = ({
+const VersionTasks: React.VFC<VersionTasksProps> = ({
   version,
   selectedTasks,
   setBaseStatusFilterTerm,

--- a/src/components/WelcomeModal/WelcomeModal.tsx
+++ b/src/components/WelcomeModal/WelcomeModal.tsx
@@ -127,7 +127,7 @@ type CarouselCardProps = {
   description: string;
 };
 
-const CarouselCard: React.FC<CarouselCardProps> = ({
+const CarouselCard: React.VFC<CarouselCardProps> = ({
   img,
   subtitle,
   description,
@@ -147,7 +147,7 @@ interface CarouselDotProps {
   slider: React.MutableRefObject<CarouselRef>;
 }
 
-const CarouselDots: React.FC<CarouselDotProps> = ({
+const CarouselDots: React.VFC<CarouselDotProps> = ({
   activeSlide,
   cards,
   slider,

--- a/src/components/projectSelect/FavoriteStar.tsx
+++ b/src/components/projectSelect/FavoriteStar.tsx
@@ -18,7 +18,7 @@ interface FavoriteStarProps {
   isFavorite: boolean;
   ["data-cy"]?: string;
 }
-export const FavoriteStar: React.FC<FavoriteStarProps> = ({
+export const FavoriteStar: React.VFC<FavoriteStarProps> = ({
   identifier,
   isFavorite,
   "data-cy": dataCy,

--- a/src/components/projectSelect/ProjectOptionGroup.tsx
+++ b/src/components/projectSelect/ProjectOptionGroup.tsx
@@ -13,7 +13,7 @@ interface OptionProps {
   isFavorite: boolean;
   onClick: (identifier: string) => void;
 }
-const ProjectOption: React.FC<OptionProps> = ({
+const ProjectOption: React.VFC<OptionProps> = ({
   displayName,
   isFavorite,
   identifier,
@@ -36,7 +36,7 @@ interface OptionGroupProps {
   }[];
   onClick: (identifier: string) => void;
 }
-export const ProjectOptionGroup: React.FC<OptionGroupProps> = ({
+export const ProjectOptionGroup: React.VFC<OptionGroupProps> = ({
   name,
   projects,
   onClick,

--- a/src/components/projectSelect/index.tsx
+++ b/src/components/projectSelect/index.tsx
@@ -25,7 +25,7 @@ interface ProjectSelectProps {
   isProjectSettingsPage?: boolean;
   getRoute: (projectIdentifier: string) => string;
 }
-export const ProjectSelect: React.FC<ProjectSelectProps> = ({
+export const ProjectSelect: React.VFC<ProjectSelectProps> = ({
   selectedProjectIdentifier,
   isProjectSettingsPage = false,
   getRoute,

--- a/src/components/styles/StyledTabs.tsx
+++ b/src/components/styles/StyledTabs.tsx
@@ -3,7 +3,7 @@ import styled from "@emotion/styled";
 import { Tabs, Tab } from "@leafygreen-ui/tabs";
 
 type StyledTabsProps = React.ComponentProps<typeof Tabs>;
-export const StyledTabs: React.FC<StyledTabsProps> = ({
+export const StyledTabs: React.VFC<StyledTabsProps> = ({
   children,
   ...rest
 }) => (

--- a/src/context/Providers.tsx
+++ b/src/context/Providers.tsx
@@ -3,7 +3,7 @@ import LeafyGreenProvider from "@leafygreen-ui/leafygreen-provider";
 import { AuthProvider } from "context/auth";
 import { ToastProvider } from "context/toast";
 
-export const ContextProviders: React.FC<{ children: React.ReactNode }> = ({
+export const ContextProviders: React.VFC<{ children: React.ReactNode }> = ({
   children,
 }) => (
   <AuthProvider>

--- a/src/context/Providers.tsx
+++ b/src/context/Providers.tsx
@@ -3,7 +3,9 @@ import LeafyGreenProvider from "@leafygreen-ui/leafygreen-provider";
 import { AuthProvider } from "context/auth";
 import { ToastProvider } from "context/toast";
 
-export const ContextProviders: React.FC = ({ children }) => (
+export const ContextProviders: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => (
   <AuthProvider>
     <LeafyGreenProvider baseFontSize={14}>
       <ToastProvider>{children}</ToastProvider>

--- a/src/context/__mocks__/toast.tsx
+++ b/src/context/__mocks__/toast.tsx
@@ -7,16 +7,16 @@ type DispatchToast = ReturnType<typeof useToastContext>;
  *  and returns a React Component which renders the component with the context mocked out.
  *  This is useful for testing components that use the useToastContext hook.
  *  It also exposes some methods to assert that the toast context was called with the correct parameters.
- * @param {React.FC} Component - A React Component which implements useToastContext
+ * @param {React.VFC} Component - A React Component which implements useToastContext
  * @returns {Object} response - An object with the following properties:
- * @returns {React.FC} response.Component - A React Component which renders the component with the context mocked out
+ * @returns {React.VFC} response.Component - A React Component which renders the component with the context mocked out
  * @returns {Object} response.dispatchToast - A series of jest.fn() methods which can be used to assert that the toast context was called with the correct parameters
  * @returns {Function} response.dispatchToast.success - A jest.fn() method which can be used to assert that the success toast context was called
  * @returns {Function} response.dispatchToast.error - A jest.fn() method which can be used to assert that the error toast context was called
  * @returns {Function} response.dispatchToast.info - A jest.fn() method which can be used to assert that the info toast context was called
  * @returns {Function} response.dispatchToast.warning - A jest.fn() method which can be used to assert that the warning toast context was called
  * @returns {Function} response.dispatchToast.hide - A jest.fn() method which can be used to assert that the hide toast context was called
- * @returns {React.FC} response.HookWrapper - A React Component which wraps a hook and has the useToastContext mocked out but utilizes the same methods
+ * @returns {React.VFC} response.HookWrapper - A React Component which wraps a hook and has the useToastContext mocked out but utilizes the same methods
  * @returns {Function} response.useToastContext - A jest.fn() method which can be used to assert that the useToastContext hook was called
  */
 const RenderFakeToastContext = (Component?: React.ReactElement) => {

--- a/src/context/auth.tsx
+++ b/src/context/auth.tsx
@@ -31,7 +31,9 @@ const reducer = (state: AuthState, action: Action): AuthState => {
 const AuthDispatchContext = React.createContext<DispatchContext | null>(null);
 const AuthStateContext = React.createContext<AuthState | null>(null);
 
-const AuthProvider: React.FC = ({ children }) => {
+const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
   const [state, dispatch] = useReducer(reducer, {
     isAuthenticated: false,
   });

--- a/src/context/auth.tsx
+++ b/src/context/auth.tsx
@@ -31,7 +31,7 @@ const reducer = (state: AuthState, action: Action): AuthState => {
 const AuthDispatchContext = React.createContext<DispatchContext | null>(null);
 const AuthStateContext = React.createContext<AuthState | null>(null);
 
-const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
+const AuthProvider: React.VFC<{ children: React.ReactNode }> = ({
   children,
 }) => {
   const [state, dispatch] = useReducer(reducer, {

--- a/src/context/toast.test.tsx
+++ b/src/context/toast.test.tsx
@@ -17,7 +17,7 @@ describe("real Toast", () => {
   // Since useToastContext relies on the toastProvider which in turn relies on the react.createPortal api we cannot test it directly
   // because the react.createPortal api is not available in the testing-library/react-hooks test environment. So we need to create a wrapper
   // component that will render the toastProvider and useToastContext and test the useToastContext hook internally.
-  const UseToastComponent: React.FC<UseToastComponentProps> = (props) => {
+  const UseToastComponent: React.VFC<UseToastComponentProps> = (props) => {
     const type = Object.keys(props)[0];
     const params = Object.values(props)[0] as [];
     const dispatchToast = useToastContext();
@@ -191,7 +191,7 @@ describe("real Toast", () => {
 });
 
 describe("mocked Fake Toast", () => {
-  const UseToastComponent: React.FC = () => {
+  const UseToastComponent: React.VFC = () => {
     const dispatchToast = useToastContext();
     return (
       <button type="button" onClick={() => dispatchToast.success("test")}>

--- a/src/context/toast.tsx
+++ b/src/context/toast.tsx
@@ -70,7 +70,7 @@ export const ToastDispatchContext = React.createContext<DispatchToast | null>(
   null
 );
 
-const ToastProvider: React.FC<{ children: React.ReactNode }> = ({
+const ToastProvider: React.VFC<{ children: React.ReactNode }> = ({
   children,
 }) => {
   const [visibleToast, setVisibleToast] = useState<ToastProps>({

--- a/src/context/toast.tsx
+++ b/src/context/toast.tsx
@@ -66,9 +66,13 @@ const variantToTitleMap = {
   [Variant.Note]: "Something Happened!",
 };
 
-export const ToastDispatchContext = React.createContext<any | null>(null);
+export const ToastDispatchContext = React.createContext<DispatchToast | null>(
+  null
+);
 
-const ToastProvider: React.FC = ({ children }) => {
+const ToastProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
   const [visibleToast, setVisibleToast] = useState<ToastProps>({
     variant: Variant.Note,
     message: "",
@@ -97,7 +101,7 @@ const ToastProvider: React.FC = ({ children }) => {
     title: null,
   };
 
-  const toastContext: DispatchToast = {
+  const toastContext = {
     success: (message = "", closable = true, options = defaultOptions) =>
       addToast({
         variant: mapToastToLeafyGreenVariant.success,

--- a/src/gql/GQLWrapper.tsx
+++ b/src/gql/GQLWrapper.tsx
@@ -16,7 +16,7 @@ const { reportError, leaveBreadcrumb } = errorReporting;
 
 const { getGQLUrl } = environmentalVariables;
 
-const GQLWrapper: React.FC = ({ children }) => {
+const GQLWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const { logoutAndRedirect, dispatchAuthenticated } = useAuthDispatchContext();
   return (
     <ApolloProvider

--- a/src/gql/GQLWrapper.tsx
+++ b/src/gql/GQLWrapper.tsx
@@ -16,7 +16,7 @@ const { reportError, leaveBreadcrumb } = errorReporting;
 
 const { getGQLUrl } = environmentalVariables;
 
-const GQLWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+const GQLWrapper: React.VFC<{ children: React.ReactNode }> = ({ children }) => {
   const { logoutAndRedirect, dispatchAuthenticated } = useAuthDispatchContext();
   return (
     <ApolloProvider

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -1502,7 +1502,7 @@ export type ProjectEventSettings = {
 
 export type RepoEventSettings = {
   githubWebhooksEnabled: Scalars["Boolean"];
-  projectRef?: Maybe<Project>;
+  projectRef?: Maybe<RepoRef>;
   vars?: Maybe<ProjectVars>;
   aliases?: Maybe<Array<ProjectAlias>>;
   subscriptions?: Maybe<Array<ProjectSubscription>>;

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,4 +1,4 @@
 import React from "react";
 import NotFound from "./404/NotFound";
 
-export const PageDoesNotExist: React.FC = () => <NotFound />;
+export const PageDoesNotExist: React.VFC = () => <NotFound />;

--- a/src/pages/CommitQueue.tsx
+++ b/src/pages/CommitQueue.tsx
@@ -20,7 +20,7 @@ import { CommitQueueCard } from "./commitqueue/CommitQueueCard";
 
 const { gray } = uiColors;
 
-export const CommitQueue: React.FC = () => {
+export const CommitQueue: React.VFC = () => {
   const { id } = useParams<{ id: string }>();
   const dispatchToast = useToastContext();
   const { data, loading } = useQuery<

--- a/src/pages/ConfigurePatch.tsx
+++ b/src/pages/ConfigurePatch.tsx
@@ -16,7 +16,7 @@ import { PageDoesNotExist } from "pages/404";
 import { ConfigurePatchCore } from "pages/configurePatch/ConfigurePatchCore";
 import { validateObjectId } from "utils/validators";
 
-export const ConfigurePatch: React.FC = () => {
+export const ConfigurePatch: React.VFC = () => {
   const { id } = useParams<{ id: string }>();
   const dispatchToast = useToastContext();
   const { data, loading, error } = useQuery<

--- a/src/pages/Host.tsx
+++ b/src/pages/Host.tsx
@@ -33,7 +33,7 @@ import { url } from "utils";
 
 const { getPageFromSearch, getLimitFromSearch } = url;
 
-export const Host: React.FC = () => {
+export const Host: React.VFC = () => {
   const dispatchToast = useToastContext();
   const { id } = useParams<{ id: string }>();
   // Query host data

--- a/src/pages/Hosts.tsx
+++ b/src/pages/Hosts.tsx
@@ -33,7 +33,7 @@ const { toArray } = array;
 const { getPageFromSearch, getLimitFromSearch } = url;
 const { getString, parseQueryString } = queryString;
 
-export const Hosts: React.FC = () => {
+export const Hosts: React.VFC = () => {
   const hostsTableAnalytics = useHostsTableAnalytics();
 
   const { search } = useLocation();

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -11,7 +11,7 @@ const getReferrer = (location: Location<{ referrer?: string }>): string => {
   return "/";
 };
 
-export const Login: React.FC<RouteComponentProps> = ({ location }) => {
+export const Login: React.VFC<RouteComponentProps> = ({ location }) => {
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
 

--- a/src/pages/MyPatches.tsx
+++ b/src/pages/MyPatches.tsx
@@ -4,7 +4,7 @@ import { getUserPatchesRoute } from "constants/routes";
 import { GetUserQuery } from "gql/generated/types";
 import { GET_USER } from "gql/queries";
 
-export const MyPatches: React.FC = () => {
+export const MyPatches: React.VFC = () => {
   const { data } = useQuery<GetUserQuery>(GET_USER);
   if (data) {
     return <Redirect to={getUserPatchesRoute(data.user.userId)} />;

--- a/src/pages/Preferences.tsx
+++ b/src/pages/Preferences.tsx
@@ -11,7 +11,7 @@ import { PreferencesTabRoutes, getPreferencesRoute } from "constants/routes";
 import { usePageTitle } from "hooks";
 import { PreferencesTabs } from "pages/preferences/PreferencesTabs";
 
-export const Preferences: React.FC = () => {
+export const Preferences: React.VFC = () => {
   usePageTitle("Preferences");
   const { tab } = useParams<{ tab: string }>();
   const { sendEvent } = usePreferencesAnalytics();

--- a/src/pages/ProjectSettings.tsx
+++ b/src/pages/ProjectSettings.tsx
@@ -35,7 +35,7 @@ const { validateObjectId } = validators;
 
 const disablePage = isProduction();
 
-export const ProjectSettings: React.FC = () => {
+export const ProjectSettings: React.VFC = () => {
   usePageTitle(`Project Settings`);
   const dispatchToast = useToastContext();
   const { identifier, tab } = useParams<{
@@ -201,7 +201,7 @@ export const ProjectSettings: React.FC = () => {
   );
 };
 
-const ProjectSettingsNavItem: React.FC<{
+const ProjectSettingsNavItem: React.VFC<{
   currentTab: ProjectSettingsTabRoutes;
   identifier: string;
   tab: ProjectSettingsTabRoutes;

--- a/src/pages/Spawn.tsx
+++ b/src/pages/Spawn.tsx
@@ -11,7 +11,7 @@ import { routes, SpawnTab } from "constants/routes";
 import { SpawnHost } from "pages/spawn/SpawnHost";
 import { SpawnVolume } from "pages/spawn/SpawnVolume";
 
-export const Spawn: React.FC = () => {
+export const Spawn: React.VFC = () => {
   const { tab } = useParams<{ tab: string }>();
   const spawnAnalytics = useSpawnAnalytics();
   useEffect(() => {}, [tab]); // eslint-disable-line react-hooks/exhaustive-deps

--- a/src/pages/TaskHistory.tsx
+++ b/src/pages/TaskHistory.tsx
@@ -30,7 +30,7 @@ const { HistoryTableProvider } = context;
 const { applyStrictRegex } = string;
 const { useTestFilters, useJumpToCommit } = hooks;
 
-const TaskHistoryContents: React.FC = () => {
+const TaskHistoryContents: React.VFC = () => {
   const { projectId, taskName } = useParams<{
     projectId: string;
     taskName: string;

--- a/src/pages/VariantHistory.tsx
+++ b/src/pages/VariantHistory.tsx
@@ -30,7 +30,7 @@ const { HistoryTableProvider } = context;
 const { useTestFilters, useJumpToCommit } = hooks;
 const { applyStrictRegex } = string;
 
-const VariantHistoryContents: React.FC = () => {
+const VariantHistoryContents: React.VFC = () => {
   const { projectId, variantName } = useParams<{
     projectId: string;
     variantName: string;

--- a/src/pages/Version.tsx
+++ b/src/pages/Version.tsx
@@ -40,7 +40,7 @@ import { ActionButtons } from "./version/index";
 import { Metadata } from "./version/Metadata";
 import { Tabs } from "./version/Tabs";
 
-export const VersionPage: React.FC = () => {
+export const VersionPage: React.VFC = () => {
   const { data: spruceConfigData } = useQuery<GetSpruceConfigQuery>(
     GET_SPRUCE_CONFIG
   );

--- a/src/pages/commitqueue/CommitQueueCard.tsx
+++ b/src/pages/commitqueue/CommitQueueCard.tsx
@@ -38,7 +38,7 @@ interface Props {
 }
 const { blue, gray } = uiColors;
 
-export const CommitQueueCard: React.FC<Props> = ({
+export const CommitQueueCard: React.VFC<Props> = ({
   issue,
   index,
   title,

--- a/src/pages/commitqueue/ConfirmPatchButton.tsx
+++ b/src/pages/commitqueue/ConfirmPatchButton.tsx
@@ -7,7 +7,7 @@ interface ConfirmPatchButtonProps {
   onConfirm: () => void;
   commitTitle: string;
 }
-export const ConfirmPatchButton: React.FC<ConfirmPatchButtonProps> = ({
+export const ConfirmPatchButton: React.VFC<ConfirmPatchButtonProps> = ({
   disabled,
   onConfirm,
   commitTitle,

--- a/src/pages/commitqueue/codeChangesModule/CodeChangesModule.tsx
+++ b/src/pages/commitqueue/codeChangesModule/CodeChangesModule.tsx
@@ -44,12 +44,11 @@ export const CodeChangeModule: React.VFC<{
               <CodeChangesBadge {...totalFileDiffs(commitDiffs)} />
             </DropDownText>
           }
-          contents={
-            <TableWrapper>
-              <CodeChangesTable fileDiffs={commitDiffs} showHeader={false} />
-            </TableWrapper>
-          }
-        />
+        >
+          <TableWrapper>
+            <CodeChangesTable fileDiffs={commitDiffs} showHeader={false} />
+          </TableWrapper>
+        </Accordion>
       </CodeChangeModuleContainer>
     );
   });

--- a/src/pages/commitqueue/codeChangesModule/CodeChangesModule.tsx
+++ b/src/pages/commitqueue/codeChangesModule/CodeChangesModule.tsx
@@ -25,7 +25,7 @@ const totalFileDiffs = (
   return { additions, deletions };
 };
 
-export const CodeChangeModule: React.FC<{
+export const CodeChangeModule: React.VFC<{
   moduleCodeChange: ModuleCodeChangeFragment;
 }> = ({ moduleCodeChange }) => {
   const { fileDiffs } = moduleCodeChange;

--- a/src/pages/commits/ActiveCommits/BuildVariantCard.tsx
+++ b/src/pages/commits/ActiveCommits/BuildVariantCard.tsx
@@ -23,7 +23,7 @@ interface Props {
   };
   order: number;
 }
-export const BuildVariantCard: React.FC<Props> = ({
+export const BuildVariantCard: React.VFC<Props> = ({
   buildVariantDisplayName,
   variant,
   tasks,
@@ -65,7 +65,7 @@ interface RenderTaskIconsProps {
   variant: string;
 }
 
-const RenderTaskIcons: React.FC<RenderTaskIconsProps> = ({ tasks, variant }) =>
+const RenderTaskIcons: React.VFC<RenderTaskIconsProps> = ({ tasks, variant }) =>
   tasks.length ? (
     <IconContainer>
       {tasks.map(({ id, status, displayName, timeTaken }) => (

--- a/src/pages/commits/ActiveCommits/ChartToggle.tsx
+++ b/src/pages/commits/ActiveCommits/ChartToggle.tsx
@@ -8,7 +8,7 @@ import { ChartTypes } from "types/commits";
 
 const { gray } = uiColors;
 
-export const ChartToggle: React.FC<{
+export const ChartToggle: React.VFC<{
   currentChartType: ChartTypes;
   onChangeChartType: (chartType: ChartTypes) => void;
 }> = ({ currentChartType, onChangeChartType }) => {

--- a/src/pages/commits/ActiveCommits/CommitChart.tsx
+++ b/src/pages/commits/ActiveCommits/CommitChart.tsx
@@ -11,7 +11,7 @@ interface Props {
   chartType: ChartTypes;
 }
 
-export const CommitChart: React.FC<Props> = ({
+export const CommitChart: React.VFC<Props> = ({
   max,
   chartType,
   groupedTaskStats,

--- a/src/pages/commits/ActiveCommits/CommitChartTooltip.tsx
+++ b/src/pages/commits/ActiveCommits/CommitChartTooltip.tsx
@@ -18,7 +18,7 @@ interface Props {
   trigger: React.ReactElement;
 }
 
-export const CommitChartTooltip: React.FC<Props> = ({
+export const CommitChartTooltip: React.VFC<Props> = ({
   groupedTaskStats,
   trigger,
 }) => {
@@ -68,7 +68,7 @@ interface TotalCountProps {
   status: string;
   active?: boolean;
 }
-export const TotalCount: React.FC<TotalCountProps> = ({
+export const TotalCount: React.VFC<TotalCountProps> = ({
   color,
   count,
   status,

--- a/src/pages/commits/ActiveCommits/Grid.tsx
+++ b/src/pages/commits/ActiveCommits/Grid.tsx
@@ -5,7 +5,7 @@ import { gridHeight } from "pages/commits/constants";
 
 const { gray } = uiColors;
 
-export const Grid: React.FC<{
+export const Grid: React.VFC<{
   numDashedLine: number;
 }> = ({ numDashedLine }) => (
   <ColumnContainer>

--- a/src/pages/commits/ActiveCommits/GridLabel.tsx
+++ b/src/pages/commits/ActiveCommits/GridLabel.tsx
@@ -11,7 +11,7 @@ const { gray } = uiColors;
 
 const percentages = [100, 80, 60, 40, 20, 0];
 
-export const GridLabel: React.FC<{
+export const GridLabel: React.VFC<{
   chartType: string;
   max: number;
   numDashedLine: number;

--- a/src/pages/commits/ActiveCommits/buildVariantCard/WaterfallTaskStatusIcon.tsx
+++ b/src/pages/commits/ActiveCommits/buildVariantCard/WaterfallTaskStatusIcon.tsx
@@ -23,7 +23,7 @@ interface WaterfallTaskStatusIconProps {
   identifier: string;
 }
 
-export const WaterfallTaskStatusIcon: React.FC<WaterfallTaskStatusIconProps> = ({
+export const WaterfallTaskStatusIcon: React.VFC<WaterfallTaskStatusIconProps> = ({
   taskId,
   status,
   displayName,

--- a/src/pages/commits/ActiveCommits/index.tsx
+++ b/src/pages/commits/ActiveCommits/index.tsx
@@ -16,7 +16,7 @@ interface ActiveCommitChartProps {
   chartType: ChartTypes;
 }
 
-export const ActiveCommitChart: React.FC<ActiveCommitChartProps> = ({
+export const ActiveCommitChart: React.VFC<ActiveCommitChartProps> = ({
   groupedTaskStats,
   max,
   total,
@@ -33,7 +33,7 @@ export const ActiveCommitChart: React.FC<ActiveCommitChartProps> = ({
 interface ActiveCommitLabelProps {
   version: CommitVersion;
 }
-export const ActiveCommitLabel: React.FC<ActiveCommitLabelProps> = ({
+export const ActiveCommitLabel: React.VFC<ActiveCommitLabelProps> = ({
   version,
 }) => (
   <CommitChartLabel
@@ -48,7 +48,7 @@ export const ActiveCommitLabel: React.FC<ActiveCommitLabelProps> = ({
 interface BuildVariantContainerProps {
   version: CommitVersion;
 }
-export const BuildVariantContainer: React.FC<BuildVariantContainerProps> = ({
+export const BuildVariantContainer: React.VFC<BuildVariantContainerProps> = ({
   version,
 }) => {
   const {

--- a/src/pages/commits/CommitsWrapper.tsx
+++ b/src/pages/commits/CommitsWrapper.tsx
@@ -41,7 +41,7 @@ interface Props {
   hasFilters: boolean;
 }
 
-export const CommitsWrapper: React.FC<Props> = ({
+export const CommitsWrapper: React.VFC<Props> = ({
   versions,
   isLoading,
   error,

--- a/src/pages/commits/InactiveCommits/index.tsx
+++ b/src/pages/commits/InactiveCommits/index.tsx
@@ -24,7 +24,7 @@ interface InactiveCommitsProps {
   rolledUpVersions: CommitRolledUpVersions;
   hasFilters: boolean;
 }
-export const InactiveCommitButton: React.FC<InactiveCommitsProps> = ({
+export const InactiveCommitButton: React.VFC<InactiveCommitsProps> = ({
   rolledUpVersions,
   hasFilters = false,
 }) => {

--- a/src/pages/commits/PaginationButtons.tsx
+++ b/src/pages/commits/PaginationButtons.tsx
@@ -9,7 +9,7 @@ interface PaginationButtonsProps {
   nextPageOrderNumber?: number;
   prevPageOrderNumber?: number;
 }
-export const PaginationButtons: React.FC<PaginationButtonsProps> = ({
+export const PaginationButtons: React.VFC<PaginationButtonsProps> = ({
   prevPageOrderNumber,
   nextPageOrderNumber,
 }) => {

--- a/src/pages/commits/RenderCommit.tsx
+++ b/src/pages/commits/RenderCommit.tsx
@@ -18,7 +18,7 @@ type RenderCommitsChartProps = ActiveCommitProps & {
   commit: Commit;
 };
 
-const RenderCommitsChart: React.FC<RenderCommitsChartProps> = ({
+const RenderCommitsChart: React.VFC<RenderCommitsChartProps> = ({
   commit,
   chartType,
   groupedResult,
@@ -46,7 +46,7 @@ interface RenderCommitsLabelProps {
   commit: Commit;
   hasFilters: boolean;
 }
-const RenderCommitsLabel: React.FC<RenderCommitsLabelProps> = ({
+const RenderCommitsLabel: React.VFC<RenderCommitsLabelProps> = ({
   commit,
   hasFilters,
 }) => {
@@ -69,7 +69,7 @@ const RenderCommitsLabel: React.FC<RenderCommitsLabelProps> = ({
 interface RenderCommitsBuildVariantProps {
   commit: Commit;
 }
-export const RenderCommitsBuildVariants: React.FC<RenderCommitsBuildVariantProps> = ({
+export const RenderCommitsBuildVariants: React.VFC<RenderCommitsBuildVariantProps> = ({
   commit,
 }) => {
   const { version } = commit;

--- a/src/pages/configurePatch/ConfigurePatchCore.tsx
+++ b/src/pages/configurePatch/ConfigurePatchCore.tsx
@@ -38,7 +38,7 @@ import { ConfigureTasks } from "./configurePatchCore/ConfigureTasks";
 interface Props {
   patch: ConfigurePatchQuery["patch"];
 }
-export const ConfigurePatchCore: React.FC<Props> = ({ patch }) => {
+export const ConfigurePatchCore: React.VFC<Props> = ({ patch }) => {
   const history = useHistory();
   const dispatchToast = useToastContext();
 

--- a/src/pages/configurePatch/ParametersContent.tsx
+++ b/src/pages/configurePatch/ParametersContent.tsx
@@ -12,7 +12,7 @@ interface Props {
   setPatchParams: (p: ParameterInput[]) => void;
 }
 
-export const ParametersContent: React.FC<Props> = ({
+export const ParametersContent: React.VFC<Props> = ({
   patchActivated,
   patchParameters,
   setPatchParams,

--- a/src/pages/configurePatch/configurePatchCore/ConfigureBuildVariants.tsx
+++ b/src/pages/configurePatch/configurePatchCore/ConfigureBuildVariants.tsx
@@ -27,7 +27,7 @@ interface Props {
   disabled: boolean;
 }
 
-export const ConfigureBuildVariants: React.FC<Props> = ({
+export const ConfigureBuildVariants: React.VFC<Props> = ({
   variants,
   aliases,
   selectedBuildVariants,
@@ -123,7 +123,7 @@ interface CardProps {
   title: string;
 }
 
-const Card: React.FC<CardProps> = ({
+const Card: React.VFC<CardProps> = ({
   "data-cy": dataCy,
   onClick,
   menuItems,

--- a/src/pages/configurePatch/configurePatchCore/ConfigureTasks.tsx
+++ b/src/pages/configurePatch/configurePatchCore/ConfigureTasks.tsx
@@ -33,7 +33,7 @@ interface Props {
   selectableAliases: PatchTriggerAlias[];
 }
 
-export const ConfigureTasks: React.FC<Props> = ({
+export const ConfigureTasks: React.VFC<Props> = ({
   selectedBuildVariants,
   selectedBuildVariantTasks,
   setSelectedBuildVariantTasks,
@@ -263,7 +263,7 @@ interface VariantTasksListProps {
   tasks: string[];
 }
 
-const VariantTasksList: React.FC<VariantTasksListProps> = ({
+const VariantTasksList: React.VFC<VariantTasksListProps> = ({
   "data-cy": dataCy,
   name,
   status,

--- a/src/pages/host/HostCard.tsx
+++ b/src/pages/host/HostCard.tsx
@@ -16,7 +16,7 @@ interface StylingProps {
   metaData: boolean;
 }
 
-export const HostCard: React.FC<Props> = ({
+export const HostCard: React.VFC<Props> = ({
   children,
   error,
   loading,

--- a/src/pages/host/HostCard.tsx
+++ b/src/pages/host/HostCard.tsx
@@ -10,6 +10,7 @@ interface Props {
   error: ApolloError;
   loading?: boolean;
   metaData: boolean;
+  children: React.ReactNode;
 }
 interface StylingProps {
   metaData: boolean;

--- a/src/pages/host/HostTable.tsx
+++ b/src/pages/host/HostTable.tsx
@@ -15,7 +15,7 @@ import { string } from "utils";
 
 const { getDateCopy } = string;
 
-export const HostTable: React.FC<{
+export const HostTable: React.VFC<{
   loading: boolean;
   eventData: HostEventsQuery;
   error: ApolloError;

--- a/src/pages/host/Metadata.tsx
+++ b/src/pages/host/Metadata.tsx
@@ -11,7 +11,7 @@ import { environmentalVariables } from "utils";
 
 const { getUiUrl } = environmentalVariables;
 
-export const Metadata: React.FC<{
+export const Metadata: React.VFC<{
   loading: boolean;
   data: HostQuery;
   error: ApolloError;

--- a/src/pages/host/getHostEventString.tsx
+++ b/src/pages/host/getHostEventString.tsx
@@ -312,7 +312,7 @@ export const StyledCollapse = styled(Collapse)`
   }
 `;
 
-export const HostEventLog: React.FC<{
+export const HostEventLog: React.VFC<{
   title: string;
   logs: string;
   isCode: boolean;

--- a/src/pages/hosts/HostsTable.tsx
+++ b/src/pages/hosts/HostsTable.tsx
@@ -40,7 +40,7 @@ type Host = HostsQuery["hosts"]["hosts"][0];
 
 type HostsUrlParam = keyof HostsQueryVariables;
 
-export const HostsTable: React.FC<Props> = ({
+export const HostsTable: React.VFC<Props> = ({
   hosts,
   sortBy,
   sortDir,

--- a/src/pages/jobLogs/JobLogsTable.tsx
+++ b/src/pages/jobLogs/JobLogsTable.tsx
@@ -37,7 +37,7 @@ interface JobLogsTableProps {
   groupId?: string;
 }
 
-export const JobLogsTable: React.FC<JobLogsTableProps> = ({
+export const JobLogsTable: React.VFC<JobLogsTableProps> = ({
   task,
   groupId,
 }) => {

--- a/src/pages/preferences/PreferencesTabs.tsx
+++ b/src/pages/preferences/PreferencesTabs.tsx
@@ -9,7 +9,7 @@ import { NotificationsTab } from "./preferencesTabs/NotificationsTab";
 import { ProfileTab } from "./preferencesTabs/ProfileTab";
 import { PublicKeysTab } from "./preferencesTabs/PublicKeysTab";
 
-export const PreferencesTabs: React.FC = () => {
+export const PreferencesTabs: React.VFC = () => {
   const { tab } = useParams<{ tab: string }>();
 
   const { title, subtitle } = getTitle(tab as PreferencesTabRoutes);

--- a/src/pages/preferences/preferencesTabs/NewUITab.tsx
+++ b/src/pages/preferences/preferencesTabs/NewUITab.tsx
@@ -13,7 +13,7 @@ import {
 import { UPDATE_USER_SETTINGS } from "gql/mutations";
 import { useUserSettingsQuery } from "hooks/useUserSettingsQuery";
 
-export const NewUITab: React.FC = () => {
+export const NewUITab: React.VFC = () => {
   const { sendEvent } = usePreferencesAnalytics();
   const { data, loadingComp } = useUserSettingsQuery();
   const { spruceV1, hasUsedSpruceBefore } =

--- a/src/pages/preferences/preferencesTabs/NotificationsTab.tsx
+++ b/src/pages/preferences/preferencesTabs/NotificationsTab.tsx
@@ -19,7 +19,7 @@ import { NotificationField } from "./notificationTab/NotificationField";
 
 const { omitTypename } = string;
 
-export const NotificationsTab: React.FC = () => {
+export const NotificationsTab: React.VFC = () => {
   const dispatchToast = useToastContext();
   const { data, loadingComp } = useUserSettingsQuery();
   const { slackUsername, notifications } = data?.userSettings ?? {};

--- a/src/pages/preferences/preferencesTabs/PreferencesModal.tsx
+++ b/src/pages/preferences/preferencesTabs/PreferencesModal.tsx
@@ -13,7 +13,7 @@ interface PreferencesModalProps {
   visible: boolean;
   disabled?: boolean;
 }
-export const PreferencesModal: React.FC<PreferencesModalProps> = ({
+export const PreferencesModal: React.VFC<PreferencesModalProps> = ({
   title,
   action,
   onSubmit,

--- a/src/pages/preferences/preferencesTabs/ProfileTab.tsx
+++ b/src/pages/preferences/preferencesTabs/ProfileTab.tsx
@@ -21,7 +21,7 @@ import { string } from "utils";
 
 const { omitTypename } = string;
 
-export const ProfileTab: React.FC = () => {
+export const ProfileTab: React.VFC = () => {
   const { sendEvent } = usePreferencesAnalytics();
   const dispatchToast = useToastContext();
 

--- a/src/pages/preferences/preferencesTabs/PublicKeysTab.tsx
+++ b/src/pages/preferences/preferencesTabs/PublicKeysTab.tsx
@@ -21,7 +21,7 @@ import {
   EditModalPropsState,
 } from "pages/preferences/preferencesTabs/publicKeysTab/EditModal";
 
-export const PublicKeysTab: React.FC = () => {
+export const PublicKeysTab: React.VFC = () => {
   const dispatchToast = useToastContext();
   const { sendEvent } = usePreferencesAnalytics();
   const [editModalProps, setEditModalProps] = useState<EditModalPropsState>(

--- a/src/pages/preferences/preferencesTabs/cliTab/DownloadCard.tsx
+++ b/src/pages/preferences/preferencesTabs/cliTab/DownloadCard.tsx
@@ -59,12 +59,9 @@ export const DownloadCard = () => {
           />
         ))}
       </CardGroup>
-      <Accordion
-        title="Show More"
-        toggledTitle="Show Less"
-        contents={<ExpandableLinkContents clientBinaries={otherBinaries} />}
-        showCaret={false}
-      />
+      <Accordion title="Show More" toggledTitle="Show Less" showCaret={false}>
+        <ExpandableLinkContents clientBinaries={otherBinaries} />
+      </Accordion>
     </Container>
   );
 };

--- a/src/pages/preferences/preferencesTabs/cliTab/DownloadCard.tsx
+++ b/src/pages/preferences/preferencesTabs/cliTab/DownloadCard.tsx
@@ -74,7 +74,7 @@ interface CliDownloadBoxProps {
   link: string | null;
   description?: string;
 }
-const CliDownloadBox: React.FC<CliDownloadBoxProps> = ({
+const CliDownloadBox: React.VFC<CliDownloadBoxProps> = ({
   title,
   description,
   link,
@@ -104,7 +104,7 @@ const CliDownloadBox: React.FC<CliDownloadBoxProps> = ({
 interface ExpandableLinkContentsProps {
   clientBinaries: ClientBinary[];
 }
-const ExpandableLinkContents: React.FC<ExpandableLinkContentsProps> = ({
+const ExpandableLinkContents: React.VFC<ExpandableLinkContentsProps> = ({
   clientBinaries,
 }) => {
   const { sendEvent } = usePreferencesAnalytics();

--- a/src/pages/preferences/preferencesTabs/cliTab/NodeList.tsx
+++ b/src/pages/preferences/preferencesTabs/cliTab/NodeList.tsx
@@ -8,7 +8,7 @@ const { gray } = uiColors;
 interface NodeListProps {
   list: NodeType[];
 }
-export const NodeList: React.FC<NodeListProps> = ({ list }) => (
+export const NodeList: React.VFC<NodeListProps> = ({ list }) => (
   <NodeContainer>
     {list.map((node, index) => (
       <Node

--- a/src/pages/preferences/preferencesTabs/cliTab/nodeList/Node.tsx
+++ b/src/pages/preferences/preferencesTabs/cliTab/nodeList/Node.tsx
@@ -14,7 +14,7 @@ export type NodeType = {
 interface NodeProps extends NodeType {
   stepNumber: number;
 }
-export const Node: React.FC<NodeProps> = ({ title, child, stepNumber }) => (
+export const Node: React.VFC<NodeProps> = ({ title, child, stepNumber }) => (
   <NodeContainer>
     <NodeHeader>
       <Step stepNumber={stepNumber} />
@@ -29,7 +29,7 @@ interface StepProps {
   stepNumber: number;
 }
 
-const Step: React.FC<StepProps> = ({ stepNumber }) => (
+const Step: React.VFC<StepProps> = ({ stepNumber }) => (
   <Circle>
     {/* @ts-expect-error */}
     <Index>{stepNumber}</Index>

--- a/src/pages/preferences/preferencesTabs/notificationTab/ClearSubscriptionsCard.tsx
+++ b/src/pages/preferences/preferencesTabs/notificationTab/ClearSubscriptionsCard.tsx
@@ -14,7 +14,7 @@ import {
 import { CLEAR_MY_SUBSCRIPTIONS } from "gql/mutations";
 import { PreferencesModal } from "pages/preferences/preferencesTabs/PreferencesModal";
 
-export const ClearSubscriptionsCard: React.FC = () => {
+export const ClearSubscriptionsCard: React.VFC = () => {
   const [showModal, setShowModal] = useState(false);
   const { sendEvent } = usePreferencesAnalytics();
   const dispatchToast = useToastContext();

--- a/src/pages/preferences/preferencesTabs/notificationTab/NotificationField.tsx
+++ b/src/pages/preferences/preferencesTabs/notificationTab/NotificationField.tsx
@@ -10,7 +10,7 @@ interface NotificationFieldProps {
   index: number;
   setNotificationStatus: (e) => void;
 }
-export const NotificationField: React.FC<NotificationFieldProps> = ({
+export const NotificationField: React.VFC<NotificationFieldProps> = ({
   notification,
   setNotificationStatus,
   notificationStatus,

--- a/src/pages/preferences/preferencesTabs/publicKeysTab/EditModal.tsx
+++ b/src/pages/preferences/preferencesTabs/publicKeysTab/EditModal.tsx
@@ -30,7 +30,7 @@ interface EditModalProps extends EditModalPropsState {
   onCancel: () => void;
 }
 
-export const EditModal: React.FC<EditModalProps> = ({
+export const EditModal: React.VFC<EditModalProps> = ({
   initialPublicKey,
   visible,
   onCancel,

--- a/src/pages/projectSettings/Context.tsx
+++ b/src/pages/projectSettings/Context.tsx
@@ -106,7 +106,7 @@ interface ProjectSettingsState {
 
 const ProjectSettingsContext = createContext<ProjectSettingsState | null>(null);
 
-const ProjectSettingsProvider: React.FC<{ children: React.ReactNode }> = ({
+const ProjectSettingsProvider: React.VFC<{ children: React.ReactNode }> = ({
   children,
 }) => {
   const [state, dispatch] = useReducer(

--- a/src/pages/projectSettings/Context.tsx
+++ b/src/pages/projectSettings/Context.tsx
@@ -106,7 +106,9 @@ interface ProjectSettingsState {
 
 const ProjectSettingsContext = createContext<ProjectSettingsState | null>(null);
 
-const ProjectSettingsProvider: React.FC = ({ children }) => {
+const ProjectSettingsProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
   const [state, dispatch] = useReducer(
     reducer,
     getDefaultRouteObject({

--- a/src/pages/projectSettings/CreateProjectModal.tsx
+++ b/src/pages/projectSettings/CreateProjectModal.tsx
@@ -69,7 +69,7 @@ interface Props {
   owner: string;
   repo: string;
 }
-export const CreateProjectModal: React.FC<Props> = ({ owner, repo }) => {
+export const CreateProjectModal: React.VFC<Props> = ({ owner, repo }) => {
   const dispatchToast = useToastContext();
   const modalFormDefinition = getModalFormDefinition(owner, repo);
 

--- a/src/pages/projectSettings/Header.tsx
+++ b/src/pages/projectSettings/Header.tsx
@@ -32,7 +32,7 @@ interface Props {
   tab: ProjectSettingsTabRoutes;
 }
 
-export const Header: React.FC<Props> = ({
+export const Header: React.VFC<Props> = ({
   id,
   isRepo,
   projectType,

--- a/src/pages/projectSettings/NavigationModal.tsx
+++ b/src/pages/projectSettings/NavigationModal.tsx
@@ -5,7 +5,7 @@ import { routes } from "constants/routes";
 import { useIsAnyTabUnsaved } from "./Context";
 import { getTabTitle } from "./getTabTitle";
 
-export const NavigationModal: React.FC = () => {
+export const NavigationModal: React.VFC = () => {
   const { hasUnsaved, unsavedTabs } = useIsAnyTabUnsaved();
 
   const shouldConfirmNavigation = (currentLocation, nextLocation): boolean => {

--- a/src/pages/projectSettings/Tabs.tsx
+++ b/src/pages/projectSettings/Tabs.tsx
@@ -32,7 +32,7 @@ interface Props {
   repoData?: RepoSettings;
 }
 
-export const ProjectSettingsTabs: React.FC<Props> = ({
+export const ProjectSettingsTabs: React.VFC<Props> = ({
   projectData,
   projectType,
   repoData,
@@ -202,7 +202,7 @@ interface TabRouteProps {
   tab: ProjectSettingsTabRoutes;
 }
 
-const TabRoute: React.FC<TabRouteProps> = ({ Component, path, tab }) => (
+const TabRoute: React.VFC<TabRouteProps> = ({ Component, path, tab }) => (
   <Route path={path} render={(props) => <Component {...props} tab={tab} />} />
 );
 

--- a/src/pages/projectSettings/tabs/AccessTab/AccessTab.tsx
+++ b/src/pages/projectSettings/tabs/AccessTab/AccessTab.tsx
@@ -11,7 +11,7 @@ import { TabProps } from "./types";
 
 const tab = ProjectSettingsTabRoutes.Access;
 
-export const AccessTab: React.FC<TabProps> = ({
+export const AccessTab: React.VFC<TabProps> = ({
   projectData,
   projectType,
   repoData,

--- a/src/pages/projectSettings/tabs/EventLogTab/EventLogTab.tsx
+++ b/src/pages/projectSettings/tabs/EventLogTab/EventLogTab.tsx
@@ -1,1 +1,1 @@
-export const EventLogTab: React.FC = () => null;
+export const EventLogTab: React.VFC = () => null;

--- a/src/pages/projectSettings/tabs/GeneralTab/Fields/RepoConfigField.tsx
+++ b/src/pages/projectSettings/tabs/GeneralTab/Fields/RepoConfigField.tsx
@@ -30,7 +30,7 @@ interface ModalProps {
   repoOwner: string;
 }
 
-export const MoveRepoModal: React.FC<ModalProps> = ({
+export const MoveRepoModal: React.VFC<ModalProps> = ({
   handleClose,
   open,
   projectId,
@@ -98,7 +98,7 @@ export const MoveRepoModal: React.FC<ModalProps> = ({
   );
 };
 
-export const AttachDetachModal: React.FC<
+export const AttachDetachModal: React.VFC<
   ModalProps & {
     shouldAttach: boolean;
   }

--- a/src/pages/projectSettings/tabs/GeneralTab/Fields/RepotrackerField.tsx
+++ b/src/pages/projectSettings/tabs/GeneralTab/Fields/RepotrackerField.tsx
@@ -18,7 +18,7 @@ interface ModalProps {
   projectId: string;
 }
 
-export const Modal: React.FC<ModalProps> = ({
+export const Modal: React.VFC<ModalProps> = ({
   closeModal,
   open,
   projectId,

--- a/src/pages/projectSettings/tabs/GeneralTab/GeneralTab.tsx
+++ b/src/pages/projectSettings/tabs/GeneralTab/GeneralTab.tsx
@@ -11,7 +11,7 @@ import { TabProps } from "./types";
 
 const tab = ProjectSettingsTabRoutes.General;
 
-export const GeneralTab: React.FC<TabProps> = ({
+export const GeneralTab: React.VFC<TabProps> = ({
   projectData,
   projectId,
   projectType,

--- a/src/pages/projectSettings/tabs/GithubCommitQueueTab/GithubCommitQueueTab.tsx
+++ b/src/pages/projectSettings/tabs/GithubCommitQueueTab/GithubCommitQueueTab.tsx
@@ -34,7 +34,7 @@ const getInitialFormState = (
   return projectData;
 };
 
-export const GithubCommitQueueTab: React.FC<TabProps> = ({
+export const GithubCommitQueueTab: React.VFC<TabProps> = ({
   githubWebhooksEnabled,
   projectData,
   projectType,

--- a/src/pages/projectSettings/tabs/NotificationsTab/NotificationsTab.tsx
+++ b/src/pages/projectSettings/tabs/NotificationsTab/NotificationsTab.tsx
@@ -11,7 +11,7 @@ import { TabProps } from "./types";
 
 const tab = ProjectSettingsTabRoutes.Notifications;
 
-export const NotificationsTab: React.FC<TabProps> = ({
+export const NotificationsTab: React.VFC<TabProps> = ({
   projectData,
   projectType,
   repoData,

--- a/src/pages/projectSettings/tabs/PatchAliasesTab/PatchAliasesTab.tsx
+++ b/src/pages/projectSettings/tabs/PatchAliasesTab/PatchAliasesTab.tsx
@@ -27,7 +27,7 @@ const getInitialFormState = (projectData, repoData) => {
   return projectData;
 };
 
-export const PatchAliasesTab: React.FC<TabProps> = ({
+export const PatchAliasesTab: React.VFC<TabProps> = ({
   projectData,
   projectType,
   repoData,

--- a/src/pages/projectSettings/tabs/PeriodicBuildsTab/PeriodicBuildsTab.tsx
+++ b/src/pages/projectSettings/tabs/PeriodicBuildsTab/PeriodicBuildsTab.tsx
@@ -1,1 +1,1 @@
-export const PeriodicBuildsTab: React.FC = () => null;
+export const PeriodicBuildsTab: React.VFC = () => null;

--- a/src/pages/projectSettings/tabs/PluginsTab/PluginsTab.tsx
+++ b/src/pages/projectSettings/tabs/PluginsTab/PluginsTab.tsx
@@ -11,7 +11,7 @@ import { TabProps } from "./types";
 
 const tab = ProjectSettingsTabRoutes.Plugins;
 
-export const PluginsTab: React.FC<TabProps> = ({
+export const PluginsTab: React.VFC<TabProps> = ({
   projectData,
   projectType,
   repoData,

--- a/src/pages/projectSettings/tabs/ProjectTriggersTab/ProjectTriggersTab.tsx
+++ b/src/pages/projectSettings/tabs/ProjectTriggersTab/ProjectTriggersTab.tsx
@@ -1,1 +1,1 @@
-export const ProjectTriggersTab: React.FC = () => null;
+export const ProjectTriggersTab: React.VFC = () => null;

--- a/src/pages/projectSettings/tabs/VariablesTab/VariableRow.tsx
+++ b/src/pages/projectSettings/tabs/VariablesTab/VariableRow.tsx
@@ -8,7 +8,7 @@ import { form } from "../utils";
 const { getFields } = form;
 const { yellow } = uiColors;
 
-export const VariableRow: React.FC<
+export const VariableRow: React.VFC<
   Pick<ObjectFieldTemplateProps, "formData" | "properties" | "uiSchema">
 > = ({ formData, properties, uiSchema }) => {
   const [variableName, variableValue, isPrivate, isAdminOnly] = getFields(

--- a/src/pages/projectSettings/tabs/VariablesTab/VariablesTab.tsx
+++ b/src/pages/projectSettings/tabs/VariablesTab/VariablesTab.tsx
@@ -17,7 +17,7 @@ const getInitialFormState = (projectData, repoData) => {
   return projectData;
 };
 
-export const VariablesTab: React.FC<TabProps> = ({
+export const VariablesTab: React.VFC<TabProps> = ({
   projectData,
   projectType,
   repoData,

--- a/src/pages/projectSettings/tabs/VirtualWorkstationTab/VirtualWorkstationTab.tsx
+++ b/src/pages/projectSettings/tabs/VirtualWorkstationTab/VirtualWorkstationTab.tsx
@@ -25,7 +25,7 @@ const getInitialFormState = (projectData, repoData) => {
   return projectData;
 };
 
-export const VirtualWorkstationTab: React.FC<TabProps> = ({
+export const VirtualWorkstationTab: React.VFC<TabProps> = ({
   identifier,
   projectData,
   projectType,

--- a/src/pages/spawn/spawnHost/EditSpawnHostButton.tsx
+++ b/src/pages/spawn/spawnHost/EditSpawnHostButton.tsx
@@ -12,7 +12,7 @@ import { MyHost } from "types/spawn";
 interface EditSpawnHostButtonProps {
   host: MyHost;
 }
-export const EditSpawnHostButton: React.FC<EditSpawnHostButtonProps> = ({
+export const EditSpawnHostButton: React.VFC<EditSpawnHostButtonProps> = ({
   host,
 }) => {
   const [openModal, setOpenModal] = useState(false);

--- a/src/pages/spawn/spawnHost/EditSpawnHostModal.tsx
+++ b/src/pages/spawn/spawnHost/EditSpawnHostModal.tsx
@@ -61,7 +61,7 @@ interface EditSpawnHostModalProps {
   onCancel: () => void;
   host: MyHost;
 }
-export const EditSpawnHostModal: React.FC<EditSpawnHostModalProps> = ({
+export const EditSpawnHostModal: React.VFC<EditSpawnHostModalProps> = ({
   visible = true,
   onCancel,
   host,

--- a/src/pages/spawn/spawnHost/SpawnHostActionButton.tsx
+++ b/src/pages/spawn/spawnHost/SpawnHostActionButton.tsx
@@ -19,7 +19,9 @@ import { usePolling } from "hooks";
 import { HostStatus } from "types/host";
 import { MyHost } from "types/spawn";
 
-export const SpawnHostActionButton: React.FC<{ host: MyHost }> = ({ host }) => {
+export const SpawnHostActionButton: React.VFC<{ host: MyHost }> = ({
+  host,
+}) => {
   const dispatchToast = useToastContext();
 
   const glyph = mapStatusToGlyph[host.status];

--- a/src/pages/spawn/spawnHost/SpawnHostCard.tsx
+++ b/src/pages/spawn/spawnHost/SpawnHostCard.tsx
@@ -16,7 +16,7 @@ interface SpawnHostCardProps {
   host: MyHost;
 }
 
-export const SpawnHostCard: React.FC<SpawnHostCardProps> = ({ host }) => (
+export const SpawnHostCard: React.VFC<SpawnHostCardProps> = ({ host }) => (
   <DetailsCard
     data-cy="spawn-host-card"
     fieldMaps={spawnHostCardFieldMaps}

--- a/src/pages/spawn/spawnHost/SpawnHostModal.tsx
+++ b/src/pages/spawn/spawnHost/SpawnHostModal.tsx
@@ -47,7 +47,7 @@ interface SpawnHostModalProps {
   visible: boolean;
   onCancel: () => void;
 }
-export const SpawnHostModal: React.FC<SpawnHostModalProps> = ({
+export const SpawnHostModal: React.VFC<SpawnHostModalProps> = ({
   visible,
   onCancel,
 }) => {

--- a/src/pages/spawn/spawnHost/SpawnHostTable.tsx
+++ b/src/pages/spawn/spawnHost/SpawnHostTable.tsx
@@ -22,7 +22,7 @@ const { sortFunctionDate, sortFunctionString } = string;
 interface SpawnHostTableProps {
   hosts: MyHost[];
 }
-export const SpawnHostTable: React.FC<SpawnHostTableProps> = ({ hosts }) => {
+export const SpawnHostTable: React.VFC<SpawnHostTableProps> = ({ hosts }) => {
   const { search } = useLocation();
   const host = parseQueryString(search)?.host;
   const spawnAnalytics = useSpawnAnalytics();

--- a/src/pages/spawn/spawnHost/SpawnHostTableActions.tsx
+++ b/src/pages/spawn/spawnHost/SpawnHostTableActions.tsx
@@ -14,7 +14,9 @@ import { SpawnHostActionButton } from "./SpawnHostActionButton";
 
 const { copyToClipboard } = string;
 
-export const SpawnHostTableActions: React.FC<{ host: MyHost }> = ({ host }) => (
+export const SpawnHostTableActions: React.VFC<{ host: MyHost }> = ({
+  host,
+}) => (
   <FlexContainer>
     <SpawnHostActionButton host={host} />
     <CopySSHCommandButton
@@ -26,7 +28,7 @@ export const SpawnHostTableActions: React.FC<{ host: MyHost }> = ({ host }) => (
   </FlexContainer>
 );
 
-export const CopySSHCommandButton: React.FC<{
+export const CopySSHCommandButton: React.VFC<{
   user: string;
   hostUrl: string;
   hostStatus: string;

--- a/src/pages/spawn/spawnHost/fields/UserTagsField.tsx
+++ b/src/pages/spawn/spawnHost/fields/UserTagsField.tsx
@@ -15,7 +15,7 @@ interface UserTagsFieldProps {
   visible?: boolean;
 }
 
-export const UserTagsField: React.FC<UserTagsFieldProps> = ({
+export const UserTagsField: React.VFC<UserTagsFieldProps> = ({
   onChange,
   instanceTags,
   visible = true,

--- a/src/pages/spawn/spawnHost/fields/VolumesField.tsx
+++ b/src/pages/spawn/spawnHost/fields/VolumesField.tsx
@@ -21,7 +21,7 @@ interface VolumesFieldProps {
   allowHomeVolume?: boolean;
 }
 
-export const VolumesField: React.FC<VolumesFieldProps> = ({
+export const VolumesField: React.VFC<VolumesFieldProps> = ({
   onChange,
   data,
   volumes,

--- a/src/pages/spawn/spawnHost/fields/__snapshots__/userTagsField.stories.storyshot
+++ b/src/pages/spawn/spawnHost/fields/__snapshots__/userTagsField.stories.storyshot
@@ -295,11 +295,6 @@ exports[`storybook Storyshots User Tags Field User Tags Field View 1`] = `
         className="leafygreen-ui-26sqyb"
         data-cy="add-tag-button"
         disabled={false}
-        glyph={
-          <Icon
-            glyph="Plus"
-          />
-        }
         onClick={[Function]}
         type="button"
       >
@@ -309,6 +304,24 @@ exports[`storybook Storyshots User Tags Field User Tags Field View 1`] = `
         <div
           className="leafygreen-ui-ie0uqp"
         >
+          <svg
+            alt=""
+            aria-hidden={true}
+            className="leafygreen-ui-1my2s1b"
+            fill="none"
+            height={16}
+            role="presentation"
+            viewBox="0 0 16 16"
+            width={16}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clipRule="evenodd"
+              d="M7.5 2a1 1 0 00-1 1v3.5H3a1 1 0 00-1 1v1a1 1 0 001 1h3.5V13a1 1 0 001 1h1a1 1 0 001-1V9.5H13a1 1 0 001-1v-1a1 1 0 00-1-1H9.5V3a1 1 0 00-1-1h-1z"
+              fill="currentColor"
+              fillRule="evenodd"
+            />
+          </svg>
           Add Tag
         </div>
       </button>

--- a/src/pages/spawn/spawnHost/spawnHostModal/DistroOptionGroup.tsx
+++ b/src/pages/spawn/spawnHost/spawnHostModal/DistroOptionGroup.tsx
@@ -10,7 +10,7 @@ interface OptionGroupProps {
   options: string[];
   onClick: (value: string) => void;
 }
-export const DistroOptionGroup: React.FC<OptionGroupProps> = ({
+export const DistroOptionGroup: React.VFC<OptionGroupProps> = ({
   label,
   options,
   onClick,

--- a/src/pages/spawn/spawnHost/spawnHostModal/HostDetailsForm.tsx
+++ b/src/pages/spawn/spawnHost/spawnHostModal/HostDetailsForm.tsx
@@ -36,7 +36,7 @@ interface HostDetailsFormProps {
   volumes: MyVolume[];
   isSpawnHostModal: boolean;
 }
-export const HostDetailsForm: React.FC<HostDetailsFormProps> = ({
+export const HostDetailsForm: React.VFC<HostDetailsFormProps> = ({
   onChange,
   data,
   volumes,

--- a/src/pages/spawn/spawnHost/spawnHostModal/PublicKeyForm.tsx
+++ b/src/pages/spawn/spawnHost/spawnHostModal/PublicKeyForm.tsx
@@ -24,7 +24,7 @@ interface PublicKeyFormProps {
   onChange: React.Dispatch<React.SetStateAction<publicKeyStateType>>;
   data: publicKeyStateType;
 }
-export const PublicKeyForm: React.FC<PublicKeyFormProps> = ({
+export const PublicKeyForm: React.VFC<PublicKeyFormProps> = ({
   publicKeys,
   onChange,
   data,

--- a/src/pages/spawn/spawnHost/spawnHostModal/SetupScriptForm.tsx
+++ b/src/pages/spawn/spawnHost/spawnHostModal/SetupScriptForm.tsx
@@ -29,7 +29,7 @@ interface SetupScriptFormProps {
   onChange: React.Dispatch<SpawnHostModalAction>;
   data: setupScriptType;
 }
-export const SetupScriptForm: React.FC<SetupScriptFormProps> = ({
+export const SetupScriptForm: React.VFC<SetupScriptFormProps> = ({
   onChange,
   data,
 }) => {

--- a/src/pages/spawn/spawnVolume/SpawnVolumeButton.tsx
+++ b/src/pages/spawn/spawnVolume/SpawnVolumeButton.tsx
@@ -10,7 +10,7 @@ import { GetSpruceConfigQuery } from "gql/generated/types";
 import { GET_SPRUCE_CONFIG } from "gql/queries";
 import { SpawnVolumeModal } from "./spawnVolumeButton/SpawnVolumeModal";
 
-export const SpawnVolumeButton: React.FC = () => {
+export const SpawnVolumeButton: React.VFC = () => {
   const [openModal, setOpenModal] = useState(false);
   const spawnAnalytics = useSpawnAnalytics();
   const { data } = useQuery<GetSpruceConfigQuery>(GET_SPRUCE_CONFIG);

--- a/src/pages/spawn/spawnVolume/SpawnVolumeTable.tsx
+++ b/src/pages/spawn/spawnVolume/SpawnVolumeTable.tsx
@@ -20,7 +20,7 @@ interface SpawnVolumeTableProps {
   volumes: MyVolume[];
 }
 
-export const SpawnVolumeTable: React.FC<SpawnVolumeTableProps> = ({
+export const SpawnVolumeTable: React.VFC<SpawnVolumeTableProps> = ({
   volumes,
 }) => {
   const { search } = useLocation();

--- a/src/pages/spawn/spawnVolume/spawnVolumeButton/SpawnVolumeModal.tsx
+++ b/src/pages/spawn/spawnVolume/spawnVolumeButton/SpawnVolumeModal.tsx
@@ -32,7 +32,7 @@ interface SpawnVolumeModalProps {
   onCancel: () => void;
 }
 
-export const SpawnVolumeModal: React.FC<SpawnVolumeModalProps> = ({
+export const SpawnVolumeModal: React.VFC<SpawnVolumeModalProps> = ({
   visible,
   onCancel,
 }) => {

--- a/src/pages/spawn/spawnVolume/spawnVolumeButton/spawnVolumeModal/AvailabilityZoneSelector.tsx
+++ b/src/pages/spawn/spawnVolume/spawnVolumeButton/spawnVolumeModal/AvailabilityZoneSelector.tsx
@@ -17,7 +17,7 @@ interface Props {
   value: string;
 }
 
-export const AvailabilityZoneSelector: React.FC<Props> = ({
+export const AvailabilityZoneSelector: React.VFC<Props> = ({
   onChange,
   value,
 }) => {

--- a/src/pages/spawn/spawnVolume/spawnVolumeButton/spawnVolumeModal/SizeSelector.tsx
+++ b/src/pages/spawn/spawnVolume/spawnVolumeButton/spawnVolumeModal/SizeSelector.tsx
@@ -9,7 +9,7 @@ interface Props {
   onChange: (s: number) => void;
 }
 
-export const SizeSelector: React.FC<Props> = ({ value, onChange, limit }) => (
+export const SizeSelector: React.VFC<Props> = ({ value, onChange, limit }) => (
   <SectionContainer>
     <SectionLabel weight="medium">Volume Size</SectionLabel>
     <ModalContent>

--- a/src/pages/spawn/spawnVolume/spawnVolumeButton/spawnVolumeModal/TypeSelector.tsx
+++ b/src/pages/spawn/spawnVolume/spawnVolumeButton/spawnVolumeModal/TypeSelector.tsx
@@ -11,7 +11,7 @@ interface Props {
   onChange: (t: string) => void;
 }
 
-export const TypeSelector: React.FC<Props> = ({ value, onChange }) => (
+export const TypeSelector: React.VFC<Props> = ({ value, onChange }) => (
   <SectionContainer>
     <SectionLabel weight="medium">Type</SectionLabel>
     <ModalContent>

--- a/src/pages/spawn/spawnVolume/spawnVolumeTable/SpawnVolumeCard.tsx
+++ b/src/pages/spawn/spawnVolume/spawnVolumeTable/SpawnVolumeCard.tsx
@@ -8,7 +8,7 @@ interface Props {
   volume: MyVolume;
 }
 
-export const SpawnVolumeCard: React.FC<Props> = ({ volume }) => (
+export const SpawnVolumeCard: React.VFC<Props> = ({ volume }) => (
   <DetailsCard
     data-cy={`spawn-volume-card-${volume.displayName || volume.id}`}
     fieldMaps={spawnVolumeCardFields}

--- a/src/pages/spawn/spawnVolume/spawnVolumeTable/SpawnVolumeTableActions.tsx
+++ b/src/pages/spawn/spawnVolume/spawnVolumeTable/SpawnVolumeTableActions.tsx
@@ -11,7 +11,7 @@ interface Props {
   volume: MyVolume;
 }
 
-export const SpawnVolumeTableActions: React.FC<Props> = ({ volume }) => (
+export const SpawnVolumeTableActions: React.VFC<Props> = ({ volume }) => (
   <FlexRow>
     <DeleteVolumeBtn
       data-cy={`trash-${volume.displayName || volume.id}`}

--- a/src/pages/spawn/spawnVolume/spawnVolumeTable/spawnVolumeTableActions/DeleteVolumeBtn.tsx
+++ b/src/pages/spawn/spawnVolume/spawnVolumeTable/spawnVolumeTableActions/DeleteVolumeBtn.tsx
@@ -16,7 +16,7 @@ interface Props {
   volume: MyVolume;
 }
 
-export const DeleteVolumeBtn: React.FC<Props> = ({ volume }) => {
+export const DeleteVolumeBtn: React.VFC<Props> = ({ volume }) => {
   const dispatchToast = useToastContext();
   const [removeVolume, { loading: loadingRemoveVolume }] = useMutation<
     RemoveVolumeMutation,

--- a/src/pages/spawn/spawnVolume/spawnVolumeTable/spawnVolumeTableActions/EditButton.tsx
+++ b/src/pages/spawn/spawnVolume/spawnVolumeTable/spawnVolumeTableActions/EditButton.tsx
@@ -7,7 +7,7 @@ interface Props {
   volume: MyVolume;
 }
 
-export const EditButton: React.FC<Props> = ({ volume }) => {
+export const EditButton: React.VFC<Props> = ({ volume }) => {
   const [openModal, setOpenModal] = useState(false);
 
   return (

--- a/src/pages/spawn/spawnVolume/spawnVolumeTable/spawnVolumeTableActions/MountBtn.tsx
+++ b/src/pages/spawn/spawnVolume/spawnVolumeTable/spawnVolumeTableActions/MountBtn.tsx
@@ -7,7 +7,7 @@ interface Props {
   volume: MyVolume;
 }
 
-export const MountBtn: React.FC<Props> = ({ volume }) => {
+export const MountBtn: React.VFC<Props> = ({ volume }) => {
   const [openModal, setOpenModal] = useState(false);
 
   return (

--- a/src/pages/spawn/spawnVolume/spawnVolumeTable/spawnVolumeTableActions/UnmountBtn.tsx
+++ b/src/pages/spawn/spawnVolume/spawnVolumeTable/spawnVolumeTableActions/UnmountBtn.tsx
@@ -20,7 +20,7 @@ interface Props {
   volume: MyVolume;
 }
 
-export const UnmountBtn: React.FC<Props> = ({ volume }) => {
+export const UnmountBtn: React.VFC<Props> = ({ volume }) => {
   const dispatchToast = useToastContext();
   const spawnAnalytics = useSpawnAnalytics();
 

--- a/src/pages/spawn/spawnVolume/spawnVolumeTable/spawnVolumeTableActions/editButton/EditVolumeModal.tsx
+++ b/src/pages/spawn/spawnVolume/spawnVolumeTable/spawnVolumeTableActions/editButton/EditVolumeModal.tsx
@@ -27,7 +27,7 @@ interface Props {
   volume: MyVolume;
 }
 
-export const EditVolumeModal: React.FC<Props> = ({
+export const EditVolumeModal: React.VFC<Props> = ({
   visible,
   onCancel,
   volume,

--- a/src/pages/spawn/spawnVolume/spawnVolumeTable/spawnVolumeTableActions/mountButton/MountVolumeModal.tsx
+++ b/src/pages/spawn/spawnVolume/spawnVolumeTable/spawnVolumeTableActions/mountButton/MountVolumeModal.tsx
@@ -21,7 +21,7 @@ interface Props {
   volume: MyVolume;
 }
 
-export const MountVolumeModal: React.FC<Props> = ({
+export const MountVolumeModal: React.VFC<Props> = ({
   visible,
   onCancel,
   volume,

--- a/src/pages/task/ActionButtons.tsx
+++ b/src/pages/task/ActionButtons.tsx
@@ -47,7 +47,7 @@ interface Props {
   task: GetTaskQuery["task"];
 }
 
-export const ActionButtons: React.FC<Props> = ({
+export const ActionButtons: React.VFC<Props> = ({
   initialPriority = 1,
   task,
   isExecutionTask,

--- a/src/pages/task/TaskTabs.tsx
+++ b/src/pages/task/TaskTabs.tsx
@@ -23,7 +23,7 @@ interface TaskTabProps {
   task: GetTaskQuery["task"];
   taskFiles: GetTaskQuery["taskFiles"];
 }
-export const TaskTabs: React.FC<TaskTabProps> = ({ task, taskFiles }) => {
+export const TaskTabs: React.VFC<TaskTabProps> = ({ task, taskFiles }) => {
   const { tab: urlTab } = useParams<{ id: string; tab: TaskTab | null }>();
 
   const history = useHistory();

--- a/src/pages/task/actionButtons/TaskNotificationModal.tsx
+++ b/src/pages/task/actionButtons/TaskNotificationModal.tsx
@@ -29,7 +29,7 @@ interface ModalProps {
   onCancel: () => void;
 }
 
-export const TaskNotificationModal: React.FC<ModalProps> = ({
+export const TaskNotificationModal: React.VFC<ModalProps> = ({
   visible,
   onCancel,
 }) => {

--- a/src/pages/task/actionButtons/previousCommits/PreviousCommits.tsx
+++ b/src/pages/task/actionButtons/previousCommits/PreviousCommits.tsx
@@ -29,7 +29,9 @@ const { reportError } = errorReporting;
 interface PreviousCommitsProps {
   taskId: string;
 }
-export const PreviousCommits: React.FC<PreviousCommitsProps> = ({ taskId }) => {
+export const PreviousCommits: React.VFC<PreviousCommitsProps> = ({
+  taskId,
+}) => {
   const [
     {
       selectState,

--- a/src/pages/task/executionDropdown/ExecutionSelector.tsx
+++ b/src/pages/task/executionDropdown/ExecutionSelector.tsx
@@ -21,7 +21,7 @@ interface ExecutionSelectProps {
   updateExecution: (execution: number) => void;
 }
 
-export const ExecutionSelect: React.FC<ExecutionSelectProps> = ({
+export const ExecutionSelect: React.VFC<ExecutionSelectProps> = ({
   id,
   currentExecution,
   latestExecution,

--- a/src/pages/task/metadata/AbortMessage.tsx
+++ b/src/pages/task/metadata/AbortMessage.tsx
@@ -4,7 +4,7 @@ import { P2 } from "components/Typography";
 import { getTaskRoute, getVersionRoute } from "constants/routes";
 import { AbortInfo } from "gql/generated/types";
 
-export const AbortMessage: React.FC<AbortInfo> = ({
+export const AbortMessage: React.VFC<AbortInfo> = ({
   buildVariantDisplayName,
   newVersion,
   prClosed,

--- a/src/pages/task/metadata/DependsOn.tsx
+++ b/src/pages/task/metadata/DependsOn.tsx
@@ -16,7 +16,7 @@ interface Props {
   name: string;
   taskId: string;
 }
-export const DependsOn: React.FC<Props> = ({
+export const DependsOn: React.VFC<Props> = ({
   buildVariant,
   metStatus,
   name,

--- a/src/pages/task/metadata/ETATimer.tsx
+++ b/src/pages/task/metadata/ETATimer.tsx
@@ -8,7 +8,7 @@ interface ETATimerProps {
   startTime: Date;
   expectedDuration: number;
 }
-export const ETATimer: React.FC<ETATimerProps> = ({
+export const ETATimer: React.VFC<ETATimerProps> = ({
   startTime,
   expectedDuration,
 }) => {

--- a/src/pages/task/metadata/index.tsx
+++ b/src/pages/task/metadata/index.tsx
@@ -33,7 +33,12 @@ interface Props {
   error: ApolloError;
 }
 
-export const Metadata: React.FC<Props> = ({ loading, task, error, taskId }) => {
+export const Metadata: React.VFC<Props> = ({
+  loading,
+  task,
+  error,
+  taskId,
+}) => {
   const taskAnalytics = useTaskAnalytics();
   const tz = useUserTimeZone();
   const {

--- a/src/pages/task/taskTabs/ExecutionTasksTable.tsx
+++ b/src/pages/task/taskTabs/ExecutionTasksTable.tsx
@@ -21,7 +21,7 @@ const useSorts = () => {
   return parseSortString(sorts);
 };
 
-export const ExecutionTasksTable: React.FC<Props> = ({
+export const ExecutionTasksTable: React.VFC<Props> = ({
   execution,
   executionTasksFull,
 }) => {

--- a/src/pages/task/taskTabs/FilesTables.tsx
+++ b/src/pages/task/taskTabs/FilesTables.tsx
@@ -42,7 +42,7 @@ const columns = [
   },
 ];
 
-export const FilesTables: React.FC = () => {
+export const FilesTables: React.VFC = () => {
   const { id } = useParams<{ id: string }>();
   const { search: queryVars } = useLocation();
   const parsed = parseQueryString(queryVars);

--- a/src/pages/task/taskTabs/Logs.tsx
+++ b/src/pages/task/taskTabs/Logs.tsx
@@ -27,7 +27,7 @@ interface Props {
   taskId: string;
   execution: number;
 }
-export const Logs: React.FC<Props> = ({ logLinks, taskId, execution }) => {
+export const Logs: React.VFC<Props> = ({ logLinks, taskId, execution }) => {
   const { search } = useLocation();
   const [currentLog, setCurrentLog] = useState<LogTypes>(DEFAULT_LOG_TYPE);
   const parsed = queryString.parse(search);

--- a/src/pages/task/taskTabs/TestsTable.tsx
+++ b/src/pages/task/taskTabs/TestsTable.tsx
@@ -42,7 +42,7 @@ const { parseQueryString, queryParamAsNumber } = queryString;
 export interface UpdateQueryArg {
   taskTests: TaskTestResult;
 }
-export const TestsTable: React.FC = () => {
+export const TestsTable: React.VFC = () => {
   const { id: taskId } = useParams<{ id: string }>();
   const { pathname, search } = useLocation();
   const parsed = parseQueryString(search);

--- a/src/pages/task/taskTabs/buildBaronAndAnnotations/AddIssueModal.tsx
+++ b/src/pages/task/taskTabs/buildBaronAndAnnotations/AddIssueModal.tsx
@@ -26,7 +26,7 @@ interface Props {
   isIssue: boolean;
 }
 
-export const AddIssueModal: React.FC<Props> = ({
+export const AddIssueModal: React.VFC<Props> = ({
   visible,
   dataCy,
   closeModal,

--- a/src/pages/task/taskTabs/buildBaronAndAnnotations/AnnotationNote.tsx
+++ b/src/pages/task/taskTabs/buildBaronAndAnnotations/AnnotationNote.tsx
@@ -31,7 +31,7 @@ interface Props {
   userCanModify: boolean;
 }
 
-export const AnnotationNote: React.FC<Props> = ({
+export const AnnotationNote: React.VFC<Props> = ({
   note,
   taskId,
   execution,

--- a/src/pages/task/taskTabs/buildBaronAndAnnotations/AnnotationTickets.tsx
+++ b/src/pages/task/taskTabs/buildBaronAndAnnotations/AnnotationTickets.tsx
@@ -69,7 +69,7 @@ const AnnotationTickets: React.VFC<AnnotationTicketsProps> = ({
             </Tooltip>
           )}
         >
-          <StyledButton
+          <StyledButton // @ts-expect-error
             onClick={onClickAdd}
             data-cy={
               isIssue ? "add-issue-button" : "add-suspected-issue-button"
@@ -195,6 +195,7 @@ export const SuspectedIssues: React.VFC<SuspectedIssuesProps> = ({
   );
 };
 
+// @ts-expect-error
 const StyledButton = styled(PlusButton)`
   margin: ${size.xs} 0;
 `;

--- a/src/pages/task/taskTabs/buildBaronAndAnnotations/AnnotationTickets.tsx
+++ b/src/pages/task/taskTabs/buildBaronAndAnnotations/AnnotationTickets.tsx
@@ -31,7 +31,7 @@ interface AnnotationTicketsProps {
   loading: boolean;
 }
 
-const AnnotationTickets: React.FC<AnnotationTicketsProps> = ({
+const AnnotationTickets: React.VFC<AnnotationTicketsProps> = ({
   tickets,
   taskId,
   execution,
@@ -114,7 +114,7 @@ interface IssuesProps {
   annotation: Annotation;
 }
 
-export const Issues: React.FC<IssuesProps> = ({
+export const Issues: React.VFC<IssuesProps> = ({
   taskId,
   execution,
   userCanModify,
@@ -158,7 +158,7 @@ interface SuspectedIssuesProps {
   annotation: Annotation;
 }
 
-export const SuspectedIssues: React.FC<SuspectedIssuesProps> = ({
+export const SuspectedIssues: React.VFC<SuspectedIssuesProps> = ({
   taskId,
   execution,
   userCanModify,

--- a/src/pages/task/taskTabs/buildBaronAndAnnotations/AnnotationTicketsTable.tsx
+++ b/src/pages/task/taskTabs/buildBaronAndAnnotations/AnnotationTicketsTable.tsx
@@ -31,7 +31,7 @@ interface AnnotationTicketsProps {
   loading: boolean;
 }
 
-export const AnnotationTicketsTable: React.FC<AnnotationTicketsProps> = ({
+export const AnnotationTicketsTable: React.VFC<AnnotationTicketsProps> = ({
   jiraIssues,
   taskId,
   execution,
@@ -248,7 +248,7 @@ interface CreatedTicketsProps {
   createdIssues: AnnotationTickets;
 }
 
-export const CustomCreatedTicketsTable: React.FC<CreatedTicketsProps> = ({
+export const CustomCreatedTicketsTable: React.VFC<CreatedTicketsProps> = ({
   createdIssues,
 }) => {
   const columns = [

--- a/src/pages/task/taskTabs/buildBaronAndAnnotations/BBComponents.tsx
+++ b/src/pages/task/taskTabs/buildBaronAndAnnotations/BBComponents.tsx
@@ -26,7 +26,7 @@ interface JiraTicketRowProps {
   jiraKey: string;
   fields: TicketFields;
 }
-export const JiraTicketRow: React.FC<JiraTicketRowProps> = ({
+export const JiraTicketRow: React.VFC<JiraTicketRowProps> = ({
   jiraKey,
   fields,
 }) => {
@@ -78,7 +78,7 @@ interface AnnotationTicketRowProps {
   loading?: boolean;
 }
 
-export const AnnotationTicketRow: React.FC<AnnotationTicketRowProps> = ({
+export const AnnotationTicketRow: React.VFC<AnnotationTicketRowProps> = ({
   issueKey,
   url,
   jiraTicket,

--- a/src/pages/task/taskTabs/buildBaronAndAnnotations/BBCreatedTickets.tsx
+++ b/src/pages/task/taskTabs/buildBaronAndAnnotations/BBCreatedTickets.tsx
@@ -10,7 +10,7 @@ interface CreatedTicketsProps {
   tickets: JiraTicket[] | IssueLink[];
 }
 
-export const CreatedTickets: React.FC<CreatedTicketsProps> = ({
+export const CreatedTickets: React.VFC<CreatedTicketsProps> = ({
   taskId,
   execution,
   buildBaronConfigured,
@@ -42,7 +42,7 @@ interface CustomCreatedTicketProps {
   tickets: JiraTicket[] | IssueLink[];
 }
 
-export const CustomCreatedTickets: React.FC<CustomCreatedTicketProps> = ({
+export const CustomCreatedTickets: React.VFC<CustomCreatedTicketProps> = ({
   taskId,
   execution,
   tickets,

--- a/src/pages/task/taskTabs/buildBaronAndAnnotations/BBFileTicket.tsx
+++ b/src/pages/task/taskTabs/buildBaronAndAnnotations/BBFileTicket.tsx
@@ -24,7 +24,7 @@ interface FileTicketProps {
   tickets: JiraTicket[] | IssueLink[];
 }
 
-export const FileTicket: React.FC<FileTicketProps> = ({
+export const FileTicket: React.VFC<FileTicketProps> = ({
   taskId,
   execution,
   tickets,

--- a/src/pages/task/taskTabs/buildBaronAndAnnotations/BuildBaron.tsx
+++ b/src/pages/task/taskTabs/buildBaronAndAnnotations/BuildBaron.tsx
@@ -14,7 +14,7 @@ interface Props {
   userCanModify: boolean;
 }
 
-const BuildBaron: React.FC<Props> = ({
+const BuildBaron: React.VFC<Props> = ({
   bbData,
   error,
   taskId,

--- a/src/pages/task/taskTabs/buildBaronAndAnnotations/BuildBaronContent.tsx
+++ b/src/pages/task/taskTabs/buildBaronAndAnnotations/BuildBaronContent.tsx
@@ -34,7 +34,7 @@ interface BuildBaronCoreProps {
   userCanModify: boolean;
 }
 
-export const BuildBaronContent: React.FC<BuildBaronCoreProps> = ({
+export const BuildBaronContent: React.VFC<BuildBaronCoreProps> = ({
   bbData,
   taskId,
   execution,

--- a/src/pages/task/taskTabs/buildBaronAndAnnotations/BuildBaronTable.tsx
+++ b/src/pages/task/taskTabs/buildBaronAndAnnotations/BuildBaronTable.tsx
@@ -15,7 +15,7 @@ const columns = [
   },
 ];
 
-export const BuildBaronTable: React.FC<{
+export const BuildBaronTable: React.VFC<{
   jiraIssues: CreatedTickets;
 }> = ({ jiraIssues }) => (
   <Table

--- a/src/pages/task/taskTabs/logs/LogTypes.tsx
+++ b/src/pages/task/taskTabs/logs/LogTypes.tsx
@@ -78,7 +78,7 @@ export const AllLog: React.VFC<Props> = (props) => {
   });
 };
 
-export const EventLog: React.VFC<Props> = (props): JSX.Element => {
+export const EventLog: React.VFC<Props> = (props) => {
   const { id } = useParams<{ id: string }>();
   const location = useLocation();
   const parsed = parseQueryString(location.search);
@@ -104,7 +104,7 @@ export const EventLog: React.VFC<Props> = (props): JSX.Element => {
   });
 };
 
-export const SystemLog: React.VFC<Props> = (props): JSX.Element => {
+export const SystemLog: React.VFC<Props> = (props) => {
   const { id } = useParams<{ id: string }>();
   const location = useLocation();
   const parsed = parseQueryString(location.search);
@@ -126,7 +126,7 @@ export const SystemLog: React.VFC<Props> = (props): JSX.Element => {
   });
 };
 
-export const AgentLog: React.VFC<Props> = (props): JSX.Element => {
+export const AgentLog: React.VFC<Props> = (props) => {
   const { id } = useParams<{ id: string }>();
   const location = useLocation();
   const parsed = parseQueryString(location.search);
@@ -148,7 +148,7 @@ export const AgentLog: React.VFC<Props> = (props): JSX.Element => {
   });
 };
 
-export const TaskLog: React.VFC<Props> = (props): JSX.Element => {
+export const TaskLog: React.VFC<Props> = (props) => {
   const { id } = useParams<{ id: string }>();
   const location = useLocation();
   const parsed = parseQueryString(location.search);

--- a/src/pages/task/taskTabs/logs/LogTypes.tsx
+++ b/src/pages/task/taskTabs/logs/LogTypes.tsx
@@ -175,7 +175,7 @@ const useRenderBody: React.VFC<{
   error: ApolloError;
   data: (TaskEventLogEntryType | LogMessageType)[];
   currentLog: LogTypes;
-  LogContainer?: React.FC<{ children: React.ReactNode }>;
+  LogContainer?: React.VFC<{ children: React.ReactNode }>;
   htmlLink: string;
   rawLink: string;
   lobsterLink: string;

--- a/src/pages/task/taskTabs/logs/LogTypes.tsx
+++ b/src/pages/task/taskTabs/logs/LogTypes.tsx
@@ -54,7 +54,7 @@ interface Props {
   lobsterLink: string;
 }
 
-export const AllLog: React.FC<Props> = (props): JSX.Element => {
+export const AllLog: React.VFC<Props> = (props) => {
   const { id } = useParams<{ id: string }>();
   const location = useLocation();
   const parsed = parseQueryString(location.search);
@@ -78,7 +78,7 @@ export const AllLog: React.FC<Props> = (props): JSX.Element => {
   });
 };
 
-export const EventLog: React.FC<Props> = (props): JSX.Element => {
+export const EventLog: React.VFC<Props> = (props): JSX.Element => {
   const { id } = useParams<{ id: string }>();
   const location = useLocation();
   const parsed = parseQueryString(location.search);
@@ -104,7 +104,7 @@ export const EventLog: React.FC<Props> = (props): JSX.Element => {
   });
 };
 
-export const SystemLog: React.FC<Props> = (props): JSX.Element => {
+export const SystemLog: React.VFC<Props> = (props): JSX.Element => {
   const { id } = useParams<{ id: string }>();
   const location = useLocation();
   const parsed = parseQueryString(location.search);
@@ -126,7 +126,7 @@ export const SystemLog: React.FC<Props> = (props): JSX.Element => {
   });
 };
 
-export const AgentLog: React.FC<Props> = (props): JSX.Element => {
+export const AgentLog: React.VFC<Props> = (props): JSX.Element => {
   const { id } = useParams<{ id: string }>();
   const location = useLocation();
   const parsed = parseQueryString(location.search);
@@ -148,7 +148,7 @@ export const AgentLog: React.FC<Props> = (props): JSX.Element => {
   });
 };
 
-export const TaskLog: React.FC<Props> = (props): JSX.Element => {
+export const TaskLog: React.VFC<Props> = (props): JSX.Element => {
   const { id } = useParams<{ id: string }>();
   const location = useLocation();
   const parsed = parseQueryString(location.search);
@@ -170,12 +170,12 @@ export const TaskLog: React.FC<Props> = (props): JSX.Element => {
   });
 };
 
-const useRenderBody: React.FC<{
+const useRenderBody: React.VFC<{
   loading: boolean;
   error: ApolloError;
   data: (TaskEventLogEntryType | LogMessageType)[];
   currentLog: LogTypes;
-  LogContainer?: React.FC;
+  LogContainer?: React.FC<{ children: React.ReactNode }>;
   htmlLink: string;
   rawLink: string;
   lobsterLink: string;

--- a/src/pages/task/taskTabs/logs/logTypes/LogMessageLine.tsx
+++ b/src/pages/task/taskTabs/logs/logTypes/LogMessageLine.tsx
@@ -9,7 +9,7 @@ import { getLogLineWrapper } from "./logMessageLine/LogLines";
 const FORMAT_STR = "yyyy/MM/d, HH:mm:ss.SSS";
 const ansiUp = new AnsiUp();
 
-export const LogMessageLine: React.FC<LogMessageFragment> = ({
+export const LogMessageLine: React.VFC<LogMessageFragment> = ({
   timestamp,
   severity,
   message,

--- a/src/pages/task/taskTabs/logs/logTypes/TaskEventLogLine.tsx
+++ b/src/pages/task/taskTabs/logs/logTypes/TaskEventLogLine.tsx
@@ -8,7 +8,7 @@ import { TaskEventLogEntry } from "gql/generated/types";
 
 const FORMAT_STR = "MMM d, yyyy, h:mm:ss aaaa";
 
-export const TaskEventLogLine: React.FC<TaskEventLogEntry> = ({
+export const TaskEventLogLine: React.VFC<TaskEventLogEntry> = ({
   timestamp,
   eventType,
   data,

--- a/src/pages/task/taskTabs/logs/logTypes/logMessageLine/LogLines.tsx
+++ b/src/pages/task/taskTabs/logs/logTypes/logMessageLine/LogLines.tsx
@@ -1,10 +1,14 @@
 import styled from "@emotion/styled";
 
-const getLogLineComp = (color: string): React.FC => styled.div`
+const getLogLineComp = (
+  color: string
+): React.FC<{ children: React.ReactNode }> => styled.div`
   color: ${color};
 `;
 
-export const getLogLineWrapper = (severity: string): React.FC => {
+export const getLogLineWrapper = (
+  severity: string
+): React.FC<{ children: React.ReactNode }> => {
   switch (severity) {
     case "D":
     case "DEBUG":

--- a/src/pages/task/taskTabs/logs/logTypes/logMessageLine/LogLines.tsx
+++ b/src/pages/task/taskTabs/logs/logTypes/logMessageLine/LogLines.tsx
@@ -2,13 +2,13 @@ import styled from "@emotion/styled";
 
 const getLogLineComp = (
   color: string
-): React.FC<{ children: React.ReactNode }> => styled.div`
+): React.VFC<{ children: React.ReactNode }> => styled.div`
   color: ${color};
 `;
 
 export const getLogLineWrapper = (
   severity: string
-): React.FC<{ children: React.ReactNode }> => {
+): React.VFC<{ children: React.ReactNode }> => {
   switch (severity) {
     case "D":
     case "DEBUG":

--- a/src/pages/task/taskTabs/testsTable/LogsColumn.tsx
+++ b/src/pages/task/taskTabs/testsTable/LogsColumn.tsx
@@ -21,7 +21,7 @@ interface Props {
   task: GetTaskForTestsTableQuery["task"];
 }
 
-export const LogsColumn: React.FC<Props> = ({
+export const LogsColumn: React.VFC<Props> = ({
   testResult,
   taskAnalytics,
   task,

--- a/src/pages/task/taskTabs/testsTable/TestStatusBadge.tsx
+++ b/src/pages/task/taskTabs/testsTable/TestStatusBadge.tsx
@@ -5,7 +5,9 @@ interface TestStatusBadgeProps {
   status: string;
 }
 
-export const TestStatusBadge: React.FC<TestStatusBadgeProps> = ({ status }) => (
+export const TestStatusBadge: React.VFC<TestStatusBadgeProps> = ({
+  status,
+}) => (
   <Badge variant={statusToBadgeColor[status] || Variant.LightGray} key={status}>
     {statusCopy[status] || status}
   </Badge>

--- a/src/pages/taskHistory/BuildVariantSelector.tsx
+++ b/src/pages/taskHistory/BuildVariantSelector.tsx
@@ -22,7 +22,7 @@ interface BuildVariantSelectorProps {
   taskName: string;
 }
 
-const BuildVariantSelector: React.FC<BuildVariantSelectorProps> = ({
+const BuildVariantSelector: React.VFC<BuildVariantSelectorProps> = ({
   projectId,
   taskName,
 }) => {

--- a/src/pages/taskHistory/ColumnHeaders.tsx
+++ b/src/pages/taskHistory/ColumnHeaders.tsx
@@ -23,7 +23,7 @@ interface ColumnHeadersProps {
   projectId: string;
   taskName: string;
 }
-const ColumnHeaders: React.FC<ColumnHeadersProps> = ({
+const ColumnHeaders: React.VFC<ColumnHeadersProps> = ({
   projectId,
   taskName,
 }) => {

--- a/src/pages/taskHistory/TaskHistoryRow.test.tsx
+++ b/src/pages/taskHistory/TaskHistoryRow.test.tsx
@@ -37,7 +37,7 @@ interface wrapperProps {
   state?: Partial<HistoryTableReducerState>;
 }
 
-const wrapper: React.FC<wrapperProps> = ({ children, mocks = [], state }) => (
+const wrapper: React.VFC<wrapperProps> = ({ children, mocks = [], state }) => (
   <MockedProvider mocks={mocks}>
     <HistoryTableProvider initialState={{ ...initialState, ...state }}>
       {children}

--- a/src/pages/taskQueue/DistroOption.tsx
+++ b/src/pages/taskQueue/DistroOption.tsx
@@ -12,7 +12,7 @@ interface DistroOptionProps {
   onClick: (val: TaskQueueDistro) => void;
 }
 
-export const DistroOption: React.FC<DistroOptionProps> = ({
+export const DistroOption: React.VFC<DistroOptionProps> = ({
   option,
   onClick,
 }) => {

--- a/src/pages/variantHistory/ColumnHeaders.tsx
+++ b/src/pages/variantHistory/ColumnHeaders.tsx
@@ -23,7 +23,7 @@ interface ColumnHeadersProps {
   variantName: string;
 }
 
-const ColumnHeaders: React.FC<ColumnHeadersProps> = ({
+const ColumnHeaders: React.VFC<ColumnHeadersProps> = ({
   projectId,
   variantName,
 }) => {

--- a/src/pages/variantHistory/TaskSelector.tsx
+++ b/src/pages/variantHistory/TaskSelector.tsx
@@ -19,7 +19,7 @@ interface TaskSelectorProps {
   buildVariant: string;
 }
 
-const TaskSelector: React.FC<TaskSelectorProps> = ({
+const TaskSelector: React.VFC<TaskSelectorProps> = ({
   projectId,
   buildVariant,
 }) => {

--- a/src/pages/variantHistory/VariantHistoryRow.test.tsx
+++ b/src/pages/variantHistory/VariantHistoryRow.test.tsx
@@ -38,7 +38,7 @@ interface wrapperProps {
   state?: Partial<HistoryTableReducerState>;
 }
 
-const wrapper: React.FC<wrapperProps> = ({ children, mocks = [], state }) => (
+const wrapper: React.VFC<wrapperProps> = ({ children, mocks = [], state }) => (
   <MockedProvider mocks={mocks}>
     <HistoryTableProvider initialState={{ ...initialState, ...state }}>
       {children}

--- a/src/pages/version/ActionButtons.tsx
+++ b/src/pages/version/ActionButtons.tsx
@@ -26,7 +26,7 @@ interface ActionButtonProps {
   activated: boolean;
 }
 
-export const ActionButtons: React.FC<ActionButtonProps> = ({
+export const ActionButtons: React.VFC<ActionButtonProps> = ({
   canEnqueueToCommitQueue,
   isPatchOnCommitQueue,
   canReconfigure,

--- a/src/pages/version/BuildVariants.tsx
+++ b/src/pages/version/BuildVariants.tsx
@@ -17,7 +17,7 @@ import { GET_BUILD_VARIANTS_STATS } from "gql/queries";
 import { usePolling } from "hooks";
 import { applyStrictRegex } from "utils/string";
 
-export const BuildVariants: React.FC = () => {
+export const BuildVariants: React.VFC = () => {
   const { id } = useParams<{ id: string }>();
   const { sendEvent } = useVersionAnalytics(id);
 
@@ -77,7 +77,7 @@ interface VariantTaskGroupProps {
   statusCounts: StatusCount[];
   versionId: string;
 }
-const VariantTaskGroup: React.FC<VariantTaskGroupProps> = ({
+const VariantTaskGroup: React.VFC<VariantTaskGroupProps> = ({
   variant,
   statusCounts,
   versionId,

--- a/src/pages/version/DownstreamTasks.tsx
+++ b/src/pages/version/DownstreamTasks.tsx
@@ -5,7 +5,7 @@ interface DownstreamTasksProps {
   childPatches: Partial<Patch>[];
 }
 
-export const DownstreamTasks: React.FC<DownstreamTasksProps> = ({
+export const DownstreamTasks: React.VFC<DownstreamTasksProps> = ({
   childPatches,
 }) => (
   <>

--- a/src/pages/version/EnqueueModal.tsx
+++ b/src/pages/version/EnqueueModal.tsx
@@ -20,7 +20,7 @@ interface EnqueueProps {
   onFinished: () => void;
   refetchQueries: string[];
 }
-export const EnqueuePatchModal: React.FC<EnqueueProps> = ({
+export const EnqueuePatchModal: React.VFC<EnqueueProps> = ({
   patchId,
   commitMessage,
   visible,

--- a/src/pages/version/ManifestBlob.tsx
+++ b/src/pages/version/ManifestBlob.tsx
@@ -9,7 +9,7 @@ interface Props {
   manifest: Manifest;
 }
 
-const ManifestBlob: React.FC<Props> = ({ manifest }) => {
+const ManifestBlob: React.VFC<Props> = ({ manifest }) => {
   const cleanedManifest = omitTypename(manifest);
   const blob = new Blob([JSON.stringify(cleanedManifest, null, 3)], {
     type: "text/json",

--- a/src/pages/version/Metadata.tsx
+++ b/src/pages/version/Metadata.tsx
@@ -19,7 +19,7 @@ interface Props {
   version: VersionQuery["version"];
 }
 
-export const Metadata: React.FC<Props> = ({ loading, version }) => {
+export const Metadata: React.VFC<Props> = ({ loading, version }) => {
   const {
     author,
     revision,

--- a/src/pages/version/ParametersModal.tsx
+++ b/src/pages/version/ParametersModal.tsx
@@ -11,7 +11,7 @@ interface ParametersProps {
   parameters: Parameter[];
 }
 
-export const ParametersModal: React.FC<ParametersProps> = ({ parameters }) => {
+export const ParametersModal: React.VFC<ParametersProps> = ({ parameters }) => {
   const [showModal, setShowModal] = useState<boolean>(false);
   return (
     <>

--- a/src/pages/version/ScheduleUndispatchedBaseTasks.tsx
+++ b/src/pages/version/ScheduleUndispatchedBaseTasks.tsx
@@ -13,7 +13,7 @@ interface Props {
   patchId: string;
   disabled: boolean;
 }
-export const ScheduleUndispatchedBaseTasks: React.FC<Props> = ({
+export const ScheduleUndispatchedBaseTasks: React.VFC<Props> = ({
   patchId,
   disabled,
 }) => {

--- a/src/pages/version/Tabs.tsx
+++ b/src/pages/version/Tabs.tsx
@@ -47,7 +47,11 @@ const tabMap = ({ taskCount, childPatches }) => ({
     </Tab>
   ),
 });
-export const Tabs: React.FC<Props> = ({ taskCount, childPatches, isPatch }) => {
+export const Tabs: React.VFC<Props> = ({
+  taskCount,
+  childPatches,
+  isPatch,
+}) => {
   const { id, tab } = useParams<{ id: string; tab: PatchTab }>();
   const { sendEvent } = useVersionAnalytics(id);
   const history = useHistory();

--- a/src/pages/version/Tasks.tsx
+++ b/src/pages/version/Tasks.tsx
@@ -28,7 +28,7 @@ interface Props {
   taskCount: number;
 }
 
-export const Tasks: React.FC<Props> = ({ taskCount }) => {
+export const Tasks: React.VFC<Props> = ({ taskCount }) => {
   const { id: versionId } = useParams<{ id: string }>();
 
   const { search } = useLocation();

--- a/src/pages/version/downstreamTasks/DownstreamProjectAccordion.tsx
+++ b/src/pages/version/downstreamTasks/DownstreamProjectAccordion.tsx
@@ -158,78 +158,72 @@ export const DownstreamProjectAccordion: React.VFC<DownstreamProjectAccordionPro
 
   return (
     <AccordionWrapper data-cy="project-accordion">
-      <Accordion
-        title={variantTitle}
-        titleTag={FlexContainer}
-        contents={
-          <AccordionContents>
-            <p>
-              Base commit:{" "}
-              <InlineCode href={`${getUiUrl()}/version/${baseVersionID}`}>
-                {githash.slice(0, 10)}
-              </InlineCode>
-            </p>
-            <TableWrapper>
-              <TableControlOuterRow>
-                <FlexContainer>
-                  <ResultCountLabel
-                    dataCyNumerator="current-task-count"
-                    dataCyDenominator="total-task-count"
-                    label="tasks"
-                    numerator={patchTasks?.count}
-                    denominator={taskCount}
-                  />
-                  <PaddedButton // @ts-expect-error
-                    onClick={() => {
-                      dispatch({ type: "clearAllFilters" });
-                    }}
-                    data-cy="clear-all-filters"
-                  >
-                    Clear All Filters
-                  </PaddedButton>
-                </FlexContainer>
-                <TableControlInnerRow>
-                  <Pagination
-                    data-cy="downstream-tasks-table-pagination"
-                    onChange={(p) =>
-                      dispatch({ type: "onChangePagination", page: p - 1 })
-                    }
-                    pageSize={state.limit}
-                    totalResults={patchTasks?.count}
-                    value={variables.page}
-                  />
-                  <PageSizeSelector
-                    data-cy="tasks-table-page-size-selector"
-                    value={variables.limit}
-                    onClick={(l) =>
-                      dispatch({ type: "onChangeLimit", limit: l })
-                    }
-                  />
-                </TableControlInnerRow>
-              </TableControlOuterRow>
-              {showSkeleton ? (
-                <Skeleton active title={false} paragraph={{ rows: 8 }} />
-              ) : (
-                <TasksTable
-                  sorts={variables.sorts}
-                  tableChangeHandler={tableChangeHandler}
-                  tasks={patchTasks?.tasks}
-                  statusSelectorProps={statusSelectorProps}
-                  baseStatusSelectorProps={baseStatusSelectorProps}
-                  taskNameInputProps={taskNameInputProps}
-                  variantInputProps={variantInputProps}
-                  onColumnHeaderClick={(sortField) =>
-                    sendEvent({
-                      name: "Sort Downstream Tasks Table",
-                      sortBy: sortField,
-                    })
-                  }
+      <Accordion title={variantTitle} titleTag={FlexContainer}>
+        <AccordionContents>
+          <p>
+            Base commit:{" "}
+            <InlineCode href={`${getUiUrl()}/version/${baseVersionID}`}>
+              {githash.slice(0, 10)}
+            </InlineCode>
+          </p>
+          <TableWrapper>
+            <TableControlOuterRow>
+              <FlexContainer>
+                <ResultCountLabel
+                  dataCyNumerator="current-task-count"
+                  dataCyDenominator="total-task-count"
+                  label="tasks"
+                  numerator={patchTasks?.count}
+                  denominator={taskCount}
                 />
-              )}
-            </TableWrapper>
-          </AccordionContents>
-        }
-      />
+                <PaddedButton // @ts-expect-error
+                  onClick={() => {
+                    dispatch({ type: "clearAllFilters" });
+                  }}
+                  data-cy="clear-all-filters"
+                >
+                  Clear All Filters
+                </PaddedButton>
+              </FlexContainer>
+              <TableControlInnerRow>
+                <Pagination
+                  data-cy="downstream-tasks-table-pagination"
+                  onChange={(p) =>
+                    dispatch({ type: "onChangePagination", page: p - 1 })
+                  }
+                  pageSize={state.limit}
+                  totalResults={patchTasks?.count}
+                  value={variables.page}
+                />
+                <PageSizeSelector
+                  data-cy="tasks-table-page-size-selector"
+                  value={variables.limit}
+                  onClick={(l) => dispatch({ type: "onChangeLimit", limit: l })}
+                />
+              </TableControlInnerRow>
+            </TableControlOuterRow>
+            {showSkeleton ? (
+              <Skeleton active title={false} paragraph={{ rows: 8 }} />
+            ) : (
+              <TasksTable
+                sorts={variables.sorts}
+                tableChangeHandler={tableChangeHandler}
+                tasks={patchTasks?.tasks}
+                statusSelectorProps={statusSelectorProps}
+                baseStatusSelectorProps={baseStatusSelectorProps}
+                taskNameInputProps={taskNameInputProps}
+                variantInputProps={variantInputProps}
+                onColumnHeaderClick={(sortField) =>
+                  sendEvent({
+                    name: "Sort Downstream Tasks Table",
+                    sortBy: sortField,
+                  })
+                }
+              />
+            )}
+          </TableWrapper>
+        </AccordionContents>
+      </Accordion>
     </AccordionWrapper>
   );
 };

--- a/src/pages/version/downstreamTasks/DownstreamProjectAccordion.tsx
+++ b/src/pages/version/downstreamTasks/DownstreamProjectAccordion.tsx
@@ -41,7 +41,7 @@ interface DownstreamProjectAccordionProps {
   childPatchId: string;
 }
 
-export const DownstreamProjectAccordion: React.FC<DownstreamProjectAccordionProps> = ({
+export const DownstreamProjectAccordion: React.VFC<DownstreamProjectAccordionProps> = ({
   baseVersionID,
   childPatchId,
   githash,

--- a/src/pages/version/tasks/PatchTasksTable.tsx
+++ b/src/pages/version/tasks/PatchTasksTable.tsx
@@ -20,7 +20,7 @@ interface Props {
   sorts: SortOrder[];
 }
 
-export const PatchTasksTable: React.FC<Props> = ({ patchTasks, sorts }) => {
+export const PatchTasksTable: React.VFC<Props> = ({ patchTasks, sorts }) => {
   const { id: versionId } = useParams<{ id: string }>();
   const updateQueryParams = useUpdateURLQueryParams();
   const { sendEvent } = useVersionAnalytics(versionId);

--- a/src/test_utils/toast-decorator.tsx
+++ b/src/test_utils/toast-decorator.tsx
@@ -7,7 +7,9 @@ const WithToastContext = (Story) => (
   </MockToastProvider>
 );
 
-const MockToastProvider = ({ children }) => {
+const MockToastProvider: React.VFC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
   const toastContext = {
     success: (message: string, closable: boolean = true) =>
       action(`Toast Success`)({ message, closable }),


### PR DESCRIPTION
[EVG-16681](https://jira.mongodb.org/browse/EVG-16681)

### Description 
This PR updates our usage of the `React.FC` prop to `React.VFC` which is functionally the same as `React.FC` without the explicit `children` prop.
 @SupaJoon  and I discovered this new type after discussing typing react components without `React.FC` like so
```ts
const SomeComponent = (props: SomePropType) => (...someReturn)
```
While the above example is explicit about the props the component accepts, avoiding a situation in which there is an incorrectly added `children` prop as is the case with `React.FC` it does not have an explicit return type defined.
This can potentially result in a user error in which we accidentally return the wrong thing from a component. 
`React.VFC` solves this issue by not including the unexpected `children` prop while preserving the the return type safety.

I think in general if you are creating a new component that does **require** the `children` prop it is safe to use either `React.FC` or `React.VFC` and explicitly type `children`. 

This is all subject to change, there is supposedly the plan to update `React.FC` to have the same behavior as `React.VFC` by default in the next major release. (React 18) 
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46643#issuecomment-801487166

But since we will likely not be upgrading to React 18 in the near future i think it's ok to make this change for now and update it when we do.


Read more here. (Yes the naming sucks)
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46643

