### PR TITLE
EVG-17051 Remove single quotes from deploy emails

### DIFF
--- a/email.sh
+++ b/email.sh
@@ -82,8 +82,6 @@ case "$OSTYPE" in
   *)        echo "unknown: $OSTYPE";;
 esac
 
-# sed remove single quote and replace with &lsquo;
-sed -e 's|["'\'']|\&lsquo;|g' body.txt
 echo "Commits Deployed:"
 cat body.txt
 

--- a/email.sh
+++ b/email.sh
@@ -67,12 +67,17 @@ fi
 case "$OSTYPE" in
   darwin*)
     echo "OSX detected using gsed"
+    # Format the email and inject the <br /> tag for line breaks
     gsed -i ':a;N;$!ba;s/\n/<br \/>/g' body.txt
-
+    # Remove single quotes from the email body
+    gsed -i 's|["'\'']||g' body.txt
   ;;
   linux*)
     echo "LINUX detected using sed"
+    # Format the email and inject the <br /> tag for line breaks
     sed -i ':a;N;$!ba;s/\n/<br \/>/g' body.txt
+    # Remove single quotes from the email body
+    sed -i 's|["'\'']||g' body.txt
   ;;
   *)        echo "unknown: $OSTYPE";;
 esac

--- a/email.sh
+++ b/email.sh
@@ -70,18 +70,20 @@ case "$OSTYPE" in
     # Format the email and inject the <br /> tag for line breaks
     gsed -i ':a;N;$!ba;s/\n/<br \/>/g' body.txt
     # Remove single quotes from the email body
-    gsed -i 's|["'\'']||g' body.txt
+    gsed -i 's|["'\'']|\&lsquo;|g' body.txt
   ;;
   linux*)
     echo "LINUX detected using sed"
     # Format the email and inject the <br /> tag for line breaks
     sed -i ':a;N;$!ba;s/\n/<br \/>/g' body.txt
     # Remove single quotes from the email body
-    sed -i 's|["'\'']||g' body.txt
+    sed -i 's|["'\'']|\&lsquo;|g' body.txt
   ;;
   *)        echo "unknown: $OSTYPE";;
 esac
 
+# sed remove single quote and replace with &lsquo;
+sed -e 's|["'\'']|\&lsquo;|g' body.txt
 echo "Commits Deployed:"
 cat body.txt
 

--- a/email.sh
+++ b/email.sh
@@ -66,17 +66,17 @@ fi
 # Detect which version of sed we have available to format the email
 case "$OSTYPE" in
   darwin*)
-    echo "OSX detected using gsed"
+    echo "OSX detected"
     # Format the email and inject the <br /> tag for line breaks
-    gsed -i ':a;N;$!ba;s/\n/<br \/>/g' body.txt
-    # Remove single quotes from the email body
-    gsed -i 's|["'\'']|\&lsquo;|g' body.txt
+    sed -i'' -e "s/$/\<br\/>/" body.txt
+    # # Remove single quotes from the email body.txt
+    sed -i'' -e "s/'/\&lsquo;/g" body.txt
   ;;
   linux*)
-    echo "LINUX detected using sed"
+    echo "LINUX detected"
     # Format the email and inject the <br /> tag for line breaks
     sed -i ':a;N;$!ba;s/\n/<br \/>/g' body.txt
-    # Remove single quotes from the email body
+    # Remove single quotes from the email body.txt
     sed -i 's|["'\'']|\&lsquo;|g' body.txt
   ;;
   *)        echo "unknown: $OSTYPE";;


### PR DESCRIPTION
[EVG-17051](https://jira.mongodb.org/browse/EVG-17051)

### Description 
Removes single quotes from strings and replaces them with an html character code equivalent. This prevents us from accidentally escaping the bash command to send an email if there is a single quote in the email message.


### Testing 
Tested both sed and gsed commands on linux and osx respectively.

