### PR TITLE
EVG-16716 Compute eventLog diff

### DIFF
--- a/src/pages/projectSettings/tabs/EventLogTab/EventLogDiffs.test.ts
+++ b/src/pages/projectSettings/tabs/EventLogTab/EventLogDiffs.test.ts
@@ -1,0 +1,98 @@
+import { getEventDiffLines } from "./EventLogDiffs";
+
+const beforeAddition = {
+  __typename: "ProjectEventSettings",
+  projectRef: {
+    __typename: "Project",
+    identifier: "viewTest",
+    patchTriggerAliases: [],
+  },
+  vars: {
+    __typename: "ProjectVars",
+    vars: { newVariable: "so new" },
+  },
+};
+
+const afterAddition = {
+  __typename: "ProjectEventSettings",
+  projectRef: {
+    __typename: "Project",
+    identifier: "viewTest",
+    patchTriggerAliases: [
+      {
+        __typename: "PatchTriggerAlias",
+        alias: "newAlias",
+        childProjectIdentifier: "evg",
+      },
+    ],
+  },
+  vars: {
+    __typename: "ProjectVars",
+    vars: { newVariable: "so new" },
+  },
+};
+
+const beforeUpdate = {
+  __typename: "ProjectEventSettings",
+  projectRef: {
+    __typename: "Project",
+    identifier: "viewTest",
+    patchTriggerAliases: [
+      {
+        __typename: "PatchTriggerAlias",
+        alias: "newAlias",
+        childProjectIdentifier: "evg",
+      },
+    ],
+  },
+  vars: {
+    __typename: "ProjectVars",
+    vars: { newVariable: "so new" },
+  },
+};
+const afterUpdate = {
+  __typename: "ProjectEventSettings",
+  projectRef: {
+    __typename: "Project",
+    identifier: "viewTest",
+    patchTriggerAliases: [
+      {
+        __typename: "PatchTriggerAlias",
+        alias: "noLongerNewAlias",
+        childProjectIdentifier: "evg",
+      },
+    ],
+  },
+  vars: {
+    __typename: "ProjectVars",
+    vars: { newVariable: "so new" },
+  },
+};
+
+describe("should transform event diffs to key, before and after", () => {
+  it("should transform updates", () => {
+    const diffLines = getEventDiffLines(beforeUpdate, afterUpdate);
+    expect(diffLines).toStrictEqual([
+      {
+        key: "projectRef.patchTriggerAliases[0].alias",
+        before: "newAlias",
+        after: "noLongerNewAlias",
+      },
+    ]);
+  });
+  it("should transform additions", () => {
+    const diffLines = getEventDiffLines(beforeAddition, afterAddition);
+    expect(diffLines).toStrictEqual([
+      {
+        key: "projectRef.patchTriggerAliases[0].alias",
+        before: undefined,
+        after: "newAlias",
+      },
+      {
+        key: "projectRef.patchTriggerAliases[0].childProjectIdentifier",
+        before: undefined,
+        after: "evg",
+      },
+    ]);
+  });
+});

--- a/src/pages/projectSettings/tabs/EventLogTab/EventLogDiffs.ts
+++ b/src/pages/projectSettings/tabs/EventLogTab/EventLogDiffs.ts
@@ -1,0 +1,64 @@
+import { diff } from "deep-object-diff";
+import { ProjectEventSettings } from "gql/generated/types";
+import { Subset } from "types/utils";
+import { string } from "utils";
+
+const { omitTypename } = string;
+
+const isObject = (val) => val && typeof val === "object" && !Array.isArray(val);
+
+const addDelimiter = (a: string, b: string) => (a ? `${a}.${b}` : b);
+
+const getDiffProperties = (eventObj: object) => {
+  const paths = (obj = {}, head = "") =>
+    Object.entries(obj).reduce((event, [key, value]) => {
+      const fullPath = addDelimiter(head, key);
+
+      return isObject(value)
+        ? event.concat(paths(value, fullPath))
+        : event.concat(fullPath);
+    }, []);
+
+  return paths(eventObj);
+};
+
+const formatArrayElements = (eventKey: string) =>
+  eventKey.replace(/.[0-9]./g, (x) => `[${x[1]}].`);
+
+const getNestedObject = (nestedObj: object, pathArr: string[]) =>
+  pathArr.reduce(
+    (obj, key) => (obj && obj[key] !== "undefined" ? obj[key] : undefined),
+    nestedObj
+  );
+
+type EventDiffLine = {
+  key: string;
+  before: string;
+  after: string;
+};
+
+export const getEventDiffLines = (
+  before: Subset<ProjectEventSettings>,
+  after: Subset<ProjectEventSettings>
+): EventDiffLine[] => {
+  const eventDiff = omitTypename(diff(before, after));
+  const pathKeys = getDiffProperties(eventDiff);
+
+  const eventDiffLines = pathKeys.map((key) => {
+    const pathsArray = key.split(".");
+    const previousValue = getNestedObject(before, pathsArray);
+    const changedValue = getNestedObject(eventDiff, pathsArray);
+
+    const formattedKey = formatArrayElements(key);
+
+    const line = {
+      key: formattedKey,
+      before: previousValue,
+      after: changedValue,
+    };
+
+    return line;
+  });
+
+  return eventDiffLines.filter((el) => el !== null);
+};

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -39,3 +39,8 @@ export type InvertedObject<T extends Record<PropertyKey, PropertyKey>> = {
 export type OneOf<T1, T2> =
   | (T1 & Partial<Record<Exclude<keyof T2, keyof T1>, never>>)
   | (T2 & Partial<Record<Exclude<keyof T1, keyof T2>, never>>);
+
+/** Helper to require only a partial set of fields on a nested object */
+export type Subset<K> = {
+  [S in keyof K]?: K[S] extends object ? Subset<K[S]> : K[S];
+};


### PR DESCRIPTION
[EVG-16716](https://jira.mongodb.org/browse/EVG-16716)

### Description 
Add functions needed to calculate and reduce event log diffs so that they can later be put into columns on the event log page. 

### Testing 
Testing on staging

