### PR TITLE
EVG-16674: Remove references to baseVersionID

### DIFF
--- a/cypress/integration/version/downstream_tasks.ts
+++ b/cypress/integration/version/downstream_tasks.ts
@@ -20,6 +20,16 @@ describe("Downstream Tasks Tab", () => {
     cy.dataCy("project-title").should("be.visible");
   });
 
+  it("Links to base commit", () => {
+    cy.dataCy("downstream-task-base-commit").should("contain.text", "1483700");
+    cy.dataCy("downstream-task-base-commit")
+      .should("have.attr", "href")
+      .and(
+        "includes",
+        "/version/logkeeper_3c5a8112efdb98f3710b89d553af602e355aa5c9"
+      );
+  });
+
   it("Filters by test name", () => {
     cy.get("tbody").first().children().should("have.length", 1);
     cy.toggleTableFilter(1);

--- a/cypress/integration/version/downstream_tasks.ts
+++ b/cypress/integration/version/downstream_tasks.ts
@@ -21,7 +21,6 @@ describe("Downstream Tasks Tab", () => {
   });
 
   it("Links to base commit", () => {
-    cy.dataCy("downstream-task-base-commit").should("contain.text", "1483700");
     cy.dataCy("downstream-task-base-commit")
       .should("have.attr", "href")
       .and(

--- a/src/components/VersionRestartModal/VersionRestartModal.tsx
+++ b/src/components/VersionRestartModal/VersionRestartModal.tsx
@@ -295,7 +295,7 @@ const ConfirmationMessage = styled(Body)`
 
 const Row = styled.div`
   display: flex;
-  >: first-child {
+  >: first-of-type {
     margin-right: ${size.s};
   }
 `;

--- a/src/gql/fragments/patchesPage.graphql
+++ b/src/gql/fragments/patchesPage.graphql
@@ -8,14 +8,6 @@ fragment PatchesPagePatches on Patches {
     status
     createTime
     commitQueuePosition
-    childPatches {
-      baseVersionID
-      githash
-      id
-      projectID
-      taskCount
-      status
-    }
     versionFull {
       id
       taskStatusStats(options: {}) {

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -2178,16 +2178,6 @@ export type PatchesPagePatchesFragment = {
     createTime?: Maybe<Date>;
     commitQueuePosition?: Maybe<number>;
     canEnqueueToCommitQueue: boolean;
-    childPatches?: Maybe<
-      Array<{
-        baseVersionID?: Maybe<string>;
-        githash: string;
-        id: string;
-        projectID: string;
-        taskCount?: Maybe<number>;
-        status: string;
-      }>
-    >;
     versionFull?: Maybe<{
       id: string;
       status: string;
@@ -3733,26 +3723,7 @@ export type PatchQuery = {
     projectIdentifier: string;
     githash: string;
     patchNumber: number;
-    taskCount?: Maybe<number>;
-    baseVersionID?: Maybe<string>;
-    canEnqueueToCommitQueue: boolean;
-    childPatches?: Maybe<
-      Array<{
-        baseVersionID?: Maybe<string>;
-        githash: string;
-        id: string;
-        projectID: string;
-        taskCount?: Maybe<number>;
-        status: string;
-      }>
-    >;
     versionFull?: Maybe<{ id: string }>;
-    duration?: Maybe<{ makespan?: Maybe<string>; timeTaken?: Maybe<string> }>;
-    time?: Maybe<{
-      started?: Maybe<string>;
-      submittedAt: string;
-      finished?: Maybe<string>;
-    }>;
   } & BasePatchFragment;
 };
 
@@ -4243,13 +4214,16 @@ export type VersionQuery = {
       canEnqueueToCommitQueue: boolean;
       childPatches?: Maybe<
         Array<{
-          baseVersionID?: Maybe<string>;
-          githash: string;
           id: string;
+          githash: string;
           projectIdentifier: string;
           taskCount?: Maybe<number>;
           status: string;
-          versionFull?: Maybe<{ id: string; status: string }>;
+          versionFull?: Maybe<{
+            id: string;
+            status: string;
+            baseVersion?: Maybe<{ id: string }>;
+          }>;
         }>
       >;
     }>;

--- a/src/gql/queries/get-patch.graphql
+++ b/src/gql/queries/get-patch.graphql
@@ -3,14 +3,6 @@
 query Patch($id: String!) {
   patch(id: $id) {
     ...basePatch
-    childPatches {
-      baseVersionID
-      githash
-      id
-      projectID
-      taskCount
-      status
-    }
     projectID
     projectIdentifier
     githash
@@ -18,17 +10,5 @@ query Patch($id: String!) {
     versionFull {
       id
     }
-    taskCount
-    baseVersionID
-    duration {
-      makespan
-      timeTaken
-    }
-    time {
-      started
-      submittedAt
-      finished
-    }
-    canEnqueueToCommitQueue
   }
 }

--- a/src/gql/queries/get-version.graphql
+++ b/src/gql/queries/get-version.graphql
@@ -53,16 +53,18 @@ query Version($id: String!) {
       commitQueuePosition
       canEnqueueToCommitQueue
       childPatches {
-        baseVersionID
-        githash
         id
+        githash
         projectIdentifier
         taskCount
+        status
         versionFull {
           id
+          baseVersion {
+            id
+          }
           status
         }
-        status
       }
     }
     ...upstreamProject

--- a/src/pages/version/DownstreamTasks.tsx
+++ b/src/pages/version/DownstreamTasks.tsx
@@ -10,15 +10,7 @@ export const DownstreamTasks: React.VFC<DownstreamTasksProps> = ({
 }) => (
   <>
     {childPatches.map(
-      ({
-        baseVersionID,
-        githash,
-        id,
-        projectIdentifier,
-        status,
-        taskCount,
-        versionFull,
-      }) => (
+      ({ githash, id, projectIdentifier, status, taskCount, versionFull }) => (
         <DownstreamProjectAccordion
           key={`downstream_project_${id}`}
           projectName={projectIdentifier}
@@ -26,7 +18,7 @@ export const DownstreamTasks: React.VFC<DownstreamTasksProps> = ({
           childPatchId={id}
           taskCount={taskCount}
           githash={githash}
-          baseVersionID={baseVersionID}
+          baseVersionID={versionFull?.baseVersion?.id}
         />
       )
     )}

--- a/src/pages/version/DownstreamTasks.tsx
+++ b/src/pages/version/DownstreamTasks.tsx
@@ -10,7 +10,7 @@ export const DownstreamTasks: React.VFC<DownstreamTasksProps> = ({
 }) => (
   <>
     {childPatches.map(
-      ({ githash, id, projectIdentifier, status, taskCount, versionFull }) => (
+      ({ id, githash, projectIdentifier, status, taskCount, versionFull }) => (
         <DownstreamProjectAccordion
           key={`downstream_project_${id}`}
           projectName={projectIdentifier}

--- a/src/pages/version/downstreamTasks/DownstreamProjectAccordion.tsx
+++ b/src/pages/version/downstreamTasks/DownstreamProjectAccordion.tsx
@@ -26,11 +26,12 @@ import {
 } from "gql/generated/types";
 import { GET_PATCH_TASKS } from "gql/queries";
 import { usePolling, useTaskStatuses } from "hooks";
-import { environmentalVariables, queryString } from "utils";
+import { environmentalVariables, queryString, string } from "utils";
 import { reducer } from "./reducer";
 
 const { getUiUrl } = environmentalVariables;
 const { parseSortString, toSortString } = queryString;
+const { shortenGithash } = string;
 
 interface DownstreamProjectAccordionProps {
   baseVersionID: string;
@@ -163,7 +164,7 @@ export const DownstreamProjectAccordion: React.VFC<DownstreamProjectAccordionPro
           <p>
             Base commit:{" "}
             <InlineCode href={`${getUiUrl()}/version/${baseVersionID}`}>
-              {githash.slice(0, 10)}
+              {shortenGithash(githash)}
             </InlineCode>
           </p>
           <TableWrapper>

--- a/src/pages/version/downstreamTasks/DownstreamProjectAccordion.tsx
+++ b/src/pages/version/downstreamTasks/DownstreamProjectAccordion.tsx
@@ -12,8 +12,13 @@ import { PageSizeSelector } from "components/PageSizeSelector";
 import { Pagination } from "components/Pagination";
 import { PatchStatusBadge } from "components/PatchStatusBadge";
 import { ResultCountLabel } from "components/ResultCountLabel";
-import { TableControlOuterRow, TableControlInnerRow } from "components/styles";
+import {
+  TableControlOuterRow,
+  TableControlInnerRow,
+  StyledRouterLink,
+} from "components/styles";
 import { TasksTable } from "components/Table/TasksTable";
+import { getVersionRoute } from "constants/routes";
 import { size } from "constants/tokens";
 import { useToastContext } from "context/toast";
 import {
@@ -26,10 +31,9 @@ import {
 } from "gql/generated/types";
 import { GET_PATCH_TASKS } from "gql/queries";
 import { usePolling, useTaskStatuses } from "hooks";
-import { environmentalVariables, queryString, string } from "utils";
+import { queryString, string } from "utils";
 import { reducer } from "./reducer";
 
-const { getUiUrl } = environmentalVariables;
 const { parseSortString, toSortString } = queryString;
 const { shortenGithash } = string;
 
@@ -163,8 +167,13 @@ export const DownstreamProjectAccordion: React.VFC<DownstreamProjectAccordionPro
         <AccordionContents>
           <p>
             Base commit:{" "}
-            <InlineCode href={`${getUiUrl()}/version/${baseVersionID}`}>
-              {shortenGithash(githash)}
+            <InlineCode>
+              <StyledRouterLink
+                data-cy="downstream-task-base-commit"
+                to={getVersionRoute(baseVersionID)}
+              >
+                {shortenGithash(githash)}
+              </StyledRouterLink>
             </InlineCode>
           </p>
           <TableWrapper>


### PR DESCRIPTION
[EVG-16674](https://jira.mongodb.org/browse/EVG-16674)

### Description 
This PR removes references to `baseVersionID`, a deprecated field. It also removes some fields that appeared to be unused from a few graphql queries that I was looking at.

I also changed the downstream task base commit link to link to Spruce (right now it links to Evergreen legacy UI). I can change it back if that was intentional.

### Screenshots

https://user-images.githubusercontent.com/47064971/171432033-8a205933-a82f-4c2f-8878-9f50d61a0b17.mov



### Testing 
- Manually, [here](https://spruce.mongodb.com/version/6228e1a33627e02c15fa71ca/downstream-tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) is an example patch on prod
- Added test in `downstream_tasks.ts` (Cypress)
