### PR TITLE
Update package.json engines field

### DIFF
--- a/package.json
+++ b/package.json
@@ -251,7 +251,7 @@
     "worker-loader": "^3.0.7"
   },
   "engines": {
-    "node": ">=12.22.0"
+    "node": ">=16.13.0"
   },
   "proxy": "http://localhost:9090"
 }


### PR DESCRIPTION
### Description 
- According to [BUILD-14325](https://jira.mongodb.org/browse/BUILD-14325), evergreen uses Node v16.13.0 to test and build spruce. We also use packages with dependencies of Node 16+, so update our engines field to ensure local processes use the correct version