### PR TITLE
EVG-16935: Make project settings visible on staging

### DIFF
--- a/cypress/integration/projectSettings/project_settings.ts
+++ b/cypress/integration/projectSettings/project_settings.ts
@@ -2,6 +2,8 @@ const getSettingsRoute = (identifier: string) =>
   `project/${identifier}/settings`;
 const getGeneralRoute = (identifier: string) =>
   `${getSettingsRoute(identifier)}/general`;
+const getGithubCommitQueueRoute = (identifier: string) =>
+  `${getSettingsRoute(identifier)}/github-commitqueue`;
 
 const project = "spruce";
 const projectUseRepoEnabled = "evergreen";
@@ -871,5 +873,23 @@ describe("Duplicating a project with errors", () => {
 
   it("Redirects to a new URL", () => {
     cy.url().should("include", "copied-project");
+  });
+});
+
+describe("A project that has GitHub webhooks disabled", () => {
+  const destination = getGithubCommitQueueRoute("logkeeper");
+
+  before(() => {
+    cy.login();
+    cy.visit(destination);
+  });
+
+  beforeEach(() => {
+    cy.preserveCookies();
+  });
+
+  it("Disables all interactive elements on the page", () => {
+    cy.get("button").should("be.disabled");
+    cy.get("input").should("be.disabled");
   });
 });

--- a/src/pages/ProjectSettings.tsx
+++ b/src/pages/ProjectSettings.tsx
@@ -30,10 +30,12 @@ import { getTabTitle } from "./projectSettings/getTabTitle";
 import { ProjectSettingsTabs } from "./projectSettings/Tabs";
 import { ProjectType } from "./projectSettings/tabs/utils";
 
-const { isProduction } = environmentalVariables;
+const { isBeta, isDevelopment, isStaging } = environmentalVariables;
 const { validateObjectId } = validators;
 
-const disablePage = isProduction();
+// Project Settings should only be disabled when deployed to spruce.mongodb.com
+// Enable when running local dev server, or when deployed to beta or staging
+const disablePage = !(isDevelopment() || isBeta() || isStaging());
 
 export const ProjectSettings: React.VFC = () => {
   usePageTitle(`Project Settings`);

--- a/src/pages/projectSettings/tabs/GithubCommitQueueTab/GithubCommitQueueTab.tsx
+++ b/src/pages/projectSettings/tabs/GithubCommitQueueTab/GithubCommitQueueTab.tsx
@@ -13,14 +13,11 @@ import {
   usePopulateForm,
   useProjectSettingsContext,
 } from "pages/projectSettings/Context";
-import { environmentalVariables } from "utils";
 import { ProjectType } from "../utils";
 import { ErrorType, getVersionControlError } from "./getErrors";
 import { getFormSchema } from "./getFormSchema";
 import { mergeProjectRepo } from "./transformers";
 import { FormState, TabProps } from "./types";
-
-const { isProduction } = environmentalVariables;
 
 const tab = ProjectSettingsTabRoutes.GithubCommitQueue;
 
@@ -106,7 +103,7 @@ export const GithubCommitQueueTab: React.VFC<TabProps> = ({
         onChange={onChange}
         schema={schema}
         uiSchema={uiSchema}
-        disabled={isProduction() && !githubWebhooksEnabled} // TODO: Remove once EVG-16608 is fixed
+        disabled={!githubWebhooksEnabled}
         validate={validateConflicts}
       />
     </>

--- a/src/utils/environmentalVariables.ts
+++ b/src/utils/environmentalVariables.ts
@@ -24,6 +24,9 @@ export const isProduction = (): boolean =>
 export const isBeta = (): boolean =>
   process.env.REACT_APP_BETA === "true" || isDevelopment();
 
+export const isStaging = (): boolean =>
+  process.env.REACT_APP_RELEASE_STAGE === "staging";
+
 export const isTest: () => boolean = () => process.env.NODE_ENV === "test";
 
 export const getGQLUrl: () => string = () =>


### PR DESCRIPTION
EVG-16935

### Description 
- Use `REACT_APP_RELEASE_STAGE` environment variable to determine if a deployment is in the staging environment
- Show project settings in every environment except on production deployment
- Bonus: remove workaround that prevented GitHub/Commit Queue page from being disabled (EVG-16958). Because the test data was updated in https://github.com/evergreen-ci/evergreen/pull/5680, this is no longer necessary for tests to run successfully.

### Testing
- View project settings at https://spruce-staging.corp.mongodb.com/project/evg/settings/general
- View the same project locally via `yarn staging` at http://localhost:3000/project/evg/settings