### PR TITLE
EVG-16933: Add project settings link

### DIFF
--- a/src/components/Header/AuxiliaryDropdown.tsx
+++ b/src/components/Header/AuxiliaryDropdown.tsx
@@ -13,12 +13,7 @@ import { GET_SPRUCE_CONFIG } from "gql/queries";
 import { environmentalVariables } from "utils";
 import { Dropdown } from "./NavDropdown";
 
-const { getUiUrl, isBeta, isDevelopment, isStaging } = environmentalVariables;
-
-// TODO: Remove in EVG-17059
-// Project Settings should only be disabled when deployed to spruce.mongodb.com
-// Enable when running local dev server, or when deployed to beta or staging
-const showProjectSettings = isDevelopment() || isBeta() || isStaging();
+const { getUiUrl, isNotProduction } = environmentalVariables;
 
 export const AuxiliaryDropdown = () => {
   const uiURL = getUiUrl();
@@ -49,7 +44,8 @@ export const AuxiliaryDropdown = () => {
       text: "Projects",
       onClick: () => sendEvent({ name: "Click Projects Link" }),
     },
-    ...(showProjectSettings
+    // TODO: Remove in EVG-17059
+    ...(isNotProduction
       ? [
           {
             text: "Project Settings",

--- a/src/components/Header/AuxiliaryDropdown.tsx
+++ b/src/components/Header/AuxiliaryDropdown.tsx
@@ -3,13 +3,22 @@ import Cookies from "js-cookie";
 import { useNavbarAnalytics } from "analytics";
 import { CURRENT_PROJECT } from "constants/cookies";
 import { legacyRoutes } from "constants/externalResources";
-import { routes, getProjectPatchesRoute } from "constants/routes";
+import {
+  routes,
+  getProjectPatchesRoute,
+  getProjectSettingsRoute,
+} from "constants/routes";
 import { GetSpruceConfigQuery } from "gql/generated/types";
 import { GET_SPRUCE_CONFIG } from "gql/queries";
 import { environmentalVariables } from "utils";
 import { Dropdown } from "./NavDropdown";
 
-const { getUiUrl } = environmentalVariables;
+const { getUiUrl, isBeta, isDevelopment, isStaging } = environmentalVariables;
+
+// TODO: Remove in EVG-17059
+// Project Settings should only be disabled when deployed to spruce.mongodb.com
+// Enable when running local dev server, or when deployed to beta or staging
+const showProjectSettings = isDevelopment() || isBeta() || isStaging();
 
 export const AuxiliaryDropdown = () => {
   const uiURL = getUiUrl();
@@ -40,6 +49,15 @@ export const AuxiliaryDropdown = () => {
       text: "Projects",
       onClick: () => sendEvent({ name: "Click Projects Link" }),
     },
+    ...(showProjectSettings
+      ? [
+          {
+            text: "Project Settings",
+            to: getProjectSettingsRoute(mostRecentProject),
+            onClick: () => sendEvent({ name: "Click Projects Link" }),
+          },
+        ]
+      : []),
     {
       "data-cy": "auxiliary-dropdown-project-patches",
       to: getProjectPatchesRoute(mostRecentProject),

--- a/src/pages/ProjectSettings.tsx
+++ b/src/pages/ProjectSettings.tsx
@@ -30,13 +30,8 @@ import { getTabTitle } from "./projectSettings/getTabTitle";
 import { ProjectSettingsTabs } from "./projectSettings/Tabs";
 import { ProjectType } from "./projectSettings/tabs/utils";
 
-const { isBeta, isDevelopment, isStaging } = environmentalVariables;
+const { isNotProduction } = environmentalVariables;
 const { validateObjectId } = validators;
-
-// TODO: Remove in EVG-17059
-// Project Settings should only be disabled when deployed to spruce.mongodb.com
-// Enable when running local dev server, or when deployed to beta or staging
-const disablePage = !(isDevelopment() || isBeta() || isStaging());
 
 export const ProjectSettings: React.VFC = () => {
   usePageTitle(`Project Settings`);
@@ -86,7 +81,8 @@ export const ProjectSettings: React.VFC = () => {
     },
   });
 
-  if (disablePage) {
+  // TODO: Remove in EVG-17059
+  if (!isNotProduction) {
     return (
       <PageWrapper>
         <PageContainer>

--- a/src/pages/ProjectSettings.tsx
+++ b/src/pages/ProjectSettings.tsx
@@ -33,6 +33,7 @@ import { ProjectType } from "./projectSettings/tabs/utils";
 const { isBeta, isDevelopment, isStaging } = environmentalVariables;
 const { validateObjectId } = validators;
 
+// TODO: Remove in EVG-17059
 // Project Settings should only be disabled when deployed to spruce.mongodb.com
 // Enable when running local dev server, or when deployed to beta or staging
 const disablePage = !(isDevelopment() || isBeta() || isStaging());

--- a/src/utils/environmentalVariables.ts
+++ b/src/utils/environmentalVariables.ts
@@ -29,6 +29,9 @@ export const isStaging = (): boolean =>
 
 export const isTest: () => boolean = () => process.env.NODE_ENV === "test";
 
+// Returns true for every environment except when deployed to prod. Useful for enabling features locally, on staging, on beta, etc.
+export const isNotProduction = isDevelopment() || isBeta() || isStaging();
+
 export const getGQLUrl: () => string = () =>
   process.env.REACT_APP_GQL_URL || "";
 


### PR DESCRIPTION
EVG-16933

### Description 
- Add project settings link, which is hidden on prod but visible on staging, beta, and local envs. I opted to rename from "Projects" to "Project Settings" because I think this more accurately captures the pages within, but let me know if there's a good reason not to.
- When EVG-17059 is completed and project settings is released, the legacy "Projects" link will be removed and the Spruce link will be made visible on prod.

### Screenshots
<img width="252" alt="image" src="https://user-images.githubusercontent.com/9298431/173108552-82edd530-f324-4190-88e4-d14c8d033bc2.png">