### PR TITLE
EVG-17085 Add periodic build as a requestor in the new UI

### DIFF
--- a/src/pages/commits/commitTypeSelect/index.tsx
+++ b/src/pages/commits/commitTypeSelect/index.tsx
@@ -33,6 +33,11 @@ const TreeData = [
     title: "Triggers",
     key: CommitRequesterTypes.TriggerRequester,
   },
+  {
+    value: CommitRequesterTypes.AdHocRequester,
+    title: "Periodic Build",
+    key: CommitRequesterTypes.AdHocRequester,
+  },
 ];
 
 const CommitTypeSelector = () => {

--- a/src/pages/commits/commitTypeSelect/index.tsx
+++ b/src/pages/commits/commitTypeSelect/index.tsx
@@ -35,7 +35,7 @@ const TreeData = [
   },
   {
     value: CommitRequesterTypes.AdHocRequester,
-    title: "Periodic Build",
+    title: "Periodic Builds",
     key: CommitRequesterTypes.AdHocRequester,
   },
 ];

--- a/src/types/commits.ts
+++ b/src/types/commits.ts
@@ -27,6 +27,7 @@ export enum CommitRequesterTypes {
   RepotrackerVersionRequester = "gitter_request",
   TriggerRequester = "trigger_request",
   GitTagRequester = "git_tag_request",
+  AdHocRequester = "ad_hoc",
 }
 
 export type Commits = MainlineCommitsQuery["mainlineCommits"]["versions"];


### PR DESCRIPTION
[EVG-17085](https://jira.mongodb.org/browse/EVG-17085)

### Description 
This adds Periodic Builds to the dropdown on the waterfall page. 

### Screenshots
<img width="249" alt="image" src="https://user-images.githubusercontent.com/13104717/175602022-17cb3221-edf3-401a-afa6-f205b3c948e7.png">

### Testing 
[Tested on staging](http://localhost:3000/commits/mci?requester=all,gitter_request,git_tag_request,trigger_request,ad_hoc&skipOrderNumber=7828) on the mci project. 

### Evergreen PR 
[5751](https://github.com/evergreen-ci/evergreen/pull/5751)
