### PR TITLE
EVG-16590: Use projectIdentifier in Project Patches route

### DIFF
--- a/src/components/Breadcrumb/index.tsx
+++ b/src/components/Breadcrumb/index.tsx
@@ -142,7 +142,7 @@ const VersionBreadcrumb: React.VFC<VersionBreadcrumbProps> = ({
   analytics,
   isTask,
 }) => {
-  const { project, projectIdentifier, revision, id } = versionMetadata;
+  const { projectIdentifier, revision, id } = versionMetadata;
   // We need to case on revision since periodic builds do not have a revision
   const breadcrumbText = shortenGithash(revision.length ? revision : id);
   return (
@@ -165,7 +165,7 @@ const VersionBreadcrumb: React.VFC<VersionBreadcrumbProps> = ({
           ) : (
             <StyledBreadcrumbLink
               data-cy="bc-my-patches"
-              to={getProjectPatchesRoute(project)}
+              to={getProjectPatchesRoute(projectIdentifier)}
               onClick={() =>
                 analytics.sendEvent({
                   name: "Click Link",

--- a/src/components/PatchesPage/PatchCard.tsx
+++ b/src/components/PatchesPage/PatchCard.tsx
@@ -39,7 +39,6 @@ export const PatchCard: React.VFC<Props> = ({
   createTime,
   author,
   authorDisplayName,
-  projectID,
   projectIdentifier,
   status,
   pageType,
@@ -86,7 +85,7 @@ export const PatchCard: React.VFC<Props> = ({
             </StyledRouterLink>
           ) : (
             <StyledRouterLink
-              to={getProjectPatchesRoute(projectID)}
+              to={getProjectPatchesRoute(projectIdentifier)}
               data-cy="project-patches-link"
             >
               <b>{projectIdentifier}</b>

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -216,8 +216,8 @@ export const getSpawnVolumeRoute = (volume: string) => {
   return `${routes.spawnVolume}?${queryParams}`;
 };
 
-export const getProjectPatchesRoute = (projectId: string) =>
-  `${paths.project}/${projectId}/${PageNames.Patches}`;
+export const getProjectPatchesRoute = (projectIdentifier: string) =>
+  `${paths.project}/${projectIdentifier}/${PageNames.Patches}`;
 
 export const getProjectSettingsRoute = (
   projectId: string,

--- a/src/gql/fragments/patchesPage.graphql
+++ b/src/gql/fragments/patchesPage.graphql
@@ -3,7 +3,6 @@ fragment PatchesPagePatches on Patches {
     id
     author
     authorDisplayName
-    projectID
     projectIdentifier
     description
     status

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -2183,7 +2183,6 @@ export type PatchesPagePatchesFragment = {
     id: string;
     author: string;
     authorDisplayName: string;
-    projectID: string;
     projectIdentifier: string;
     description: string;
     status: string;
@@ -4017,7 +4016,6 @@ export type GetTaskQuery = {
       finishTime?: Maybe<Date>;
       hostId?: Maybe<string>;
       requester: string;
-      projectId: string;
       patchNumber?: Maybe<number>;
       canOverrideDependencies: boolean;
       startTime?: Maybe<Date>;

--- a/src/gql/queries/get-task.graphql
+++ b/src/gql/queries/get-task.graphql
@@ -51,7 +51,6 @@ query GetTask($taskId: String!, $execution: Int) {
       order
     }
     requester
-    projectId
     project {
       identifier
     }

--- a/src/pages/task/metadata/__snapshots__/Metadata.stories.storyshot
+++ b/src/pages/task/metadata/__snapshots__/Metadata.stories.storyshot
@@ -42,7 +42,9 @@ exports[`storybook Storyshots Metadata Base 1`] = `
         data-cy="project-link"
         href="/project/spruce/patches"
         onClick={[Function]}
-      />
+      >
+        spruce
+      </a>
     </p>
     <p
       className="css-1ui13f0-P2-wordBreakCss eplk6ht0"
@@ -168,7 +170,9 @@ exports[`storybook Storyshots Metadata With Abort Message 1`] = `
         data-cy="project-link"
         href="/project/spruce/patches"
         onClick={[Function]}
-      />
+      >
+        spruce
+      </a>
     </p>
     <p
       className="css-1ui13f0-P2-wordBreakCss eplk6ht0"
@@ -294,7 +298,9 @@ exports[`storybook Storyshots Metadata With Dependencies 1`] = `
         data-cy="project-link"
         href="/project/spruce/patches"
         onClick={[Function]}
-      />
+      >
+        spruce
+      </a>
     </p>
     <p
       className="css-1ui13f0-P2-wordBreakCss eplk6ht0"

--- a/src/pages/task/metadata/index.tsx
+++ b/src/pages/task/metadata/index.tsx
@@ -61,7 +61,6 @@ export const Metadata: React.VFC<Props> = ({
     generatedBy,
     generatedByName,
     minQueuePosition: taskQueuePosition,
-    projectId,
     abortInfo,
     displayTask,
     project,
@@ -99,7 +98,7 @@ export const Metadata: React.VFC<Props> = ({
           Project:{" "}
           <StyledRouterLink
             data-cy="project-link"
-            to={getProjectPatchesRoute(projectId)}
+            to={getProjectPatchesRoute(projectIdentifier)}
             onClick={() =>
               taskAnalytics.sendEvent({ name: "Click Project Link" })
             }

--- a/src/pages/task/metadata/taskData.js
+++ b/src/pages/task/metadata/taskData.js
@@ -68,6 +68,9 @@ export const taskQuery = {
     buildVariant: "ubuntu1604",
     minQueuePosition: 0,
     projectId: "spruce",
+    project: {
+      identifier: "spruce",
+    },
     expectedDuration: 123,
   },
 };

--- a/src/pages/version/Metadata.tsx
+++ b/src/pages/version/Metadata.tsx
@@ -57,7 +57,7 @@ export const Metadata: React.VFC<Props> = ({ loading, version }) => {
     >
       <P2>
         Project:{" "}
-        <StyledRouterLink to={getProjectPatchesRoute(project)}>
+        <StyledRouterLink to={getProjectPatchesRoute(projectIdentifier)}>
           {projectIdentifier}
         </StyledRouterLink>
       </P2>


### PR DESCRIPTION
[EVG-16590](https://jira.mongodb.org/browse/EVG-16590)

### Description 
This PR makes it so that the `projectIdentifier` is used instead of the `id` (`projectId`) in the project patches route.

The reason this still works despite there being no changes in the Evergreen repo is because the [ById](https://github.com/evergreen-ci/evergreen/blob/main/model/project_ref.go#L1210-L1217) function used to look up projects actually matches on either the project ID or identifier. In fact, if you go to the [sandbox](https://spruce-staging.corp.mongodb.com/project/5ffe393097b1d3759dd3c1a3/patches?commitQueue=false) project on spruce-staging and replace the ID in the url with `sandbox`, you'll see that this functionality already works.

### Screenshots
- No visible changes (only the links have changed)

### Testing 
- Manually on prod; an example of a project that has a different ID than its identifier is the [patch-analysis](https://spruce.mongodb.com/project/602e77ec5623435862026af3/patches) project

