### PR TITLE
EVG-16740 Control LG tooltip enabled behavior on waterfall icons

### DIFF
--- a/src/pages/commits/ActiveCommits/buildVariantCard/WaterfallTaskStatusIcon.tsx
+++ b/src/pages/commits/ActiveCommits/buildVariantCard/WaterfallTaskStatusIcon.tsx
@@ -43,7 +43,7 @@ export const WaterfallTaskStatusIcon: React.VFC<WaterfallTaskStatusIconProps> = 
   const failedTestDifference = filteredTestCount - testResults?.length;
 
   let timeout;
-  const onHover = () => {
+  const onMouseEnter = () => {
     timeout = setTimeout(() => {
       setEnabled(true);
       // Only query failing test names if the task has failed.
@@ -58,11 +58,15 @@ export const WaterfallTaskStatusIcon: React.VFC<WaterfallTaskStatusIconProps> = 
       clearTimeout(timeout);
     }
   };
-  useEffect(() => () => {
-    if (timeout) {
-      clearTimeout(timeout);
-    }
-  });
+  useEffect(
+    () => () => {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  );
   return (
     <Tooltip
       align="top"
@@ -71,7 +75,7 @@ export const WaterfallTaskStatusIcon: React.VFC<WaterfallTaskStatusIconProps> = 
       enabled={enabled}
       trigger={
         <IconWrapper
-          onMouseEnter={onHover}
+          onMouseEnter={onMouseEnter}
           onMouseLeave={onMouseLeave}
           key={`task_${taskId}`}
           aria-label={`${status} icon`}

--- a/src/pages/commits/ActiveCommits/buildVariantCard/WaterfallTaskStatusIcon.tsx
+++ b/src/pages/commits/ActiveCommits/buildVariantCard/WaterfallTaskStatusIcon.tsx
@@ -74,7 +74,7 @@ export const WaterfallTaskStatusIcon: React.VFC<WaterfallTaskStatusIconProps> = 
           onMouseEnter={onHover}
           onMouseLeave={onMouseLeave}
           key={`task_${taskId}`}
-          aria-label={`${displayName} : ${status} icon link`}
+          aria-label={`${status} icon`}
           to={getTaskRoute(taskId)}
           onClick={() => {
             sendEvent({ name: "Click task status icon", status });


### PR DESCRIPTION
[EVG-16740](https://jira.mongodb.org/browse/EVG-16740)

### Description 
Currently LG tooltips try to render as soon as you hover over them. This is problematic if a user mouses over several icons because they will all try to render and then stop rendering which causes the page to jitter when rendering all of the tooltips that are never used.  

### Screenshots

https://user-images.githubusercontent.com/4605522/163607717-312bc841-1b13-4359-8486-baf61abfb5ca.mov


