### PR TITLE
EVG-16519: Reset page number on patch description search

### DIFF
--- a/cypress/integration/myPatches/my_patches.ts
+++ b/cypress/integration/myPatches/my_patches.ts
@@ -46,6 +46,11 @@ describe("My Patches Page", () => {
       paramName: "patchName",
       search: inputVal,
     });
+    urlSearchParamsAreUpdated({
+      pathname: MY_PATCHES_ROUTE,
+      paramName: "page",
+      search: 0,
+    });
     cy.dataCy("patch-description-input").clear();
   });
 

--- a/src/components/PatchesPage/index.tsx
+++ b/src/components/PatchesPage/index.tsx
@@ -53,7 +53,7 @@ export const PatchesPage: React.VFC<Props> = ({
   const { limit, page } = getPatchesInputFromURLSearch(search);
   const { inputValue, setAndSubmitInputValue } = useFilterInputChangeHandler({
     urlParam: PatchPageQueryParams.PatchName,
-    resetPage: false,
+    resetPage: true,
     sendAnalyticsEvent: (filterBy: string) =>
       analyticsObject.sendEvent({ name: "Filter Patches", filterBy }),
   });


### PR DESCRIPTION
[EVG-16519](https://jira.mongodb.org/browse/EVG-16519)

### Description 
Small PR to reset the page number to 0 whenever a user uses the search box on the My Patches page.

### Screenshots
https://user-images.githubusercontent.com/47064971/167480428-8a002e14-49e7-4804-871e-7557dd9f9a74.mov

### Testing 
- Modified `my_patches.ts` (Cypress)
