### PR TITLE
EVG-16445: Handle different casing for test result statuses

### DIFF
--- a/src/pages/task/taskTabs/testsTable/TestStatusBadge.tsx
+++ b/src/pages/task/taskTabs/testsTable/TestStatusBadge.tsx
@@ -8,7 +8,10 @@ interface TestStatusBadgeProps {
 export const TestStatusBadge: React.VFC<TestStatusBadgeProps> = ({
   status,
 }) => (
-  <Badge variant={statusToBadgeColor[status] || Variant.LightGray} key={status}>
-    {statusCopy[status] || status}
+  <Badge
+    variant={statusToBadgeColor[status.toLowerCase()] || Variant.LightGray}
+    key={status}
+  >
+    {statusCopy[status.toLowerCase()] || status}
   </Badge>
 );


### PR DESCRIPTION
[EVG-16445](https://jira.mongodb.org/browse/EVG-16445)

### Description 
From this [task](https://spruce-beta.corp.mongodb.com/task/mongo_python_driver_4.0_tests_python_version_amazon1_test_ssl__platform~awslinux_auth_ssl~auth_ssl_python_version~3.7_coverage~coverage_test_5.0_replica_set_cbae04f13c896ef112339ed601ca149715cd4f38_22_02_17_01_13_50/tests?execution=0&sortBy=STATUS&sortDir=ASC) you can see that if a test result has different casing (in this case `PASS` is in all caps), the test result status badge is shown incorrectly. This PR makes it so that casing is ignored when rendering the test result status badges.

Note: The test result status can be any arbitrary value, so there is no guarantee that the reported status will match one of our badge variants. However, we can at least make it so that casing doesn't matter.

### Screenshots

<img width="1389" alt="Screen Shot 2022-05-25 at 9 43 45 AM" src="https://user-images.githubusercontent.com/47064971/170277944-53f0ae22-c64b-410f-b96b-23f7700109ed.png">


### Testing 
- Manually

