### PR TITLE
EVG-16660 Add upstreamProject field to versions and mainline commits

### DIFF
--- a/cypress/integration/projectHealth/commits.ts
+++ b/cypress/integration/projectHealth/commits.ts
@@ -149,7 +149,7 @@ describe("commits page", () => {
       cy.dataCy("tuple-select-option-taskNames").click();
       cy.getInputByLabel("Add New Task Filter").type(".").type("{enter}");
       cy.dataCy("grouped-task-status-badge").should("not.exist");
-      cy.dataCy("waterfall-task-status-icon").should("have.length", 33);
+      cy.dataCy("waterfall-task-status-icon").should("have.length", 26);
       cy.dataCy("waterfall-task-status-icon")
         .get("[aria-label='failed icon']")
         .should("exist");
@@ -161,7 +161,7 @@ describe("commits page", () => {
         .should("exist");
       cy.dataCy("waterfall-task-status-icon")
         .get("[aria-label='success icon']")
-        .should("have.length", 32);
+        .should("have.length", 25);
     });
     it("should hide commits that don't match applied filters", () => {
       cy.dataCy("project-task-status-select").should("exist");
@@ -259,7 +259,7 @@ describe("commits page", () => {
         cy.dataCy("grouped-task-status-badge-tooltip").should("be.visible");
         cy.dataCy("grouped-task-status-badge-tooltip").should(
           "contain.text",
-          "8 Succeeded"
+          "1 Succeeded"
         );
       });
       it("should direct you to the version page with the build variant and task status filters applied", () => {

--- a/src/components/CommitChartLabel/index.tsx
+++ b/src/components/CommitChartLabel/index.tsx
@@ -4,13 +4,14 @@ import { uiColors } from "@leafygreen-ui/palette";
 import { Body } from "@leafygreen-ui/typography";
 import ExpandedText from "components/ExpandedText";
 import { StyledRouterLink } from "components/styles";
-import { getVersionRoute } from "constants/routes";
+import { getVersionRoute, getTaskRoute } from "constants/routes";
 import { size, zIndex } from "constants/tokens";
 import {
   GetSpruceConfigQuery,
   GetSpruceConfigQueryVariables,
 } from "gql/generated/types";
 import { GET_SPRUCE_CONFIG } from "gql/queries";
+import { ProjectTriggerLevel } from "types/triggers";
 import { string } from "utils";
 import { shortenGithash } from "utils/string";
 import { jiraLinkify } from "utils/string/jiraLinkify";
@@ -24,6 +25,17 @@ interface Props {
   author: string;
   message: string;
   versionId: string;
+  upstreamProject?: {
+    triggerType: string;
+    project: string;
+
+    task?: {
+      id: string;
+    };
+    version?: {
+      id: string;
+    };
+  };
 }
 
 const CommitChartLabel: React.VFC<Props> = ({
@@ -32,6 +44,7 @@ const CommitChartLabel: React.VFC<Props> = ({
   author,
   message,
   versionId,
+  upstreamProject,
 }) => {
   const createDate = new Date(createTime);
   const shortenMessage = message.length > MAX_CHAR;
@@ -41,7 +54,13 @@ const CommitChartLabel: React.VFC<Props> = ({
     GetSpruceConfigQueryVariables
   >(GET_SPRUCE_CONFIG);
   const jiraHost = configData?.spruceConfig?.jira?.host;
-
+  const {
+    triggerType,
+    project: upstreamProjectIdentifier,
+    task: upstreamTask,
+    task: upstreamVersion,
+  } = upstreamProject || {};
+  console.log(upstreamProject);
   return (
     <LabelContainer data-cy="commit-label">
       <LabelText>
@@ -50,6 +69,21 @@ const CommitChartLabel: React.VFC<Props> = ({
         </StyledRouterLink>{" "}
         <b>{shortDate(createDate)}</b>
       </LabelText>
+      {upstreamProject && (
+        <LabelText>
+          Triggered from:{" "}
+          <StyledRouterLink
+            to={
+              triggerType === ProjectTriggerLevel.TASK
+                ? getTaskRoute(upstreamTask?.id)
+                : getVersionRoute(upstreamVersion?.id)
+            }
+          >
+            {upstreamProjectIdentifier}
+          </StyledRouterLink>
+        </LabelText>
+      )}
+
       <LabelText>{author} -</LabelText>
       <LabelText>
         {jiraLinkify(shortenMessage ? shortenedMessage : message, jiraHost)}

--- a/src/components/CommitChartLabel/index.tsx
+++ b/src/components/CommitChartLabel/index.tsx
@@ -9,6 +9,7 @@ import { size, zIndex } from "constants/tokens";
 import {
   GetSpruceConfigQuery,
   GetSpruceConfigQueryVariables,
+  UpstreamProjectFragment,
 } from "gql/generated/types";
 import { GET_SPRUCE_CONFIG } from "gql/queries";
 import { ProjectTriggerLevel } from "types/triggers";
@@ -25,17 +26,7 @@ interface Props {
   author: string;
   message: string;
   versionId: string;
-  upstreamProject?: {
-    triggerType: string;
-    project: string;
-
-    task?: {
-      id: string;
-    };
-    version?: {
-      id: string;
-    };
-  };
+  upstreamProject?: UpstreamProjectFragment["upstreamProject"];
 }
 
 const CommitChartLabel: React.VFC<Props> = ({
@@ -58,9 +49,8 @@ const CommitChartLabel: React.VFC<Props> = ({
     triggerType,
     project: upstreamProjectIdentifier,
     task: upstreamTask,
-    task: upstreamVersion,
+    version: upstreamVersion,
   } = upstreamProject || {};
-  console.log(upstreamProject);
   return (
     <LabelContainer data-cy="commit-label">
       <LabelText>
@@ -75,15 +65,14 @@ const CommitChartLabel: React.VFC<Props> = ({
           <StyledRouterLink
             to={
               triggerType === ProjectTriggerLevel.TASK
-                ? getTaskRoute(upstreamTask?.id)
-                : getVersionRoute(upstreamVersion?.id)
+                ? getTaskRoute(upstreamTask.id)
+                : getVersionRoute(upstreamVersion.id)
             }
           >
             {upstreamProjectIdentifier}
           </StyledRouterLink>
         </LabelText>
       )}
-
       <LabelText>{author} -</LabelText>
       <LabelText>
         {jiraLinkify(shortenMessage ? shortenedMessage : message, jiraHost)}

--- a/src/components/HistoryTable/HistoryTableRow/FoldedCommit.tsx
+++ b/src/components/HistoryTable/HistoryTableRow/FoldedCommit.tsx
@@ -58,6 +58,7 @@ export const FoldedCommit = memo<FoldedCommitProps>(
             createTime={commit.createTime}
             author={commit.author}
             message={commit.message}
+            upstreamProject={commit.upstreamProject}
           />
         </LabelCellContainer>
         {columns}

--- a/src/components/HistoryTable/HistoryTableRow/Row.tsx
+++ b/src/components/HistoryTable/HistoryTableRow/Row.tsx
@@ -40,6 +40,7 @@ const Row: React.VFC<RowProps> = ({
       author,
       message,
       id: versionId,
+      upstreamProject,
     } = commit.commit;
 
     return (
@@ -51,6 +52,7 @@ const Row: React.VFC<RowProps> = ({
             createTime={createTime}
             author={author}
             message={message}
+            upstreamProject={upstreamProject}
           />
         </LabelCellContainer>
         {columns}

--- a/src/gql/fragments/upstreamProject.graphql
+++ b/src/gql/fragments/upstreamProject.graphql
@@ -1,0 +1,15 @@
+fragment upstreamProject on Version {
+  upstreamProject {
+    triggerID
+    triggerType
+    repo
+    project
+    task {
+      id
+      execution
+    }
+    version {
+      id
+    }
+  }
+}

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -534,6 +534,7 @@ export type Version = {
   taskStatuses: Array<Scalars["String"]>;
   baseTaskStatuses: Array<Scalars["String"]>;
   manifest?: Maybe<Manifest>;
+  upstreamProject?: Maybe<UpstreamProject>;
 };
 
 export type VersionTaskStatusCountsArgs = {
@@ -546,6 +547,18 @@ export type VersionBuildVariantsArgs = {
 
 export type VersionBuildVariantStatsArgs = {
   options?: Maybe<BuildVariantOptions>;
+};
+
+export type UpstreamProject = {
+  owner: Scalars["String"];
+  repo: Scalars["String"];
+  revision: Scalars["String"];
+  project: Scalars["String"];
+  triggerID: Scalars["String"];
+  resourceID: Scalars["String"];
+  task?: Maybe<Task>;
+  version?: Maybe<Version>;
+  triggerType: Scalars["String"];
 };
 
 export type Manifest = {
@@ -2557,6 +2570,17 @@ export type RepoVirtualWorkstationSettingsFragment = {
   };
 };
 
+export type UpstreamProjectFragment = {
+  upstreamProject?: Maybe<{
+    triggerID: string;
+    triggerType: string;
+    repo: string;
+    project: string;
+    task?: Maybe<{ id: string; execution: number }>;
+    version?: Maybe<{ id: string }>;
+  }>;
+};
+
 export type AbortTaskMutationVariables = Exact<{
   taskId: Scalars["String"];
 }>;
@@ -3441,41 +3465,45 @@ export type MainlineCommitsForHistoryQuery = {
     nextPageOrderNumber?: Maybe<number>;
     prevPageOrderNumber?: Maybe<number>;
     versions: Array<{
-      version?: Maybe<{
-        id: string;
-        author: string;
-        createTime: Date;
-        message: string;
-        revision: string;
-        order: number;
-        buildVariants?: Maybe<
-          Array<
-            Maybe<{
-              displayName: string;
-              variant: string;
-              tasks?: Maybe<
-                Array<
-                  Maybe<{
-                    id: string;
-                    execution: number;
-                    status: string;
-                    displayName: string;
-                  }>
-                >
-              >;
-            }>
-          >
-        >;
-      }>;
-      rolledUpVersions?: Maybe<
-        Array<{
+      version?: Maybe<
+        {
           id: string;
-          createTime: Date;
           author: string;
-          order: number;
+          createTime: Date;
           message: string;
           revision: string;
-        }>
+          order: number;
+          buildVariants?: Maybe<
+            Array<
+              Maybe<{
+                displayName: string;
+                variant: string;
+                tasks?: Maybe<
+                  Array<
+                    Maybe<{
+                      id: string;
+                      execution: number;
+                      status: string;
+                      displayName: string;
+                    }>
+                  >
+                >;
+              }>
+            >
+          >;
+        } & UpstreamProjectFragment
+      >;
+      rolledUpVersions?: Maybe<
+        Array<
+          {
+            id: string;
+            createTime: Date;
+            author: string;
+            order: number;
+            message: string;
+            revision: string;
+          } & UpstreamProjectFragment
+        >
       >;
     }>;
   }>;
@@ -3494,51 +3522,55 @@ export type MainlineCommitsQuery = {
     nextPageOrderNumber?: Maybe<number>;
     prevPageOrderNumber?: Maybe<number>;
     versions: Array<{
-      version?: Maybe<{
-        projectIdentifier: string;
-        id: string;
-        author: string;
-        createTime: Date;
-        message: string;
-        revision: string;
-        order: number;
-        taskStatusCounts?: Maybe<Array<{ status: string; count: number }>>;
-        buildVariantStats?: Maybe<
-          Array<{
-            displayName: string;
-            variant: string;
-            statusCounts: Array<{ count: number; status: string }>;
-          }>
-        >;
-        buildVariants?: Maybe<
-          Array<
-            Maybe<{
-              displayName: string;
-              variant: string;
-              tasks?: Maybe<
-                Array<
-                  Maybe<{
-                    id: string;
-                    execution: number;
-                    status: string;
-                    displayName: string;
-                    timeTaken?: Maybe<number>;
-                  }>
-                >
-              >;
-            }>
-          >
-        >;
-      }>;
-      rolledUpVersions?: Maybe<
-        Array<{
+      version?: Maybe<
+        {
+          projectIdentifier: string;
           id: string;
-          createTime: Date;
           author: string;
-          order: number;
+          createTime: Date;
           message: string;
           revision: string;
-        }>
+          order: number;
+          taskStatusCounts?: Maybe<Array<{ status: string; count: number }>>;
+          buildVariantStats?: Maybe<
+            Array<{
+              displayName: string;
+              variant: string;
+              statusCounts: Array<{ count: number; status: string }>;
+            }>
+          >;
+          buildVariants?: Maybe<
+            Array<
+              Maybe<{
+                displayName: string;
+                variant: string;
+                tasks?: Maybe<
+                  Array<
+                    Maybe<{
+                      id: string;
+                      execution: number;
+                      status: string;
+                      displayName: string;
+                      timeTaken?: Maybe<number>;
+                    }>
+                  >
+                >;
+              }>
+            >
+          >;
+        } & UpstreamProjectFragment
+      >;
+      rolledUpVersions?: Maybe<
+        Array<
+          {
+            id: string;
+            createTime: Date;
+            author: string;
+            order: number;
+            message: string;
+            revision: string;
+          } & UpstreamProjectFragment
+        >
       >;
     }>;
   }>;
@@ -4189,7 +4221,7 @@ export type VersionQuery = {
         }>
       >;
     }>;
-  };
+  } & UpstreamProjectFragment;
 };
 
 export type GetViewableProjectRefsQueryVariables = Exact<{

--- a/src/gql/queries/get-mainline-commits-for-history.graphql
+++ b/src/gql/queries/get-mainline-commits-for-history.graphql
@@ -1,3 +1,5 @@
+#import "../fragments/upstreamProject.graphql"
+
 query MainlineCommitsForHistory(
   $mainlineCommitsOptions: MainlineCommitsOptions!
   $buildVariantOptions: BuildVariantOptions!
@@ -14,6 +16,7 @@ query MainlineCommitsForHistory(
         message
         revision
         order
+        ...upstreamProject
         buildVariants(options: $buildVariantOptions) {
           displayName
           variant
@@ -32,6 +35,7 @@ query MainlineCommitsForHistory(
         order
         message
         revision
+        ...upstreamProject
       }
     }
     nextPageOrderNumber

--- a/src/gql/queries/get-mainline-commits.graphql
+++ b/src/gql/queries/get-mainline-commits.graphql
@@ -1,3 +1,5 @@
+#import "../fragments/upstreamProject.graphql"
+
 query MainlineCommits(
   $mainlineCommitsOptions: MainlineCommitsOptions!
   $buildVariantOptions: BuildVariantOptions!
@@ -18,6 +20,7 @@ query MainlineCommits(
         message
         revision
         order
+        ...upstreamProject
         taskStatusCounts(options: $buildVariantOptionsForGraph) {
           status
           count
@@ -49,6 +52,7 @@ query MainlineCommits(
         order
         message
         revision
+        ...upstreamProject
       }
     }
     nextPageOrderNumber

--- a/src/gql/queries/get-version.graphql
+++ b/src/gql/queries/get-version.graphql
@@ -1,3 +1,5 @@
+#import "../fragments/upstreamProject.graphql"
+
 query Version($id: String!) {
   version(id: $id) {
     id
@@ -55,5 +57,6 @@ query Version($id: String!) {
         status
       }
     }
+    ...upstreamProject
   }
 }

--- a/src/pages/commits/ActiveCommits/index.tsx
+++ b/src/pages/commits/ActiveCommits/index.tsx
@@ -42,6 +42,7 @@ export const ActiveCommitLabel: React.VFC<ActiveCommitLabelProps> = ({
     createTime={version.createTime}
     author={version.author}
     message={version.message}
+    upstreamProject={version.upstreamProject}
   />
 );
 

--- a/src/pages/commits/InactiveCommits/InactiveCommits.stories.tsx
+++ b/src/pages/commits/InactiveCommits/InactiveCommits.stories.tsx
@@ -30,6 +30,16 @@ const versions = [
     order: 39365,
     author: "Mohamed Khelif",
     revision: "4337c33fa4a0d5c747a1115f0853b5f70e46f112",
+    upstreamProject: {
+      triggerID: "123",
+      triggerType: "task",
+      repo: "evergreen-ci",
+      project: "spruce",
+      task: {
+        id: "123",
+        execution: 0,
+      },
+    },
   },
   {
     id: "123",

--- a/src/pages/commits/InactiveCommits/index.tsx
+++ b/src/pages/commits/InactiveCommits/index.tsx
@@ -5,9 +5,11 @@ import Tooltip from "@leafygreen-ui/tooltip";
 import { Disclaimer } from "@leafygreen-ui/typography";
 import { DisplayModal } from "components/DisplayModal";
 import { StyledRouterLink } from "components/styles";
-import { getVersionRoute } from "constants/routes";
+import { getVersionRoute, getTaskRoute } from "constants/routes";
 import { size, zIndex, fontSize } from "constants/tokens";
 import { CommitRolledUpVersions } from "types/commits";
+import { ProjectTriggerLevel } from "types/triggers";
+import { Unpacked } from "types/utils";
 import { string } from "utils";
 import { commitChartHeight } from "../constants";
 
@@ -99,7 +101,10 @@ export const InactiveCommitButton: React.VFC<InactiveCommitsProps> = ({
  * @param {CommitRolledUpVersions[0]} v: rolled up version
  * @param {boolean} isTooltip: boolean to indicate if used in tooltip
  */
-const getCommitCopy = (v: CommitRolledUpVersions[0], isTooltip: boolean) => (
+const getCommitCopy = (
+  v: Unpacked<CommitRolledUpVersions>,
+  isTooltip: boolean
+) => (
   <CommitText key={v.revision} data-cy="commit-text" tooltip={isTooltip}>
     <CommitTitleText>
       <StyledRouterLink to={getVersionRoute(v.id)}>
@@ -107,6 +112,20 @@ const getCommitCopy = (v: CommitRolledUpVersions[0], isTooltip: boolean) => (
       </StyledRouterLink>{" "}
       {getDateCopy(v.createTime)}
     </CommitTitleText>
+    {v.upstreamProject && (
+      <>
+        Triggered from:{" "}
+        <StyledRouterLink
+          to={
+            v.upstreamProject.triggerType === ProjectTriggerLevel.TASK
+              ? getTaskRoute(v.upstreamProject.task.id)
+              : getVersionRoute(v.upstreamProject.version.id)
+          }
+        >
+          {v.upstreamProject.project}
+        </StyledRouterLink>
+      </>
+    )}
     <CommitBodyText>
       {v.author} -{" "}
       {isTooltip

--- a/src/pages/version/Metadata.tsx
+++ b/src/pages/version/Metadata.tsx
@@ -107,8 +107,8 @@ export const Metadata: React.VFC<Props> = ({ loading, version }) => {
           <StyledRouterLink
             to={
               triggerType === ProjectTriggerLevel.TASK
-                ? getTaskRoute(upstreamTask?.id)
-                : getVersionRoute(upstreamVersion?.id)
+                ? getTaskRoute(upstreamTask.id)
+                : getVersionRoute(upstreamVersion.id)
             }
           >
             {upstreamProjectIdentifier}

--- a/src/pages/version/Metadata.tsx
+++ b/src/pages/version/Metadata.tsx
@@ -5,9 +5,11 @@ import { P2 } from "components/Typography";
 import {
   getCommitQueueRoute,
   getProjectPatchesRoute,
+  getTaskRoute,
   getVersionRoute,
 } from "constants/routes";
 import { VersionQuery } from "gql/generated/types";
+import { ProjectTriggerLevel } from "types/triggers";
 import { string } from "utils";
 import ManifestBlob from "./ManifestBlob";
 import { ParametersModal } from "./ParametersModal";
@@ -36,10 +38,17 @@ export const Metadata: React.VFC<Props> = ({ loading, version }) => {
     manifest,
     id,
     previousVersion,
+    upstreamProject,
   } = version || {};
   const { sendEvent } = useVersionAnalytics(id);
   const { commitQueuePosition } = patch || {};
   const { makespan, timeTaken } = versionTiming || {};
+  const {
+    project: upstreamProjectIdentifier,
+    triggerType,
+    task: upstreamTask,
+    version: upstreamVersion,
+  } = upstreamProject || {};
   return (
     <MetadataCard
       loading={loading}
@@ -92,6 +101,20 @@ export const Metadata: React.VFC<Props> = ({ loading, version }) => {
         </P2>
       )}
       {manifest && <ManifestBlob manifest={manifest} />}
+      {upstreamProject && (
+        <P2>
+          Triggered from:{" "}
+          <StyledRouterLink
+            to={
+              triggerType === ProjectTriggerLevel.TASK
+                ? getTaskRoute(upstreamTask?.id)
+                : getVersionRoute(upstreamVersion?.id)
+            }
+          >
+            {upstreamProjectIdentifier}
+          </StyledRouterLink>
+        </P2>
+      )}
       <ParametersModal parameters={parameters} />
     </MetadataCard>
   );

--- a/src/types/triggers.ts
+++ b/src/types/triggers.ts
@@ -4,6 +4,11 @@ export enum ResourceType {
   BUILD = "BUILD",
 }
 
+export enum ProjectTriggerLevel {
+  TASK = "task",
+  BUILD = "build",
+}
+
 export enum TriggerType {
   OUTCOME = "outcome",
   FAILURE = "failure",


### PR DESCRIPTION
[EVG-16660](https://jira.mongodb.org/browse/EVG-16660)

### Description 
Upstream Projects triggered versions will now link to the triggering task or version

Since we do not have the concept of builds on the spruce UI we will default to linking the version associated with a build.

### Screenshots

![image](https://user-images.githubusercontent.com/4605522/162848202-7c7ec2e3-0dd9-44c4-b404-85fbd4935bfc.png)

![image](https://user-images.githubusercontent.com/4605522/162848231-7c843ce7-97db-477a-b6ce-967f64272ee7.png)

### Testing 
Staging and locally

### Evergreen PR 
https://github.com/evergreen-ci/evergreen/pull/5565