### PR TITLE
EVG-17090: Hide "Attach to Repo" button on production

### DIFF
--- a/src/pages/projectSettings/tabs/GeneralTab/Fields/RepoConfigField.tsx
+++ b/src/pages/projectSettings/tabs/GeneralTab/Fields/RepoConfigField.tsx
@@ -9,9 +9,12 @@ import { SpruceForm } from "components/SpruceForm";
 import { size, zIndex } from "constants/tokens";
 import { GetGithubOrgsQuery } from "gql/generated/types";
 import { GET_GITHUB_ORGS } from "gql/queries";
+import { environmentalVariables } from "utils";
 import { ProjectType } from "../../utils";
 import { AttachDetachModal } from "./AttachDetachModal";
 import { MoveRepoModal } from "./MoveRepoModal";
+
+const { isProduction } = environmentalVariables;
 
 export const RepoConfigField: Field = ({
   formData,
@@ -61,35 +64,38 @@ export const RepoConfigField: Field = ({
                 Move to New Repo
               </Button>
             )}
-            <ConditionalWrapper
-              condition={ownerOrRepoHasChanges}
-              wrapper={(children) => (
-                <Tooltip
-                  align="top"
-                  data-cy="attach-repo-disabled-tooltip"
-                  justify="middle"
-                  popoverZIndex={zIndex.popover}
-                  triggerEvent="hover"
-                  trigger={children}
-                >
-                  Project must be saved with new owner/repo before it can be
-                  attached.
-                </Tooltip>
-              )}
-            >
-              <ButtonWrapper>
-                <Button
-                  size="small"
-                  onClick={() => setAttachModalOpen(true)}
-                  data-cy="attach-repo-button"
-                  disabled={ownerOrRepoHasChanges}
-                >
-                  {isAttachedProject
-                    ? "Detach from Current Repo"
-                    : "Attach to Current Repo"}
-                </Button>
-              </ButtonWrapper>
-            </ConditionalWrapper>
+            {/* TODO: Remove isProduction check as part of EVG-17091 */}
+            {!isProduction() && (
+              <ConditionalWrapper
+                condition={ownerOrRepoHasChanges}
+                wrapper={(children) => (
+                  <Tooltip
+                    align="top"
+                    data-cy="attach-repo-disabled-tooltip"
+                    justify="middle"
+                    popoverZIndex={zIndex.popover}
+                    triggerEvent="hover"
+                    trigger={children}
+                  >
+                    Project must be saved with new owner/repo before it can be
+                    attached.
+                  </Tooltip>
+                )}
+              >
+                <ButtonWrapper>
+                  <Button
+                    size="small"
+                    onClick={() => setAttachModalOpen(true)}
+                    data-cy="attach-repo-button"
+                    disabled={ownerOrRepoHasChanges}
+                  >
+                    {isAttachedProject
+                      ? "Detach from Current Repo"
+                      : "Attach to Current Repo"}
+                  </Button>
+                </ButtonWrapper>
+              </ConditionalWrapper>
+            )}
           </ButtonRow>
           <MoveRepoModal
             githubOrgs={githubOrgs}


### PR DESCRIPTION
EVG-17090

### Description 
- To facilitate the release of project settings sans attaching to repos, hide the "attach" button in production environment