### PR TITLE
EVG-16849: Strip new lines for ssh keys only if they are defined

### DIFF
--- a/src/pages/spawn/spawnHost/EditSpawnHostModal.tsx
+++ b/src/pages/spawn/spawnHost/EditSpawnHostModal.tsx
@@ -331,7 +331,7 @@ const computeDiff = (defaultEditSpawnHostState, editSpawnHostState) => {
     const keyToSubmit = mutationParams.publicKey;
     mutationParams.publicKey = omitTypename({
       name: keyToSubmit?.name || "",
-      key: stripNewLines(keyToSubmit?.key) || "",
+      key: stripNewLines(keyToSubmit?.key || ""),
     });
   }
   // diff returns an object to compare the differences in positions of an array. So we take this object

--- a/src/pages/spawn/spawnHost/EditSpawnHostModal.tsx
+++ b/src/pages/spawn/spawnHost/EditSpawnHostModal.tsx
@@ -331,7 +331,7 @@ const computeDiff = (defaultEditSpawnHostState, editSpawnHostState) => {
     const keyToSubmit = mutationParams.publicKey;
     mutationParams.publicKey = omitTypename({
       name: keyToSubmit?.name || "",
-      key: stripNewLines(keyToSubmit.key),
+      key: stripNewLines(keyToSubmit?.key) || "",
     });
   }
   // diff returns an object to compare the differences in positions of an array. So we take this object

--- a/src/utils/string/index.ts
+++ b/src/utils/string/index.ts
@@ -227,4 +227,4 @@ export const joinWithConjunction = (array: string[], conjunction: string) => {
  * @param {string} str - string to remove new lines from
  * @return {string} string with new lines removed
  */
-export const stripNewLines = (str: string) => str?.replace(/\n/g, "");
+export const stripNewLines = (str: string) => str.replace(/\n/g, "");

--- a/src/utils/string/index.ts
+++ b/src/utils/string/index.ts
@@ -227,4 +227,4 @@ export const joinWithConjunction = (array: string[], conjunction: string) => {
  * @param {string} str - string to remove new lines from
  * @return {string} string with new lines removed
  */
-export const stripNewLines = (str: string) => str.replace(/\n/g, "");
+export const stripNewLines = (str: string) => str?.replace(/\n/g, "");


### PR DESCRIPTION
[EVG-16849](https://jira.mongodb.org/browse/EVG-16849)

### Description 
This PR resolves an issue where SSH keys that are `undefined` throw an error when being passed to the `stripNewLines` function.
