### PR TITLE
EVG-17397: Fix event log caching bug

### DIFF
--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -976,7 +976,6 @@ export type Project = {
   batchTime: Scalars["Int"];
   branch: Scalars["String"];
   buildBaronSettings: BuildBaronSettings;
-  cedarTestResultsEnabled?: Maybe<Scalars["Boolean"]>;
   commitQueue: CommitQueueParams;
   deactivatePrevious?: Maybe<Scalars["Boolean"]>;
   defaultLogger: Scalars["String"];
@@ -1083,7 +1082,6 @@ export type ProjectInput = {
   batchTime?: InputMaybe<Scalars["Int"]>;
   branch?: InputMaybe<Scalars["String"]>;
   buildBaronSettings?: InputMaybe<BuildBaronSettingsInput>;
-  cedarTestResultsEnabled?: InputMaybe<Scalars["Boolean"]>;
   commitQueue?: InputMaybe<CommitQueueParamsInput>;
   deactivatePrevious?: InputMaybe<Scalars["Boolean"]>;
   defaultLogger?: InputMaybe<Scalars["String"]>;
@@ -1418,7 +1416,6 @@ export type RepoRef = {
   batchTime: Scalars["Int"];
   branch: Scalars["String"];
   buildBaronSettings: BuildBaronSettings;
-  cedarTestResultsEnabled: Scalars["Boolean"];
   commitQueue: RepoCommitQueueParams;
   deactivatePrevious: Scalars["Boolean"];
   defaultLogger: Scalars["String"];
@@ -1461,7 +1458,6 @@ export type RepoRefInput = {
   batchTime?: InputMaybe<Scalars["Int"]>;
   branch?: InputMaybe<Scalars["String"]>;
   buildBaronSettings?: InputMaybe<BuildBaronSettingsInput>;
-  cedarTestResultsEnabled?: InputMaybe<Scalars["Boolean"]>;
   commitQueue?: InputMaybe<CommitQueueParamsInput>;
   deactivatePrevious?: InputMaybe<Scalars["Boolean"]>;
   defaultLogger?: InputMaybe<Scalars["String"]>;

--- a/src/pages/projectSettings/tabs/EventLogTab/EventLogTab.tsx
+++ b/src/pages/projectSettings/tabs/EventLogTab/EventLogTab.tsx
@@ -42,6 +42,7 @@ export const EventLogTab: React.VFC<TabProps> = ({ projectType }) => {
     variables: { identifier },
     errorPolicy: "all",
     skip: isRepo,
+    fetchPolicy: "no-cache",
     onError: (e) => {
       dispatchToast.error(`Unable to fetch events for ${identifier}: ${e}`);
     },


### PR DESCRIPTION
EVG-17397

### Description 
- Disable cache on project settings events so that fields are not combined in the name of caching

### Screenshots
Before (task regex renaming is missing -- since the alias has the same `id` field before and after the change is made, Apollo thinks it's being smart by caching and reusing the data):
<img width="953" alt="image" src="https://user-images.githubusercontent.com/9298431/183700050-9c795816-854f-4b49-804d-4d4af0545dae.png">

After:
<img width="968" alt="image" src="https://user-images.githubusercontent.com/9298431/183699980-cd4df8d8-b2c5-4e4f-a9cd-ed69882870b8.png">