### PR TITLE
EVG-15580: Fix unit tests to always use await before waitFor

### DIFF
--- a/src/components/Popconfirm/PopconfirmWithCheckbox.test.tsx
+++ b/src/components/Popconfirm/PopconfirmWithCheckbox.test.tsx
@@ -30,7 +30,7 @@ describe("popconfirmWithCheckbox", () => {
       </PopconfirmWithCheckbox>
     );
     fireEvent.click(queryByText("btn"));
-    waitFor(() => expect(queryByText(checkboxLabel)).not.toBeVisible());
+    expect(queryByText(checkboxLabel)).not.toBeInTheDocument();
     expect(queryByDataCy("popconfirm-checkbox")).not.toBeInTheDocument();
   });
 
@@ -41,7 +41,7 @@ describe("popconfirmWithCheckbox", () => {
       </PopconfirmWithCheckbox>
     );
     fireEvent.click(queryByText("btn"));
-    waitFor(() => expect(queryByText(checkboxLabel)).not.toBeVisible());
+    expect(queryByText(checkboxLabel)).not.toBeInTheDocument();
     expect(queryByDataCy("popconfirm-checkbox")).not.toBeInTheDocument();
   });
 

--- a/src/hooks/tests/useVersionStatusSelect.test.ts
+++ b/src/hooks/tests/useVersionStatusSelect.test.ts
@@ -1,6 +1,5 @@
 import { renderHook, act } from "@testing-library/react-hooks";
 import { useVersionTaskStatusSelect } from "hooks";
-import { waitFor } from "test_utils";
 
 const allFalse = {
   evergreen_lint_generate_lint: false,
@@ -82,12 +81,10 @@ describe("useVersionStatusSelect", () => {
         mainVersion: ["success"],
       });
     });
-    waitFor(() =>
-      expect(result.current.selectedTasks).toStrictEqual({
-        ...allFalse,
-        evergreen_ubuntu1604_test_service: true,
-      })
-    );
+    expect(result.current.selectedTasks[versionId]).toStrictEqual({
+      ...allFalse,
+      evergreen_ubuntu1604_test_service: true,
+    });
   });
 
   it("tasks with undefined base statuses do not match with any base status filter state.", () => {
@@ -104,11 +101,9 @@ describe("useVersionStatusSelect", () => {
         mainVersion: ["success", "fakeStatus", "random"],
       });
     });
-    waitFor(() =>
-      expect(result.current.selectedTasks).toStrictEqual({
-        ...allFalse,
-      })
-    );
+    expect(result.current.selectedTasks[versionId]).toStrictEqual({
+      ...allFalse,
+    });
   });
 
   it("should deselect all tasks with statuses that do not match any patch status filter terms.", () => {
@@ -188,66 +183,72 @@ describe("useVersionStatusSelect", () => {
     });
   });
 
-  it("batch toggling tasks will set them all to checked when they are orignially unchecked", () => {
+  it("batch toggling tasks will set them all to checked when they are originally unchecked", () => {
     const { result } = renderHook(() =>
       useVersionTaskStatusSelect(groupedBuildVariants, versionId, childVersion)
     );
-    waitFor(() =>
-      expect(result.current.selectedTasks).toStrictEqual({ ...allFalse })
-    );
+    expect(result.current.selectedTasks[versionId]).toStrictEqual({
+      ...allFalse,
+    });
     act(() =>
       result.current.toggleSelectedTask({
         mainVersion: Object.keys(allFalse),
       })
     );
-    waitFor(() =>
-      expect(result.current.selectedTasks).toStrictEqual({ ...allTrue })
-    );
+    expect(result.current.selectedTasks[versionId]).toStrictEqual({
+      ...allTrue,
+    });
   });
 
   it("batch toggling tasks will set them all to checked when some and not all are originally checked.", () => {
     const { result } = renderHook(() =>
       useVersionTaskStatusSelect(groupedBuildVariants, versionId, childVersion)
     );
-    waitFor(() =>
-      expect(result.current.selectedTasks).toStrictEqual({ ...allFalse })
-    );
+    expect(result.current.selectedTasks[versionId]).toStrictEqual({
+      ...allFalse,
+    });
     act(() =>
       result.current.toggleSelectedTask({
         mainVersion: "evergreen_lint_generate_lint",
       })
     );
-    waitFor(() =>
-      expect(result.current.selectedTasks).toStrictEqual({
-        ...allFalse,
-        evergreen_lint_generate_lint: true,
-      })
-    );
+    expect(result.current.selectedTasks[versionId]).toStrictEqual({
+      ...allFalse,
+      evergreen_lint_generate_lint: true,
+    });
     act(() =>
       result.current.toggleSelectedTask({
         mainVersion: Object.keys(allFalse),
       })
     );
-    waitFor(() =>
-      expect(result.current.selectedTasks).toStrictEqual({ ...allTrue })
-    );
+    expect(result.current.selectedTasks[versionId]).toStrictEqual({
+      ...allTrue,
+    });
   });
 
   it("batch toggling tasks will set them all to unchecked when they are all originally checked.", () => {
     const { result } = renderHook(() =>
       useVersionTaskStatusSelect(groupedBuildVariants, versionId, childVersion)
     );
-    waitFor(() =>
-      expect(result.current.selectedTasks).toStrictEqual({ ...allTrue })
-    );
+    expect(result.current.selectedTasks[versionId]).toStrictEqual({
+      ...allFalse,
+    });
     act(() =>
       result.current.toggleSelectedTask({
-        mainVersion: Object.keys(allTrue),
+        mainVersion: Object.keys(allFalse),
       })
     );
-    waitFor(() =>
-      expect(result.current.selectedTasks).toStrictEqual({ ...allFalse })
+    expect(result.current.selectedTasks[versionId]).toStrictEqual({
+      ...allTrue,
+    });
+    act(() =>
+      result.current.toggleSelectedTask({
+        mainVersion: Object.keys(allFalse),
+      })
     );
+    expect(result.current.selectedTasks[versionId]).toStrictEqual({
+      ...allFalse,
+    });
   });
 });
 
@@ -328,9 +329,10 @@ const groupedBuildVariants = [
 ];
 
 const versionId = "mainVersion";
+const childVersionId = "childVersionId";
 const childVersion = [
   {
-    id: "childVersionId",
+    id: childVersionId,
     projectIdentifier: "childProjectIdentifier",
     buildVariants: groupedBuildVariants,
   },

--- a/src/pages/commits/InactiveCommits/InactiveCommits.test.tsx
+++ b/src/pages/commits/InactiveCommits/InactiveCommits.test.tsx
@@ -99,7 +99,7 @@ describe("inactiveCommitButton", () => {
 const time = new Date("2021-06-16T23:38:13Z");
 const versions = [
   {
-    id: "123",
+    id: "1",
     createTime: time,
     message: "SERVER-57332 Create skeleton InternalDocumentSourceDensify",
     order: 39365,
@@ -107,7 +107,7 @@ const versions = [
     revision: "4137c33fa4a0d5c747a1115f0853b5f70e46f112",
   },
   {
-    id: "123",
+    id: "2",
     createTime: time,
     message: "SERVER-57333 Some complicated server commit",
     order: 39366,
@@ -115,7 +115,7 @@ const versions = [
     revision: "4237c33fa4a0d5c747a1115f0853b5f70e46f113",
   },
   {
-    id: "123",
+    id: "3",
     createTime: time,
     message: "SERVER-57332 Create skeleton InternalDocumentSourceDensify",
     order: 39365,
@@ -123,7 +123,7 @@ const versions = [
     revision: "4337c33fa4a0d5c747a1115f0853b5f70e46f114",
   },
   {
-    id: "123",
+    id: "4",
     createTime: time,
     message: "SERVER-57333 Some complicated server commit",
     order: 39366,
@@ -131,7 +131,7 @@ const versions = [
     revision: "4437c33fa4a0d5c747a1115f0853b5f70e46f115",
   },
   {
-    id: "123",
+    id: "5",
     createTime: time,
     message: "SERVER-57332 Create skeleton InternalDocumentSourceDensify",
     order: 39365,
@@ -139,7 +139,7 @@ const versions = [
     revision: "4537c33fa4a0d5c747a1115f0853b5f70e46f116",
   },
   {
-    id: "123",
+    id: "6",
     createTime: time,
     message: "SERVER-57333 Some complicated server commit",
     order: 39366,

--- a/src/pages/projectSettings/tabs/GeneralTab/Fields/RepoConfigField.test.tsx
+++ b/src/pages/projectSettings/tabs/GeneralTab/Fields/RepoConfigField.test.tsx
@@ -154,7 +154,7 @@ describe("repoConfigField", () => {
     await waitFor(() =>
       expect(queryByDataCy("move-repo-button")).toBeInTheDocument()
     );
-    await fireEvent.click(queryByDataCy("move-repo-button"));
+    fireEvent.click(queryByDataCy("move-repo-button"));
     await waitFor(() => expect(queryByDataCy("move-repo-modal")).toBeVisible());
   });
 

--- a/src/pages/task/taskTabs/buildBaronAndAnnotations/BBComponents.tsx
+++ b/src/pages/task/taskTabs/buildBaronAndAnnotations/BBComponents.tsx
@@ -112,7 +112,7 @@ export const AnnotationTicketRow: React.VFC<AnnotationTicketRowProps> = ({
       </JiraSummaryLink>
       {loading ? (
         <LoadingWrapper>
-          <Skeleton active title={false} data-cy="loading-annotation-ticket" />
+          <Skeleton active title={false} />
         </LoadingWrapper>
       ) : (
         <>

--- a/src/pages/task/taskTabs/buildBaronAndAnnotations/BuildBaron.test.tsx
+++ b/src/pages/task/taskTabs/buildBaronAndAnnotations/BuildBaron.test.tsx
@@ -59,8 +59,8 @@ describe("buildBaron", () => {
     expect(queryByDataCy("bb-error")).toBeNull();
   });
 
-  it("clicking on file a new ticket dispatches a banner.", async () => {
-    const { Component } = RenderFakeToastContext(
+  it("clicking on file a new ticket dispatches a toast", async () => {
+    const { Component, dispatchToast } = RenderFakeToastContext(
       <MockedProvider mocks={buildBaronMocks} addTypename={false}>
         <BuildBaron
           annotation={null}
@@ -78,14 +78,14 @@ describe("buildBaron", () => {
       path: "/task/:id",
     });
     fireEvent.click(queryByDataCy("file-ticket-button"));
-    await expect(getByText("File Ticket")).toBeInTheDocument();
-    await fireEvent.click(getByText("File Ticket"));
+    expect(getByText("File Ticket")).toBeInTheDocument();
+    fireEvent.click(getByText("File Ticket"));
 
-    waitFor(() =>
-      expect(
-        getByText("Ticket successfully created for this task")
-      ).toBeInTheDocument()
-    );
+    await waitFor(() => {
+      expect(dispatchToast.success).toHaveBeenCalledWith(
+        "Ticket successfully created for this task."
+      );
+    });
   });
 
   it("the correct JiraTicket rows are rendered in the component", () => {
@@ -131,7 +131,7 @@ describe("buildBaron", () => {
 });
 
 describe("annotationTicketsTable", () => {
-  it("should display the link and jiraIssue key while waiting for data to fetch.", async () => {
+  it("should still display the JIRA issue link and key while waiting for data to load", () => {
     const { Component } = RenderFakeToastContext(
       <MockedProvider mocks={ticketsTableMocks} addTypename={false}>
         <AnnotationTicketsTable
@@ -151,15 +151,15 @@ describe("annotationTicketsTable", () => {
         />
       </MockedProvider>
     );
-    const { getByText, queryByDataCy } = render(() => <Component />, {
+    const { getByText } = render(() => <Component />, {
       route: `/task/${taskId}`,
       path: "/task/:id",
     });
-
-    waitFor(() =>
-      expect(queryByDataCy("loading-annotation-ticket")).toBeInTheDocument()
-    );
     expect(getByText("EVG-1234567")).toBeInTheDocument();
+    expect(getByText("EVG-1234567")).toHaveAttribute(
+      "href",
+      "https://fake-url/EVG-1234567"
+    );
   });
 });
 


### PR DESCRIPTION
[EVG-15580](https://jira.mongodb.org/browse/EVG-15580)

### Description 
This PR improves our unit tests by making sure to always use `await` when we use `waitFor`.

I removed `waitFor` from places that didn't actually need it.

### Screenshots
- No visible changes

### Testing 
- This entire PR! 😎
