### PR TITLE
EVG-15798: Remove <PageTitle hasData />

### DIFF
--- a/src/components/PageTitle.tsx
+++ b/src/components/PageTitle.tsx
@@ -7,7 +7,6 @@ type Size = "large" | "medium";
 
 interface Props {
   loading: boolean;
-  hasData: boolean;
   title: string | JSX.Element | React.ReactNodeArray;
   badge: JSX.Element;
   buttons?: JSX.Element;
@@ -33,19 +32,18 @@ const TitleTypography: React.VFC<TitleTypographyProps> = ({
 
 export const PageTitle: React.VFC<Props> = ({
   loading,
-  hasData,
   title,
   badge,
   buttons,
   size = "medium",
 }) => (
   <>
-    {!hasData && loading && (
+    {loading && (
       <PageHeader size={size}>
         <Skeleton active paragraph={{ rows: 0 }} />
       </PageHeader>
     )}
-    {hasData && !loading && (
+    {!loading && (
       <PageHeader size={size}>
         <TitleWrapper size={size}>
           <TitleTypography size={size}>

--- a/src/components/TaskStatusBadge/index.tsx
+++ b/src/components/TaskStatusBadge/index.tsx
@@ -31,6 +31,10 @@ interface TaskStatusBadgeProps {
   status: string;
 }
 const TaskStatusBadge: React.VFC<TaskStatusBadgeProps> = ({ status }) => {
+  if (!status) {
+    return <></>;
+  }
+
   let displayStatus = getStatusBadgeCopy(status);
 
   if (taskStatusToCopy[status] === undefined) {

--- a/src/pages/CommitQueue.tsx
+++ b/src/pages/CommitQueue.tsx
@@ -48,7 +48,6 @@ export const CommitQueue: React.VFC = () => {
           </Badge>
         }
         loading={loading}
-        hasData
       />
       {commitQueue?.message && (
         <P1 data-cy="commit-queue-message">{commitQueue.message}</P1>

--- a/src/pages/Host.tsx
+++ b/src/pages/Host.tsx
@@ -90,7 +90,6 @@ export const Host: React.VFC = () => {
             title={`Host: ${hostId}`}
             badge={<HostStatusBadge status={status} />}
             loading={hostMetaDataLoading}
-            hasData
             size="large"
             buttons={
               <div>

--- a/src/pages/Task.tsx
+++ b/src/pages/Task.tsx
@@ -56,14 +56,13 @@ export const Task = () => {
     displayName,
     patchNumber,
     priority,
-    status,
     annotation,
     latestExecution,
     versionMetadata,
     displayTask,
   } = task ?? {};
   const attributed = annotation?.issues?.length > 0;
-
+  const status = null;
   if (
     id === task?.id &&
     Number.isNaN(selectedExecution) &&
@@ -79,6 +78,7 @@ export const Task = () => {
   if (error) {
     return <PageDoesNotExist />;
   }
+  console.log(displayName, status);
   return (
     <PageWrapper>
       {task && (
@@ -90,7 +90,6 @@ export const Task = () => {
       )}
       <PageTitle
         loading={loading}
-        hasData={!!(displayName && status)}
         title={displayName}
         badge={
           <StyledBadgeWrapper>

--- a/src/pages/Task.tsx
+++ b/src/pages/Task.tsx
@@ -53,16 +53,17 @@ export const Task = () => {
 
   const { task, taskFiles } = data ?? {};
   const {
+    annotation,
     displayName,
+    displayTask,
+    latestExecution,
     patchNumber,
     priority,
-    annotation,
-    latestExecution,
+    status,
     versionMetadata,
-    displayTask,
   } = task ?? {};
   const attributed = annotation?.issues?.length > 0;
-  const status = null;
+
   if (
     id === task?.id &&
     Number.isNaN(selectedExecution) &&

--- a/src/pages/Task.tsx
+++ b/src/pages/Task.tsx
@@ -78,7 +78,6 @@ export const Task = () => {
   if (error) {
     return <PageDoesNotExist />;
   }
-  console.log(displayName, status);
   return (
     <PageWrapper>
       {task && (

--- a/src/pages/Version.tsx
+++ b/src/pages/Version.tsx
@@ -178,7 +178,6 @@ export const VersionPage: React.VFC = () => {
       />
       <PageTitle
         loading={false}
-        hasData
         title={linkifiedMessage || `Version ${order}`}
         badge={<PatchStatusBadge status={status} />}
         buttons={

--- a/src/utils/statuses/getStatusBadgeCopy.test.ts
+++ b/src/utils/statuses/getStatusBadgeCopy.test.ts
@@ -10,4 +10,10 @@ describe("getStatusBadgeCopy", () => {
     expect(getStatusBadgeCopy("setup-failed")).toBe("Setup-Failed");
     expect(getStatusBadgeCopy("test-timed-out")).toBe("Test-Timed-Out");
   });
+
+  it("returns an empty string when passed a falsy value", () => {
+    expect(getStatusBadgeCopy("")).toBe("");
+    expect(getStatusBadgeCopy(undefined)).toBe("");
+    expect(getStatusBadgeCopy(null)).toBe("");
+  });
 });

--- a/src/utils/statuses/getStatusBadgeCopy.ts
+++ b/src/utils/statuses/getStatusBadgeCopy.ts
@@ -1,7 +1,7 @@
 // &#8209; is a non-breaking hyphen used so that statuses with a hyphen do not word break when the page width shrinks
 export const getStatusBadgeCopy = (status: string) =>
-  status
+  (status || "")
     .split("-")
-    .map((s) => `${s[0].toLocaleUpperCase()}${s.slice(1)}`)
+    .map((s) => `${(s[0] ?? "").toLocaleUpperCase()}${s.slice(1)}`)
     .join("-")
     .replace("/-/g", "#8209;");

--- a/src/utils/statuses/getStatusBadgeCopy.ts
+++ b/src/utils/statuses/getStatusBadgeCopy.ts
@@ -1,7 +1,9 @@
 // &#8209; is a non-breaking hyphen used so that statuses with a hyphen do not word break when the page width shrinks
 export const getStatusBadgeCopy = (status: string) =>
-  (status || "")
-    .split("-")
-    .map((s) => `${(s[0] ?? "").toLocaleUpperCase()}${s.slice(1)}`)
-    .join("-")
-    .replace("/-/g", "#8209;");
+  status
+    ? status
+        .split("-")
+        .map((s) => `${s[0].toLocaleUpperCase()}${s.slice(1)}`)
+        .join("-")
+        .replace("/-/g", "#8209;")
+    : "";


### PR DESCRIPTION
[EVG-15798](https://jira.mongodb.org/browse/EVG-15798)

### Description 
Originally we were hiding the action buttons on the task page when the task status was null. These code changes make sure that we always show the action buttons by removing `<PageTitle hasData />`
