### PR TITLE
EVG-16760 Support modern ssh key types

### DIFF
--- a/cypress/integration/preferences/public_key_managment.ts
+++ b/cypress/integration/preferences/public_key_managment.ts
@@ -89,6 +89,20 @@ describe("Public Key Management Page", () => {
       cy.dataCy("edit-btn").first().click();
       cy.dataCy("key-name-input").should("have.value", keyName4);
       cy.dataCy("key-value-input").should("have.value", pubKey2);
+      cy.dataCy("key-value-input").paste(pubKey3);
+      cy.dataCy("save-key-button").click();
+      cy.dataCy("key-edit-modal").should("not.be.visible");
+      cy.dataCy("table-key-name").first().contains(keyName4);
+      cy.dataCy("edit-btn").first().click();
+      cy.dataCy("key-name-input").should("have.value", keyName4);
+      cy.dataCy("key-value-input").should("have.value", pubKey3);
+      cy.dataCy("key-value-input").paste(pubKey4);
+      cy.dataCy("save-key-button").click();
+      cy.dataCy("key-edit-modal").should("not.be.visible");
+      cy.dataCy("table-key-name").first().contains(keyName4);
+      cy.dataCy("edit-btn").first().click();
+      cy.dataCy("key-name-input").should("have.value", keyName4);
+      cy.dataCy("key-value-input").should("have.value", pubKey4);
     });
 
     it("Modal has correct title", () => {
@@ -114,9 +128,14 @@ const keyName2 = "bKey";
 const keyName3 = "a unique key name";
 const keyName4 = "stuff!";
 const err1 = "The key name cannot be empty.";
-const err2 = "The SSH key must begin with 'ssh-rsa' or 'ssh-dss'.";
+const err2 =
+  "The SSH key must begin with 'ssh-rsa' or 'ssh-dss' or 'ssh-ed25519' or 'ecdsa-sha2-nistp256'..";
 const err3 = "The key name already exists.";
 const pubKey =
   "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAklOUpkDHrfHY17SbrmTIpNLTGK9Tjom/BWDSUGPl+nafzlHDTYW7hdI4yZ5ew18JH4JW9jbhUFrviQzM7xlELEVf4h9lFX5QVkbPppSwg0cda3Pbv7kOdJ/MTyBlWXFCR+HAo3FXRitBqxiX1nKhXpHAZsMciLq8V6RjsNAQwdsdMFvSlVK/7XAt3FaoJoAsncM1Q9x5+3V0Ww68/eIFmb1zuUFljQJKprrX88XypNDvjYNby6vw/Pb0rwert/EnmZ+AW4OZPnTPI89ZPmVMLuayrD2cE86Z/il8b+gw3r3+1nKatmIkjn2so1d01QraTlMqVSsbxNrRFi9wrf+M7Q== schacon@mylaptop.local";
 const pubKey2 =
   "ssh-dss AAAAB3NzaC1yc2EAAAABIwAAAQEAklOUpkDHrfHY17SbrmTIpNLTGK9Tjom/BWDSUGPl+nafzlHDTYW7hdI4yZ5ew18JH4JW9jbhUFrviQzM7xlELEVf4h9lFX5QVkbPppSwg0cda3Pbv7kOdJ/MTyBlWXFCR+HAo3FXRitBqxiX1nKhXpHAZsMciLq8V6RjsNAQwdsdMFvSlVK/7XAt3FaoJoAsncM1Q9x5+3V0Ww68/eIFmb1zuUFljQJKprrX88XypNDvjYNby6vw/Pb0rwert/EnmZ+AW4OZPnTPI89ZPmVMLuayrD2cE86Z/il8b+gw3r3+1nKatmIkjn2so1d01QraTlMqVSsbxNrRFi9wrf+M7Q== schacon@mylaptop.local";
+const pubKey3 =
+  "ssh-ed25519 AAAAB3NzaC1yc2EAAAABIwAAAQEAklOUpkDHrfHY17SbrmTIpNLTGK9Tjom/BWDSUGPl+nafzlHDTYW7hdI4yZ5ew18JH4JW9jbhUFrviQzM7xlELEVf4h9lFX5QVkbPppSwg0cda3Pbv7kOdJ/MTyBlWXFCR+HAo3FXRitBqxiX1nKhXpHAZsMciLq8V6RjsNAQwdsdMFvSlVK/7XAt3FaoJoAsncM1Q9x5+3V0Ww68/eIFmb1zuUFljQJKprrX88XypNDvjYNby6vw/Pb0rwert/EnmZ+AW4OZPnTPI89ZPmVMLuayrD2cE86Z/il8b+gw3r3+1nKatmIkjn2so1d01QraTlMqVSsbxNrRFi9wrf+M7Q== schacon@mylaptop.local";
+const pubKey4 =
+  "ecdsa-sha2-nistp256 AAAAB3NzaC1yc2EAAAABIwAAAQEAklOUpkDHrfHY17SbrmTIpNLTGK9Tjom/BWDSUGPl+nafzlHDTYW7hdI4yZ5ew18JH4JW9jbhUFrviQzM7xlELEVf4h9lFX5QVkbPppSwg0cda3Pbv7kOdJ/MTyBlWXFCR+HAo3FXRitBqxiX1nKhXpHAZsMciLq8V6RjsNAQwdsdMFvSlVK/7XAt3FaoJoAsncM1Q9x5+3V0Ww68/eIFmb1zuUFljQJKprrX88XypNDvjYNby6vw/Pb0rwert/EnmZ+AW4OZPnTPI89ZPmVMLuayrD2cE86Z/il8b+gw3r3+1nKatmIkjn2so1d01QraTlMqVSsbxNrRFi9wrf+M7Q== schacon@mylaptop.local";

--- a/cypress/integration/preferences/public_key_managment.ts
+++ b/cypress/integration/preferences/public_key_managment.ts
@@ -47,7 +47,7 @@ describe("Public Key Management Page", () => {
 
     it("Error messages go away after typing valid input", () => {
       cy.dataCy("key-name-input").type(keyName3);
-      cy.dataCy("key-value-input").paste("ssh-dss");
+      cy.dataCy("key-value-input").paste("ssh-dss someHash");
       cy.dataCy("error-message").should("have.length", 0);
     });
 
@@ -115,7 +115,7 @@ describe("Public Key Management Page", () => {
       cy.visit(route);
       cy.dataCy("add-key-button").click();
       cy.dataCy("key-name-input").type("rsioeantarsn");
-      cy.dataCy("key-value-input").paste("ssh-rsa");
+      cy.dataCy("key-value-input").paste("ssh-rsa ");
       cy.dataCy("save-key-button").click();
       cy.validateToast("error");
     });

--- a/cypress/integration/preferences/public_key_managment.ts
+++ b/cypress/integration/preferences/public_key_managment.ts
@@ -129,7 +129,7 @@ const keyName3 = "a unique key name";
 const keyName4 = "stuff!";
 const err1 = "The key name cannot be empty.";
 const err2 =
-  "The SSH key must begin with 'ssh-rsa' or 'ssh-dss' or 'ssh-ed25519' or 'ecdsa-sha2-nistp256'..";
+  "The SSH key must begin with 'ssh-rsa' or 'ssh-dss' or 'ssh-ed25519' or 'ecdsa-sha2-nistp256'.";
 const err3 = "The key name already exists.";
 const pubKey =
   "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAklOUpkDHrfHY17SbrmTIpNLTGK9Tjom/BWDSUGPl+nafzlHDTYW7hdI4yZ5ew18JH4JW9jbhUFrviQzM7xlELEVf4h9lFX5QVkbPppSwg0cda3Pbv7kOdJ/MTyBlWXFCR+HAo3FXRitBqxiX1nKhXpHAZsMciLq8V6RjsNAQwdsdMFvSlVK/7XAt3FaoJoAsncM1Q9x5+3V0Ww68/eIFmb1zuUFljQJKprrX88XypNDvjYNby6vw/Pb0rwert/EnmZ+AW4OZPnTPI89ZPmVMLuayrD2cE86Z/il8b+gw3r3+1nKatmIkjn2so1d01QraTlMqVSsbxNrRFi9wrf+M7Q== schacon@mylaptop.local";

--- a/src/pages/preferences/preferencesTabs/publicKeysTab/EditModal.tsx
+++ b/src/pages/preferences/preferencesTabs/publicKeysTab/EditModal.tsx
@@ -100,12 +100,7 @@ export const EditModal: React.VFC<EditModalProps> = ({
     ) {
       inputErrors.push(DUPLICATE_KEY_NAME);
     }
-    const hasRSA = keyValue?.substring(0, SSH_RSA.length) === SSH_RSA;
-    const hasDSS = keyValue?.substring(0, SSH_DSS.length) === SSH_DSS;
-    const hasED25519 =
-      keyValue?.substring(0, SSH_ED25519.length) === SSH_ED25519;
-    const hasECDSA = keyValue?.substring(0, SSH_ECDSA.length) === SSH_ECDSA;
-    if (!hasRSA && !hasDSS && !hasED25519 && !hasECDSA) {
+    if (!VALID_SSH_KEY.test(keyValue)) {
       inputErrors.push(INVALID_SSH_KEY);
     }
     setErrors(inputErrors);
@@ -203,7 +198,4 @@ const DUPLICATE_KEY_NAME = "The key name already exists.";
 const INVALID_SSH_KEY =
   "The SSH key must begin with 'ssh-rsa' or 'ssh-dss' or 'ssh-ed25519' or 'ecdsa-sha2-nistp256'.";
 const EMPTY_KEY_NAME = "The key name cannot be empty.";
-const SSH_RSA = "ssh-rsa";
-const SSH_DSS = "ssh-dss";
-const SSH_ED25519 = "ssh-ed25519";
-const SSH_ECDSA = "ecdsa-sha2-nistp256";
+const VALID_SSH_KEY = /^(ssh-rsa|ssh-dss|ssh-ed25519|ecdsa-sha2-nistp256) /g;

--- a/src/pages/preferences/preferencesTabs/publicKeysTab/EditModal.tsx
+++ b/src/pages/preferences/preferencesTabs/publicKeysTab/EditModal.tsx
@@ -18,6 +18,7 @@ import {
 } from "gql/generated/types";
 import { CREATE_PUBLIC_KEY, UPDATE_PUBLIC_KEY } from "gql/mutations";
 import { GET_MY_PUBLIC_KEYS } from "gql/queries";
+import { validateSSHPublicKey } from "utils/validators";
 
 const { TextArea } = Input;
 
@@ -100,7 +101,7 @@ export const EditModal: React.VFC<EditModalProps> = ({
     ) {
       inputErrors.push(DUPLICATE_KEY_NAME);
     }
-    if (!VALID_SSH_KEY.test(keyValue)) {
+    if (!validateSSHPublicKey(keyValue)) {
       inputErrors.push(INVALID_SSH_KEY);
     }
     setErrors(inputErrors);
@@ -198,6 +199,3 @@ const DUPLICATE_KEY_NAME = "The key name already exists.";
 const INVALID_SSH_KEY =
   "The SSH key must begin with 'ssh-rsa' or 'ssh-dss' or 'ssh-ed25519' or 'ecdsa-sha2-nistp256'.";
 const EMPTY_KEY_NAME = "The key name cannot be empty.";
-const VALID_SSH_KEY = new RegExp(
-  /^(ssh-rsa|ssh-dss|ssh-ed25519|ecdsa-sha2-nistp256) /
-);

--- a/src/pages/preferences/preferencesTabs/publicKeysTab/EditModal.tsx
+++ b/src/pages/preferences/preferencesTabs/publicKeysTab/EditModal.tsx
@@ -102,7 +102,10 @@ export const EditModal: React.VFC<EditModalProps> = ({
     }
     const hasRSA = keyValue?.substring(0, SSH_RSA.length) === SSH_RSA;
     const hasDSS = keyValue?.substring(0, SSH_DSS.length) === SSH_DSS;
-    if (!hasRSA && !hasDSS) {
+    const hasED25519 =
+      keyValue?.substring(0, SSH_ED25519.length) === SSH_ED25519;
+    const hasECDSA = keyValue?.substring(0, SSH_ECDSA.length) === SSH_ECDSA;
+    if (!hasRSA && !hasDSS && !hasED25519 && !hasECDSA) {
       inputErrors.push(INVALID_SSH_KEY);
     }
     setErrors(inputErrors);
@@ -197,7 +200,10 @@ const ErrorContainer = styled.div`
 const KEY_NAME_ID = "key-name-input";
 const KEY_VALUE_ID = "key-value-input";
 const DUPLICATE_KEY_NAME = "The key name already exists.";
-const INVALID_SSH_KEY = "The SSH key must begin with 'ssh-rsa' or 'ssh-dss'.";
+const INVALID_SSH_KEY =
+  "The SSH key must begin with 'ssh-rsa' or 'ssh-dss' or 'ssh-ed25519' or 'ecdsa-sha2-nistp256'.";
 const EMPTY_KEY_NAME = "The key name cannot be empty.";
 const SSH_RSA = "ssh-rsa";
 const SSH_DSS = "ssh-dss";
+const SSH_ED25519 = "ssh-ed25519";
+const SSH_ECDSA = "ecdsa-sha2-nistp256";

--- a/src/pages/preferences/preferencesTabs/publicKeysTab/EditModal.tsx
+++ b/src/pages/preferences/preferencesTabs/publicKeysTab/EditModal.tsx
@@ -198,4 +198,6 @@ const DUPLICATE_KEY_NAME = "The key name already exists.";
 const INVALID_SSH_KEY =
   "The SSH key must begin with 'ssh-rsa' or 'ssh-dss' or 'ssh-ed25519' or 'ecdsa-sha2-nistp256'.";
 const EMPTY_KEY_NAME = "The key name cannot be empty.";
-const VALID_SSH_KEY = /^(ssh-rsa|ssh-dss|ssh-ed25519|ecdsa-sha2-nistp256) /g;
+const VALID_SSH_KEY = new RegExp(
+  /^(ssh-rsa|ssh-dss|ssh-ed25519|ecdsa-sha2-nistp256) /
+);

--- a/src/utils/validators/index.ts
+++ b/src/utils/validators/index.ts
@@ -12,6 +12,13 @@ export const validateEmail = (v: string): boolean => /\S+@\S+\.\S+/.test(v);
 
 export const validateJira = (v: string) => v.match(".+-[0-9]+") !== null;
 
+export const validateSSHPublicKey = (v: string): boolean => {
+  const validSSHKey = new RegExp(
+    /^(ssh-rsa|ssh-dss|ssh-ed25519|ecdsa-sha2-nistp256) /
+  );
+  return validSSHKey.test(v);
+};
+
 export const validatePercentage = (percent: any) => {
   const posNumRegex = /^[0-9]+([,.][0-9]+)?$/g;
   if (!posNumRegex.test(percent)) {

--- a/src/utils/validators/validators.test.ts
+++ b/src/utils/validators/validators.test.ts
@@ -1,4 +1,4 @@
-import { validateObjectId } from ".";
+import { validateObjectId, validateSSHPublicKey } from ".";
 
 describe("validateObjectId", () => {
   it("validates object ids", () => {
@@ -12,5 +12,16 @@ describe("validateObjectId", () => {
         "mongodb_mongo_master_16085c4b28bd438e1c7608d0aa645de1c1811e7f"
       )
     ).toBeFalsy();
+  });
+});
+
+describe("validateSSHPublicKey", () => {
+  it("validates ssh public keys", () => {
+    expect(validateSSHPublicKey("ssh-rsa someHash")).toBeTruthy();
+    expect(validateSSHPublicKey("ssh-dss someHash")).toBeTruthy();
+    expect(validateSSHPublicKey("ssh-ed25519 someHash")).toBeTruthy();
+    expect(validateSSHPublicKey("ecdsa-sha2-nistp256 someHash")).toBeTruthy();
+    expect(validateSSHPublicKey("ssh-dssNoSpace")).toBeFalsy();
+    expect(validateSSHPublicKey("ssh-badStart someHash")).toBeFalsy();
   });
 });


### PR DESCRIPTION
[EVG-13451](https://jira.mongodb.org/browse/EVG-13451)

### Description 
allow more ssh key types

### Screenshots
![image](https://user-images.githubusercontent.com/26491602/164080664-8d0ab0b5-9c9d-4511-b473-0927d6bf88f0.png)
![image](https://user-images.githubusercontent.com/26491602/164080708-700e2e3f-65e2-4e90-9e24-28766aed9eb0.png)


### Testing 
cypress

### Evergreen PR 
[  < link to a corresponding evergreen PR if applicable >
](https://github.com/evergreen-ci/evergreen/pull/5591)