### PR TITLE
EVG-16449 Add link to github commits

### DIFF
--- a/src/analytics/version/useVersionAnalytics.ts
+++ b/src/analytics/version/useVersionAnalytics.ts
@@ -47,6 +47,7 @@ type Action =
   | { name: "Toggle Display Task Dropdown"; expanded: boolean }
   | { name: "Click Base Commit Link" }
   | { name: "Click Previous Version Link" }
+  | { name: "Click Github Commit Link" }
   | { name: "Open Schedule Tasks Modal" };
 
 interface V extends Properties {

--- a/src/constants/externalResources.ts
+++ b/src/constants/externalResources.ts
@@ -33,6 +33,12 @@ export const getGithubPullRequestUrl = (
   issue: number | string
 ) => `https://github.com/${owner}/${repo}/pull/${issue}`;
 
+export const getGithubCommitUrl = (
+  owner: string,
+  repo: string,
+  githash: string
+) => `https://github.com/${owner}/${repo}/commit/${githash}`;
+
 export const getLobsterTaskLink = (
   logType: LogTypes,
   taskId: string,

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -517,6 +517,7 @@ export type Version = {
   repo: Scalars["String"];
   project: Scalars["String"];
   projectIdentifier: Scalars["String"];
+  projectMetadata?: Maybe<Project>;
   branch: Scalars["String"];
   requester: Scalars["String"];
   activated?: Maybe<Scalars["Boolean"]>;
@@ -4277,6 +4278,7 @@ export type VersionQuery = {
       modules?: Maybe<any>;
     }>;
     previousVersion?: Maybe<{ id: string; revision: string }>;
+    projectMetadata?: Maybe<{ repo: string; owner: string }>;
     patch?: Maybe<{
       id: string;
       patchNumber: number;

--- a/src/gql/queries/get-version.graphql
+++ b/src/gql/queries/get-version.graphql
@@ -42,6 +42,10 @@ query Version($id: String!) {
       id
       revision
     }
+    projectMetadata {
+      repo
+      owner
+    }
     patch {
       id
       patchNumber

--- a/src/pages/task/metadata/__snapshots__/Metadata.stories.storyshot
+++ b/src/pages/task/metadata/__snapshots__/Metadata.stories.storyshot
@@ -74,7 +74,7 @@ exports[`storybook Storyshots Metadata Base 1`] = `
         href="/task/spruce_ubuntu1604_e2e_test_e0ece5ad52ad01630bdf29f55b9382a26d6256b3_20_08_26_19_20_41"
         onClick={[Function]}
       >
-        e0ece5ad52
+        e0ece5a
       </a>
     </p>
     <p
@@ -202,7 +202,7 @@ exports[`storybook Storyshots Metadata With Abort Message 1`] = `
         href="/task/spruce_ubuntu1604_e2e_test_e0ece5ad52ad01630bdf29f55b9382a26d6256b3_20_08_26_19_20_41"
         onClick={[Function]}
       >
-        e0ece5ad52
+        e0ece5a
       </a>
     </p>
     <p
@@ -330,7 +330,7 @@ exports[`storybook Storyshots Metadata With Dependencies 1`] = `
         href="/task/spruce_ubuntu1604_e2e_test_e0ece5ad52ad01630bdf29f55b9382a26d6256b3_20_08_26_19_20_41"
         onClick={[Function]}
       >
-        e0ece5ad52
+        e0ece5a
       </a>
     </p>
     <p

--- a/src/pages/task/metadata/__snapshots__/Metadata.stories.storyshot
+++ b/src/pages/task/metadata/__snapshots__/Metadata.stories.storyshot
@@ -68,14 +68,18 @@ exports[`storybook Storyshots Metadata Base 1`] = `
     >
       Base commit:
        
-      <a
-        className="css-1bct88o-StyledRouterLink-linkStyles es7lfqt0"
-        data-cy="base-task-link"
-        href="/task/spruce_ubuntu1604_e2e_test_e0ece5ad52ad01630bdf29f55b9382a26d6256b3_20_08_26_19_20_41"
-        onClick={[Function]}
+      <code
+        className="leafygreen-ui-1tty64i"
       >
-        e0ece5a
-      </a>
+        <a
+          className="css-1bct88o-StyledRouterLink-linkStyles es7lfqt0"
+          data-cy="base-task-link"
+          href="/task/spruce_ubuntu1604_e2e_test_e0ece5ad52ad01630bdf29f55b9382a26d6256b3_20_08_26_19_20_41"
+          onClick={[Function]}
+        >
+          e0ece5a
+        </a>
+      </code>
     </p>
     <p
       className="css-1ui13f0-P2-wordBreakCss eplk6ht0"
@@ -196,14 +200,18 @@ exports[`storybook Storyshots Metadata With Abort Message 1`] = `
     >
       Base commit:
        
-      <a
-        className="css-1bct88o-StyledRouterLink-linkStyles es7lfqt0"
-        data-cy="base-task-link"
-        href="/task/spruce_ubuntu1604_e2e_test_e0ece5ad52ad01630bdf29f55b9382a26d6256b3_20_08_26_19_20_41"
-        onClick={[Function]}
+      <code
+        className="leafygreen-ui-1tty64i"
       >
-        e0ece5a
-      </a>
+        <a
+          className="css-1bct88o-StyledRouterLink-linkStyles es7lfqt0"
+          data-cy="base-task-link"
+          href="/task/spruce_ubuntu1604_e2e_test_e0ece5ad52ad01630bdf29f55b9382a26d6256b3_20_08_26_19_20_41"
+          onClick={[Function]}
+        >
+          e0ece5a
+        </a>
+      </code>
     </p>
     <p
       className="css-1ui13f0-P2-wordBreakCss eplk6ht0"
@@ -324,14 +332,18 @@ exports[`storybook Storyshots Metadata With Dependencies 1`] = `
     >
       Base commit:
        
-      <a
-        className="css-1bct88o-StyledRouterLink-linkStyles es7lfqt0"
-        data-cy="base-task-link"
-        href="/task/spruce_ubuntu1604_e2e_test_e0ece5ad52ad01630bdf29f55b9382a26d6256b3_20_08_26_19_20_41"
-        onClick={[Function]}
+      <code
+        className="leafygreen-ui-1tty64i"
       >
-        e0ece5a
-      </a>
+        <a
+          className="css-1bct88o-StyledRouterLink-linkStyles es7lfqt0"
+          data-cy="base-task-link"
+          href="/task/spruce_ubuntu1604_e2e_test_e0ece5ad52ad01630bdf29f55b9382a26d6256b3_20_08_26_19_20_41"
+          onClick={[Function]}
+        >
+          e0ece5a
+        </a>
+      </code>
     </p>
     <p
       className="css-1ui13f0-P2-wordBreakCss eplk6ht0"

--- a/src/pages/task/metadata/index.tsx
+++ b/src/pages/task/metadata/index.tsx
@@ -22,7 +22,7 @@ import { AbortMessage } from "./AbortMessage";
 import { DependsOn } from "./DependsOn";
 import { ETATimer } from "./ETATimer";
 
-const { msToDuration, getDateCopy } = string;
+const { msToDuration, getDateCopy, shortenGithash } = string;
 const { getUiUrl } = environmentalVariables;
 const { red } = uiColors;
 
@@ -68,7 +68,7 @@ export const Metadata: React.VFC<Props> = ({
     baseTask,
   } = task || {};
 
-  const baseCommit = revision?.slice(0, 10);
+  const baseCommit = shortenGithash(revision);
   const { id: baseTaskId, timeTaken: baseTaskDuration } = baseTask ?? {};
   const projectIdentifier = project?.identifier;
   const { author, id: versionID } = versionMetadata ?? {};

--- a/src/pages/task/metadata/index.tsx
+++ b/src/pages/task/metadata/index.tsx
@@ -1,7 +1,7 @@
-import React from "react";
 import { ApolloError } from "@apollo/client";
 import styled from "@emotion/styled";
 import { uiColors } from "@leafygreen-ui/palette";
+import { InlineCode } from "@leafygreen-ui/typography";
 import { useTaskAnalytics } from "analytics";
 import { MetadataCard } from "components/MetadataCard";
 import { StyledLink, Divider, StyledRouterLink } from "components/styles";
@@ -161,15 +161,17 @@ export const Metadata: React.VFC<Props> = ({
         {baseTaskId && (
           <P2>
             Base commit:{" "}
-            <StyledRouterLink
-              data-cy="base-task-link"
-              to={getTaskRoute(baseTaskId)}
-              onClick={() =>
-                taskAnalytics.sendEvent({ name: "Click Base Commit" })
-              }
-            >
-              {baseCommit}
-            </StyledRouterLink>
+            <InlineCode>
+              <StyledRouterLink
+                data-cy="base-task-link"
+                to={getTaskRoute(baseTaskId)}
+                onClick={() =>
+                  taskAnalytics.sendEvent({ name: "Click Base Commit" })
+                }
+              >
+                {baseCommit}
+              </StyledRouterLink>
+            </InlineCode>
           </P2>
         )}
         {details?.status === TaskStatus.Failed && (

--- a/src/pages/version/Metadata.tsx
+++ b/src/pages/version/Metadata.tsx
@@ -96,7 +96,7 @@ export const Metadata: React.VFC<Props> = ({ loading, version }) => {
       )}
       {!isPatch && (
         <P2>
-          Github Commit:
+          Github Commit:{" "}
           <StyledLink
             data-cy="version-github-commit"
             href={getGithubCommitUrl(owner, repo, revision)}

--- a/src/pages/version/Metadata.tsx
+++ b/src/pages/version/Metadata.tsx
@@ -15,7 +15,7 @@ import { string } from "utils";
 import ManifestBlob from "./ManifestBlob";
 import { ParametersModal } from "./ParametersModal";
 
-const { msToDuration, getDateCopy } = string;
+const { msToDuration, getDateCopy, shortenGithash } = string;
 
 interface Props {
   loading: boolean;
@@ -79,7 +79,7 @@ export const Metadata: React.VFC<Props> = ({ loading, version }) => {
             to={getVersionRoute(baseVersion?.id)}
             onClick={() => sendEvent({ name: "Click Base Commit Link" })}
           >
-            {revision.slice(0, 10)}
+            {shortenGithash(revision)}
           </StyledRouterLink>
         </P2>
       ) : (
@@ -90,7 +90,7 @@ export const Metadata: React.VFC<Props> = ({ loading, version }) => {
             to={getVersionRoute(previousVersion?.id)}
             onClick={() => sendEvent({ name: "Click Previous Version Link" })}
           >
-            {previousVersion?.revision.slice(0, 10)}
+            {shortenGithash(previousVersion?.revision)}
           </StyledRouterLink>
         </P2>
       )}
@@ -102,7 +102,7 @@ export const Metadata: React.VFC<Props> = ({ loading, version }) => {
             href={getGithubCommitUrl(owner, repo, revision)}
             onClick={() => sendEvent({ name: "Click Github Commit Link" })}
           >
-            {revision.slice(0, 10)}
+            {shortenGithash(revision)}
           </StyledLink>
         </P2>
       )}

--- a/src/pages/version/Metadata.tsx
+++ b/src/pages/version/Metadata.tsx
@@ -1,7 +1,8 @@
 import { useVersionAnalytics } from "analytics";
 import { MetadataCard } from "components/MetadataCard";
-import { StyledRouterLink } from "components/styles";
+import { StyledLink, StyledRouterLink } from "components/styles";
 import { P2 } from "components/Typography";
+import { getGithubCommitUrl } from "constants/externalResources";
 import {
   getCommitQueueRoute,
   getProjectPatchesRoute,
@@ -39,6 +40,7 @@ export const Metadata: React.VFC<Props> = ({ loading, version }) => {
     id,
     previousVersion,
     upstreamProject,
+    projectMetadata,
   } = version || {};
   const { sendEvent } = useVersionAnalytics(id);
   const { commitQueuePosition } = patch || {};
@@ -49,6 +51,8 @@ export const Metadata: React.VFC<Props> = ({ loading, version }) => {
     task: upstreamTask,
     version: upstreamVersion,
   } = upstreamProject || {};
+
+  const { repo, owner } = projectMetadata || {};
   return (
     <MetadataCard
       loading={loading}
@@ -88,6 +92,18 @@ export const Metadata: React.VFC<Props> = ({ loading, version }) => {
           >
             {previousVersion?.revision.slice(0, 10)}
           </StyledRouterLink>
+        </P2>
+      )}
+      {!isPatch && (
+        <P2>
+          Github Commit:
+          <StyledLink
+            data-cy="version-github-commit"
+            href={getGithubCommitUrl(owner, repo, revision)}
+            onClick={() => sendEvent({ name: "Click Github Commit Link" })}
+          >
+            {revision.slice(0, 10)}
+          </StyledLink>
         </P2>
       )}
       {isPatch && commitQueuePosition !== null && (

--- a/src/pages/version/Metadata.tsx
+++ b/src/pages/version/Metadata.tsx
@@ -1,3 +1,4 @@
+import { InlineCode } from "@leafygreen-ui/typography";
 import { useVersionAnalytics } from "analytics";
 import { MetadataCard } from "components/MetadataCard";
 import { StyledLink, StyledRouterLink } from "components/styles";
@@ -74,36 +75,42 @@ export const Metadata: React.VFC<Props> = ({ loading, version }) => {
       {isPatch ? (
         <P2>
           Base commit:{" "}
-          <StyledRouterLink
-            data-cy="patch-base-commit"
-            to={getVersionRoute(baseVersion?.id)}
-            onClick={() => sendEvent({ name: "Click Base Commit Link" })}
-          >
-            {shortenGithash(revision)}
-          </StyledRouterLink>
+          <InlineCode>
+            <StyledRouterLink
+              data-cy="patch-base-commit"
+              to={getVersionRoute(baseVersion?.id)}
+              onClick={() => sendEvent({ name: "Click Base Commit Link" })}
+            >
+              {shortenGithash(revision)}
+            </StyledRouterLink>
+          </InlineCode>
         </P2>
       ) : (
         <P2>
           Previous commit:{" "}
-          <StyledRouterLink
-            data-cy="version-previous-commit"
-            to={getVersionRoute(previousVersion?.id)}
-            onClick={() => sendEvent({ name: "Click Previous Version Link" })}
-          >
-            {shortenGithash(previousVersion?.revision)}
-          </StyledRouterLink>
+          <InlineCode>
+            <StyledRouterLink
+              data-cy="version-previous-commit"
+              to={getVersionRoute(previousVersion?.id)}
+              onClick={() => sendEvent({ name: "Click Previous Version Link" })}
+            >
+              {shortenGithash(previousVersion?.revision)}
+            </StyledRouterLink>
+          </InlineCode>
         </P2>
       )}
       {!isPatch && (
         <P2>
           Github Commit:{" "}
-          <StyledLink
-            data-cy="version-github-commit"
-            href={getGithubCommitUrl(owner, repo, revision)}
-            onClick={() => sendEvent({ name: "Click Github Commit Link" })}
-          >
-            {shortenGithash(revision)}
-          </StyledLink>
+          <InlineCode>
+            <StyledLink
+              data-cy="version-github-commit"
+              href={getGithubCommitUrl(owner, repo, revision)}
+              onClick={() => sendEvent({ name: "Click Github Commit Link" })}
+            >
+              {shortenGithash(revision)}
+            </StyledLink>
+          </InlineCode>
         </P2>
       )}
       {isPatch && commitQueuePosition !== null && (


### PR DESCRIPTION
[EVG-16449](https://jira.mongodb.org/browse/EVG-16449)

### Description 
Link to github commit from version metadata.
use `shortenGithash` function to trim githashes for consistency.
### Screenshots
![image](https://user-images.githubusercontent.com/4605522/167921302-5c0fc605-f62c-4d0a-922d-43ed3ddad89d.png)


### Evergreen PR 
https://github.com/evergreen-ci/evergreen/pull/5653