### PR TITLE
EVG-16438: Allow commit queue removal modal to be closed 

### DIFF
--- a/src/pages/commitqueue/ConfirmPatchButton.tsx
+++ b/src/pages/commitqueue/ConfirmPatchButton.tsx
@@ -30,6 +30,7 @@ export const ConfirmPatchButton: React.VFC<ConfirmPatchButtonProps> = ({
           onConfirm();
           setOpen(false);
         }}
+        onCancel={() => setOpen(false)}
         title="Are you sure you want to remove this patch from the commit queue?"
         buttonText="Remove"
         variant={Variant.Danger}


### PR DESCRIPTION
[EVG-16438](https://jira.mongodb.org/browse/EVG-16438)

### Description 
Super small change to just make the `X` button and `Cancel` button functional for this modal 😀 (they did not work before)

### Screenshots
https://user-images.githubusercontent.com/47064971/164327504-bd9ebdd7-180b-4206-a1ef-f4031d48aebc.mov

### Testing 
- Manually
