### PR TITLE
EVG-16595: Fix ui:orderable bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@leafygreen-ui/toggle": "7.0.4",
     "@leafygreen-ui/tooltip": "6.3.1",
     "@leafygreen-ui/typography": "8.1.0",
-    "@rjsf/core": "4.1.0",
+    "@rjsf/core": "4.2.0",
     "ansi_up": "5.0.0",
     "antd": "4.12.1",
     "axios": "0.21.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3428,10 +3428,10 @@
   resolved "https://registry.yarnpkg.com/@repeaterjs/repeater/-/repeater-3.0.4.tgz#a04d63f4d1bf5540a41b01a921c9a7fddc3bd1ca"
   integrity sha512-AW8PKd6iX3vAZ0vA43nOUOnbq/X5ihgU+mSXXqunMkeQADGiqw/PY0JNeYtD5sr0PAy51YPgAPbDoeapv9r8WA==
 
-"@rjsf/core@4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@rjsf/core/-/core-4.1.0.tgz#43714518b339b26f9a2b11223625069642cb3397"
-  integrity sha512-rLtBJzqqFUUYx3c0bycqBYiQePug9keKrwISAd6bZ5xghHNgbXGI8rMtDbwpYoF4sQPiPCO+zlfpUOusK5vsVw==
+"@rjsf/core@4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@rjsf/core/-/core-4.2.0.tgz#9ec807737039b5f63433682f332ecbcd6067a847"
+  integrity sha512-bGWWCZjXHhBCkzag1Yh6F7a15/D6AqKRyks1szYWdCe+4jwWU3maC3apUxHJlHFRz3V1aBW6j6i/UB6zHmFXLQ==
   dependencies:
     "@types/json-schema" "^7.0.7"
     ajv "^6.7.0"


### PR DESCRIPTION
EVG-16595

### Description 
- Update RJSF to 4.2.0, which includes a commit that fixes the orderable bug: https://github.com/rjsf-team/react-jsonschema-form/pull/2797

### Screenshots
All arrays using `ui:orderable: false` (i.e. all besides virtual workstation commands) no longer include arrow buttons for reordering.
<img width="711" alt="image" src="https://user-images.githubusercontent.com/9298431/167180256-9263388b-09c0-4540-b843-ee815eb80e65.png">