### PR TITLE
EVG-16689: Upgrade LG Radio Group to remove console error

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@leafygreen-ui/palette": "3.2.2",
     "@leafygreen-ui/popover": "7.2.2",
     "@leafygreen-ui/radio-box-group": "6.1.4",
-    "@leafygreen-ui/radio-group": "7.0.5",
+    "@leafygreen-ui/radio-group": "7.0.6",
     "@leafygreen-ui/segmented-control": "0.9.1",
     "@leafygreen-ui/select": "3.1.0",
     "@leafygreen-ui/side-nav": "7.2.1",

--- a/src/pages/commits/ActiveCommits/__snapshots__/ProjectHealth.stories.storyshot
+++ b/src/pages/commits/ActiveCommits/__snapshots__/ProjectHealth.stories.storyshot
@@ -347,6 +347,7 @@ exports[`storybook Storyshots Project Health Page Actual Waterfall Page 1`] = `
                 >
                   <input
                     aria-disabled={false}
+                    checked={false}
                     className="leafygreen-ui-x2r5fc"
                     data-cy="cy-chart-percent-radio"
                     data-leafygreen-ui="input-element"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2817,11 +2817,12 @@
     "@leafygreen-ui/lib" "^9.0.0"
     "@leafygreen-ui/palette" "^3.2.2"
 
-"@leafygreen-ui/radio-group@7.0.5":
-  version "7.0.5"
-  resolved "https://registry.yarnpkg.com/@leafygreen-ui/radio-group/-/radio-group-7.0.5.tgz#ee112b9ca1bc9b1833ff31ab8b3e02f00388fadd"
-  integrity sha512-BHlN9i1ycUEntGGvzgp3eoipdgFN+rCDXuYXrWxEnMzmW4+V4ijQiKrlel6n0q4YopY0fAXwsEyfjUoGw65GXg==
+"@leafygreen-ui/radio-group@7.0.6":
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/@leafygreen-ui/radio-group/-/radio-group-7.0.6.tgz#2e36c975eb25f9c9f93694a1d0a4b65bde5ceb8c"
+  integrity sha512-LsokgU+fX2b9teMeiE0VPNH6K9RsGOwesmiZr40q3Df+LWVTMqsjWqIMhXWe1gAwgqqHewdkaXb4eLCLG3rs2w==
   dependencies:
+    "@leafygreen-ui/hooks" "^7.0.0"
     "@leafygreen-ui/interaction-ring" "^1.1.0"
     "@leafygreen-ui/lib" "^9.0.0"
     "@leafygreen-ui/palette" "^3.2.2"


### PR DESCRIPTION
[EVG-16689](https://jira.mongodb.org/browse/EVG-16689)

### Description 
The following error was occurring when interacting with the Chart Toggle on the Project Health page:

![image](https://user-images.githubusercontent.com/47064971/164030910-bc8cac7b-4168-4654-9481-72c544fa9af4.png)

This was an error also noticed by other LG users. The error was addressed in [PD-1485](https://jira.mongodb.org/browse/PD-1485). 

If you click on the code sandbox in the ticket and change the `leafygreen-ui/radio-group` version to `v7.0.5` (our current version), you will see that this error occurs. If you change the version to `v7.0.6`, the error no longer occurs. For this reason I upgraded our dependency to `v7.0.6` so that the error would be removed.

### Note
There is a way to remove the error on our current version by making use of the `checked` prop on the `Radio` component (see docs [here](https://www.mongodb.design/component/radio-group/documentation/)), but I thought it would be simpler to just upgrade.

### Screenshots
https://user-images.githubusercontent.com/47064971/164031748-ec3186cb-9a4d-4d56-b089-d660105bb8df.mov


