### PR TITLE
EVG-15881: Update date format

### DIFF
--- a/src/components/CommitChartLabel/CommitChartLabel.test.tsx
+++ b/src/components/CommitChartLabel/CommitChartLabel.test.tsx
@@ -23,7 +23,7 @@ describe("commitChartLabel", () => {
       <RenderCommitChartLabel version={versionShort} />
     );
     expect(queryByDataCy("commit-label")).toHaveTextContent(
-      "4137c33 6/16/21 11:38 PMMohamed Khelif"
+      "4137c33 Jun 16, 2021, 11:38:13 PMMohamed Khelif"
     );
   });
 
@@ -55,7 +55,7 @@ describe("commitChartLabel", () => {
     );
     expect(queryByText("more")).toBeInTheDocument();
     expect(queryByDataCy("commit-label")).toHaveTextContent(
-      "4137c33 6/16/21 11:38 PMMohamed Khelif -SERVER-57332 Create skeleton Internal...more"
+      "4137c33 Jun 16, 2021, 11:38:13 PMMohamed Khelif -SERVER-57332 Create skeleton Internal...more"
     );
   });
 

--- a/src/components/CommitChartLabel/index.tsx
+++ b/src/components/CommitChartLabel/index.tsx
@@ -8,12 +8,10 @@ import { size, zIndex } from "constants/tokens";
 import { UpstreamProjectFragment } from "gql/generated/types";
 import { useSpruceConfig } from "hooks";
 import { ProjectTriggerLevel } from "types/triggers";
-import { string } from "utils";
-import { shortenGithash } from "utils/string";
+import { getDateCopy, shortenGithash } from "utils/string";
 import { jiraLinkify } from "utils/string/jiraLinkify";
 
 const { gray } = uiColors;
-const { shortDate } = string;
 const MAX_CHAR = 40;
 interface Props {
   githash: string;
@@ -58,7 +56,7 @@ const CommitChartLabel: React.VFC<Props> = ({
         >
           {shortenGithash(githash)}
         </StyledRouterLink>{" "}
-        <b>{shortDate(createDate)}</b>
+        <b>{getDateCopy(createDate)}</b>
       </LabelText>
       {upstreamProject && (
         <LabelText>

--- a/src/components/HistoryTable/HistoryTableRow/DateSeparator.tsx
+++ b/src/components/HistoryTable/HistoryTableRow/DateSeparator.tsx
@@ -2,9 +2,9 @@ import { CSSProperties } from "react";
 import styled from "@emotion/styled";
 import { uiColors } from "@leafygreen-ui/palette";
 import { Body } from "@leafygreen-ui/typography";
-import { format, utcToZonedTime } from "date-fns-tz";
 import { size } from "constants/tokens";
 import { useUserTimeZone } from "hooks/useUserTimeZone";
+import { getDateCopy } from "utils/string";
 
 const { gray } = uiColors;
 interface DateSeparatorProps {
@@ -19,9 +19,7 @@ export const DateSeparator: React.VFC<DateSeparatorProps> = ({
   const tz = useUserTimeZone();
   return (
     <Container style={style}>
-      <DateWrapper>
-        {format(utcToZonedTime(new Date(date), tz), "MMM d")}
-      </DateWrapper>
+      <DateWrapper>{getDateCopy(date, { tz, dateOnly: true })}</DateWrapper>
       <Line />
     </Container>
   );

--- a/src/components/PatchesPage/PatchCard.tsx
+++ b/src/components/PatchesPage/PatchCard.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import styled from "@emotion/styled";
 import { uiColors } from "@leafygreen-ui/palette";
-import { format } from "date-fns";
 import { Analytics } from "analytics/addPageAction";
 import { GroupedTaskStatusBadge } from "components/GroupedTaskStatusBadge";
 import { PatchStatusBadge } from "components/PatchStatusBadge";
@@ -15,6 +14,7 @@ import { fontSize, size } from "constants/tokens";
 import { PatchesPagePatchesFragment } from "gql/generated/types";
 import { Unpacked } from "types/utils";
 import { groupStatusesByUmbrellaStatus } from "utils/statuses";
+import { getDateCopy } from "utils/string";
 import { DropdownMenu } from "./patchCard/DropdownMenu";
 
 type P = Unpacked<PatchesPagePatchesFragment["patches"]>;
@@ -74,8 +74,7 @@ export const PatchCard: React.VFC<Props> = ({
           {description || "no description"}
         </DescriptionLink>
         <TimeAndProject>
-          {format(createDate, "M/d/yy")} at {format(createDate, "h:mm:ss aaaa")}{" "}
-          {pageType === "project" ? "by" : "on"}{" "}
+          {getDateCopy(createDate)} {pageType === "project" ? "by" : "on"}{" "}
           {pageType === "project" ? (
             <StyledRouterLink
               to={getUserPatchesRoute(author)}

--- a/src/pages/commitqueue/CommitQueueCard.tsx
+++ b/src/pages/commitqueue/CommitQueueCard.tsx
@@ -4,7 +4,6 @@ import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import { uiColors } from "@leafygreen-ui/palette";
 import { Subtitle, Body } from "@leafygreen-ui/typography";
-import { format } from "date-fns";
 import { ConditionalWrapper } from "components/ConditionalWrapper";
 import { StyledLink, StyledRouterLink } from "components/styles";
 import { getGithubPullRequestUrl } from "constants/externalResources";
@@ -17,10 +16,9 @@ import {
   RemoveItemFromCommitQueueMutationVariables,
 } from "gql/generated/types";
 import { REMOVE_ITEM_FROM_COMMIT_QUEUE } from "gql/mutations";
+import { getDateCopy } from "utils/string";
 import { CodeChangeModule } from "./codeChangesModule/CodeChangesModule";
 import { ConfirmPatchButton } from "./ConfirmPatchButton";
-
-const FORMAT_STR = "MM/dd/yy' at 'hh:mm:ss' 'aa";
 
 interface Props {
   issue: string;
@@ -107,7 +105,7 @@ export const CommitQueueCard: React.VFC<Props> = ({
               <>{title}</>
             </ConditionalWrapper>
             <CardMetaData>
-              By <b>{author}</b> on {format(new Date(commitTime), FORMAT_STR)}
+              By <b>{author}</b> on {getDateCopy(commitTime)}
             </CardMetaData>
             <Container>
               {moduleCodeChanges?.map((moduleCodeChange) => (

--- a/src/pages/task/executionDropdown/ExecutionSelector.tsx
+++ b/src/pages/task/executionDropdown/ExecutionSelector.tsx
@@ -11,9 +11,8 @@ import {
 } from "gql/generated/types";
 import { GET_TASK_ALL_EXECUTIONS } from "gql/queries";
 import { executionAsDisplay } from "pages/task/util/execution";
-import { string } from "utils";
+import { getDateCopy } from "utils/string";
 
-const { shortDate } = string;
 interface ExecutionSelectProps {
   id: string;
   currentExecution: number;
@@ -60,7 +59,7 @@ export const ExecutionSelect: React.VFC<ExecutionSelectProps> = ({
             <StyledTaskStatusIcon status={singleExecution.status} />
             <StyledP1>
               Execution {executionAsDisplay(singleExecution.execution)} -{" "}
-              {shortDate(
+              {getDateCopy(
                 singleExecution.activatedTime ?? singleExecution.ingestTime
               )}
             </StyledP1>

--- a/src/pages/task/taskTabs/logs/logTypes/TaskEventLogLine.tsx
+++ b/src/pages/task/taskTabs/logs/logTypes/TaskEventLogLine.tsx
@@ -1,12 +1,10 @@
 import React from "react";
 import styled from "@emotion/styled";
-import { format } from "date-fns";
 import { StyledLink, StyledRouterLink } from "components/styles";
 import { getHostRoute } from "constants/routes";
 import { size } from "constants/tokens";
 import { TaskEventLogEntry } from "gql/generated/types";
-
-const FORMAT_STR = "MMM d, yyyy, h:mm:ss aaaa";
+import { getDateCopy } from "utils/string";
 
 export const TaskEventLogLine: React.VFC<TaskEventLogEntry> = ({
   timestamp,
@@ -77,7 +75,7 @@ export const TaskEventLogLine: React.VFC<TaskEventLogEntry> = ({
     case "TASK_SCHEDULED":
       message = (
         <span className="cy-event-scheduled">
-          Scheduled at {format(new Date(timestamp), FORMAT_STR)}
+          Scheduled at {getDateCopy(timestamp)}
         </span>
       );
       break;
@@ -97,9 +95,7 @@ export const TaskEventLogLine: React.VFC<TaskEventLogEntry> = ({
 
   return (
     <Row>
-      <Timestamp className="cy-event-ts">
-        {format(new Date(timestamp), FORMAT_STR)}
-      </Timestamp>
+      <Timestamp className="cy-event-ts">{getDateCopy(timestamp)}</Timestamp>
       {message}
     </Row>
   );

--- a/src/utils/string/index.ts
+++ b/src/utils/string/index.ts
@@ -119,10 +119,6 @@ export const getDateCopy = (
   return format(new Date(time), dateFormat);
 };
 
-const SHORT_DATE_FORMAT = "M/d/yy h:mm aa";
-export const shortDate = (d: Date): string =>
-  d ? format(new Date(d), SHORT_DATE_FORMAT) : "";
-
 export const copyToClipboard = (str: string) => {
   const el = document.createElement("textarea");
   el.value = str;


### PR DESCRIPTION
[EVG-15881](https://jira.mongodb.org/browse/EVG-15881)

### Description 
I didn't change the format for [LogMessageLine](https://github.com/evergreen-ci/spruce/blob/ab6d3de345e95f93a4ae124c713f342d42410b58/src/pages/task/taskTabs/logs/logTypes/LogMessageLine.tsx#L17) since that format is shown in the logs. For example, the timestamp for the logs shown on this [page](https://spruce.mongodb.com/task/spruce_ubuntu1604_test_patch_ab6d3de345e95f93a4ae124c713f342d42410b58_62a7591a3e8e860fc104b130_22_06_13_15_35_05/logs?execution=0&sortBy=STATUS&sortDir=ASC) come from the TaskLogs query.
