### PR TITLE
EVG-16935: Show disabled projects at bottom of project selector

### DIFF
--- a/cypress/integration/projectSettings/project_settings.ts
+++ b/cypress/integration/projectSettings/project_settings.ts
@@ -2,6 +2,8 @@ const getSettingsRoute = (identifier: string) =>
   `project/${identifier}/settings`;
 const getGeneralRoute = (identifier: string) =>
   `${getSettingsRoute(identifier)}/general`;
+const getGithubCommitQueueRoute = (identifier: string) =>
+  `${getSettingsRoute(identifier)}/github-commitqueue`;
 
 const project = "spruce";
 const projectUseRepoEnabled = "evergreen";
@@ -871,5 +873,23 @@ describe("Duplicating a project with errors", () => {
 
   it("Redirects to a new URL", () => {
     cy.url().should("include", "copied-project");
+  });
+});
+
+describe("A project that has GitHub webhooks disabled", () => {
+  const destination = getGithubCommitQueueRoute("logkeeper");
+
+  before(() => {
+    cy.login();
+    cy.visit(destination);
+  });
+
+  beforeEach(() => {
+    cy.preserveCookies();
+  });
+
+  it("Disables all interactive elements on the page", () => {
+    cy.get("button").should("be.disabled");
+    cy.get("input").should("be.disabled");
   });
 });

--- a/src/components/projectSelect/ProjectOptionGroup.tsx
+++ b/src/components/projectSelect/ProjectOptionGroup.tsx
@@ -54,7 +54,7 @@ export const ProjectOptionGroup: React.VFC<OptionGroupProps> = ({
         {name}
       </Overline>
     ) : (
-      <Overline>{name} </Overline>
+      <Overline>{name}</Overline>
     )}
 
     <ListContainer>

--- a/src/components/projectSelect/ProjectSelect.stories.tsx
+++ b/src/components/projectSelect/ProjectSelect.stories.tsx
@@ -69,7 +69,7 @@ const getProjectsMock = {
     data: {
       projects: [
         {
-          name: "evergreen-ci/evergreen",
+          groupDisplayName: "evergreen-ci/evergreen",
           projects: [
             {
               id: "evergreen",
@@ -82,7 +82,7 @@ const getProjectsMock = {
           ],
         },
         {
-          name: "logkeeper/logkeeper",
+          groupDisplayName: "logkeeper/logkeeper",
           projects: [
             {
               id: "logkeeper",
@@ -95,7 +95,7 @@ const getProjectsMock = {
           ],
         },
         {
-          name: "mongodb/mongo",
+          groupDisplayName: "mongodb/mongo",
           projects: [
             {
               id: "sys-perf",
@@ -116,7 +116,7 @@ const getProjectsMock = {
           ],
         },
         {
-          name: "mongodb/mongodb",
+          groupDisplayName: "mongodb/mongodb",
           projects: [
             {
               id: "mongodb-mongo-master",
@@ -129,7 +129,7 @@ const getProjectsMock = {
           ],
         },
         {
-          name: "mongodb/mongodb-test",
+          groupDisplayName: "mongodb/mongodb-test",
           projects: [
             {
               id: "mongodb-mongo-test",
@@ -154,7 +154,7 @@ const viewableProjectsMock = {
     data: {
       viewableProjectRefs: [
         {
-          name: "evergreen-ci/evergreen",
+          groupDisplayName: "evergreen-ci/evergreen",
           projects: [
             {
               id: "evergreen",
@@ -168,7 +168,7 @@ const viewableProjectsMock = {
           ],
         },
         {
-          name: "mongodb/mongodb-test",
+          groupDisplayName: "mongodb/mongodb-test",
           projects: [
             {
               id: "mongodb-mongo-test",

--- a/src/components/projectSelect/ProjectSelect.test.tsx
+++ b/src/components/projectSelect/ProjectSelect.test.tsx
@@ -78,7 +78,7 @@ const mocks = [
       data: {
         projects: [
           {
-            name: "evergreen-ci/evergreen",
+            groupDisplayName: "evergreen-ci/evergreen",
             projects: [
               {
                 id: "evergreen",
@@ -91,7 +91,7 @@ const mocks = [
             ],
           },
           {
-            name: "logkeeper/logkeeper",
+            groupDisplayName: "logkeeper/logkeeper",
             projects: [
               {
                 id: "logkeeper",
@@ -104,7 +104,7 @@ const mocks = [
             ],
           },
           {
-            name: "mongodb/mongo",
+            groupDisplayName: "mongodb/mongo",
             projects: [
               {
                 id: "sys-perf",
@@ -125,7 +125,7 @@ const mocks = [
             ],
           },
           {
-            name: "mongodb/mongodb",
+            groupDisplayName: "mongodb/mongodb",
             projects: [
               {
                 id: "mongodb-mongo-master",
@@ -138,7 +138,7 @@ const mocks = [
             ],
           },
           {
-            name: "mongodb/mongodb-test",
+            groupDisplayName: "mongodb/mongodb-test",
             projects: [
               {
                 id: "mongodb-mongo-test",

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -3783,7 +3783,7 @@ export type GetProjectsQueryVariables = Exact<{ [key: string]: never }>;
 export type GetProjectsQuery = {
   projects: Array<
     Maybe<{
-      name: string;
+      groupDisplayName: string;
       projects: Array<{
         id: string;
         identifier: string;
@@ -3791,6 +3791,7 @@ export type GetProjectsQuery = {
         owner: string;
         displayName: string;
         isFavorite: boolean;
+        enabled?: Maybe<boolean>;
       }>;
     }>
   >;
@@ -4262,7 +4263,8 @@ export type GetViewableProjectRefsQueryVariables = Exact<{
 export type GetViewableProjectRefsQuery = {
   viewableProjectRefs: Array<
     Maybe<{
-      name: string;
+      groupDisplayName: string;
+      repo?: Maybe<{ id: string }>;
       projects: Array<{
         id: string;
         identifier: string;
@@ -4271,6 +4273,7 @@ export type GetViewableProjectRefsQuery = {
         owner: string;
         displayName: string;
         isFavorite: boolean;
+        enabled?: Maybe<boolean>;
       }>;
     }>
   >;

--- a/src/gql/queries/get-projects.graphql
+++ b/src/gql/queries/get-projects.graphql
@@ -1,14 +1,14 @@
 query GetProjects {
   projects {
-      name
-      projects {
-        id
-        identifier
-        repo
-        owner
-        displayName
-        isFavorite
-      }
+    groupDisplayName
+    projects {
+      id
+      identifier
+      repo
+      owner
+      displayName
+      isFavorite
+      enabled
+    }
   }
 }
-

--- a/src/gql/queries/get-viewable-projects.graphql
+++ b/src/gql/queries/get-viewable-projects.graphql
@@ -1,6 +1,9 @@
 query GetViewableProjectRefs {
   viewableProjectRefs {
-    name
+    groupDisplayName
+    repo {
+      id
+    }
     projects {
       id
       identifier
@@ -9,6 +12,7 @@ query GetViewableProjectRefs {
       owner
       displayName
       isFavorite
+      enabled
     }
   }
 }

--- a/src/pages/ProjectSettings.tsx
+++ b/src/pages/ProjectSettings.tsx
@@ -30,10 +30,12 @@ import { getTabTitle } from "./projectSettings/getTabTitle";
 import { ProjectSettingsTabs } from "./projectSettings/Tabs";
 import { ProjectType } from "./projectSettings/tabs/utils";
 
-const { isProduction } = environmentalVariables;
+const { isBeta, isDevelopment, isStaging } = environmentalVariables;
 const { validateObjectId } = validators;
 
-const disablePage = isProduction();
+// Project Settings should only be disabled when deployed to spruce.mongodb.com
+// Enable when running local dev server, or when deployed to beta or staging
+const disablePage = !(isDevelopment() || isBeta() || isStaging());
 
 export const ProjectSettings: React.VFC = () => {
   usePageTitle(`Project Settings`);

--- a/src/pages/projectSettings/tabs/GithubCommitQueueTab/GithubCommitQueueTab.tsx
+++ b/src/pages/projectSettings/tabs/GithubCommitQueueTab/GithubCommitQueueTab.tsx
@@ -13,14 +13,11 @@ import {
   usePopulateForm,
   useProjectSettingsContext,
 } from "pages/projectSettings/Context";
-import { environmentalVariables } from "utils";
 import { ProjectType } from "../utils";
 import { ErrorType, getVersionControlError } from "./getErrors";
 import { getFormSchema } from "./getFormSchema";
 import { mergeProjectRepo } from "./transformers";
 import { FormState, TabProps } from "./types";
-
-const { isProduction } = environmentalVariables;
 
 const tab = ProjectSettingsTabRoutes.GithubCommitQueue;
 
@@ -106,7 +103,7 @@ export const GithubCommitQueueTab: React.VFC<TabProps> = ({
         onChange={onChange}
         schema={schema}
         uiSchema={uiSchema}
-        disabled={isProduction() && !githubWebhooksEnabled} // TODO: Remove once EVG-16608 is fixed
+        disabled={!githubWebhooksEnabled}
         validate={validateConflicts}
       />
     </>

--- a/src/utils/environmentalVariables.ts
+++ b/src/utils/environmentalVariables.ts
@@ -24,6 +24,9 @@ export const isProduction = (): boolean =>
 export const isBeta = (): boolean =>
   process.env.REACT_APP_BETA === "true" || isDevelopment();
 
+export const isStaging = (): boolean =>
+  process.env.REACT_APP_RELEASE_STAGE === "staging";
+
 export const isTest: () => boolean = () => process.env.NODE_ENV === "test";
 
 export const getGQLUrl: () => string = () =>


### PR DESCRIPTION
EVG-16935

### Description
- Show disabled projects at bottom of project selector, both in project settings on on mainline commits
- Replace usage of [deprecated `name` field](https://github.com/evergreen-ci/evergreen/blob/1d229b273bb8f680e8fa06cd56053c825c74702b/graphql/schema.graphql#L1129) with `groupDisplayName`

### Screenshots
<img width="194" alt="image" src="https://user-images.githubusercontent.com/9298431/170137762-32ab665e-b015-4e79-95e0-d840181e400c.png">

### Testing 
- Recommend testing on staging, where there are many disabled projects