### PR TITLE
EVG-17282 Require owner and repo field in order to save

### DIFF
--- a/src/pages/projectSettings/tabs/GeneralTab/getFormSchema.tsx
+++ b/src/pages/projectSettings/tabs/GeneralTab/getFormSchema.tsx
@@ -34,6 +34,7 @@ export const getFormSchema = (
       generalConfiguration: {
         type: "object" as "object",
         title: "General Configuration",
+        required: ["branch"],
         properties: {
           enabled: {
             type: ["boolean", "null"],

--- a/src/pages/projectSettings/tabs/GeneralTab/getFormSchema.tsx
+++ b/src/pages/projectSettings/tabs/GeneralTab/getFormSchema.tsx
@@ -45,6 +45,7 @@ export const getFormSchema = (
           repositoryInfo: {
             type: "object" as "object",
             title: "Repository Info",
+            required: ["owner", "repo"],
             properties: {
               owner: {
                 type: "string" as "string",


### PR DESCRIPTION
[EVG-17282](https://jira.mongodb.org/browse/EVG-17282)

### Description 
It was possible to save a project without a owner and repo this would cause issues when it came to enabling github tracking. We should disable the ability to save projects that are missing a owner and repo

