### PR TITLE
EVG-17491: Make git tag user/team fields not orderable

### DIFF
--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -892,15 +892,6 @@ export type PatchProject = {
   variants: Array<ProjectBuildVariant>;
 };
 
-/**
- * PatchTasks is the return value of the PatchTasks query.
- * It contains an array of Tasks based on filter criteria, as well as a count for the number of Tasks in that array.
- */
-export type PatchTasks = {
-  count: Scalars["Int"];
-  tasks: Array<Task>;
-};
-
 export type PatchTime = {
   finished?: Maybe<Scalars["String"]>;
   started?: Maybe<Scalars["String"]>;
@@ -1223,8 +1214,6 @@ export type Query = {
   myPublicKeys: Array<PublicKey>;
   myVolumes: Array<Volume>;
   patch: Patch;
-  /** @deprecated patchTasks is deprecated, use version.tasks instead. */
-  patchTasks: PatchTasks;
   project: Project;
   projectEvents: ProjectEvents;
   projectSettings: ProjectSettings;
@@ -1312,18 +1301,6 @@ export type QueryMainlineCommitsArgs = {
 
 export type QueryPatchArgs = {
   id: Scalars["String"];
-};
-
-export type QueryPatchTasksArgs = {
-  baseStatuses?: InputMaybe<Array<Scalars["String"]>>;
-  includeEmptyActivation?: InputMaybe<Scalars["Boolean"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  page?: InputMaybe<Scalars["Int"]>;
-  patchId: Scalars["String"];
-  sorts?: InputMaybe<Array<SortOrder>>;
-  statuses?: InputMaybe<Array<Scalars["String"]>>;
-  taskName?: InputMaybe<Scalars["String"]>;
-  variant?: InputMaybe<Scalars["String"]>;
 };
 
 export type QueryProjectArgs = {
@@ -1554,7 +1531,7 @@ export enum SortDirection {
   Desc = "DESC",
 }
 
-/** SortOrder[] is an input value for the patchTasks query. It is used to define where to sort by ASC/DEC for a given sort key. */
+/** SortOrder[] is an input value for version.tasks. It is used to define whether to sort by ASC/DEC for a given sort key. */
 export type SortOrder = {
   Direction: SortDirection;
   Key: TaskSortCategory;

--- a/src/pages/projectSettings/tabs/GithubCommitQueueTab/getFormSchema.tsx
+++ b/src/pages/projectSettings/tabs/GithubCommitQueueTab/getFormSchema.tsx
@@ -525,11 +525,13 @@ const userTeamStyling = (
   },
   [fieldName]: {
     "ui:addButtonText": addButtonText,
+    "ui:orderable": false,
     "ui:showLabel": false,
   },
   repoData: {
     [fieldName]: {
       "ui:disabled": true,
+      "ui:orderable": false,
       "ui:readonly": true,
       "ui:showLabel": false,
     },


### PR DESCRIPTION
EVG-17491

### Description
<!-- add description, context, thought process, etc -->
- Authorized users/teams for git tags should not be able to be reordered

### Screenshots
<!-- add screenshots of visible changes -->
Field no longer has arrows next to each array item:
<img width="444" alt="image" src="https://user-images.githubusercontent.com/9298431/184146784-675fc59b-d8a1-4066-870b-2ce1c70abd62.png">