### PR TITLE
EVG-16759 Exclude base tasks for mainline commits queries

### DIFF
--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -591,7 +591,7 @@ export type BuildVariantOptions = {
   variants?: Maybe<Array<Scalars["String"]>>;
   tasks?: Maybe<Array<Scalars["String"]>>;
   statuses?: Maybe<Array<Scalars["String"]>>;
-  excludeBaseTasks?: Maybe<Scalars["Boolean"]>;
+  includeBaseTasks?: Maybe<Scalars["Boolean"]>;
 };
 
 export type MainlineCommitsOptions = {

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -591,6 +591,7 @@ export type BuildVariantOptions = {
   variants?: Maybe<Array<Scalars["String"]>>;
   tasks?: Maybe<Array<Scalars["String"]>>;
   statuses?: Maybe<Array<Scalars["String"]>>;
+  excludeBaseTasks?: Maybe<Scalars["Boolean"]>;
 };
 
 export type MainlineCommitsOptions = {

--- a/src/pages/TaskHistory.tsx
+++ b/src/pages/TaskHistory.tsx
@@ -55,6 +55,7 @@ const TaskHistoryContents: React.VFC = () => {
       },
       buildVariantOptions: {
         tasks: [applyStrictRegex(taskName)],
+        excludeBaseTasks: true,
       },
     },
   });

--- a/src/pages/TaskHistory.tsx
+++ b/src/pages/TaskHistory.tsx
@@ -55,7 +55,7 @@ const TaskHistoryContents: React.VFC = () => {
       },
       buildVariantOptions: {
         tasks: [applyStrictRegex(taskName)],
-        excludeBaseTasks: true,
+        includeBaseTasks: false,
       },
     },
   });

--- a/src/pages/VariantHistory.tsx
+++ b/src/pages/VariantHistory.tsx
@@ -55,6 +55,7 @@ const VariantHistoryContents: React.VFC = () => {
       },
       buildVariantOptions: {
         variants: [applyStrictRegex(variantName)],
+        excludeBaseTasks: true,
       },
     },
   });

--- a/src/pages/VariantHistory.tsx
+++ b/src/pages/VariantHistory.tsx
@@ -55,7 +55,7 @@ const VariantHistoryContents: React.VFC = () => {
       },
       buildVariantOptions: {
         variants: [applyStrictRegex(variantName)],
-        excludeBaseTasks: true,
+        includeBaseTasks: false,
       },
     },
   });

--- a/src/pages/commits/utils.test.ts
+++ b/src/pages/commits/utils.test.ts
@@ -186,6 +186,7 @@ describe("getMainlineCommitsQueryVariables", () => {
         tasks: [],
         variants: [],
         statuses: [],
+        excludeBaseTasks: true,
       });
       expect(
         getMainlineCommitsQueryVariables({
@@ -205,6 +206,7 @@ describe("getMainlineCommitsQueryVariables", () => {
         tasks: [],
         variants: [],
         statuses: [TaskStatus.Failed],
+        excludeBaseTasks: true,
       });
       expect(
         getMainlineCommitsQueryVariables({
@@ -224,6 +226,7 @@ describe("getMainlineCommitsQueryVariables", () => {
         tasks: ["task1"],
         variants: [],
         statuses: [],
+        excludeBaseTasks: true,
       });
     });
   });
@@ -329,6 +332,7 @@ describe("getMainlineCommitsQueryVariables", () => {
         tasks: [],
         variants: [],
         statuses: FAILED_STATUSES,
+        excludeBaseTasks: true,
       });
     });
     it("should not return any task icons when a non failing status filter is applied", () => {
@@ -350,6 +354,7 @@ describe("getMainlineCommitsQueryVariables", () => {
         tasks: [impossibleMatch],
         variants: [],
         statuses: [],
+        excludeBaseTasks: true,
       });
     });
     it("should only show failing task icons when there are multiple statuses with mixed failing and non failing statuses", () => {
@@ -371,6 +376,7 @@ describe("getMainlineCommitsQueryVariables", () => {
         tasks: [],
         variants: [],
         statuses: [TaskStatus.Failed],
+        excludeBaseTasks: true,
       });
     });
     it("should return all matching tasks when a task filter is applied regardless of status", () => {
@@ -392,6 +398,7 @@ describe("getMainlineCommitsQueryVariables", () => {
         tasks: ["task1"],
         variants: [],
         statuses: [],
+        excludeBaseTasks: true,
       });
       expect(
         getMainlineCommitsQueryVariables({
@@ -411,6 +418,7 @@ describe("getMainlineCommitsQueryVariables", () => {
         tasks: ["task1"],
         variants: [],
         statuses: [TaskStatus.Succeeded],
+        excludeBaseTasks: true,
       });
     });
     it("should only return failing tasks when a variant filter is applied with no other filters", () => {
@@ -432,6 +440,7 @@ describe("getMainlineCommitsQueryVariables", () => {
         tasks: [],
         variants: ["variant1"],
         statuses: FAILED_STATUSES,
+        excludeBaseTasks: true,
       });
     });
   });

--- a/src/pages/commits/utils.test.ts
+++ b/src/pages/commits/utils.test.ts
@@ -186,7 +186,7 @@ describe("getMainlineCommitsQueryVariables", () => {
         tasks: [],
         variants: [],
         statuses: [],
-        excludeBaseTasks: true,
+        includeBaseTasks: false,
       });
       expect(
         getMainlineCommitsQueryVariables({
@@ -206,7 +206,7 @@ describe("getMainlineCommitsQueryVariables", () => {
         tasks: [],
         variants: [],
         statuses: [TaskStatus.Failed],
-        excludeBaseTasks: true,
+        includeBaseTasks: false,
       });
       expect(
         getMainlineCommitsQueryVariables({
@@ -226,7 +226,7 @@ describe("getMainlineCommitsQueryVariables", () => {
         tasks: ["task1"],
         variants: [],
         statuses: [],
-        excludeBaseTasks: true,
+        includeBaseTasks: false,
       });
     });
   });
@@ -332,7 +332,7 @@ describe("getMainlineCommitsQueryVariables", () => {
         tasks: [],
         variants: [],
         statuses: FAILED_STATUSES,
-        excludeBaseTasks: true,
+        includeBaseTasks: false,
       });
     });
     it("should not return any task icons when a non failing status filter is applied", () => {
@@ -354,7 +354,7 @@ describe("getMainlineCommitsQueryVariables", () => {
         tasks: [impossibleMatch],
         variants: [],
         statuses: [],
-        excludeBaseTasks: true,
+        includeBaseTasks: false,
       });
     });
     it("should only show failing task icons when there are multiple statuses with mixed failing and non failing statuses", () => {
@@ -376,7 +376,7 @@ describe("getMainlineCommitsQueryVariables", () => {
         tasks: [],
         variants: [],
         statuses: [TaskStatus.Failed],
-        excludeBaseTasks: true,
+        includeBaseTasks: false,
       });
     });
     it("should return all matching tasks when a task filter is applied regardless of status", () => {
@@ -398,7 +398,7 @@ describe("getMainlineCommitsQueryVariables", () => {
         tasks: ["task1"],
         variants: [],
         statuses: [],
-        excludeBaseTasks: true,
+        includeBaseTasks: false,
       });
       expect(
         getMainlineCommitsQueryVariables({
@@ -418,7 +418,7 @@ describe("getMainlineCommitsQueryVariables", () => {
         tasks: ["task1"],
         variants: [],
         statuses: [TaskStatus.Succeeded],
-        excludeBaseTasks: true,
+        includeBaseTasks: false,
       });
     });
     it("should only return failing tasks when a variant filter is applied with no other filters", () => {
@@ -440,7 +440,7 @@ describe("getMainlineCommitsQueryVariables", () => {
         tasks: [],
         variants: ["variant1"],
         statuses: FAILED_STATUSES,
-        excludeBaseTasks: true,
+        includeBaseTasks: false,
       });
     });
   });

--- a/src/pages/commits/utils.ts
+++ b/src/pages/commits/utils.ts
@@ -62,7 +62,7 @@ const generateBuildVariantOptionsFromState = (
     tasks,
     variants,
     statuses,
-    excludeBaseTasks: true,
+    includeBaseTasks: false,
   };
 
   return buildVariantOptions;
@@ -94,7 +94,7 @@ const generateBuildVariantOptionsForTaskIconsFromState = (
     tasks: shouldShowTaskIcons ? filterState.tasks : [impossibleMatch],
     variants: filterState.variants,
     statuses: statusesToShow,
-    excludeBaseTasks: true,
+    includeBaseTasks: false,
   };
   return buildVariantOptions;
 };

--- a/src/pages/commits/utils.ts
+++ b/src/pages/commits/utils.ts
@@ -62,6 +62,7 @@ const generateBuildVariantOptionsFromState = (
     tasks,
     variants,
     statuses,
+    excludeBaseTasks: true,
   };
 
   return buildVariantOptions;
@@ -93,6 +94,7 @@ const generateBuildVariantOptionsForTaskIconsFromState = (
     tasks: shouldShowTaskIcons ? filterState.tasks : [impossibleMatch],
     variants: filterState.variants,
     statuses: statusesToShow,
+    excludeBaseTasks: true,
   };
   return buildVariantOptions;
 };


### PR DESCRIPTION
[EVG-16759](https://jira.mongodb.org/browse/EVG-16759)

### Description 
Uses the toggle introduced in https://github.com/evergreen-ci/evergreen/pull/5598 to prevent fetching base tasks for mainline commits. 
### Evergreen PR 
https://github.com/evergreen-ci/evergreen/pull/5598