### PR TITLE
EVG-14731: Indicate when commits will be preserved in Enqueue Modal

### DIFF
--- a/src/components/CodeChanges/CodeChanges.tsx
+++ b/src/components/CodeChanges/CodeChanges.tsx
@@ -17,7 +17,7 @@ import {
 import { GET_CODE_CHANGES } from "gql/queries";
 import { commits } from "utils";
 
-const { bucketByCommit } = commits;
+const { bucketByCommit, shouldPreserveCommits } = commits;
 
 export const CodeChanges: React.VFC = () => {
   const { id } = useParams<{ id: string }>();
@@ -101,15 +101,6 @@ export const CodeChanges: React.VFC = () => {
       })}
     </div>
   );
-};
-
-// We can tell that the user opted to preserve commits if the description of a fileDiff is non-empty,
-// as it will contain the associated commit message.
-const shouldPreserveCommits = (fileDiffs: FileDiffsFragment[]): boolean => {
-  if (fileDiffs.length && fileDiffs[0].description !== "") {
-    return true;
-  }
-  return false;
 };
 
 const sortFileDiffs = (fileDiffs: FileDiffsFragment[]): FileDiffsFragment[] =>

--- a/src/components/PatchActionButtons/EnqueuePatch.tsx
+++ b/src/components/PatchActionButtons/EnqueuePatch.tsx
@@ -1,15 +1,6 @@
 import { useState } from "react";
-import { useQuery } from "@apollo/client";
 import { DropdownItem } from "components/ButtonDropdown";
-import {
-  CodeChangesQuery,
-  CodeChangesQueryVariables,
-} from "gql/generated/types";
-import { GET_CODE_CHANGES } from "gql/queries";
 import { EnqueuePatchModal } from "pages/version/index";
-import { commits } from "utils";
-
-const { shouldPreserveCommits } = commits;
 
 interface EnqueuePatchProps {
   patchId: string;
@@ -32,19 +23,6 @@ export const EnqueuePatch: React.VFC<EnqueuePatchProps> = ({
       ? visibilityControl
       : fallbackVisibilityControl;
 
-  const { data, previousData } = useQuery<
-    CodeChangesQuery,
-    CodeChangesQueryVariables
-  >(GET_CODE_CHANGES, {
-    variables: { id: patchId },
-    skip: !isVisible,
-  });
-  const { patch } = data ?? previousData ?? {};
-  const { moduleCodeChanges } = patch ?? {};
-  const preserveCommits = moduleCodeChanges?.length
-    ? shouldPreserveCommits(moduleCodeChanges[0].fileDiffs)
-    : false;
-
   return (
     <>
       <DropdownItem
@@ -60,7 +38,6 @@ export const EnqueuePatch: React.VFC<EnqueuePatchProps> = ({
         visible={isVisible}
         onFinished={() => setIsVisible(false)}
         refetchQueries={refetchQueries}
-        preserveCommits={preserveCommits}
       />
     </>
   );

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -748,6 +748,7 @@ export type SubscriberInput = {
 
 export type UseSpruceOptionsInput = {
   hasUsedSpruceBefore?: Maybe<Scalars["Boolean"]>;
+  hasUsedMainlineCommitsBefore?: Maybe<Scalars["Boolean"]>;
   spruceV1?: Maybe<Scalars["Boolean"]>;
 };
 
@@ -1871,6 +1872,7 @@ export type UserSettings = {
 
 export type UseSpruceOptions = {
   hasUsedSpruceBefore?: Maybe<Scalars["Boolean"]>;
+  hasUsedMainlineCommitsBefore?: Maybe<Scalars["Boolean"]>;
   spruceV1?: Maybe<Scalars["Boolean"]>;
 };
 

--- a/src/pages/version/EnqueueModal.tsx
+++ b/src/pages/version/EnqueueModal.tsx
@@ -1,10 +1,10 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useMutation } from "@apollo/client";
 import styled from "@emotion/styled";
-import Button from "@leafygreen-ui/button";
 import TextArea from "@leafygreen-ui/text-area";
+import { Description, InlineCode } from "@leafygreen-ui/typography";
 import { useVersionAnalytics } from "analytics";
-import { Modal } from "components/Modal";
+import { ConfirmationModal } from "components/ConfirmationModal";
 import { size } from "constants/tokens";
 import { useToastContext } from "context/toast";
 import {
@@ -19,6 +19,7 @@ interface EnqueueProps {
   visible: boolean;
   onFinished: () => void;
   refetchQueries: string[];
+  preserveCommits: boolean;
 }
 export const EnqueuePatchModal: React.VFC<EnqueueProps> = ({
   patchId,
@@ -26,8 +27,14 @@ export const EnqueuePatchModal: React.VFC<EnqueueProps> = ({
   visible,
   onFinished,
   refetchQueries,
+  preserveCommits,
 }) => {
   const dispatchToast = useToastContext();
+  const { sendEvent } = useVersionAnalytics(patchId);
+  const [commitMessageValue, setCommitMessageValue] = useState<string>(
+    commitMessage || ""
+  );
+
   const [enqueuePatch, { loading: loadingEnqueuePatch }] = useMutation<
     EnqueuePatchMutation,
     EnqueuePatchMutationVariables
@@ -41,47 +48,40 @@ export const EnqueuePatchModal: React.VFC<EnqueueProps> = ({
     refetchQueries,
   });
 
-  const { sendEvent } = useVersionAnalytics(patchId);
-  const [commitMessageValue, setCommitMessageValue] = useState<string>(
-    commitMessage || ""
-  );
+  const onConfirm = () => {
+    enqueuePatch({
+      variables: { patchId, commitMessage: commitMessageValue },
+    });
+    sendEvent({ name: "Enqueue" });
+    onFinished();
+  };
 
   return (
-    <Modal
+    <ConfirmationModal
       title="Enqueue Patch"
-      visible={visible}
-      onOk={onFinished}
+      open={visible}
+      onConfirm={onConfirm}
       onCancel={onFinished}
-      footer={[
-        <Button key="cancel" onClick={onFinished}>
-          Cancel
-        </Button>,
-        <Button
-          key="enqueue"
-          data-cy="enqueue-patch-button"
-          disabled={commitMessageValue.length === 0 || loadingEnqueuePatch}
-          onClick={() => {
-            onFinished();
-            enqueuePatch({
-              variables: { patchId, commitMessage: commitMessageValue },
-            });
-            sendEvent({ name: "Enqueue" });
-          }}
-          variant="primary"
-        >
-          Enqueue
-        </Button>,
-      ]}
+      buttonText="Enqueue"
+      submitDisabled={commitMessageValue.length === 0 || loadingEnqueuePatch}
       data-cy="enqueue-modal"
     >
-      <StyledTextArea
-        id={COMMIT_MESSAGE_ID}
-        label="Commit Message"
-        description="Warning: submitting a patch to the commit queue will squash the commits."
-        value={commitMessageValue}
-        onChange={(e) => setCommitMessageValue(e.target.value)}
-      />
-    </Modal>
+      {preserveCommits ? (
+        <Description>
+          This patch was created with the{" "}
+          <InlineCode>--preserve-commits</InlineCode> option. All commits will
+          be preserved when merging.
+        </Description>
+      ) : (
+        <StyledTextArea
+          id={COMMIT_MESSAGE_ID}
+          label="Commit Message"
+          description="Warning: submitting a patch to the commit queue will squash the commits."
+          value={commitMessageValue}
+          onChange={(e) => setCommitMessageValue(e.target.value)}
+        />
+      )}
+    </ConfirmationModal>
   );
 };
 

--- a/src/utils/commits/index.ts
+++ b/src/utils/commits/index.ts
@@ -1,1 +1,19 @@
-export * from "./bucketByCommit";
+import { FileDiffsFragment } from "gql/generated/types";
+
+export { bucketByCommit } from "./bucketByCommit";
+
+/**
+ * Indicates if a user created a patch with the --preserve-commits flag.
+ * We can tell that the user opted to preserve commits if the description of a fileDiff is non-empty,
+ * as it will contain the associated commit message.
+ * @param {FileDiffsFragment[]} fileDiffs - array containing the fileDiffs for a particular commit
+ * @return {boolean} true if commits are preserved, false if otherwise
+ */
+export const shouldPreserveCommits = (
+  fileDiffs: FileDiffsFragment[]
+): boolean => {
+  if (fileDiffs.length && fileDiffs[0].description !== "") {
+    return true;
+  }
+  return false;
+};


### PR DESCRIPTION
[EVG-14731](https://jira.mongodb.org/browse/EVG-14731)

### Description 
This PR makes it so that if a user tries to enqueue a patch that was created with the `--preserve-commits` option, there will be 1) a message that says the commits will be preserved and 2) no text box as the commit message cannot be edited.

Note: The enqueue button is only enabled for patches. So this modal would never be reachable from a version.

### Screenshots
https://user-images.githubusercontent.com/47064971/166992260-66986e3a-5f8f-47b3-a1dd-f6639811dcc3.mov

### Testing 
- manually, example patch [here](https://spruce.mongodb.com/user/minna.kt/patches?commitQueue=true&patchName=preserve%20commits)
