### PR TITLE
EVG-17049: Fix project settings e2e flakiness

### DIFF
--- a/cypress/integration/projectSettings/project_settings.ts
+++ b/cypress/integration/projectSettings/project_settings.ts
@@ -211,25 +211,6 @@ describe("Repo Settings", () => {
     });
   });
 
-  describe("GitHub/Commit Queue page after adding patch trigger alias", () => {
-    before(() => {
-      cy.dataCy("navitem-github-commitqueue").click();
-    });
-
-    it("Shows the patch trigger alias", () => {
-      cy.dataCy("pta-item").should("have.length", 1);
-    });
-
-    it("Hovering over the alias name shows its details", () => {
-      cy.dataCy("pta-item").scrollIntoView();
-      cy.dataCy("pta-item").trigger("mouseover");
-      cy.dataCy("pta-tooltip").should("be.visible");
-      cy.dataCy("pta-tooltip").contains("spruce");
-      cy.dataCy("pta-tooltip").contains("module_name");
-      cy.dataCy("pta-tooltip").contains("Variant/Task Regex Pairs");
-    });
-  });
-
   describe("Virtual Workstation page", () => {
     before(() => {
       cy.dataCy("navitem-virtual-workstation").click();
@@ -257,6 +238,25 @@ describe("Repo Settings", () => {
 
       cy.dataCy("command-input").first().should("have.value", "command 2");
       cy.dataCy("command-input").eq(1).should("have.value", "command 1");
+    });
+  });
+
+  describe("GitHub/Commit Queue page after adding patch trigger alias", () => {
+    before(() => {
+      cy.dataCy("navitem-github-commitqueue").click();
+    });
+
+    it("Shows the patch trigger alias", () => {
+      cy.dataCy("pta-item").should("have.length", 1);
+    });
+
+    it("Hovering over the alias name shows its details", () => {
+      cy.dataCy("pta-item").scrollIntoView();
+      cy.dataCy("pta-item").trigger("mouseover");
+      cy.dataCy("pta-tooltip").should("be.visible");
+      cy.dataCy("pta-tooltip").contains("spruce");
+      cy.dataCy("pta-tooltip").contains("module_name");
+      cy.dataCy("pta-tooltip").contains("Variant/Task Regex Pairs");
     });
   });
 });


### PR DESCRIPTION
EVG-17049

### Description 
- Fix flakiness by reordering tests

### Testing 
- I ran 6 executions [here](https://spruce.mongodb.com/task/spruce_ubuntu1604_e2e_test_patch_6849eb041f3093b76b6416d5f8afd5b2a4b2513b_62a2392e0ae6062ba1f50dab_22_06_09_18_17_25/tests?execution=2&sortBy=STATUS&sortDir=ASC) and [here](https://spruce.mongodb.com/task/spruce_ubuntu1604_e2e_test_patch_6849eb041f3093b76b6416d5f8afd5b2a4b2513b_62a2395f7742ae6c9b241abf_22_06_09_18_18_08/tests?execution=2&sortBy=STATUS&sortDir=ASC) which all passed