### PR TITLE
EVG-16080: Show correct idle times on Hosts page

### DIFF
--- a/src/pages/hosts/HostsTable.tsx
+++ b/src/pages/hosts/HostsTable.tsx
@@ -145,8 +145,8 @@ export const HostsTable: React.VFC<Props> = ({
     },
     {
       title: "Distro",
-      defaultSortOrder: getDefaultSortOrder(HostSortBy.Distro),
       dataIndex: "distroId",
+      defaultSortOrder: getDefaultSortOrder(HostSortBy.Distro),
       key: HostSortBy.Distro,
       sorter: true,
       width: "15%",
@@ -203,8 +203,8 @@ export const HostsTable: React.VFC<Props> = ({
     },
     {
       title: "Elapsed",
-      defaultSortOrder: getDefaultSortOrder(HostSortBy.Elapsed),
       dataIndex: "elapsed",
+      defaultSortOrder: getDefaultSortOrder(HostSortBy.Elapsed),
       key: HostSortBy.Elapsed,
       sorter: true,
       className: "cy-task-table-col-ELAPSED",
@@ -225,19 +225,21 @@ export const HostsTable: React.VFC<Props> = ({
     },
     {
       title: "Idle Time",
-      defaultSortOrder: getDefaultSortOrder(HostSortBy.IdleTime),
       dataIndex: "totalIdleTime",
+      defaultSortOrder: getDefaultSortOrder(HostSortBy.IdleTime),
       key: HostSortBy.IdleTime,
       sorter: true,
       width: "10%",
       className: "cy-task-table-col-IDLE-TIME",
       render: (_, { totalIdleTime }) =>
-        totalIdleTime ? formatDistanceToNow(new Date(totalIdleTime)) : "N/A",
+        totalIdleTime
+          ? formatDistanceToNow(new Date(Date.now() - totalIdleTime))
+          : "N/A",
     },
     {
       title: "Owner",
-      defaultSortOrder: getDefaultSortOrder(HostSortBy.Owner),
       dataIndex: "startedBy",
+      defaultSortOrder: getDefaultSortOrder(HostSortBy.Owner),
       key: HostSortBy.Owner,
       sorter: true,
       width: "10%",


### PR DESCRIPTION
[EVG-16080](https://jira.mongodb.org/browse/EVG-16080)

### Description 
The idle time on the Hosts page always says "51 years" or "52 years" because we incorrectly interpret the idle time as a date when it's actually a duration.

Example: if a host has been idle for 1 hour, we were interpreting that as 1 hour since January 1st, 1970, which is 52 years ago.

### Screenshots
https://user-images.githubusercontent.com/47064971/167657756-2b709a90-0c9d-4485-83fa-012ced605e57.mov

### Testing 
- Manually looked at the idle time durations and plugged them into a calculator to see if the new times were correct
- Note: easiest way to see idle times that aren't `N/A` is to sort by DESC
