### PR TITLE
EVG-16650 fix pagination test

### DIFF
--- a/cypress/integration/host/host_events.ts
+++ b/cypress/integration/host/host_events.ts
@@ -190,10 +190,7 @@ describe("Host events", () => {
 
   it("host event pagination last page displays the right items", () => {
     cy.visit("host/i-0f81a2d39744003dd?limit=10&page=3");
-    const hostTypes = ["host-running-task-set-link", "host-provisioned"];
-    hostTypes.forEach((hostType) => {
-      cy.dataCy(hostType).should("exist");
-    });
+    cy.dataCy("host-provisioned").should("exist");
   });
 
   it("host events are displayed in the right timezone", () => {


### PR DESCRIPTION
[EVG-16650](https://jira.mongodb.org/browse/EVG-16650)

### Description 
Follow on change to #1320.
The removal of the `host pid set` event in https://github.com/evergreen-ci/evergreen/pull/5714 will cause the pages to be off and [this assertion](https://github.com/evergreen-ci/spruce/blob/a0b7414b031c8b39668b13ec52dff23d6df2c5a1/cypress/integration/host/host_events.ts#L191) to fail.
With the changes in this PR the e2e test passes ([Spruce patch with Evergreen changes applied as a module)](https://spruce.mongodb.com/version/62a8bf353066157de6c298f7/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC).

When this is approved I will merge the two PRs as close as possible to each other (Evergreen first) to minimize the time the e2e test is broken. (Unless there's a better strategy)

### Screenshots
This is a screenshot from the [failing downstream e2e test](https://spruce.mongodb.com/task/spruce_ubuntu1604_e2e_test_patch_64856dc847f18af6bad813a2d99178588554c39b_62a7a61c2a60ed17e0913a5e_22_06_13_21_03_25/logs?execution=0&sortBy=STATUS&sortDir=ASC) from the Evergreen PR

![failing e2e test](https://mciuploads.s3.amazonaws.com/spruce/spruce_ubuntu1604_e2e_test_patch_64856dc847f18af6bad813a2d99178588554c39b_62a7a61c2a60ed17e0913a5e_22_06_13_21_03_25/Host%20events%20--%20host%20event%20pagination%20last%20page%20displays%20the%20right%20items%20(failed).png)