### PR TITLE
EVG-17210 Add GP3 volume type

### DIFF
--- a/src/constants/volumes.ts
+++ b/src/constants/volumes.ts
@@ -1,1 +1,1 @@
-export const volumeTypes = ["gp2", "io1", "sc1", "st1", "standard"];
+export const volumeTypes = ["gp2", "gp3", "io1", "sc1", "st1", "standard"];


### PR DESCRIPTION
EVG-17210

### Description
GP3 volume type is accessible via the backend and can be inputted in the old UI, but Spruce does not have it in the volume types allowed

### Screenshots
<img width="1728" alt="Screen Shot 2022-08-10 at 12 34 43 PM" src="https://user-images.githubusercontent.com/64446617/183964756-1b918335-d1f2-4810-938b-59dad32b7ede.png">

### Evergreen PR
https://github.com/evergreen-ci/evergreen/pull/5769
