### PR TITLE
EVG-13880: Remove baseStatus from version.tasks query

### DIFF
--- a/cypress/integration/subscription_modal.ts
+++ b/cypress/integration/subscription_modal.ts
@@ -12,7 +12,7 @@ const testSharedSubscriptionModalFunctionality = (
   describe(description, () => {
     it("Displays success toast after submitting a valid form and request succeeds", () => {
       openSubscriptionModal(route, dataCyToggleModalButton);
-      cy.dataCy(dataCyModal).should("exist");
+      cy.dataCy(dataCyModal).should("be.visible");
 
       selectAntdOption("event-trigger-select", `This ${type} finishes`);
       selectAntdOption("notification-method-select", "JIRA issue");

--- a/cypress/integration/task/annotations.ts
+++ b/cypress/integration/task/annotations.ts
@@ -17,6 +17,7 @@ describe("Task Annotation Tab", () => {
   it("annotations can be moved between lists", () => {
     cy.get(issuesTable).should("have.length", 1);
     cy.get(suspectedIssuesTable).should("have.length", 3);
+    cy.dataCy("loading-annotation-ticket").should("have.length", 0);
 
     // move from suspectedIssues to Issues
     cy.dataCy("move-btn-AnotherOne").click();
@@ -40,6 +41,7 @@ describe("Task Annotation Tab", () => {
   it("annotations add and delete correctly", () => {
     cy.get(issuesTable).should("have.length", 1);
     cy.get(suspectedIssuesTable).should("have.length", 3);
+    cy.dataCy("loading-annotation-ticket").should("have.length", 0);
 
     // add a ticket
     cy.dataCy("add-suspected-issue-button").click();

--- a/cypress/integration/task/annotations.ts
+++ b/cypress/integration/task/annotations.ts
@@ -20,13 +20,18 @@ describe("Task Annotation Tab", () => {
 
     // move from suspectedIssues to Issues
     cy.dataCy("move-btn-AnotherOne").click();
-    cy.get(popconfirmYesClassName).should("exist").should("not.be.disabled");
+    cy.get(popconfirmYesClassName)
+      .should("be.visible")
+      .should("not.be.disabled");
     cy.get(popconfirmYesClassName).click();
     cy.get(issuesTable).should("have.length", 2);
     cy.get(suspectedIssuesTable).should("have.length", 2);
 
     // move from Issues to suspectedIssues
     cy.dataCy("move-btn-AnotherOne").click();
+    cy.get(popconfirmYesClassName)
+      .should("be.visible")
+      .should("not.be.disabled");
     cy.get(popconfirmYesClassName).click();
     cy.get(issuesTable).should("have.length", 1);
     cy.get(suspectedIssuesTable).should("have.length", 3);
@@ -46,7 +51,9 @@ describe("Task Annotation Tab", () => {
 
     // delete the added ticket
     cy.dataCy("A-New-Ticket-delete-btn").click();
-    cy.get(popconfirmYesClassName).should("exist").should("not.be.disabled");
+    cy.get(popconfirmYesClassName)
+      .should("be.visible")
+      .should("not.be.disabled");
     cy.get(popconfirmYesClassName).click();
     cy.get(issuesTable).should("have.length", 1);
     cy.get(suspectedIssuesTable).should("have.length", 3);

--- a/cypress/integration/version/task_filters.ts
+++ b/cypress/integration/version/task_filters.ts
@@ -117,7 +117,7 @@ describe("Tasks filters", () => {
       cy.dataCy("current-task-count")
         .invoke("text")
         .then((preFilterCount) => {
-          selectCheckboxOption("Failed");
+          selectCheckboxOption("Failed", true);
           urlSearchParamsAreUpdated({
             pathname: pathTasks,
             paramName: urlParam,
@@ -134,7 +134,7 @@ describe("Tasks filters", () => {
                 "not.have.text",
                 preFilterCount
               );
-              selectCheckboxOption("Succeeded");
+              selectCheckboxOption("Succeeded", true);
               urlSearchParamsAreUpdated({
                 pathname: pathTasks,
                 paramName: urlParam,
@@ -161,7 +161,7 @@ describe("Tasks filters", () => {
         "Aborted",
         "Blocked",
       ];
-      selectCheckboxOption("All");
+      selectCheckboxOption("All", true);
       assertChecked(taskStatuses, true);
       urlSearchParamsAreUpdated({
         pathname: pathTasks,
@@ -170,7 +170,7 @@ describe("Tasks filters", () => {
       });
       waitForTable();
 
-      selectCheckboxOption("All");
+      selectCheckboxOption("All", false);
       assertChecked(taskStatuses, false);
       urlSearchParamsAreUpdated({
         pathname: pathTasks,
@@ -193,7 +193,7 @@ describe("Tasks filters", () => {
       cy.dataCy("current-task-count")
         .invoke("text")
         .then((preFilterCount) => {
-          selectCheckboxOption("Succeeded");
+          selectCheckboxOption("Succeeded", true);
           urlSearchParamsAreUpdated({
             pathname: pathTasks,
             paramName: urlParam,
@@ -210,7 +210,7 @@ describe("Tasks filters", () => {
                 "have.text",
                 preFilterCount
               );
-              selectCheckboxOption("Succeeded");
+              selectCheckboxOption("Succeeded", false);
               urlSearchParamsAreUpdated({
                 pathname: pathTasks,
                 paramName: urlParam,
@@ -226,7 +226,7 @@ describe("Tasks filters", () => {
 
     it("Clicking on 'All' checkbox adds all the base statuses and clicking again removes them", () => {
       const taskStatuses = ["All", "Succeeded"];
-      selectCheckboxOption("All");
+      selectCheckboxOption("All", true);
       assertChecked(taskStatuses, true);
       urlSearchParamsAreUpdated({
         pathname: pathTasks,
@@ -235,7 +235,7 @@ describe("Tasks filters", () => {
       });
       waitForTable();
 
-      selectCheckboxOption("All");
+      selectCheckboxOption("All", false);
       assertChecked(taskStatuses, false);
       urlSearchParamsAreUpdated({
         pathname: pathTasks,
@@ -275,14 +275,23 @@ const assertChecked = (statuses: string[], checked: boolean) => {
 /**
  * Function used to select a checkbox option from the table filter dropdown.
  * @param label label of the checkbox option to click on
+ * @param checked true if should be checked, false if should be unchecked
  */
-const selectCheckboxOption = (label: string) => {
+const selectCheckboxOption = (label: string, checked: boolean) => {
   cy.get(":not(.ant-dropdown-hidden) > .ant-table-filter-dropdown")
     .find(".cy-checkbox")
     .should("not.be.disabled")
     .each((el) => {
       if (el.text() === label) {
-        cy.wrap(el).click({ scrollBehavior: false });
+        if (checked) {
+          cy.wrap(el)
+            .find('input[type="checkbox"]')
+            .check({ force: true, scrollBehavior: false });
+        } else {
+          cy.wrap(el)
+            .find('input[type="checkbox"]')
+            .uncheck({ force: true, scrollBehavior: false });
+        }
       }
     });
 };

--- a/cypress/integration/version/task_filters.ts
+++ b/cypress/integration/version/task_filters.ts
@@ -66,6 +66,7 @@ describe("Tasks filters", () => {
         paramName: urlParam,
         search: null,
       });
+      waitForTable();
       cy.dataCy("current-task-count").should("contain.text", 50);
     });
   });
@@ -101,6 +102,7 @@ describe("Tasks filters", () => {
         paramName: urlParam,
         search: null,
       });
+      waitForTable();
       cy.dataCy("current-task-count").should("contain.text", 50);
     });
   });
@@ -127,6 +129,7 @@ describe("Tasks filters", () => {
           cy.dataCy("current-task-count")
             .invoke("text")
             .should("have.length.greaterThan", 0);
+
           cy.dataCy("current-task-count")
             .invoke("text")
             .then((postFilterCount) => {
@@ -140,6 +143,7 @@ describe("Tasks filters", () => {
                 paramName: urlParam,
                 search: "failed,success",
               });
+              waitForTable();
               cy.dataCy("current-task-count").should(
                 "not.have.text",
                 postFilterCount
@@ -203,6 +207,7 @@ describe("Tasks filters", () => {
           cy.dataCy("current-task-count")
             .invoke("text")
             .should("have.length.greaterThan", 0);
+
           cy.dataCy("current-task-count")
             .invoke("text")
             .then((postFilterCount) => {
@@ -216,6 +221,7 @@ describe("Tasks filters", () => {
                 paramName: urlParam,
                 search: null,
               });
+              waitForTable();
               cy.dataCy("current-task-count").should(
                 "have.text",
                 postFilterCount

--- a/cypress/integration/version/task_filters.ts
+++ b/cypress/integration/version/task_filters.ts
@@ -56,8 +56,9 @@ describe("Tasks filters", () => {
         search: variantInputValue,
       });
       cy.dataCy("tasks-table").should("be.visible");
-      cy.toggleTableFilter(4);
       cy.dataCy("current-task-count").should("contain.text", 2);
+
+      cy.toggleTableFilter(4);
       cy.dataCy("variant-input-wrapper")
         .find("input")
         .focus()
@@ -88,6 +89,8 @@ describe("Tasks filters", () => {
         search: taskNameInputValue,
       });
       cy.dataCy("tasks-table").should("be.visible");
+      cy.dataCy("current-task-count").should("contain.text", 2);
+
       cy.toggleTableFilter(1);
       cy.dataCy("taskname-input-wrapper")
         .find("input")

--- a/cypress/integration/version/task_filters.ts
+++ b/cypress/integration/version/task_filters.ts
@@ -55,6 +55,7 @@ describe("Tasks filters", () => {
         paramName: urlParam,
         search: variantInputValue,
       });
+      cy.dataCy("tasks-table").should("be.visible");
       cy.toggleTableFilter(4);
       cy.dataCy("current-task-count").should("contain.text", 2);
       cy.dataCy("variant-input-wrapper")
@@ -86,18 +87,19 @@ describe("Tasks filters", () => {
         paramName: urlParam,
         search: taskNameInputValue,
       });
+      cy.dataCy("tasks-table").should("be.visible");
       cy.toggleTableFilter(1);
       cy.dataCy("taskname-input-wrapper")
         .find("input")
         .focus()
         .clear()
-        .type(`{enter}`);
-      cy.toggleTableFilter(1);
+        .type(`{enter}`, { scrollBehavior: false });
       urlSearchParamsAreUpdated({
         pathname: pathTasks,
         paramName: urlParam,
         search: null,
       });
+      cy.dataCy("current-task-count").should("contain.text", 50);
     });
   });
 
@@ -118,6 +120,10 @@ describe("Tasks filters", () => {
             paramName: urlParam,
             search: "failed",
           });
+          cy.dataCy("tasks-table").should("be.visible");
+          cy.dataCy("current-task-count")
+            .invoke("text")
+            .should("have.length.greaterThan", 0);
           cy.dataCy("current-task-count")
             .invoke("text")
             .then((postFilterCount) => {

--- a/cypress/integration/version/task_filters.ts
+++ b/cypress/integration/version/task_filters.ts
@@ -82,7 +82,7 @@ describe("Tasks filters", () => {
         .find("input")
         .focus()
         .type(taskNameInputValue)
-        .type("{enter}");
+        .type("{enter}", { scrollBehavior: false });
       urlSearchParamsAreUpdated({
         pathname: pathTasks,
         paramName: urlParam,
@@ -110,6 +110,7 @@ describe("Tasks filters", () => {
     const urlParam = "statuses";
     before(() => {
       cy.contains("Clear All Filters").click();
+      cy.dataCy("tasks-table").should("be.visible");
       cy.toggleTableFilter(2);
     });
 
@@ -140,7 +141,6 @@ describe("Tasks filters", () => {
                 paramName: urlParam,
                 search: "failed-umbrella,failed,known-issue,success",
               });
-
               cy.dataCy("current-task-count").should(
                 "not.have.text",
                 postFilterCount
@@ -177,7 +177,7 @@ describe("Tasks filters", () => {
       urlSearchParamsAreUpdated({
         pathname: pathTasks,
         paramName: urlParam,
-        search: "",
+        search: null,
       });
     });
   });
@@ -185,7 +185,7 @@ describe("Tasks filters", () => {
   describe("Task Base Statuses select", () => {
     const urlParam = "baseStatuses";
     before(() => {
-      cy.visit(pathTasks);
+      cy.contains("Clear All Filters").click();
       cy.dataCy("tasks-table").should("be.visible");
       cy.toggleTableFilter(3);
     });
@@ -216,7 +216,7 @@ describe("Tasks filters", () => {
               urlSearchParamsAreUpdated({
                 pathname: pathTasks,
                 paramName: urlParam,
-                search: "",
+                search: null,
               });
               cy.dataCy("current-task-count").should(
                 "have.text",
@@ -227,30 +227,25 @@ describe("Tasks filters", () => {
     });
 
     it("Clicking on 'All' checkbox adds all the base statuses and clicking again removes them", () => {
-      cy.toggleTableFilter(3);
       const taskStatuses = ["All", "Succeeded"];
-      cy.getInputByLabel("All").check({ force: true });
+      cy.toggleTableFilter(3);
+      cy.getInputByLabel("All").check({ force: true, scrollBehavior: false });
       taskStatuses.forEach((status) => {
         cy.getInputByLabel(status).should("be.checked");
       });
-
-      cy.toggleTableFilter(3);
       urlSearchParamsAreUpdated({
         pathname: pathTasks,
         paramName: urlParam,
-        search: "all,success",
+        search: "all",
       });
-
-      cy.getInputByLabel("All").uncheck({ force: true });
+      cy.getInputByLabel("All").uncheck({ force: true, scrollBehavior: false });
       taskStatuses.forEach((status) => {
         cy.getInputByLabel(status).should("not.be.checked");
       });
-      cy.toggleTableFilter(3);
-
       urlSearchParamsAreUpdated({
         pathname: pathTasks,
         paramName: urlParam,
-        search: "",
+        search: null,
       });
     });
   });

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -61,7 +61,9 @@ Cypress.Commands.add("toggleTableFilter", (colNum: number) => {
     .find("[role=button]")
     .first()
     .click();
-  cy.get(".ant-table-filter-dropdown").should("be.visible");
+  cy.get(":not(.ant-dropdown-hidden) > .ant-table-filter-dropdown").should(
+    "be.visible"
+  );
 });
 
 Cypress.Commands.add(

--- a/cypress/utils/index.ts
+++ b/cypress/utils/index.ts
@@ -72,6 +72,7 @@ export const clickOnPageSizeBtnAndAssertURLandTableSize = (
  */
 export const selectAntdOption = (dataCy: string, option: string) => {
   // open select
+  cy.dataCy(dataCy).should("be.visible").should("not.be.disabled");
   cy.dataCy(dataCy).click();
   // click on option
   cy.get(".ant-select-dropdown :not(.ant-select-dropdown-hidden)")

--- a/src/components/Table/TasksTable.stories.tsx
+++ b/src/components/Table/TasksTable.stories.tsx
@@ -6,11 +6,13 @@ const tasks = [
     aborted: false,
     displayName: "Some Fancy ID",
     version: "123",
-    status: "success",
+    status: "started",
     buildVariant: "ubuntu1604",
     buildVariantDisplayName: "Ubuntu 16.04",
     blocked: false,
-    baseStatus: "failed",
+    baseTask: {
+      status: "unscheduled",
+    },
   },
   {
     id: "some_id_2",
@@ -21,7 +23,9 @@ const tasks = [
     buildVariant: "ubuntu1604",
     buildVariantDisplayName: "Ubuntu 16.04",
     blocked: false,
-    baseStatus: "failed",
+    baseTask: {
+      status: "failed",
+    },
   },
   {
     id: "some_id_3",
@@ -32,7 +36,9 @@ const tasks = [
     buildVariant: "Windows",
     buildVariantDisplayName: "Windows 97",
     blocked: false,
-    baseStatus: "failed",
+    baseTask: {
+      status: "failed",
+    },
   },
 ];
 
@@ -47,7 +53,9 @@ const nestedTasks = [
     buildVariant: "Windows",
     buildVariantDisplayName: "Windows 97",
     blocked: false,
-    baseStatus: "failed",
+    baseTask: {
+      status: "failed",
+    },
     executionTasksFull: [
       {
         id: "some_id_5",
@@ -58,7 +66,9 @@ const nestedTasks = [
         buildVariant: "Windows",
         buildVariantDisplayName: "Windows 97",
         blocked: false,
-        baseStatus: "aborted",
+        baseTask: {
+          status: "aborted",
+        },
       },
       {
         id: "some_id_6",
@@ -69,7 +79,9 @@ const nestedTasks = [
         buildVariant: "Windows",
         buildVariantDisplayName: "Windows 97",
         blocked: false,
-        baseStatus: "failed",
+        baseTask: {
+          status: "system-failed",
+        },
       },
     ],
   },

--- a/src/components/Table/TasksTable.tsx
+++ b/src/components/Table/TasksTable.tsx
@@ -172,7 +172,8 @@ const getColumnDefs = ({
       },
     }),
     sorter: {
-      compare: (a, b) => sortTasks(a.baseStatus, b.baseStatus),
+      compare: (a, b) =>
+        sortTasks(a?.baseTask?.status, b?.baseTask?.baseStatus),
       multiple: 4,
     },
     className: "cy-task-table-col-BASE_STATUS",

--- a/src/components/Table/TasksTable.tsx
+++ b/src/components/Table/TasksTable.tsx
@@ -67,6 +67,7 @@ export const TasksTable: React.VFC<TasksTableProps> = ({
     rowKey={rowKey}
     pagination={false}
     loading={loading}
+    data-loading={loading}
     columns={
       sorts
         ? getColumnDefsWithSort({

--- a/src/components/Table/TasksTable.tsx
+++ b/src/components/Table/TasksTable.tsx
@@ -172,8 +172,7 @@ const getColumnDefs = ({
       },
     }),
     sorter: {
-      compare: (a, b) =>
-        sortTasks(a?.baseTask?.status, b?.baseTask?.baseStatus),
+      compare: (a, b) => sortTasks(a?.baseTask?.status, b?.baseTask?.status),
       multiple: 4,
     },
     className: "cy-task-table-col-BASE_STATUS",

--- a/src/components/Table/__snapshots__/TasksTable.stories.storyshot
+++ b/src/components/Table/__snapshots__/TasksTable.stories.storyshot
@@ -13,6 +13,7 @@ exports[`storybook Storyshots Components/Tasks Table Base Task Table 1`] = `
       <div
         className="ant-table"
         data-cy="tasks-table"
+        data-loading={false}
       >
         <div
           className="ant-table-container"
@@ -557,6 +558,7 @@ exports[`storybook Storyshots Components/Tasks Table Execution Tasks Table 1`] =
       <div
         className="ant-table"
         data-cy="tasks-table"
+        data-loading={false}
       >
         <div
           className="ant-table-container"

--- a/src/components/Table/__snapshots__/TasksTable.stories.storyshot
+++ b/src/components/Table/__snapshots__/TasksTable.stories.storyshot
@@ -350,10 +350,10 @@ exports[`storybook Storyshots Components/Tasks Table Base Task Table 1`] = `
                     style={Object {}}
                   >
                     <div
-                      className="css-11x3fkx-StyledBadge-badgeWidthMaxContent-badgeWidthMaxContent e19oz5u0 leafygreen-ui-114ed4x"
+                      className="css-11x3fkx-StyledBadge-badgeWidthMaxContent-badgeWidthMaxContent e19oz5u0 leafygreen-ui-1e1vnx9"
                       data-cy="task-status-badge"
                     >
-                      Succeeded
+                      Running
                     </div>
                   </td>
                   <td
@@ -363,7 +363,14 @@ exports[`storybook Storyshots Components/Tasks Table Base Task Table 1`] = `
                     onMouseLeave={[Function]}
                     rowSpan={null}
                     style={Object {}}
-                  />
+                  >
+                    <div
+                      className="css-11x3fkx-StyledBadge-badgeWidthMaxContent-badgeWidthMaxContent e19oz5u0 leafygreen-ui-13xc3rv"
+                      data-cy="task-status-badge"
+                    >
+                      Unscheduled
+                    </div>
+                  </td>
                   <td
                     className="ant-table-cell cy-task-table-col-VARIANT"
                     colSpan={null}
@@ -429,7 +436,14 @@ exports[`storybook Storyshots Components/Tasks Table Base Task Table 1`] = `
                     onMouseLeave={[Function]}
                     rowSpan={null}
                     style={Object {}}
-                  />
+                  >
+                    <div
+                      className="css-11x3fkx-StyledBadge-badgeWidthMaxContent-badgeWidthMaxContent e19oz5u0 leafygreen-ui-1sq0is2"
+                      data-cy="task-status-badge"
+                    >
+                      Failed
+                    </div>
+                  </td>
                   <td
                     className="ant-table-cell cy-task-table-col-VARIANT"
                     colSpan={null}
@@ -495,7 +509,14 @@ exports[`storybook Storyshots Components/Tasks Table Base Task Table 1`] = `
                     onMouseLeave={[Function]}
                     rowSpan={null}
                     style={Object {}}
-                  />
+                  >
+                    <div
+                      className="css-11x3fkx-StyledBadge-badgeWidthMaxContent-badgeWidthMaxContent e19oz5u0 leafygreen-ui-1sq0is2"
+                      data-cy="task-status-badge"
+                    >
+                      Failed
+                    </div>
+                  </td>
                   <td
                     className="ant-table-cell cy-task-table-col-VARIANT"
                     colSpan={null}
@@ -887,10 +908,10 @@ exports[`storybook Storyshots Components/Tasks Table Execution Tasks Table 1`] =
                     style={Object {}}
                   >
                     <div
-                      className="css-11x3fkx-StyledBadge-badgeWidthMaxContent-badgeWidthMaxContent e19oz5u0 leafygreen-ui-114ed4x"
+                      className="css-11x3fkx-StyledBadge-badgeWidthMaxContent-badgeWidthMaxContent e19oz5u0 leafygreen-ui-1e1vnx9"
                       data-cy="task-status-badge"
                     >
-                      Succeeded
+                      Running
                     </div>
                   </td>
                   <td
@@ -900,7 +921,14 @@ exports[`storybook Storyshots Components/Tasks Table Execution Tasks Table 1`] =
                     onMouseLeave={[Function]}
                     rowSpan={null}
                     style={Object {}}
-                  />
+                  >
+                    <div
+                      className="css-11x3fkx-StyledBadge-badgeWidthMaxContent-badgeWidthMaxContent e19oz5u0 leafygreen-ui-13xc3rv"
+                      data-cy="task-status-badge"
+                    >
+                      Unscheduled
+                    </div>
+                  </td>
                   <td
                     className="ant-table-cell cy-task-table-col-VARIANT"
                     colSpan={null}
@@ -980,7 +1008,14 @@ exports[`storybook Storyshots Components/Tasks Table Execution Tasks Table 1`] =
                     onMouseLeave={[Function]}
                     rowSpan={null}
                     style={Object {}}
-                  />
+                  >
+                    <div
+                      className="css-11x3fkx-StyledBadge-badgeWidthMaxContent-badgeWidthMaxContent e19oz5u0 leafygreen-ui-1sq0is2"
+                      data-cy="task-status-badge"
+                    >
+                      Failed
+                    </div>
+                  </td>
                   <td
                     className="ant-table-cell cy-task-table-col-VARIANT"
                     colSpan={null}
@@ -1060,7 +1095,14 @@ exports[`storybook Storyshots Components/Tasks Table Execution Tasks Table 1`] =
                     onMouseLeave={[Function]}
                     rowSpan={null}
                     style={Object {}}
-                  />
+                  >
+                    <div
+                      className="css-11x3fkx-StyledBadge-badgeWidthMaxContent-badgeWidthMaxContent e19oz5u0 leafygreen-ui-1sq0is2"
+                      data-cy="task-status-badge"
+                    >
+                      Failed
+                    </div>
+                  </td>
                   <td
                     className="ant-table-cell cy-task-table-col-VARIANT"
                     colSpan={null}
@@ -1140,7 +1182,14 @@ exports[`storybook Storyshots Components/Tasks Table Execution Tasks Table 1`] =
                     onMouseLeave={[Function]}
                     rowSpan={null}
                     style={Object {}}
-                  />
+                  >
+                    <div
+                      className="css-11x3fkx-StyledBadge-badgeWidthMaxContent-badgeWidthMaxContent e19oz5u0 leafygreen-ui-1sq0is2"
+                      data-cy="task-status-badge"
+                    >
+                      Failed
+                    </div>
+                  </td>
                   <td
                     className="ant-table-cell cy-task-table-col-VARIANT"
                     colSpan={null}

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -5992,7 +5992,6 @@ export type VersionTasksQuery = {
         executionTasksFull?: Maybe<
           Array<{
             id: string;
-            baseStatus?: Maybe<string>;
             buildVariant: string;
             buildVariantDisplayName?: Maybe<string>;
             displayName: string;

--- a/src/gql/queries/get-version-tasks.graphql
+++ b/src/gql/queries/get-version-tasks.graphql
@@ -20,7 +20,6 @@ query VersionTasks(
         execution
         executionTasksFull {
           id
-          baseStatus
           baseTask {
             id
             execution


### PR DESCRIPTION
[EVG-13880](https://jira.mongodb.org/browse/EVG-13880)

### Description 
Since `version.tasks` already fetches the `baseTask` for every task, there's no reason to also fetch the `baseStatus`.

### Screenshots
- No visible changes

### Testing 
- Modified `TasksTable.stories.tsx`
