### PR TITLE
EVG-15998 Refactor query param logic in filter badges and prevent clearing unrelated query params.

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,6 +1,7 @@
 import { MockedProvider } from "@apollo/client/testing";
 import { WithApolloClient } from "storybook-addon-apollo-client/dist/decorators";
 import { addDecorator, addParameters } from "@storybook/react";
+import StoryRouter from 'storybook-react-router';
 
 
 addDecorator(WithApolloClient)
@@ -11,3 +12,4 @@ addParameters({
     // any props you want to pass to MockedProvider on every story
   }
 })
+addDecorator(StoryRouter())

--- a/src/components/FilterBadges/FilterBadge.tsx
+++ b/src/components/FilterBadges/FilterBadge.tsx
@@ -14,17 +14,15 @@ const { gray } = uiColors;
 const tooltipInModalZIndex = zIndex.tooltip; // necessary due to SeeMoreModal, which has zIndex 40
 const maxBadgeLength = 25;
 
+interface FilterBadgeType {
+  key: string;
+  value: string;
+}
 interface FilterBadgeProps {
-  badge: {
-    key: string;
-    value: string;
-  };
+  badge: FilterBadgeType;
   onClose: () => void;
 }
-export const FilterBadge: React.VFC<FilterBadgeProps> = ({
-  badge,
-  onClose,
-}) => {
+const FilterBadge: React.VFC<FilterBadgeProps> = ({ badge, onClose }) => {
   // the trimmed name needs to account for the label
   const trimmedBadgeName = trimStringFromMiddle(
     badge.value,
@@ -93,3 +91,6 @@ const BadgeContent = styled.div`
 const StyledTooltip = styled(Tooltip)`
   padding: ${size.xxs} ${size.xs};
 `;
+
+export default FilterBadge;
+export type { FilterBadgeType };

--- a/src/components/FilterBadges/FilterBadges.test.tsx
+++ b/src/components/FilterBadges/FilterBadges.test.tsx
@@ -113,6 +113,22 @@ describe("filterBadges", () => {
     expect(location.search).toBe(``);
   });
 
+  it("should only remove query params for displayable badges when clear all is pressed", () => {
+    const { queryAllByDataCy, queryByDataCy, history } = render(Content, {
+      route: `/commits/evergreen?buildVariants=variant1,variant2&tests=test1,test2&notRelated=notRelated`,
+      path: "/commits/:projectId",
+    });
+
+    let badges = queryAllByDataCy("filter-badge");
+    expect(badges).toHaveLength(4);
+
+    fireEvent.click(queryByDataCy("clear-all-filters"));
+    badges = queryAllByDataCy("filter-badge");
+    expect(badges).toHaveLength(0);
+    const { location } = history;
+
+    expect(location.search).toBe(`?notRelated=notRelated`);
+  });
   it("should show a max of 8 badges and a link to show more if there are more", () => {
     const { queryAllByDataCy, queryByText } = render(Content, {
       route: `/commits/evergreen?buildVariants=variant1,variant2,variant3,variant4&tests=test1,test2,test3,test4&taskNames=task1`,

--- a/src/components/FilterBadges/FilterBadges.test.tsx
+++ b/src/components/FilterBadges/FilterBadges.test.tsx
@@ -1,157 +1,172 @@
-import {
-  renderWithRouterMatch as render,
-  fireEvent,
-  waitFor,
-} from "test_utils";
-import { ProjectFilterOptions } from "types/commits";
-import { FilterBadges } from ".";
-
-const Content = () => (
-  <FilterBadges
-    queryParamsToDisplay={
-      new Set([
-        ProjectFilterOptions.BuildVariant,
-        ProjectFilterOptions.Task,
-        ProjectFilterOptions.Test,
-      ])
-    }
-  />
-);
+import { render, fireEvent, within, waitFor } from "test_utils";
+import FilterBadges from ".";
 
 describe("filterBadges", () => {
-  it("should not render any badges if there are no query params", () => {
-    const { queryByDataCy } = render(Content, {
-      route: `/commits/evergreen`,
-      path: "/commits/:projectId",
-    });
-    expect(queryByDataCy("filter-badge")).not.toBeInTheDocument();
+  it("should not render any badges if there are none passed in", () => {
+    const onRemove = jest.fn();
+    const onClearAll = jest.fn();
+    const { queryAllByDataCy } = render(
+      <FilterBadges badges={[]} onRemove={onRemove} onClearAll={onClearAll} />
+    );
+    expect(queryAllByDataCy("filter-badge")).toHaveLength(0);
   });
-
-  it("should render a singular filter badge if there is only one query param", () => {
-    const { queryAllByDataCy } = render(Content, {
-      route: `/commits/evergreen?buildVariants=variant1`,
-      path: "/commits/:projectId",
-    });
+  it("should render badges if there are some passed in", () => {
+    const onRemove = jest.fn();
+    const onClearAll = jest.fn();
+    const { queryAllByDataCy, queryByText } = render(
+      <FilterBadges
+        badges={[{ key: "test", value: "value" }]}
+        onRemove={onRemove}
+        onClearAll={onClearAll}
+      />
+    );
     expect(queryAllByDataCy("filter-badge")).toHaveLength(1);
+    expect(queryByText("test : value")).toBeInTheDocument();
   });
-
-  it("should render multiple filter badges with the same key but different values", () => {
-    const { queryAllByDataCy } = render(Content, {
-      route: `/commits/evergreen?buildVariants=variant1,variant2`,
-      path: "/commits/:projectId",
-    });
-    const badges = queryAllByDataCy("filter-badge");
-    expect(badges).toHaveLength(2);
-
-    expect(badges[0]).toHaveTextContent("buildVariants : variant1");
-    expect(badges[1]).toHaveTextContent("buildVariants : variant2");
+  it("should render a badge for each key/value pair passed in", () => {
+    const onRemove = jest.fn();
+    const onClearAll = jest.fn();
+    const { queryAllByDataCy, queryByText } = render(
+      <FilterBadges
+        badges={[
+          { key: "test", value: "value" },
+          { key: "test2", value: "value2" },
+        ]}
+        onRemove={onRemove}
+        onClearAll={onClearAll}
+      />
+    );
+    expect(queryAllByDataCy("filter-badge")).toHaveLength(2);
+    expect(queryByText("test : value")).toBeInTheDocument();
+    expect(queryByText("test2 : value2")).toBeInTheDocument();
   });
-
-  it("should render multiple filter badges with the different keys and different values", () => {
-    const { queryAllByDataCy } = render(Content, {
-      route: `/commits/evergreen?buildVariants=variant1&tests=test1`,
-      path: "/commits/:projectId",
-    });
-    const badges = queryAllByDataCy("filter-badge");
-    expect(badges).toHaveLength(2);
-    expect(badges[0]).toHaveTextContent("buildVariants : variant1");
-    expect(badges[1]).toHaveTextContent("tests : test1");
+  it("only renders badges up to the limit", () => {
+    const onRemove = jest.fn();
+    const onClearAll = jest.fn();
+    const { queryAllByDataCy, queryByText } = render(
+      <FilterBadges
+        badges={[
+          { key: "test", value: "value" },
+          { key: "test2", value: "value2" },
+          { key: "test3", value: "value3" },
+          { key: "test4", value: "value4" },
+          { key: "test5", value: "value5" },
+          { key: "test6", value: "value6" },
+          { key: "test7", value: "value7" },
+          { key: "test8", value: "value8" },
+          { key: "test9", value: "value9" },
+          { key: "test10", value: "value10" },
+        ]}
+        onRemove={onRemove}
+        onClearAll={onClearAll}
+      />
+    );
+    expect(queryAllByDataCy("filter-badge")).toHaveLength(8);
+    expect(queryByText("test : value")).toBeInTheDocument();
+    expect(queryByText("test8 : value8")).toBeInTheDocument();
+    expect(queryByText("see 2 more")).toBeInTheDocument();
   });
-
-  it("closing out a badge should remove it from the url", () => {
-    const { queryByDataCy, history } = render(Content, {
-      route: `/commits/evergreen?buildVariants=variant1`,
-      path: "/commits/:projectId",
-    });
-
-    const badge = queryByDataCy("filter-badge");
-    expect(badge).toHaveTextContent("buildVariants : variant1");
-    const closeBadge = queryByDataCy("close-badge");
+  it("clicking see more should display a modal with all of the badges", () => {
+    const onRemove = jest.fn();
+    const onClearAll = jest.fn();
+    const { queryByDataCy, queryByText } = render(
+      <FilterBadges
+        badges={[
+          { key: "test1", value: "value1" },
+          { key: "test2", value: "value2" },
+          { key: "test3", value: "value3" },
+          { key: "test4", value: "value4" },
+          { key: "test5", value: "value5" },
+          { key: "test6", value: "value6" },
+          { key: "test7", value: "value7" },
+          { key: "test8", value: "value8" },
+          { key: "test9", value: "value9" },
+          { key: "test10", value: "value10" },
+        ]}
+        onRemove={onRemove}
+        onClearAll={onClearAll}
+      />
+    );
+    fireEvent.click(queryByText("see 2 more"));
+    expect(queryByDataCy("see-more-modal")).toBeInTheDocument();
+    expect(
+      within(queryByDataCy("see-more-modal")).queryAllByDataCy("filter-badge")
+    ).toHaveLength(10);
+    for (let i = 0; i < 10; i++) {
+      expect(
+        within(queryByDataCy("see-more-modal")).queryByText(
+          `test${i + 1} : value${i + 1}`
+        )
+      ).toBeInTheDocument();
+    }
+  });
+  it("clicking clear all should call the clear all callback", () => {
+    const onRemove = jest.fn();
+    const onClearAll = jest.fn();
+    const { queryByText } = render(
+      <FilterBadges
+        badges={[
+          { key: "test1", value: "value1" },
+          { key: "test2", value: "value2" },
+          { key: "test3", value: "value3" },
+          { key: "test4", value: "value4" },
+          { key: "test5", value: "value5" },
+          { key: "test6", value: "value6" },
+          { key: "test7", value: "value7" },
+          { key: "test8", value: "value8" },
+          { key: "test9", value: "value9" },
+          { key: "test10", value: "value10" },
+        ]}
+        onRemove={onRemove}
+        onClearAll={onClearAll}
+      />
+    );
+    fireEvent.click(queryByText("CLEAR ALL FILTERS"));
+    expect(onClearAll).toHaveBeenCalledTimes(1);
+  });
+  it("clicking a badge should call the remove callback", () => {
+    const onRemove = jest.fn();
+    const onClearAll = jest.fn();
+    const { queryAllByDataCy } = render(
+      <FilterBadges
+        badges={[
+          { key: "test1", value: "value1" },
+          { key: "test2", value: "value2" },
+          { key: "test3", value: "value3" },
+          { key: "test4", value: "value4" },
+          { key: "test5", value: "value5" },
+          { key: "test6", value: "value6" },
+          { key: "test7", value: "value7" },
+          { key: "test8", value: "value8" },
+          { key: "test9", value: "value9" },
+          { key: "test10", value: "value10" },
+        ]}
+        onRemove={onRemove}
+        onClearAll={onClearAll}
+      />
+    );
+    const closeBadge = queryAllByDataCy("close-badge")[0];
     expect(closeBadge).toBeInTheDocument();
     fireEvent.click(closeBadge);
-    const { location } = history;
-
-    expect(queryByDataCy("filter-badge")).toBeNull();
-    expect(location.search).toBe(``);
+    expect(onRemove).toHaveBeenCalledWith({ key: "test1", value: "value1" });
   });
-
-  it("should only remove one badge from the url if it is closed and more remain", () => {
-    const { queryAllByDataCy, queryByText, history } = render(Content, {
-      route: `/commits/evergreen?buildVariants=variant1,variant2`,
-      path: "/commits/:projectId",
-    });
-
-    let badges = queryAllByDataCy("filter-badge");
-    expect(badges).toHaveLength(2);
-    expect(queryByText("buildVariants : variant1")).toBeInTheDocument();
-    const closeBadge = queryAllByDataCy("close-badge");
-    fireEvent.click(closeBadge[0]);
-    badges = queryAllByDataCy("filter-badge");
-    expect(badges).toHaveLength(1);
-    expect(queryByText("buildVariants : variant1")).toBeNull();
-
-    const { location } = history;
-
-    expect(queryAllByDataCy("filter-badge")).toHaveLength(1);
-    expect(location.search).toBe(`?buildVariants=variant2`);
-  });
-
-  it("should remove all badges when clicking on clear all button", () => {
-    const { queryAllByDataCy, queryByDataCy, history } = render(Content, {
-      route: `/commits/evergreen?buildVariants=variant1,variant2&tests=test1,test2`,
-      path: "/commits/:projectId",
-    });
-
-    let badges = queryAllByDataCy("filter-badge");
-    expect(badges).toHaveLength(4);
-
-    fireEvent.click(queryByDataCy("clear-all-filters"));
-    badges = queryAllByDataCy("filter-badge");
-    expect(badges).toHaveLength(0);
-    const { location } = history;
-
-    expect(location.search).toBe(``);
-  });
-
-  it("should only remove query params for displayable badges when clear all is pressed", () => {
-    const { queryAllByDataCy, queryByDataCy, history } = render(Content, {
-      route: `/commits/evergreen?buildVariants=variant1,variant2&tests=test1,test2&notRelated=notRelated`,
-      path: "/commits/:projectId",
-    });
-
-    let badges = queryAllByDataCy("filter-badge");
-    expect(badges).toHaveLength(4);
-
-    fireEvent.click(queryByDataCy("clear-all-filters"));
-    badges = queryAllByDataCy("filter-badge");
-    expect(badges).toHaveLength(0);
-    const { location } = history;
-
-    expect(location.search).toBe(`?notRelated=notRelated`);
-  });
-  it("should show a max of 8 badges and a link to show more if there are more", () => {
-    const { queryAllByDataCy, queryByText } = render(Content, {
-      route: `/commits/evergreen?buildVariants=variant1,variant2,variant3,variant4&tests=test1,test2,test3,test4&taskNames=task1`,
-      path: "/commits/:projectId",
-    });
-
-    const badges = queryAllByDataCy("filter-badge");
-    expect(badges).toHaveLength(8);
-
-    expect(queryByText("see 1 more")).toBeInTheDocument();
-  });
-
-  it("should truncate a badge name if it's too long, with hover showing full name", async () => {
-    const longVariantName = "long_long_long_long_long_long_build_variant_name";
-    const { queryByDataCy, queryByText } = render(Content, {
-      route: `/commits/evergreen?buildVariants=${longVariantName}`,
-      path: "/commits/:projectId",
-    });
-
-    expect(queryByText(longVariantName)).not.toBeInTheDocument();
+  it("should truncate a badge value if it is too long", async () => {
+    const onRemove = jest.fn();
+    const onClearAll = jest.fn();
+    const longName = "this is a really long name that should be truncated";
+    const { queryByDataCy, queryByText } = render(
+      <FilterBadges
+        badges={[{ key: "some", value: longName }]}
+        onRemove={onRemove}
+        onClearAll={onClearAll}
+      />
+    );
+    const truncatedBadge = queryByDataCy("filter-badge");
+    expect(truncatedBadge).toBeInTheDocument();
+    expect(truncatedBadge).not.toHaveTextContent(longName);
     fireEvent.mouseEnter(queryByDataCy("filter-badge"));
     await waitFor(() => {
-      expect(queryByText(longVariantName)).toBeVisible();
+      expect(queryByText(longName)).toBeVisible();
     });
   });
 });

--- a/src/components/FilterBadges/SeeMoreModal.tsx
+++ b/src/components/FilterBadges/SeeMoreModal.tsx
@@ -4,15 +4,12 @@ import Button, { Variant, Size } from "@leafygreen-ui/button";
 import { Link } from "@leafygreen-ui/typography";
 import { DisplayModal } from "components/DisplayModal";
 import { size } from "constants/tokens";
-import { FilterBadge } from "./FilterBadge";
+import FilterBadge, { FilterBadgeType } from "./FilterBadge";
 
 interface SeeMoreModalProps {
-  badges: {
-    key: string;
-    value: string;
-  }[];
+  badges: FilterBadgeType[];
   notVisibleCount: number;
-  onRemoveBadge: (key: string, value: string) => void;
+  onRemoveBadge: (badge: FilterBadgeType) => void;
   onClearAll: () => void;
 }
 export const SeeMoreModal: React.VFC<SeeMoreModalProps> = ({
@@ -39,7 +36,7 @@ export const SeeMoreModal: React.VFC<SeeMoreModalProps> = ({
             <FilterBadge
               key={`filter_badge_${b.key}_${b.value}`}
               badge={b}
-              onClose={() => onRemoveBadge(b.key, b.value)}
+              onClose={() => onRemoveBadge(b)}
             />
           ))}
         </BadgeContainer>

--- a/src/components/FilterBadges/SeeMoreModal.tsx
+++ b/src/components/FilterBadges/SeeMoreModal.tsx
@@ -30,6 +30,7 @@ export const SeeMoreModal: React.VFC<SeeMoreModalProps> = ({
         setOpen={setOpen}
         size="large"
         title="Applied Filters"
+        data-cy="see-more-modal"
       >
         <BadgeContainer>
           {badges.map((b) => (

--- a/src/components/FilterBadges/__snapshots__/FilterBadges.stories.storyshot
+++ b/src/components/FilterBadges/__snapshots__/FilterBadges.stories.storyshot
@@ -1,130 +1,155 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`storybook Storyshots FilterBadges Default 1`] = `
-<div
-  className="css-19f1xe2-Container e3qndfh0"
->
+<div>
   <div
-    className="css-1cf5xhz-PaddedBadge e1vs77ku2 leafygreen-ui-187420t"
-    data-cy="filter-badge"
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
+    className="css-19f1xe2-Container e3qndfh0"
   >
     <div
-      className="css-1i7u60d-BadgeContent e1vs77ku1"
+      className="css-1cf5xhz-PaddedBadge e1vs77ku2 leafygreen-ui-13xc3rv"
+      data-cy="filter-badge"
     >
-      buildVariants
-       : 
-      ! Ente…g Tidy
+      <div
+        className="css-1i7u60d-BadgeContent e1vs77ku1"
+      >
+        test
+         : 
+        test
+      </div>
+      <svg
+        aria-label="X Icon"
+        className="css-4ijbt0-ClickableIcon e1vs77ku3"
+        data-cy="close-badge"
+        fill="none"
+        height={16}
+        onClick={[Function]}
+        role="img"
+        viewBox="0 0 16 16"
+        width={16}
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          clipRule="evenodd"
+          d="M12.203 3.404a1 1 0 00-1.414 0L8.314 5.879 5.839 3.404a1 1 0 00-1.414 0l-.707.707a1 1 0 000 1.414L6.192 8l-2.474 2.475a1 1 0 000 1.414l.707.707a1 1 0 001.414 0l2.475-2.475 2.475 2.475a1 1 0 001.414 0l.707-.707a1 1 0 000-1.414L10.435 8l2.475-2.475a1 1 0 000-1.414l-.707-.707z"
+          fill="currentColor"
+          fillRule="evenodd"
+        />
+      </svg>
     </div>
-    <svg
-      aria-label="X Icon"
-      className="css-4ijbt0-ClickableIcon e1vs77ku3"
-      data-cy="close-badge"
-      fill="none"
-      height={16}
+    <button
+      aria-disabled={false}
+      className="leafygreen-ui-126lu42"
+      data-cy="clear-all-filters"
+      disabled={false}
       onClick={[Function]}
-      role="img"
-      viewBox="0 0 16 16"
-      width={16}
-      xmlns="http://www.w3.org/2000/svg"
+      type="button"
     >
-      <path
-        clipRule="evenodd"
-        d="M12.203 3.404a1 1 0 00-1.414 0L8.314 5.879 5.839 3.404a1 1 0 00-1.414 0l-.707.707a1 1 0 000 1.414L6.192 8l-2.474 2.475a1 1 0 000 1.414l.707.707a1 1 0 001.414 0l2.475-2.475 2.475 2.475a1 1 0 001.414 0l.707-.707a1 1 0 000-1.414L10.435 8l2.475-2.475a1 1 0 000-1.414l-.707-.707z"
-        fill="currentColor"
-        fillRule="evenodd"
+      <div
+        className="leafygreen-ui-1ktj4tm"
       />
-    </svg>
+      <div
+        className="leafygreen-ui-jfktkt"
+      >
+        CLEAR ALL FILTERS
+      </div>
+    </button>
   </div>
-  <div
-    className="css-1cf5xhz-PaddedBadge e1vs77ku2 leafygreen-ui-187420t"
-    data-cy="filter-badge"
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-  >
+  <div>
     <div
-      className="css-1i7u60d-BadgeContent e1vs77ku1"
+      className="leafygreen-ui-1iyoj2o"
     >
-      buildVariants
-       : 
-      ! Ente…indows
+      <label
+        className="leafygreen-ui-ly82bp"
+        htmlFor="textinput-1"
+      >
+        key
+      </label>
+      <div
+        className="leafygreen-ui-lzja97"
+      >
+        <div
+          className="leafygreen-ui-1i2djk5"
+        >
+          <input
+            autoComplete="on"
+            className="leafygreen-ui-1il5lef"
+            disabled={false}
+            id="textinput-1"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder="key"
+            required={true}
+            type="text"
+            value=""
+          />
+          <div
+            className="leafygreen-ui-3x1o6h"
+            data-leafygreen-ui="interaction-ring"
+          />
+        </div>
+        <div
+          className="leafygreen-ui-m329s1"
+          data-leafygreen-ui="icon-selector"
+        />
+      </div>
     </div>
-    <svg
-      aria-label="X Icon"
-      className="css-4ijbt0-ClickableIcon e1vs77ku3"
-      data-cy="close-badge"
-      fill="none"
-      height={16}
+    <div
+      className="leafygreen-ui-1iyoj2o"
+    >
+      <label
+        className="leafygreen-ui-ly82bp"
+        htmlFor="textinput-2"
+      >
+        value
+      </label>
+      <div
+        className="leafygreen-ui-lzja97"
+      >
+        <div
+          className="leafygreen-ui-1i2djk5"
+        >
+          <input
+            autoComplete="on"
+            className="leafygreen-ui-1il5lef"
+            disabled={false}
+            id="textinput-2"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onSubmit={[Function]}
+            placeholder="value"
+            required={true}
+            type="text"
+            value=""
+          />
+          <div
+            className="leafygreen-ui-3x1o6h"
+            data-leafygreen-ui="interaction-ring"
+          />
+        </div>
+        <div
+          className="leafygreen-ui-m329s1"
+          data-leafygreen-ui="icon-selector"
+        />
+      </div>
+    </div>
+    <button
+      aria-disabled={false}
+      className="leafygreen-ui-26sqyb"
+      disabled={false}
       onClick={[Function]}
-      role="img"
-      viewBox="0 0 16 16"
-      width={16}
-      xmlns="http://www.w3.org/2000/svg"
+      type="button"
     >
-      <path
-        clipRule="evenodd"
-        d="M12.203 3.404a1 1 0 00-1.414 0L8.314 5.879 5.839 3.404a1 1 0 00-1.414 0l-.707.707a1 1 0 000 1.414L6.192 8l-2.474 2.475a1 1 0 000 1.414l.707.707a1 1 0 001.414 0l2.475-2.475 2.475 2.475a1 1 0 001.414 0l.707-.707a1 1 0 000-1.414L10.435 8l2.475-2.475a1 1 0 000-1.414l-.707-.707z"
-        fill="currentColor"
-        fillRule="evenodd"
+      <div
+        className="leafygreen-ui-1ktj4tm"
       />
-    </svg>
+      <div
+        className="leafygreen-ui-ie0uqp"
+      >
+        Add
+      </div>
+    </button>
   </div>
-  <div
-    className="css-1cf5xhz-PaddedBadge e1vs77ku2 leafygreen-ui-187420t"
-    data-cy="filter-badge"
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-  >
-    <div
-      className="css-1i7u60d-BadgeContent e1vs77ku1"
-    >
-      buildVariants
-       : 
-      Enterp…abled)
-    </div>
-    <svg
-      aria-label="X Icon"
-      className="css-4ijbt0-ClickableIcon e1vs77ku3"
-      data-cy="close-badge"
-      fill="none"
-      height={16}
-      onClick={[Function]}
-      role="img"
-      viewBox="0 0 16 16"
-      width={16}
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        clipRule="evenodd"
-        d="M12.203 3.404a1 1 0 00-1.414 0L8.314 5.879 5.839 3.404a1 1 0 00-1.414 0l-.707.707a1 1 0 000 1.414L6.192 8l-2.474 2.475a1 1 0 000 1.414l.707.707a1 1 0 001.414 0l2.475-2.475 2.475 2.475a1 1 0 001.414 0l.707-.707a1 1 0 000-1.414L10.435 8l2.475-2.475a1 1 0 000-1.414l-.707-.707z"
-        fill="currentColor"
-        fillRule="evenodd"
-      />
-    </svg>
-  </div>
-  <button
-    aria-disabled={false}
-    className="leafygreen-ui-126lu42"
-    data-cy="clear-all-filters"
-    disabled={false}
-    onClick={[Function]}
-    type="button"
-  >
-    <div
-      className="leafygreen-ui-1ktj4tm"
-    />
-    <div
-      className="leafygreen-ui-jfktkt"
-    >
-      CLEAR ALL FILTERS
-    </div>
-  </button>
 </div>
 `;

--- a/src/components/FilterBadges/index.tsx
+++ b/src/components/FilterBadges/index.tsx
@@ -36,9 +36,11 @@ export const FilterBadges: React.VFC<FilterBadgesProps> = ({
   const handleClearAll = () => {
     // Need to manually set keys to undefined inorder to overwrite and clear queryParams
     const params = { ...queryParams };
-    Object.keys(params).forEach((v) => {
-      params[v] = undefined;
-    });
+    Object.keys(params)
+      .filter((badge) => queryParamsToDisplay.has(badge))
+      .forEach((v) => {
+        params[v] = undefined;
+      });
     onClearAll();
     updateQueryParams(params);
   };

--- a/src/components/FilterBadges/index.tsx
+++ b/src/components/FilterBadges/index.tsx
@@ -1,72 +1,47 @@
 import styled from "@emotion/styled";
 import Button, { Variant, Size } from "@leafygreen-ui/button";
-import { useLocation } from "react-router";
-import { useUpdateURLQueryParams } from "hooks/useUpdateURLQueryParams";
-import { queryString, array } from "utils";
-import { FilterBadge } from "./FilterBadge";
+import FilterBadge, { FilterBadgeType } from "./FilterBadge";
 import { SeeMoreModal } from "./SeeMoreModal";
 
-const { convertObjectToArray } = array;
-const { parseQueryString } = queryString;
-
 interface FilterBadgesProps {
-  queryParamsToDisplay: Set<string>;
-  onRemove?: () => void;
+  badges: FilterBadgeType[];
+  onRemove?: (badge: FilterBadgeType) => void;
   onClearAll?: () => void;
 }
-export const FilterBadges: React.VFC<FilterBadgesProps> = ({
-  queryParamsToDisplay,
+const FilterBadges: React.VFC<FilterBadgesProps> = ({
+  badges,
   onRemove = () => {},
   onClearAll = () => {},
 }) => {
-  const updateQueryParams = useUpdateURLQueryParams();
-  const location = useLocation();
-  const { search } = location;
-  const queryParams = parseQueryString(search);
-  const queryParamsList = convertObjectToArray(queryParams).filter(({ key }) =>
-    queryParamsToDisplay.has(key as any)
-  );
-
-  const handleOnRemove = (key: string, value: string) => {
-    const updatedParam = popQueryParams(queryParams[key], value);
-    onRemove();
-    updateQueryParams({ [key]: updatedParam });
+  const handleOnRemove = (badge: FilterBadgeType) => {
+    onRemove(badge);
   };
 
   const handleClearAll = () => {
-    // Need to manually set keys to undefined inorder to overwrite and clear queryParams
-    const params = { ...queryParams };
-    Object.keys(params)
-      .filter((badge) => queryParamsToDisplay.has(badge))
-      .forEach((v) => {
-        params[v] = undefined;
-      });
     onClearAll();
-    updateQueryParams(params);
   };
-  const visibileQueryParams = queryParamsList.slice(0, 8);
-  const notVisibleCount = queryParamsList.slice(8, queryParamsList.length)
-    .length;
+  const visibleBadges = badges.slice(0, 8);
+  const notVisibleCount = badges.slice(8, badges.length).length;
   return (
     <Container>
-      {visibileQueryParams.map((p) => (
+      {visibleBadges.map((p) => (
         <FilterBadge
           key={`filter_badge_${p.key}_${p.value}`}
           badge={p}
           onClose={() => {
-            handleOnRemove(p.key, p.value);
+            handleOnRemove(p);
           }}
         />
       ))}
-      {queryParamsList.length > 8 && (
+      {badges.length > 8 && (
         <SeeMoreModal
-          badges={queryParamsList}
+          badges={badges}
           notVisibleCount={notVisibleCount}
           onRemoveBadge={handleOnRemove}
           onClearAll={handleClearAll}
         />
       )}
-      {queryParamsList.length > 0 && (
+      {badges.length > 0 && (
         <Button
           variant={Variant.Default}
           size={Size.XSmall}
@@ -80,14 +55,9 @@ export const FilterBadges: React.VFC<FilterBadgesProps> = ({
   );
 };
 
-const popQueryParams = (param: string | string[], value: string) => {
-  if (Array.isArray(param)) {
-    return param.filter((p) => p !== value);
-  }
-  return undefined;
-};
-
 const Container = styled.div`
   max-height: 72px; // height of 2 rows of @leafygreen-ui/badge elements
   overflow: hidden;
 `;
+
+export default FilterBadges;

--- a/src/components/HistoryTable/HistoryTableTestSearch/HistoryTableTestSearch.stories.tsx
+++ b/src/components/HistoryTable/HistoryTableTestSearch/HistoryTableTestSearch.stories.tsx
@@ -1,24 +1,29 @@
-import StoryRouter from "storybook-react-router";
-import { FilterBadges } from "components/FilterBadges";
+import FilterBadges from "components/FilterBadges";
 import { size } from "constants/tokens";
+import { useFilterBadgeQueryParams } from "hooks";
 import { TestStatus } from "types/history";
 import { HistoryTableTestSearch } from "./HistoryTableTestSearch";
 
 export default {
-  component: HistoryTableTestSearch,
   title: "HistoryTableTestSearch",
-  decorators: [StoryRouter()],
+  component: HistoryTableTestSearch,
 };
 
-export const TestSearch = () => (
-  <div style={{ display: "flex", flexDirection: "column" }}>
-    <HistoryTableTestSearch />
-    <div style={{ paddingTop: size.s }}>
-      <FilterBadges
-        queryParamsToDisplay={
-          new Set([TestStatus.Failed, TestStatus.Passed, TestStatus.All])
-        }
-      />
+export const TestSearch = () => {
+  const { badges, handleClearAll, handleOnRemove } = useFilterBadgeQueryParams(
+    new Set([TestStatus.Failed, TestStatus.Passed, TestStatus.All])
+  );
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column" }}>
+      <HistoryTableTestSearch />
+      <div style={{ paddingTop: size.s }}>
+        <FilterBadges
+          badges={badges}
+          onRemove={handleOnRemove}
+          onClearAll={handleClearAll}
+        />
+      </div>
     </div>
-  </div>
-);
+  );
+};

--- a/src/components/HistoryTable/HistoryTableTestSearch/__snapshots__/HistoryTableTestSearch.stories.storyshot
+++ b/src/components/HistoryTable/HistoryTableTestSearch/__snapshots__/HistoryTableTestSearch.stories.storyshot
@@ -20,7 +20,7 @@ exports[`storybook Storyshots HistoryTableTestSearch Test Search 1`] = `
       >
         <label
           className="leafygreen-ui-ly82bp"
-          htmlFor="textinput-2"
+          htmlFor="textinput-4"
         >
           Filter by Failed Tests
         </label>
@@ -35,7 +35,7 @@ exports[`storybook Storyshots HistoryTableTestSearch Test Search 1`] = `
               autoComplete="on"
               className="leafygreen-ui-1il5lef"
               disabled={false}
-              id="textinput-2"
+              id="textinput-4"
               onBlur={[Function]}
               onChange={[Function]}
               onFocus={[Function]}

--- a/src/components/HistoryTable/__snapshots__/HistoryTable.stories.storyshot
+++ b/src/components/HistoryTable/__snapshots__/HistoryTable.stories.storyshot
@@ -759,7 +759,7 @@ exports[`storybook Storyshots History Table Test Search 1`] = `
       >
         <label
           className="leafygreen-ui-ly82bp"
-          htmlFor="textinput-1"
+          htmlFor="textinput-3"
         >
           Filter by Failed Tests
         </label>
@@ -774,7 +774,7 @@ exports[`storybook Storyshots History Table Test Search 1`] = `
               autoComplete="on"
               className="leafygreen-ui-1il5lef"
               disabled={false}
-              id="textinput-1"
+              id="textinput-3"
               onBlur={[Function]}
               onChange={[Function]}
               onFocus={[Function]}

--- a/src/components/PatchActionButtons/ScheduleTasks.stories.tsx
+++ b/src/components/PatchActionButtons/ScheduleTasks.stories.tsx
@@ -1,4 +1,3 @@
-import StoryRouter from "storybook-react-router";
 import { GET_UNSCHEDULED_TASKS } from "gql/queries";
 import WithToastContext from "test_utils/toast-decorator";
 import { ScheduleTasks } from ".";
@@ -6,7 +5,7 @@ import { ScheduleTasks } from ".";
 export default {
   title: "Schedule Tasks",
   component: ScheduleTasks,
-  decorators: [StoryRouter(), (story) => WithToastContext(story)],
+  decorators: [(story) => WithToastContext(story)],
 };
 
 export const ScheduleTasksPopulated = () => (

--- a/src/components/SpruceForm/__snapshots__/SpruceForm.stories.storyshot
+++ b/src/components/SpruceForm/__snapshots__/SpruceForm.stories.storyshot
@@ -171,7 +171,7 @@ exports[`storybook Storyshots Spruce Form Example 1 1`] = `
                           >
                             <label
                               className="leafygreen-ui-ly82bp"
-                              htmlFor="textinput-3"
+                              htmlFor="textinput-5"
                             >
                               key
                             </label>
@@ -186,7 +186,7 @@ exports[`storybook Storyshots Spruce Form Example 1 1`] = `
                                   autoComplete="on"
                                   className="leafygreen-ui-1il5lef"
                                   disabled={false}
-                                  id="textinput-3"
+                                  id="textinput-5"
                                   onBlur={[Function]}
                                   onChange={[Function]}
                                   onFocus={[Function]}
@@ -223,7 +223,7 @@ exports[`storybook Storyshots Spruce Form Example 1 1`] = `
                           >
                             <label
                               className="leafygreen-ui-ly82bp"
-                              htmlFor="textinput-4"
+                              htmlFor="textinput-6"
                             >
                               value
                             </label>
@@ -238,7 +238,7 @@ exports[`storybook Storyshots Spruce Form Example 1 1`] = `
                                   autoComplete="on"
                                   className="leafygreen-ui-1il5lef"
                                   disabled={false}
-                                  id="textinput-4"
+                                  id="textinput-6"
                                   onBlur={[Function]}
                                   onChange={[Function]}
                                   onFocus={[Function]}

--- a/src/components/projectSelect/ProjectSelect.stories.tsx
+++ b/src/components/projectSelect/ProjectSelect.stories.tsx
@@ -1,4 +1,3 @@
-import StoryRouter from "storybook-react-router";
 import { getCommitsRoute } from "constants/routes";
 import { ADD_FAVORITE_PROJECT, REMOVE_FAVORITE_PROJECT } from "gql/mutations";
 import { GET_PROJECTS, GET_VIEWABLE_PROJECTS } from "gql/queries";
@@ -8,7 +7,7 @@ import { ProjectSelect } from ".";
 export default {
   title: "ProjectSelect",
   component: ProjectSelect,
-  decorators: [StoryRouter(), (story) => WithToastContext(story)],
+  decorators: [(story) => WithToastContext(story)],
 };
 
 export const WithClickableHeader = () => (

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,5 @@
+import useFilterBadgeQueryParams from "./useFilterBadgeQueryParams";
+
 export { useDefaultPath } from "hooks/useDefaultPath";
 export { useFilterInputChangeHandler } from "hooks/useFilterInputChangeHandler";
 export { useGetUserPatchesPageTitleAndLink } from "hooks/useGetUserPatchesPageTitleAndLink";
@@ -19,3 +21,4 @@ export { usePrevious } from "./usePrevious";
 export { useDisableSpawnExpirationCheckbox } from "./useDisableSpawnExpirationCheckbox";
 export { useUpdateURLQueryParams } from "./useUpdateURLQueryParams";
 export { useTaskStatuses } from "./useTaskStatuses";
+export { useFilterBadgeQueryParams };

--- a/src/hooks/useFilterBadgeQueryParams.test.tsx
+++ b/src/hooks/useFilterBadgeQueryParams.test.tsx
@@ -1,0 +1,162 @@
+import FilterBadges from "components/FilterBadges";
+import {
+  renderWithRouterMatch as render,
+  fireEvent,
+  waitFor,
+} from "test_utils";
+import { ProjectFilterOptions } from "types/commits";
+import useFilterBadgeQueryParams from "./useFilterBadgeQueryParams";
+
+const Content = () => {
+  const { badges, handleClearAll, handleOnRemove } = useFilterBadgeQueryParams(
+    new Set([
+      ProjectFilterOptions.BuildVariant,
+      ProjectFilterOptions.Test,
+      ProjectFilterOptions.Task,
+    ])
+  );
+  return (
+    <FilterBadges
+      badges={badges}
+      onRemove={handleOnRemove}
+      onClearAll={handleClearAll}
+    />
+  );
+};
+describe("filterBadges - queryParams", () => {
+  it("should not render any badges if there are no query params", () => {
+    const { queryByDataCy } = render(Content, {
+      route: `/commits/evergreen`,
+      path: "/commits/:projectId",
+    });
+    expect(queryByDataCy("filter-badge")).not.toBeInTheDocument();
+  });
+
+  it("should render a singular filter badge if there is only one query param", () => {
+    const { queryAllByDataCy } = render(Content, {
+      route: `/commits/evergreen?buildVariants=variant1`,
+      path: "/commits/:projectId",
+    });
+    expect(queryAllByDataCy("filter-badge")).toHaveLength(1);
+  });
+
+  it("should render multiple filter badges with the same key but different values", () => {
+    const { queryAllByDataCy } = render(Content, {
+      route: `/commits/evergreen?buildVariants=variant1,variant2`,
+      path: "/commits/:projectId",
+    });
+    const badges = queryAllByDataCy("filter-badge");
+    expect(badges).toHaveLength(2);
+
+    expect(badges[0]).toHaveTextContent("buildVariants : variant1");
+    expect(badges[1]).toHaveTextContent("buildVariants : variant2");
+  });
+
+  it("should render multiple filter badges with the different keys and different values", () => {
+    const { queryAllByDataCy } = render(Content, {
+      route: `/commits/evergreen?buildVariants=variant1&tests=test1`,
+      path: "/commits/:projectId",
+    });
+    const badges = queryAllByDataCy("filter-badge");
+    expect(badges).toHaveLength(2);
+    expect(badges[0]).toHaveTextContent("buildVariants : variant1");
+    expect(badges[1]).toHaveTextContent("tests : test1");
+  });
+
+  it("closing out a badge should remove it from the url", () => {
+    const { queryByDataCy, history } = render(Content, {
+      route: `/commits/evergreen?buildVariants=variant1`,
+      path: "/commits/:projectId",
+    });
+
+    const badge = queryByDataCy("filter-badge");
+    expect(badge).toHaveTextContent("buildVariants : variant1");
+    const closeBadge = queryByDataCy("close-badge");
+    expect(closeBadge).toBeInTheDocument();
+    fireEvent.click(closeBadge);
+    const { location } = history;
+
+    expect(queryByDataCy("filter-badge")).toBeNull();
+    expect(location.search).toBe(``);
+  });
+
+  it("should only remove one badge from the url if it is closed and more remain", () => {
+    const { queryAllByDataCy, queryByText, history } = render(Content, {
+      route: `/commits/evergreen?buildVariants=variant1,variant2`,
+      path: "/commits/:projectId",
+    });
+
+    let badges = queryAllByDataCy("filter-badge");
+    expect(badges).toHaveLength(2);
+    expect(queryByText("buildVariants : variant1")).toBeInTheDocument();
+    const closeBadge = queryAllByDataCy("close-badge");
+    fireEvent.click(closeBadge[0]);
+    badges = queryAllByDataCy("filter-badge");
+    expect(badges).toHaveLength(1);
+    expect(queryByText("buildVariants : variant1")).toBeNull();
+
+    const { location } = history;
+
+    expect(queryAllByDataCy("filter-badge")).toHaveLength(1);
+    expect(location.search).toBe(`?buildVariants=variant2`);
+  });
+
+  it("should remove all badges when clicking on clear all button", () => {
+    const { queryAllByDataCy, queryByDataCy, history } = render(Content, {
+      route: `/commits/evergreen?buildVariants=variant1,variant2&tests=test1,test2`,
+      path: "/commits/:projectId",
+    });
+
+    let badges = queryAllByDataCy("filter-badge");
+    expect(badges).toHaveLength(4);
+
+    fireEvent.click(queryByDataCy("clear-all-filters"));
+    badges = queryAllByDataCy("filter-badge");
+    expect(badges).toHaveLength(0);
+    const { location } = history;
+
+    expect(location.search).toBe(``);
+  });
+
+  it("should only remove query params for displayable badges when clear all is pressed", () => {
+    const { queryAllByDataCy, queryByDataCy, history } = render(Content, {
+      route: `/commits/evergreen?buildVariants=variant1,variant2&tests=test1,test2&notRelated=notRelated`,
+      path: "/commits/:projectId",
+    });
+
+    let badges = queryAllByDataCy("filter-badge");
+    expect(badges).toHaveLength(4);
+
+    fireEvent.click(queryByDataCy("clear-all-filters"));
+    badges = queryAllByDataCy("filter-badge");
+    expect(badges).toHaveLength(0);
+    const { location } = history;
+
+    expect(location.search).toBe(`?notRelated=notRelated`);
+  });
+  it("should show a max of 8 badges and a link to show more if there are more", () => {
+    const { queryAllByDataCy, queryByText } = render(Content, {
+      route: `/commits/evergreen?buildVariants=variant1,variant2,variant3,variant4&tests=test1,test2,test3,test4&taskNames=task1`,
+      path: "/commits/:projectId",
+    });
+
+    const badges = queryAllByDataCy("filter-badge");
+    expect(badges).toHaveLength(8);
+
+    expect(queryByText("see 1 more")).toBeInTheDocument();
+  });
+
+  it("should truncate a badge name if it's too long, with hover showing full name", async () => {
+    const longVariantName = "long_long_long_long_long_long_build_variant_name";
+    const { queryByDataCy, queryByText } = render(Content, {
+      route: `/commits/evergreen?buildVariants=${longVariantName}`,
+      path: "/commits/:projectId",
+    });
+
+    expect(queryByText(longVariantName)).not.toBeInTheDocument();
+    fireEvent.mouseEnter(queryByDataCy("filter-badge"));
+    await waitFor(() => {
+      expect(queryByText(longVariantName)).toBeVisible();
+    });
+  });
+});

--- a/src/hooks/useFilterBadgeQueryParams.test.tsx
+++ b/src/hooks/useFilterBadgeQueryParams.test.tsx
@@ -1,9 +1,5 @@
 import FilterBadges from "components/FilterBadges";
-import {
-  renderWithRouterMatch as render,
-  fireEvent,
-  waitFor,
-} from "test_utils";
+import { renderWithRouterMatch as render, fireEvent } from "test_utils";
 import { ProjectFilterOptions } from "types/commits";
 import useFilterBadgeQueryParams from "./useFilterBadgeQueryParams";
 
@@ -133,30 +129,5 @@ describe("filterBadges - queryParams", () => {
     const { location } = history;
 
     expect(location.search).toBe(`?notRelated=notRelated`);
-  });
-  it("should show a max of 8 badges and a link to show more if there are more", () => {
-    const { queryAllByDataCy, queryByText } = render(Content, {
-      route: `/commits/evergreen?buildVariants=variant1,variant2,variant3,variant4&tests=test1,test2,test3,test4&taskNames=task1`,
-      path: "/commits/:projectId",
-    });
-
-    const badges = queryAllByDataCy("filter-badge");
-    expect(badges).toHaveLength(8);
-
-    expect(queryByText("see 1 more")).toBeInTheDocument();
-  });
-
-  it("should truncate a badge name if it's too long, with hover showing full name", async () => {
-    const longVariantName = "long_long_long_long_long_long_build_variant_name";
-    const { queryByDataCy, queryByText } = render(Content, {
-      route: `/commits/evergreen?buildVariants=${longVariantName}`,
-      path: "/commits/:projectId",
-    });
-
-    expect(queryByText(longVariantName)).not.toBeInTheDocument();
-    fireEvent.mouseEnter(queryByDataCy("filter-badge"));
-    await waitFor(() => {
-      expect(queryByText(longVariantName)).toBeVisible();
-    });
   });
 });

--- a/src/hooks/useFilterBadgeQueryParams.ts
+++ b/src/hooks/useFilterBadgeQueryParams.ts
@@ -18,7 +18,6 @@ const useFilterBadgeQueryParams = (validQueryParams: Set<string>) => {
     validQueryParams.has(key as string)
   );
 
-  console.log(validQueryParams, queryParamsList);
   const handleClearAll = () => {
     const params = { ...queryParams };
     Object.keys(params)

--- a/src/hooks/useFilterBadgeQueryParams.ts
+++ b/src/hooks/useFilterBadgeQueryParams.ts
@@ -1,0 +1,50 @@
+import { useLocation } from "react-router";
+import { FilterBadgeType } from "components/FilterBadges/FilterBadge";
+import { queryString, array } from "utils";
+import { useUpdateURLQueryParams } from "./useUpdateURLQueryParams";
+
+const { convertObjectToArray } = array;
+const { parseQueryString } = queryString;
+
+/**
+ * useFilterBadgeQueryParams is used alongside the FilterBadges component to tie its state to query params
+ */
+const useFilterBadgeQueryParams = (validQueryParams: Set<string>) => {
+  const updateQueryParams = useUpdateURLQueryParams();
+  const location = useLocation();
+  const { search } = location;
+  const queryParams = parseQueryString(search);
+  const queryParamsList = convertObjectToArray(queryParams).filter(({ key }) =>
+    validQueryParams.has(key as string)
+  );
+
+  console.log(validQueryParams, queryParamsList);
+  const handleClearAll = () => {
+    const params = { ...queryParams };
+    Object.keys(params)
+      .filter((badge) => validQueryParams.has(badge))
+      .forEach((v) => {
+        params[v] = undefined;
+      });
+    updateQueryParams(params);
+  };
+  const handleOnRemove = (badge: FilterBadgeType) => {
+    const updatedParam = popQueryParams(queryParams[badge.key], badge.value);
+    updateQueryParams({ [badge.key]: updatedParam });
+  };
+
+  return {
+    badges: queryParamsList,
+    handleClearAll,
+    handleOnRemove,
+  };
+};
+
+const popQueryParams = (param: string | string[], value: string) => {
+  if (Array.isArray(param)) {
+    return param.filter((p) => p !== value);
+  }
+  return undefined;
+};
+
+export default useFilterBadgeQueryParams;

--- a/src/pages/Commits.tsx
+++ b/src/pages/Commits.tsx
@@ -4,7 +4,7 @@ import styled from "@emotion/styled";
 import Cookies from "js-cookie";
 import { useParams, useLocation, useHistory } from "react-router-dom";
 import { useProjectHealthAnalytics } from "analytics/projectHealth/useProjectHealthAnalytics";
-import { FilterBadges } from "components/FilterBadges";
+import FilterBadges from "components/FilterBadges";
 import { ProjectSelect } from "components/projectSelect";
 import { PageWrapper } from "components/styles";
 import { ALL_VALUE } from "components/TreeSelect";
@@ -21,7 +21,7 @@ import {
   MainlineCommitsQueryVariables,
 } from "gql/generated/types";
 import { GET_MAINLINE_COMMITS, GET_SPRUCE_CONFIG } from "gql/queries";
-import { usePageTitle, usePolling } from "hooks";
+import { usePageTitle, usePolling, useFilterBadgeQueryParams } from "hooks";
 import { ProjectFilterOptions, MainlineCommitQueryParams } from "types/commits";
 import { array, queryString } from "utils";
 import { CommitsWrapper } from "./commits/CommitsWrapper";
@@ -113,6 +113,9 @@ export const Commits = () => {
     ProjectFilterOptions.Task,
   ]);
 
+  const { badges, handleOnRemove, handleClearAll } = useFilterBadgeQueryParams(
+    queryParamsToDisplay
+  );
   const onSubmitTupleSelect = ({ category }: { category: string }) => {
     switch (category) {
       case ProjectFilterOptions.BuildVariant:
@@ -154,13 +157,15 @@ export const Commits = () => {
         </HeaderWrapper>
         <BadgeWrapper>
           <FilterBadges
-            onRemove={() => {
+            onRemove={(b) => {
               sendEvent({ name: "Remove badge" });
+              handleOnRemove(b);
             }}
             onClearAll={() => {
               sendEvent({ name: "Clear all badges" });
+              handleClearAll();
             }}
-            queryParamsToDisplay={queryParamsToDisplay}
+            badges={badges}
           />
         </BadgeWrapper>
         <PaginationWrapper>

--- a/src/pages/TaskHistory.tsx
+++ b/src/pages/TaskHistory.tsx
@@ -4,7 +4,7 @@ import styled from "@emotion/styled";
 import { H2 } from "@leafygreen-ui/typography";
 import { useParams } from "react-router-dom";
 import { useProjectHealthAnalytics } from "analytics/projectHealth/useProjectHealthAnalytics";
-import { FilterBadges } from "components/FilterBadges";
+import FilterBadges from "components/FilterBadges";
 import HistoryTable, {
   context,
   ColumnPaginationButtons,
@@ -19,7 +19,7 @@ import {
   MainlineCommitsForHistoryQueryVariables,
 } from "gql/generated/types";
 import { GET_MAINLINE_COMMITS_FOR_HISTORY } from "gql/queries";
-import { usePageTitle } from "hooks";
+import { useFilterBadgeQueryParams, usePageTitle } from "hooks";
 import { string } from "utils";
 import {
   BuildVariantSelector,
@@ -42,6 +42,9 @@ const TaskHistoryContents: React.VFC = () => {
   useTestFilters();
   useJumpToCommit();
 
+  const { badges, handleOnRemove, handleClearAll } = useFilterBadgeQueryParams(
+    constants.queryParamsToDisplay
+  );
   const { data } = useQuery<
     MainlineCommitsForHistoryQuery,
     MainlineCommitsForHistoryQueryVariables
@@ -80,12 +83,14 @@ const TaskHistoryContents: React.VFC = () => {
         <PaginationFilterWrapper>
           <BadgeWrapper>
             <FilterBadges
-              queryParamsToDisplay={constants.queryParamsToDisplay}
-              onRemove={() => {
+              badges={badges}
+              onRemove={(b) => {
                 sendEvent({ name: "Remove badge" });
+                handleOnRemove(b);
               }}
               onClearAll={() => {
                 sendEvent({ name: "Clear all badges" });
+                handleClearAll();
               }}
             />
           </BadgeWrapper>

--- a/src/pages/VariantHistory.tsx
+++ b/src/pages/VariantHistory.tsx
@@ -4,7 +4,7 @@ import styled from "@emotion/styled";
 import { H2 } from "@leafygreen-ui/typography";
 import { useParams } from "react-router-dom";
 import { useProjectHealthAnalytics } from "analytics/projectHealth/useProjectHealthAnalytics";
-import { FilterBadges } from "components/FilterBadges";
+import FilterBadges from "components/FilterBadges";
 import HistoryTable, {
   context,
   ColumnPaginationButtons,
@@ -19,7 +19,7 @@ import {
   MainlineCommitsForHistoryQueryVariables,
 } from "gql/generated/types";
 import { GET_MAINLINE_COMMITS_FOR_HISTORY } from "gql/queries";
-import { usePageTitle } from "hooks";
+import { useFilterBadgeQueryParams, usePageTitle } from "hooks";
 import { string } from "utils";
 import {
   ColumnHeaders,
@@ -41,7 +41,9 @@ const VariantHistoryContents: React.VFC = () => {
   const [nextPageOrderNumber, setNextPageOrderNumber] = useState(null);
   useJumpToCommit();
   useTestFilters();
-
+  const { badges, handleOnRemove, handleClearAll } = useFilterBadgeQueryParams(
+    constants.queryParamsToDisplay
+  );
   const { data } = useQuery<
     MainlineCommitsForHistoryQuery,
     MainlineCommitsForHistoryQueryVariables
@@ -80,12 +82,14 @@ const VariantHistoryContents: React.VFC = () => {
         <PaginationFilterWrapper>
           <BadgeWrapper>
             <FilterBadges
-              queryParamsToDisplay={constants.queryParamsToDisplay}
-              onRemove={() => {
+              badges={badges}
+              onRemove={(b) => {
                 sendEvent({ name: "Remove badge" });
+                handleOnRemove(b);
               }}
               onClearAll={() => {
                 sendEvent({ name: "Clear all badges" });
+                handleClearAll();
               }}
             />
           </BadgeWrapper>

--- a/src/pages/task/metadata/Metadata.stories.tsx
+++ b/src/pages/task/metadata/Metadata.stories.tsx
@@ -1,6 +1,5 @@
 import styled from "@emotion/styled";
 import { withKnobs, boolean, select } from "@storybook/addon-knobs";
-import StoryRouter from "storybook-react-router";
 import { MetStatus, RequiredStatus } from "gql/generated/types";
 import { Metadata } from "./index";
 import { taskQuery } from "./taskData";
@@ -89,7 +88,7 @@ export const WithAbortMessage = () => {
 
 export default {
   title: "Metadata",
-  decorators: [StoryRouter(), withKnobs],
+  decorators: [withKnobs],
   component: Base,
 };
 

--- a/src/test_utils/index.tsx
+++ b/src/test_utils/index.tsx
@@ -4,6 +4,7 @@ import {
   queries,
   RenderResult,
   RenderOptions,
+  within,
 } from "@testing-library/react";
 import { createMemoryHistory } from "history";
 import { Router, Route } from "react-router-dom";
@@ -25,6 +26,9 @@ const customRender = (
     queries: { ...queries, ...customQueries },
     ...options,
   }) as RenderResult<CustomRenderType>;
+
+const customWithin = (ui: HTMLElement) =>
+  within(ui, { ...queries, ...customQueries });
 
 interface renderWithRouterMatchOptions extends customRenderOptions {
   route?: string;
@@ -77,4 +81,8 @@ export const mockUUID = () => {
 export * from "@testing-library/react";
 
 // override render method
-export { customRender as render, renderWithRouterMatch };
+export {
+  customRender as render,
+  renderWithRouterMatch,
+  customWithin as within,
+};

--- a/src/utils/array/index.ts
+++ b/src/utils/array/index.ts
@@ -1,3 +1,5 @@
+import { Unpacked } from "types/utils";
+
 /**
  * This takes in an array of values regardless of type and a new value and safely inserts the value if it doesn't exist in the array.
  * It removes the value from the array if it already exists
@@ -64,14 +66,22 @@ export const convertArrayToObject = <T = { [key: string]: any }>(
  * @param object The object to convert to an array
  * @returns The array created from the object
  */
-export const convertObjectToArray = <T>(object: { [key: string]: T[] | T }) => {
+export const convertObjectToArray = <T extends object>(
+  obj: T
+): KeyValue<T>[] => {
   const result = [];
-  if (object === undefined) return result;
-  const objectEntries = Object.entries(object);
+  if (obj === undefined) return result;
+  const objectEntries = Object.entries(obj);
   return objectEntries.flatMap(([key, value]) => {
     const entries = toArray(value);
-    return entries.map((v) => ({ key, value: v }));
+
+    return entries.map((v) => ({ key, value: v } as KeyValue<T>));
   });
+};
+
+type KeyValue<T> = {
+  key: string;
+  value: Unpacked<T[keyof T]>;
 };
 
 /**


### PR DESCRIPTION
[EVG-15598](https://jira.mongodb.org/browse/EVG-15598)

### Description 
Filter badges now only consume  and render badges as props they no longer update query params I extracted that logic into a hook. Clearing all will not delete unrelated query params.
### Screenshots
No visible changes.
