### PR TITLE
EVG-15181 Fix revert emails not being sent

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -298,7 +298,6 @@ functions:
       script: |
         export AUTHOR_EMAIL=${author_email}
         export REACT_APP_DEPLOYS_EMAIL=${REACT_APP_DEPLOYS_EMAIL}
-        export TASK_NAME=${task_name}
         bash email.sh
 
 

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -298,6 +298,7 @@ functions:
       script: |
         export AUTHOR_EMAIL=${author_email}
         export REACT_APP_DEPLOYS_EMAIL=${REACT_APP_DEPLOYS_EMAIL}
+        export EXECUTION=${execution}
         bash email.sh
 
 

--- a/email.sh
+++ b/email.sh
@@ -22,19 +22,7 @@ then
     exit 1
 fi
 
-# Detect which version of sed we have available to format the email
-case "$OSTYPE" in
-  darwin*)
-    echo "OSX detected using gsed"
-    gsed -i ':a;N;$!ba;s/\n/<br \/>/g' body.txt
 
-  ;;
-  linux*)
-    echo "LINUX detected using sed"
-    sed -i ':a;N;$!ba;s/\n/<br \/>/g' body.txt
-  ;;
-  *)        echo "unknown: $OSTYPE";;
-esac
 
 # Determine which verson of evergreen is available and use that
 if ! [ -x "$(command -v evergreen)" ]
@@ -61,11 +49,26 @@ PREVIOUS_TAG=$(git describe --abbrev=0 $CURRENT_COMMIT_HASH\^)
 # get all commits since the previous tag
 git log --no-merges $PREVIOUS_TAG..$CURRENT_COMMIT_HASH --pretty="%h %s" >> body.txt
 
+
+# Detect which version of sed we have available to format the email
+case "$OSTYPE" in
+  darwin*)
+    echo "OSX detected using gsed"
+    gsed -i ':a;N;$!ba;s/\n/<br \/>/g' body.txt
+
+  ;;
+  linux*)
+    echo "LINUX detected using sed"
+    sed -i ':a;N;$!ba;s/\n/<br \/>/g' body.txt
+  ;;
+  *)        echo "unknown: $OSTYPE";;
+esac
+
 echo "Commits Deployed:"
 cat body.txt
 
 TITLE="Spruce Deploy to $CURRENT_COMMIT_HASH"
-BODY_HTML=$(cat body.txt)
+BODY_HTML=$(cat body.txt)$(echo "<br /> <br /><b> To revert to previous version rerun task from previous release tag ($PREVIOUS_TAG)</b>")
 DATE=$(date +'%Y-%m-%d')
 
 COMMAND="$EVERGREEN $CREDENTIALS notify email -f $AUTHOR_EMAIL -r $REACT_APP_DEPLOYS_EMAIL -s "

--- a/email.sh
+++ b/email.sh
@@ -22,6 +22,12 @@ then
     exit 1
 fi
 
+IS_REVERT=false
+# If execution exists and is not 0 (i.e. not a revert), then set the revert flag
+if [ "$EXECUTION" != '' ] && [ "$EXECUTION" != '0' ]
+then
+    IS_REVERT=true
+fi
 
 
 # Determine which verson of evergreen is available and use that
@@ -46,8 +52,15 @@ fi
 # Fetch previous release tag and get the commits since that tag
 CURRENT_COMMIT_HASH=$(git rev-parse --short HEAD)
 PREVIOUS_TAG=$(git describe --abbrev=0 $CURRENT_COMMIT_HASH\^)
+
+# If this is a revert, then only include the currently deployed commit
+if [ "$IS_REVERT" == 'true' ]
+then
+  echo "spruce-$(git rev-parse HEAD)" > body.txt
+else
 # get all commits since the previous tag
-git log --no-merges $PREVIOUS_TAG..$CURRENT_COMMIT_HASH --pretty="%h %s" >> body.txt
+  git log --no-merges $PREVIOUS_TAG..$CURRENT_COMMIT_HASH --pretty="%h %s" > body.txt
+fi
 
 
 # Detect which version of sed we have available to format the email

--- a/email.sh
+++ b/email.sh
@@ -30,8 +30,12 @@ then
 fi
 
 # Fetch previous release tag and get the commits since that tag
-PREVIOUS_VERSION=$(git describe --tags  --abbrev=0  `git rev-list --tags --max-count=1 --skip=1`)
-git log --no-merges $PREVIOUS_VERSION..HEAD --pretty="format:%s (%h)" > body.txt
+CURRENT_COMMIT_HASH=$(git rev-parse HEAD)
+PREVIOUS_TAG=$(git describe --abbrev=0 $CURRENT_COMMIT_HASH\^)
+# get all commits since the previous tag
+COMMITS_SINCE_TAG=$(git log --no-merges $PREVIOUS_TAG..$CURRENT_COMMIT_HASH --pretty="format:%s (%h)")
+echo $COMMITS_SINCE_TAG
+echo $COMMITS_SINCE_TAG > body.txt
 
 # Determine which verson of evergreen is available and use that
 if ! [ -x "$(command -v evergreen)" ]

--- a/email.sh
+++ b/email.sh
@@ -22,12 +22,19 @@ then
     exit 1
 fi
 
+# Detect which version of sed we have available to format the email
+case "$OSTYPE" in
+  darwin*)
+    echo "OSX detected using gsed"
+    gsed -i ':a;N;$!ba;s/\n/<br \/>/g' body.txt
 
-# Fetch previous release tag and get the commits since that tag
-CURRENT_COMMIT_HASH=$(git rev-parse --short HEAD)
-PREVIOUS_TAG=$(git describe --abbrev=0 $CURRENT_COMMIT_HASH\^)
-# get all commits since the previous tag
-git log --no-merges $PREVIOUS_TAG..$CURRENT_COMMIT_HASH --pretty="%h %s" >> body.txt
+  ;;
+  linux*)
+    echo "LINUX detected using sed"
+    sed -i ':a;N;$!ba;s/\n/<br \/>/g' body.txt
+  ;;
+  *)        echo "unknown: $OSTYPE";;
+esac
 
 # Determine which verson of evergreen is available and use that
 if ! [ -x "$(command -v evergreen)" ]
@@ -48,19 +55,11 @@ else
   EVERGREEN=evergreen
 fi
 
-# Detect which version of sed we have available to format the email
-case "$OSTYPE" in
-  darwin*)
-    echo "OSX detected using gsed"
-    gsed -i ':a;N;$!ba;s/\n/<br \/>/g' body.txt
-
-  ;;
-  linux*)
-    echo "LINUX detected using sed"
-    sed -i ':a;N;$!ba;s/\n/<br \/>/g' body.txt
-  ;;
-  *)        echo "unknown: $OSTYPE";;
-esac
+# Fetch previous release tag and get the commits since that tag
+CURRENT_COMMIT_HASH=$(git rev-parse --short HEAD)
+PREVIOUS_TAG=$(git describe --abbrev=0 $CURRENT_COMMIT_HASH\^)
+# get all commits since the previous tag
+git log --no-merges $PREVIOUS_TAG..$CURRENT_COMMIT_HASH --pretty="%h %s" >> body.txt
 
 echo "Commits Deployed:"
 cat body.txt
@@ -78,5 +77,6 @@ COMMAND+=" -b"
 COMMAND+=" '"
 COMMAND+="$BODY_HTML"
 COMMAND+="'"
+
 echo $COMMAND
 eval $COMMAND


### PR DESCRIPTION
[EVG-15181](https://jira.mongodb.org/browse/EVG-15181)

### Description 
Now tries to fetch the tagged commit before the currently checked out commit. Since we rely on git tags to determine what is deployed it should accurately track the commits between the two tags. 
Fixed some formatting now spruce deploy emails look like evergreen and cedar emails.
Added a hint for reverts.

### Screenshots
<img width="664" alt="image" src="https://user-images.githubusercontent.com/4605522/171511838-3bd68d25-a011-4149-98ff-c3efa860fa25.png">


### Testing 
Checked out a previous tag commit that is not HEAD and attempted to send an email.