### PR TITLE
EVG-16962 Add breadcrumbs for auth checks

### DIFF
--- a/src/context/auth.tsx
+++ b/src/context/auth.tsx
@@ -1,6 +1,7 @@
 import React, { useContext, useReducer } from "react";
 import axios from "axios";
 import { environmentalVariables } from "utils";
+import { leaveBreadcrumb } from "utils/errorReporting";
 
 const { getLoginDomain } = environmentalVariables;
 interface AuthState {
@@ -20,9 +21,9 @@ const reducer = (state: AuthState, action: Action): AuthState => {
   // check to see if the authenticate state has changed otherwise dont update the reducer
   switch (action.type) {
     case "authenticated":
-      return state.isAuthenticated ? state : { isAuthenticated: true };
+      return { ...state, isAuthenticated: true };
     case "deauthenticated":
-      return !state.isAuthenticated ? state : { isAuthenticated: false };
+      return { ...state, isAuthenticated: false };
     default:
       return state;
   }
@@ -52,7 +53,10 @@ const AuthProvider: React.VFC<{ children: React.ReactNode }> = ({
       window.location.href = `${getLoginDomain()}/login`;
     },
     dispatchAuthenticated: () => {
-      dispatch({ type: "authenticated" });
+      if (!state.isAuthenticated) {
+        dispatch({ type: "authenticated" });
+        leaveBreadcrumb("Authenticated", {}, "user");
+      }
     },
   };
 

--- a/src/gql/GQLWrapper.tsx
+++ b/src/gql/GQLWrapper.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import {
   ApolloClient,
   ApolloProvider,
@@ -78,6 +77,7 @@ const authLink = (logout: () => void): ApolloLink =>
       networkError.statusCode === 401 &&
       window.location.pathname !== routes.login
     ) {
+      leaveBreadcrumb("Not Authenticated", { statusCode: 401 }, "user");
       logout();
     }
   });
@@ -96,7 +96,9 @@ const logErrorsLink = onError(({ graphQLErrors }) => {
   // very common when a user is not authenticated
 });
 
-const authenticateIfSuccessfulLink = (dispatchAuthenticated): ApolloLink =>
+const authenticateIfSuccessfulLink = (
+  dispatchAuthenticated: () => void
+): ApolloLink =>
   new ApolloLink((operation, forward) =>
     forward(operation).map((response) => {
       if (response && response.data) {
@@ -108,7 +110,7 @@ const authenticateIfSuccessfulLink = (dispatchAuthenticated): ApolloLink =>
         {
           operationName: operation.operationName,
           variables: operation.variables,
-          status: response.data ? "OK" : "ERROR",
+          status: !response.errors ? "OK" : "ERROR",
           errors: response.errors,
         },
         "request"


### PR DESCRIPTION
[EVG-15962](https://jira.mongodb.org/browse/EVG-15962)

### Description 
It may not be possible to tie an errored network request to a specific line of code through a stack trace. Graphql requests are technically dispatched by the Apollo client provider not from a useQuery function. (useQuery simply tells apollo provider that it wants some data and the Apollo provider handles the network request. (It does things like managing retries, updating the cache, etc). So the stack trace would never link to a line since the error does not technically originate from a given line in our code base.

Since we already leave breadcrumbs for Graphql requests i think it's fine to leave as is.

I did find a bug with how we were error checking requests for a breadcrumb they wouldn't say "Error" on the breadcrumb. 


