### PR TITLE
EVG-15920: Improve message for task failed due to spot host termination

### DIFF
--- a/src/pages/task/metadata/index.tsx
+++ b/src/pages/task/metadata/index.tsx
@@ -173,7 +173,9 @@ export const Metadata: React.VFC<Props> = ({
           </P2>
         )}
         {details?.status === TaskStatus.Failed && (
-          <P2>Failing command: {details?.description}</P2>
+          <P2>
+            Failing command: {processFailingCommand(details?.description)}
+          </P2>
         )}
         {details?.timeoutType && details?.timeoutType !== "" && (
           <P2>Timeout type: {details?.timeoutType}</P2>
@@ -281,6 +283,13 @@ export const Metadata: React.VFC<Props> = ({
       </MetadataCard>
     </>
   );
+};
+
+const processFailingCommand = (description: string): string => {
+  if (description === "stranded") {
+    return "Task failed because spot host was unexpectedly terminated by AWS.";
+  }
+  return description;
 };
 
 const OOMTrackerMessage = styled(P2)`


### PR DESCRIPTION
[EVG-15920](https://jira.mongodb.org/browse/EVG-15920)

### Description 
The failing command is "stranded" when a task failure is caused by AWS terminating a spot host. This causes some confusion among users because they don't know how to interpret this message. This PR updates the "stranded" failing command to be more informative.

### Screenshots
<img width="1245" alt="Screen Shot 2022-05-10 at 11 17 31 AM" src="https://user-images.githubusercontent.com/47064971/167665684-a51da4d1-8839-4a46-be3b-56b454ede6dc.png">


### Testing 
- Manually
- Example of a task with "stranded" failing command: [here](https://spruce.mongodb.com/task/mongodb_mongo_master_enterprise_rhel_62_64_bit_dynamic_required_compile_no_archive_patch_b87b25eea7b2edac7507f384311dc9009148cc4c_5f44233b2fbabe1c7bc2fc39_20_08_24_20_29_48/logs?execution=0)
- Example of a task with a different failing command: [here](https://spruce.mongodb.com/task/spruce_ubuntu1604_e2e_test_patch_4310136499774900f05aadf0cfd2b9525ad4bf62_62792a6fd1fe0738fc1a1cc3_22_05_09_14_51_36/tests?execution=0&sortBy=STATUS&sortDir=ASC)
