### PR TITLE
EVG-14353: Use activated time as "Submitted At" in Task Metadata

### DIFF
--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -4018,6 +4018,7 @@ export type GetTaskQuery = {
       aborted: boolean;
       activatedBy?: Maybe<string>;
       ingestTime?: Maybe<Date>;
+      activatedTime?: Maybe<Date>;
       estimatedStart?: Maybe<number>;
       finishTime?: Maybe<Date>;
       hostId?: Maybe<string>;

--- a/src/gql/queries/get-task.graphql
+++ b/src/gql/queries/get-task.graphql
@@ -38,6 +38,7 @@ query GetTask($taskId: String!, $execution: Int) {
       displayName
     }
     ingestTime
+    activatedTime
     estimatedStart
     finishTime
     hostId

--- a/src/pages/task/metadata/index.tsx
+++ b/src/pages/task/metadata/index.tsx
@@ -45,6 +45,7 @@ export const Metadata: React.VFC<Props> = ({
     status,
     spawnHostLink,
     ingestTime,
+    activatedTime,
     finishTime,
     hostId,
     startTime,
@@ -69,6 +70,7 @@ export const Metadata: React.VFC<Props> = ({
   } = task || {};
 
   const baseCommit = shortenGithash(revision);
+  const submittedTime = activatedTime || ingestTime;
   const { id: baseTaskId, timeTaken: baseTaskDuration } = baseTask ?? {};
   const projectIdentifier = project?.identifier;
   const { author, id: versionID } = versionMetadata ?? {};
@@ -108,9 +110,9 @@ export const Metadata: React.VFC<Props> = ({
         </P2>
         <P2>Submitted by: {author}</P2>
 
-        {ingestTime && (
+        {submittedTime && (
           <P2 data-cy="task-metadata-submitted-at">
-            Submitted at: {getDateCopy(ingestTime, { tz })}
+            Submitted at: {getDateCopy(submittedTime, { tz })}
           </P2>
         )}
         {generatedBy && (

--- a/src/pages/task/metadata/index.tsx
+++ b/src/pages/task/metadata/index.tsx
@@ -70,7 +70,7 @@ export const Metadata: React.VFC<Props> = ({
   } = task || {};
 
   const baseCommit = shortenGithash(revision);
-  const submittedTime = activatedTime || ingestTime;
+  const submittedTime = activatedTime ?? ingestTime;
   const { id: baseTaskId, timeTaken: baseTaskDuration } = baseTask ?? {};
   const projectIdentifier = project?.identifier;
   const { author, id: versionID } = versionMetadata ?? {};


### PR DESCRIPTION
[EVG-14353](https://jira.mongodb.org/browse/EVG-14353)

### Description 
Currently the "Submitted At" timestamp in the task metadata is always the same time, no matter what task execution you click on. (See example [here](https://spruce.mongodb.com/task/spruce_ubuntu1604_e2e_test_patch_f405163513f97f35fa83e9dce5b842ca6510d274_627b2984a4cf473d7821f66d_22_05_11_03_12_05/tests?execution=1&sortBy=STATUS&sortDir=ASC).)

This leads to some confusion among users, because they don't understand where the timestamps in the Execution Dropdown come from. This PR makes it so that the "Submitted At" timestamp always matches with the timestamp of the current selected execution.

### Screenshots
(I'm looking at Execution 2 for this task. The "Submitted At" timestamp matches the timestamp for Execution 2 in the dropdown.)

<img width="307" alt="Screen Shot 2022-05-25 at 9 28 08 AM" src="https://user-images.githubusercontent.com/47064971/170274334-58a5e196-f670-46af-92db-f075db4cd142.png">

### Testing 
- Manually
