### PR TITLE
EVG-16951: Disable history links for Commit Queue Merge & merge-patch

### DIFF
--- a/src/components/ConditionalWrapper/index.tsx
+++ b/src/components/ConditionalWrapper/index.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 interface ConditionalWrapperProps {
   condition: boolean;
   wrapper: (children: any) => JSX.Element;

--- a/src/components/Table/TasksTable.tsx
+++ b/src/components/Table/TasksTable.tsx
@@ -1,6 +1,7 @@
 import { Table } from "antd";
 import { ColumnProps } from "antd/es/table";
 import { SortOrder as antSortOrder } from "antd/lib/table/interface";
+import { ConditionalWrapper } from "components/ConditionalWrapper";
 import { StyledRouterLink } from "components/styles";
 import {
   InputFilterProps,
@@ -9,6 +10,7 @@ import {
 } from "components/Table/Filters";
 import TaskStatusBadge from "components/TaskStatusBadge";
 import { TreeSelectProps } from "components/TreeSelect";
+import { mergeTaskVariant } from "constants/patch";
 import { getVariantHistoryRoute } from "constants/routes";
 import {
   Task,
@@ -199,11 +201,18 @@ const getColumnDefs = ({
         "data-cy": "variant-input",
       })),
     render: (displayName, { projectIdentifier, buildVariant }) => (
-      <StyledRouterLink
-        to={getVariantHistoryRoute(projectIdentifier, buildVariant)}
+      <ConditionalWrapper
+        condition={buildVariant !== mergeTaskVariant}
+        wrapper={(children) => (
+          <StyledRouterLink
+            to={getVariantHistoryRoute(projectIdentifier, buildVariant)}
+          >
+            {children}
+          </StyledRouterLink>
+        )}
       >
         {displayName}
-      </StyledRouterLink>
+      </ConditionalWrapper>
     ),
   },
 ];

--- a/src/components/Table/TasksTable.tsx
+++ b/src/components/Table/TasksTable.tsx
@@ -10,8 +10,8 @@ import {
 } from "components/Table/Filters";
 import TaskStatusBadge from "components/TaskStatusBadge";
 import { TreeSelectProps } from "components/TreeSelect";
-import { mergeTaskVariant } from "constants/patch";
 import { getVariantHistoryRoute } from "constants/routes";
+import { mergeTaskVariant } from "constants/task";
 import {
   Task,
   SortDirection,

--- a/src/constants/patch.ts
+++ b/src/constants/patch.ts
@@ -1,2 +1,5 @@
 export const commitQueueAlias = "__commit_queue";
 export const commitQueueRequester = "merge_test";
+
+export const mergeTaskName = "merge-patch";
+export const mergeTaskVariant = "commit-queue-merge";

--- a/src/constants/patch.ts
+++ b/src/constants/patch.ts
@@ -1,5 +1,2 @@
 export const commitQueueAlias = "__commit_queue";
 export const commitQueueRequester = "merge_test";
-
-export const mergeTaskName = "merge-patch";
-export const mergeTaskVariant = "commit-queue-merge";

--- a/src/constants/task.ts
+++ b/src/constants/task.ts
@@ -270,3 +270,7 @@ export const finishedTaskStatuses = [
   ...failedTaskStatuses,
   TaskStatus.Succeeded,
 ];
+
+// Task name and build variant for Commit Queue
+export const mergeTaskName = "merge-patch";
+export const mergeTaskVariant = "commit-queue-merge";

--- a/src/constants/task.ts
+++ b/src/constants/task.ts
@@ -271,6 +271,6 @@ export const finishedTaskStatuses = [
   TaskStatus.Succeeded,
 ];
 
-// Task name and build variant for Commit Queue
+// Task name and build variant for the commit queue. Both are owned by Evergreen.
 export const mergeTaskName = "merge-patch";
 export const mergeTaskVariant = "commit-queue-merge";

--- a/src/pages/task/ActionButtons.tsx
+++ b/src/pages/task/ActionButtons.tsx
@@ -8,8 +8,9 @@ import { Button } from "components/Button";
 import { DropdownItem, ButtonDropdown } from "components/ButtonDropdown";
 import { ConditionalWrapper } from "components/ConditionalWrapper";
 import { PageButtonRow } from "components/styles";
-import { commitQueueRequester, mergeTaskName } from "constants/patch";
+import { commitQueueRequester } from "constants/patch";
 import { getTaskHistoryRoute } from "constants/routes";
+import { mergeTaskName } from "constants/task";
 import { useToastContext } from "context/toast";
 import {
   SetTaskPriorityMutation,

--- a/src/pages/task/ActionButtons.tsx
+++ b/src/pages/task/ActionButtons.tsx
@@ -8,7 +8,7 @@ import { Button } from "components/Button";
 import { DropdownItem, ButtonDropdown } from "components/ButtonDropdown";
 import { ConditionalWrapper } from "components/ConditionalWrapper";
 import { PageButtonRow } from "components/styles";
-import { commitQueueRequester } from "constants/patch";
+import { commitQueueRequester, mergeTaskName } from "constants/patch";
 import { getTaskHistoryRoute } from "constants/routes";
 import { useToastContext } from "context/toast";
 import {
@@ -274,6 +274,7 @@ export const ActionButtons: React.VFC<Props> = ({
               to={getTaskHistoryRoute(project.identifier, displayName, {
                 selectedCommit: !isPatch && order,
               })}
+              disabled={displayName === mergeTaskName}
             >
               See history
             </Button>


### PR DESCRIPTION
[EVG-16951](https://jira.mongodb.org/browse/EVG-16951)

### Description 
It's possible to visit the task history for the `merge-patch` task and the variant history for the `Commit Queue Merge` build variant. However, this task and build variant only appears on commit queue patches, so we don't maintain their history on mainline commits at all.

This PR disables the links for the `merge-patch` task and the `Commit Queue Merge` build variant so that a user cannot reach their corresponding variant & task history pages.

 (This task and build variant are something that we own and are defined in the Evergreen repo [here](https://github.com/evergreen-ci/evergreen/blob/main/globals.go#L262-L263).)


### Screenshots
https://user-images.githubusercontent.com/47064971/172473660-54018890-6e61-4785-9016-695ab913f5d3.mov


### Testing 
- Manually

