### PR TITLE
EVG-15841 Add ability to specify a custom date format 

### DIFF
--- a/src/components/CommitChartLabel/index.tsx
+++ b/src/components/CommitChartLabel/index.tsx
@@ -6,10 +6,9 @@ import { StyledRouterLink } from "components/styles";
 import { getVersionRoute, getTaskRoute } from "constants/routes";
 import { size, zIndex } from "constants/tokens";
 import { UpstreamProjectFragment } from "gql/generated/types";
-import { useSpruceConfig } from "hooks";
-import { useUserTimeZone } from "hooks/useUserTimeZone";
+import { useSpruceConfig, useDateFormat } from "hooks";
 import { ProjectTriggerLevel } from "types/triggers";
-import { getDateCopy, shortenGithash } from "utils/string";
+import { shortenGithash } from "utils/string";
 import { jiraLinkify } from "utils/string/jiraLinkify";
 
 const { gray } = uiColors;
@@ -37,7 +36,7 @@ const CommitChartLabel: React.VFC<Props> = ({
   onClickUpstreamProject = () => {},
   upstreamProject,
 }) => {
-  const tz = useUserTimeZone();
+  const getDateCopy = useDateFormat();
   const createDate = new Date(createTime);
   const shortenMessage = message.length > MAX_CHAR;
   const shortenedMessage = message.substring(0, MAX_CHAR - 3).concat("...");
@@ -58,7 +57,7 @@ const CommitChartLabel: React.VFC<Props> = ({
         >
           {shortenGithash(githash)}
         </StyledRouterLink>{" "}
-        <b>{getDateCopy(createDate, { omitSeconds: true, tz })}</b>
+        <b>{getDateCopy(createDate, { omitSeconds: true })}</b>
       </LabelText>
       {upstreamProject && (
         <LabelText>

--- a/src/components/HistoryTable/HistoryTableRow/DateSeparator.tsx
+++ b/src/components/HistoryTable/HistoryTableRow/DateSeparator.tsx
@@ -3,8 +3,7 @@ import styled from "@emotion/styled";
 import { uiColors } from "@leafygreen-ui/palette";
 import { Body } from "@leafygreen-ui/typography";
 import { size } from "constants/tokens";
-import { useUserTimeZone } from "hooks/useUserTimeZone";
-import { getDateCopy } from "utils/string";
+import { useDateFormat } from "hooks";
 
 const { gray } = uiColors;
 interface DateSeparatorProps {
@@ -16,10 +15,10 @@ export const DateSeparator: React.VFC<DateSeparatorProps> = ({
   style,
   date,
 }) => {
-  const tz = useUserTimeZone();
+  const getDateCopy = useDateFormat();
   return (
     <Container style={style}>
-      <DateWrapper>{getDateCopy(date, { tz, dateOnly: true })}</DateWrapper>
+      <DateWrapper>{getDateCopy(date, { dateOnly: true })}</DateWrapper>
       <Line />
     </Container>
   );

--- a/src/components/PatchesPage/PatchCard.tsx
+++ b/src/components/PatchesPage/PatchCard.tsx
@@ -11,10 +11,10 @@ import {
 } from "constants/routes";
 import { fontSize, size } from "constants/tokens";
 import { PatchesPagePatchesFragment } from "gql/generated/types";
-import { useUserTimeZone } from "hooks/useUserTimeZone";
+import { useDateFormat } from "hooks";
 import { Unpacked } from "types/utils";
 import { groupStatusesByUmbrellaStatus } from "utils/statuses";
-import { getDateCopy } from "utils/string";
+
 import { DropdownMenu } from "./patchCard/DropdownMenu";
 
 type P = Unpacked<PatchesPagePatchesFragment["patches"]>;
@@ -48,7 +48,7 @@ export const PatchCard: React.VFC<Props> = ({
   versionFull,
 }) => {
   const createDate = new Date(createTime);
-  const tz = useUserTimeZone();
+  const getDateCopy = useDateFormat();
   const { taskStatusStats, id: versionId } = versionFull || {};
   const { stats } = groupStatusesByUmbrellaStatus(
     taskStatusStats?.counts ?? []
@@ -75,8 +75,7 @@ export const PatchCard: React.VFC<Props> = ({
           {description || "no description"}
         </DescriptionLink>
         <TimeAndProject>
-          {getDateCopy(createDate, { tz })}{" "}
-          {pageType === "project" ? "by" : "on"}{" "}
+          {getDateCopy(createDate)} {pageType === "project" ? "by" : "on"}{" "}
           {pageType === "project" ? (
             <StyledRouterLink
               to={getUserPatchesRoute(author)}

--- a/src/constants/fieldMaps.ts
+++ b/src/constants/fieldMaps.ts
@@ -172,6 +172,8 @@ export const awsRegions = [
   },
 ];
 
+export const dateFormats = ["MM/DD/YYYY", "DD/MM/YYYY", "YYYY/MM/DD"];
+
 export const notificationFields = {
   patchFinish: "Patch finish",
   patchFirstFailure: "Patch first task failure",

--- a/src/constants/fieldMaps.ts
+++ b/src/constants/fieldMaps.ts
@@ -1,3 +1,5 @@
+import { getDateCopy } from "utils/string";
+
 export const timeZones = [
   {
     str: "Coordinated Universal Time",
@@ -172,8 +174,50 @@ export const awsRegions = [
   },
 ];
 
-export const dateFormats = ["MM/DD/YYYY", "DD/MM/YYYY", "YYYY/MM/DD"];
-
+export const dateFormats = [
+  {
+    value: "MM-dd-yyyy",
+    str: `MM-dd-yyyy - ${getDateCopy("08/31/2022", {
+      dateFormat: "MM-dd-yyyy",
+    })}`,
+  },
+  {
+    value: "dd-MM-yyyy",
+    str: `dd-MM-yyyy - ${getDateCopy("08/31/2022", {
+      dateFormat: "dd/MM/yyyy",
+    })}`,
+  },
+  {
+    value: "yyyy-MM-dd",
+    str: `yyyy-MM-dd - ${getDateCopy("08/31/2022", {
+      dateFormat: "yyyy-MM-dd",
+    })}`,
+  },
+  {
+    value: "MM/dd/yyyy",
+    str: `MM/dd/yyyy - ${getDateCopy("08/31/2022", {
+      dateFormat: "MM/dd/yyyy",
+    })}`,
+  },
+  {
+    value: "dd/MM/yyyy",
+    str: `dd/MM/yyyy - ${getDateCopy("08/31/2022", {
+      dateFormat: "dd/MM/yyyy",
+    })}`,
+  },
+  {
+    value: "yyyy/MM/dd",
+    str: `yyyy/MM/dd - ${getDateCopy("08/31/2022", {
+      dateFormat: "yyyy/MM/dd",
+    })}`,
+  },
+  {
+    value: "MMM d, yyyy",
+    str: `MMM d, yyyy - ${getDateCopy("08/31/2022", {
+      dateFormat: "MMM d, yyyy",
+    })}`,
+  },
+];
 export const notificationFields = {
   patchFinish: "Patch finish",
   patchFirstFailure: "Patch first task failure",

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -2038,6 +2038,7 @@ export type UserConfig = {
  * It contains information about a user's settings, such as their GitHub username or timezone.
  */
 export type UserSettings = {
+  dateFormat?: Maybe<Scalars["String"]>;
   githubUser?: Maybe<GithubUser>;
   notifications?: Maybe<Notifications>;
   region?: Maybe<Scalars["String"]>;
@@ -2051,6 +2052,7 @@ export type UserSettings = {
  * It is used to update user information such as GitHub or Slack username.
  */
 export type UserSettingsInput = {
+  dateFormat?: InputMaybe<Scalars["String"]>;
   githubUser?: InputMaybe<GithubUserInput>;
   notifications?: InputMaybe<NotificationsInput>;
   region?: InputMaybe<Scalars["String"]>;
@@ -5866,6 +5868,7 @@ export type GetUserSettingsQuery = {
     timezone?: Maybe<string>;
     region?: Maybe<string>;
     slackUsername?: Maybe<string>;
+    dateFormat?: Maybe<string>;
     notifications?: Maybe<{
       buildBreak?: Maybe<string>;
       commitQueue?: Maybe<string>;

--- a/src/gql/queries/get-user-settings.graphql
+++ b/src/gql/queries/get-user-settings.graphql
@@ -19,5 +19,6 @@ query GetUserSettings {
       spruceV1
       hasUsedMainlineCommitsBefore
     }
+    dateFormat
   }
 }

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -20,3 +20,4 @@ export { useTaskStatuses } from "./useTaskStatuses";
 export { useUpsertQueryParams } from "./useUpsertQueryParams";
 export { useSpruceConfig } from "./useSpruceConfig";
 export { useUserSettings } from "./useUserSettings";
+export { useDateFormat } from "./useDateFormat";

--- a/src/hooks/useDateFormat.ts
+++ b/src/hooks/useDateFormat.ts
@@ -1,0 +1,16 @@
+import { getDateCopy, DateCopyOptions } from "utils/string";
+import { useUserSettings } from "./useUserSettings";
+import { useUserTimeZone } from "./useUserTimeZone";
+
+export const useDateFormat = () => {
+  const timezone = useUserTimeZone();
+  const { userSettings } = useUserSettings();
+  const { dateFormat } = userSettings || {};
+
+  return (date: string | number | Date, options: DateCopyOptions = {}) =>
+    getDateCopy(date, {
+      tz: timezone,
+      dateFormat,
+      ...options,
+    });
+};

--- a/src/pages/Host.tsx
+++ b/src/pages/Host.tsx
@@ -25,7 +25,6 @@ import {
 } from "gql/generated/types";
 import { GET_HOST, GET_HOST_EVENTS } from "gql/queries/index";
 import { usePageTitle } from "hooks/usePageTitle";
-import { useUserTimeZone } from "hooks/useUserTimeZone";
 import { HostTable } from "pages/host/HostTable";
 import { Metadata } from "pages/host/Metadata";
 import { HostStatus } from "types/host";
@@ -56,7 +55,6 @@ export const Host: React.VFC = () => {
   const status = host?.status as HostStatus;
   const sshCommand = `ssh ${user}@${hostUrl}`;
   const tag = host?.tag ?? "";
-  const timeZone = useUserTimeZone();
 
   const { search } = useLocation();
 
@@ -143,7 +141,6 @@ export const Host: React.VFC = () => {
                   loading={hostEventLoading}
                   eventData={hostEventData}
                   error={error}
-                  timeZone={timeZone}
                   page={page}
                   limit={limit}
                   eventsCount={eventsCount}

--- a/src/pages/commitqueue/CommitQueueCard.tsx
+++ b/src/pages/commitqueue/CommitQueueCard.tsx
@@ -15,8 +15,8 @@ import {
   RemoveItemFromCommitQueueMutationVariables,
 } from "gql/generated/types";
 import { REMOVE_ITEM_FROM_COMMIT_QUEUE } from "gql/mutations";
-import { useUserTimeZone } from "hooks/useUserTimeZone";
-import { getDateCopy } from "utils/string";
+import { useDateFormat } from "hooks";
+
 import { CodeChangeModule } from "./codeChangesModule/CodeChangesModule";
 import { ConfirmPatchButton } from "./ConfirmPatchButton";
 
@@ -51,7 +51,7 @@ export const CommitQueueCard: React.VFC<Props> = ({
   activated,
 }) => {
   const dispatchToast = useToastContext();
-  const tz = useUserTimeZone();
+  const getDateCopy = useDateFormat();
   const [removeItemFromCommitQueue, { loading }] = useMutation<
     RemoveItemFromCommitQueueMutation,
     RemoveItemFromCommitQueueMutationVariables
@@ -104,7 +104,7 @@ export const CommitQueueCard: React.VFC<Props> = ({
               <>{title}</>
             </ConditionalWrapper>
             <CardMetaData>
-              By <b>{author}</b> on {getDateCopy(commitTime, { tz })}
+              By <b>{author}</b> on {getDateCopy(commitTime)}
             </CardMetaData>
             <Container>
               {moduleCodeChanges?.map((moduleCodeChange) => (

--- a/src/pages/commits/InactiveCommits/index.tsx
+++ b/src/pages/commits/InactiveCommits/index.tsx
@@ -8,8 +8,7 @@ import { DisplayModal } from "components/DisplayModal";
 import { StyledRouterLink } from "components/styles";
 import { getVersionRoute, getTaskRoute } from "constants/routes";
 import { size, zIndex, fontSize } from "constants/tokens";
-import { useSpruceConfig } from "hooks";
-import { useUserTimeZone } from "hooks/useUserTimeZone";
+import { useSpruceConfig, useDateFormat } from "hooks";
 import { CommitRolledUpVersions } from "types/commits";
 import { ProjectTriggerLevel } from "types/triggers";
 import { Unpacked } from "types/utils";
@@ -17,7 +16,7 @@ import { string } from "utils";
 import { jiraLinkify } from "utils/string/jiraLinkify";
 import { commitChartHeight } from "../constants";
 
-const { getDateCopy, shortenGithash, trimStringFromMiddle } = string;
+const { shortenGithash, trimStringFromMiddle } = string;
 const { focus, gray } = uiColors;
 
 export const InactiveCommitsLine = () => (
@@ -131,7 +130,7 @@ const CommitCopy = ({
   isTooltip: boolean;
 }) => {
   const { sendEvent } = useProjectHealthAnalytics({ page: "Commit chart" });
-  const tz = useUserTimeZone();
+  const getDateCopy = useDateFormat();
   const spruceConfig = useSpruceConfig();
   const jiraHost = spruceConfig?.jira?.host;
   const message = isTooltip
@@ -152,7 +151,7 @@ const CommitCopy = ({
         >
           {shortenGithash(v.revision)}
         </StyledRouterLink>{" "}
-        {getDateCopy(v.createTime, { tz })}
+        {getDateCopy(v.createTime)}
       </CommitTitleText>
       {v.upstreamProject && (
         <>

--- a/src/pages/host/HostTable.tsx
+++ b/src/pages/host/HostTable.tsx
@@ -10,25 +10,22 @@ import PageSizeSelector, {
 import { Pagination } from "components/Pagination";
 import { size } from "constants/tokens";
 import { HostEventsQuery, HostEventLogEntry } from "gql/generated/types";
+import { useDateFormat } from "hooks";
 import { getHostEventString } from "pages/host/getHostEventString";
 import { HostCard } from "pages/host/HostCard";
-import { string } from "utils";
-
-const { getDateCopy } = string;
 
 export const HostTable: React.VFC<{
   loading: boolean;
   eventData: HostEventsQuery;
   error: ApolloError;
-  timeZone: string;
   page: number;
   limit: number;
   eventsCount: number;
-}> = ({ loading, eventData, error, timeZone, page, limit, eventsCount }) => {
+}> = ({ loading, eventData, error, page, limit, eventsCount }) => {
   const isHostPage = true;
   const hostsTableAnalytics = useHostsTableAnalytics(isHostPage);
   const setPageSize = usePageSizeSelector();
-
+  const getDateCopy = useDateFormat();
   const hostEvents = eventData?.hostEvents;
   const logEntries = hostEvents?.eventLogEntries;
   const columnsTemplate: Array<ColumnProps<HostEventLogEntry>> = [
@@ -37,9 +34,7 @@ export const HostTable: React.VFC<{
       dataIndex: "timestamp",
       width: "25%",
       render: (_, { eventType, timestamp }: HostEventLogEntry): JSX.Element => (
-        <div data-cy={`${eventType}-time`}>
-          {getDateCopy(timestamp, { tz: timeZone })}
-        </div>
+        <div data-cy={`${eventType}-time`}>{getDateCopy(timestamp)}</div>
       ),
     },
     {

--- a/src/pages/preferences/preferencesTabs/ProfileTab.tsx
+++ b/src/pages/preferences/preferencesTabs/ProfileTab.tsx
@@ -146,7 +146,13 @@ export const ProfileTab: React.VFC = () => {
                 dateFormat: {
                   type: "string",
                   title: "Date Format",
-                  enum: dateFormats,
+                  oneOf: [
+                    ...dateFormats.map(({ str, value }) => ({
+                      type: "string" as "string",
+                      title: str,
+                      enum: [value],
+                    })),
+                  ],
                 },
               },
             }}

--- a/src/pages/projectSettings/tabs/EventLogTab/EventLogTab.tsx
+++ b/src/pages/projectSettings/tabs/EventLogTab/EventLogTab.tsx
@@ -14,8 +14,8 @@ import {
   RepoEventLogsQueryVariables,
 } from "gql/generated/types";
 import { GET_PROJECT_EVENT_LOGS, GET_REPO_EVENT_LOGS } from "gql/queries";
-import { useUserTimeZone } from "hooks/useUserTimeZone";
-import { getDateCopy } from "utils/string";
+import { useDateFormat } from "hooks";
+
 import { ProjectType } from "../utils";
 import { EventDiffLine, EventValue, getEventDiffLines } from "./EventLogDiffs";
 
@@ -116,10 +116,10 @@ interface Props {
 }
 
 const EventLogHeader: React.VFC<Props> = ({ user, timestamp }) => {
-  const tz = useUserTimeZone();
+  const getDateCopy = useDateFormat();
   return (
     <StyledHeader>
-      <H3>{getDateCopy(timestamp, { tz })}</H3>
+      <H3>{getDateCopy(timestamp)}</H3>
       <div>{user}</div>
     </StyledHeader>
   );

--- a/src/pages/spawn/spawnHost/SpawnHostCard.tsx
+++ b/src/pages/spawn/spawnHost/SpawnHostCard.tsx
@@ -5,12 +5,9 @@ import { StyledLink, StyledRouterLink } from "components/styles";
 import { getIdeUrl } from "constants/externalResources";
 import { getSpawnVolumeRoute } from "constants/routes";
 import { size } from "constants/tokens";
-import { useUserTimeZone } from "hooks/useUserTimeZone";
+import { useDateFormat } from "hooks";
 import { HostStatus } from "types/host";
 import { MyHost } from "types/spawn";
-import { string } from "utils";
-
-const { getDateCopy } = string;
 
 interface SpawnHostCardProps {
   host: MyHost;
@@ -25,17 +22,13 @@ export const SpawnHostCard: React.VFC<SpawnHostCardProps> = ({ host }) => (
 );
 
 const HostUptime: React.VFC<MyHost> = ({ uptime }) => {
-  const tz = useUserTimeZone();
-  return <span>{getDateCopy(uptime, { tz })}</span>;
+  const getDateCopy = useDateFormat();
+  return <span>{getDateCopy(uptime)}</span>;
 };
 
 const HostExpiration: React.VFC<MyHost> = ({ noExpiration, expiration }) => {
-  const tz = useUserTimeZone();
-  return (
-    <span>
-      {noExpiration ? DoesNotExpire : getDateCopy(expiration, { tz })}
-    </span>
-  );
+  const getDateCopy = useDateFormat();
+  return <span>{noExpiration ? DoesNotExpire : getDateCopy(expiration)}</span>;
 };
 const spawnHostCardFieldMaps = {
   ID: (host: MyHost) => <span>{host?.id}</span>,

--- a/src/pages/spawn/spawnVolume/spawnVolumeTable/SpawnVolumeCard.tsx
+++ b/src/pages/spawn/spawnVolume/spawnVolumeTable/SpawnVolumeCard.tsx
@@ -1,9 +1,7 @@
 import { DoesNotExpire, DetailsCard } from "components/Spawn";
-import { useUserTimeZone } from "hooks/useUserTimeZone";
+import { useDateFormat } from "hooks";
 import { MyVolume } from "types/spawn";
-import { string } from "utils";
 
-const { getDateCopy } = string;
 interface Props {
   volume: MyVolume;
 }
@@ -17,20 +15,18 @@ export const SpawnVolumeCard: React.VFC<Props> = ({ volume }) => (
 );
 
 const VolumeCreationTime: React.VFC<MyVolume> = ({ creationTime }) => {
-  const tz = useUserTimeZone();
-  return <>{getDateCopy(creationTime, { tz })}</>;
+  const getDateCopy = useDateFormat();
+  return <>{getDateCopy(creationTime)}</>;
 };
 
 const VolumeExpiration: React.VFC<MyVolume> = ({
   noExpiration,
   expiration,
 }) => {
-  const tz = useUserTimeZone();
+  const getDateCopy = useDateFormat();
   return (
     <span>
-      {noExpiration || !expiration
-        ? DoesNotExpire
-        : getDateCopy(expiration, { tz })}
+      {noExpiration || !expiration ? DoesNotExpire : getDateCopy(expiration)}
     </span>
   );
 };

--- a/src/pages/task/executionDropdown/ExecutionSelector.tsx
+++ b/src/pages/task/executionDropdown/ExecutionSelector.tsx
@@ -9,9 +9,8 @@ import {
   GetTaskAllExecutionsQueryVariables,
 } from "gql/generated/types";
 import { GET_TASK_ALL_EXECUTIONS } from "gql/queries";
-import { useUserTimeZone } from "hooks/useUserTimeZone";
+import { useDateFormat } from "hooks";
 import { executionAsDisplay } from "pages/task/util/execution";
-import { getDateCopy } from "utils/string";
 
 interface ExecutionSelectProps {
   id: string;
@@ -35,8 +34,7 @@ export const ExecutionSelect: React.VFC<ExecutionSelectProps> = ({
   const allExecutions = allExecutionsResult?.data?.taskAllExecutions;
   const executionsLoading = allExecutionsResult?.loading;
   const { Option } = Select;
-  const tz = useUserTimeZone();
-
+  const getDateCopy = useDateFormat();
   return (
     <StyledSelect
       placeholder="Choose an execution"
@@ -61,8 +59,7 @@ export const ExecutionSelect: React.VFC<ExecutionSelectProps> = ({
             <StyledP1>
               Execution {executionAsDisplay(singleExecution.execution)} -{" "}
               {getDateCopy(
-                singleExecution.activatedTime ?? singleExecution.ingestTime,
-                { tz }
+                singleExecution.activatedTime ?? singleExecution.ingestTime
               )}
             </StyledP1>
           </Row>

--- a/src/pages/task/metadata/index.tsx
+++ b/src/pages/task/metadata/index.tsx
@@ -15,14 +15,14 @@ import {
   getProjectPatchesRoute,
 } from "constants/routes";
 import { GetTaskQuery } from "gql/generated/types";
-import { useUserTimeZone } from "hooks/useUserTimeZone";
+import { useDateFormat } from "hooks";
 import { TaskStatus } from "types/task";
 import { environmentalVariables, string } from "utils";
 import { AbortMessage } from "./AbortMessage";
 import { DependsOn } from "./DependsOn";
 import { ETATimer } from "./ETATimer";
 
-const { msToDuration, getDateCopy, shortenGithash } = string;
+const { msToDuration, shortenGithash } = string;
 const { getUiUrl } = environmentalVariables;
 const { red } = uiColors;
 
@@ -40,7 +40,7 @@ export const Metadata: React.VFC<Props> = ({
   taskId,
 }) => {
   const taskAnalytics = useTaskAnalytics();
-  const tz = useUserTimeZone();
+  const getDateCopy = useDateFormat();
   const {
     status,
     spawnHostLink,
@@ -111,7 +111,7 @@ export const Metadata: React.VFC<Props> = ({
 
       {submittedTime && (
         <P2 data-cy="task-metadata-submitted-at">
-          Submitted at: {getDateCopy(submittedTime, { tz })}
+          Submitted at: {getDateCopy(submittedTime)}
         </P2>
       )}
       {generatedBy && (
@@ -136,16 +136,14 @@ export const Metadata: React.VFC<Props> = ({
       {startTime && (
         <P2>
           Started:{" "}
-          <span data-cy="task-metadata-started">
-            {getDateCopy(startTime, { tz })}
-          </span>
+          <span data-cy="task-metadata-started">{getDateCopy(startTime)}</span>
         </P2>
       )}
       {finishTime && (
         <P2>
           Finished:{" "}
           <span data-cy="task-metadata-finished">
-            {getDateCopy(finishTime, { tz })}
+            {getDateCopy(finishTime)}
           </span>
         </P2>
       )}

--- a/src/pages/task/taskTabs/buildBaronAndAnnotations/AnnotationNote.tsx
+++ b/src/pages/task/taskTabs/buildBaronAndAnnotations/AnnotationNote.tsx
@@ -11,11 +11,8 @@ import {
   Note,
 } from "gql/generated/types";
 import { EDIT_ANNOTATION_NOTE } from "gql/mutations";
-import { useUserTimeZone } from "hooks/useUserTimeZone";
-import { string } from "utils";
+import { useDateFormat } from "hooks";
 import { ButtonWrapper, NonTableWrapper } from "./BBComponents";
-
-const { getDateCopy } = string;
 
 interface Props {
   note: Note;
@@ -30,7 +27,7 @@ const AnnotationNote: React.VFC<Props> = ({
   execution,
   userCanModify,
 }) => {
-  const tz = useUserTimeZone();
+  const getDateCopy = useDateFormat();
   const annotationAnalytics = useAnnotationAnalytics();
   const originalMessage = note?.message || "";
   const dispatchToast = useToastContext();
@@ -77,7 +74,7 @@ const AnnotationNote: React.VFC<Props> = ({
         label="Note"
         description={
           note &&
-          `Updated: ${getDateCopy(note.source.time, { tz, dateOnly: true })}
+          `Updated: ${getDateCopy(note.source.time, { dateOnly: true })}
           Last Edited By: ${note.source.author}
           `
         }

--- a/src/pages/task/taskTabs/buildBaronAndAnnotations/AnnotationTicketsTable/AnnotationTicketRow.tsx
+++ b/src/pages/task/taskTabs/buildBaronAndAnnotations/AnnotationTicketsTable/AnnotationTicketRow.tsx
@@ -6,11 +6,10 @@ import { useAnnotationAnalytics } from "analytics";
 import { StyledLink } from "components/styles";
 import { size } from "constants/tokens";
 import { JiraTicket } from "gql/generated/types";
-import { useUserTimeZone } from "hooks/useUserTimeZone";
-import { string, numbers } from "utils";
+import { useDateFormat } from "hooks";
+import { numbers } from "utils";
 
 const { toPercent } = numbers;
-const { getDateCopy } = string;
 
 interface AnnotationTicketRowProps {
   issueKey: string;
@@ -27,7 +26,7 @@ export const AnnotationTicketRow: React.VFC<AnnotationTicketRowProps> = ({
   confidenceScore,
   loading = false,
 }) => {
-  const tz = useUserTimeZone();
+  const getDateCopy = useDateFormat();
   const annotationAnalytics = useAnnotationAnalytics();
   const fields = jiraTicket?.fields;
   const {
@@ -76,12 +75,12 @@ export const AnnotationTicketRow: React.VFC<AnnotationTicketRowProps> = ({
           <BottomMetaDataWrapper data-cy={`${issueKey}-metadata`}>
             {created && (
               <Disclaimer>
-                Created: {getDateCopy(created, { dateOnly: true, tz })}
+                Created: {getDateCopy(created, { dateOnly: true })}
               </Disclaimer>
             )}
             {updated && (
               <Disclaimer>
-                Updated: {getDateCopy(updated, { dateOnly: true, tz })}
+                Updated: {getDateCopy(updated, { dateOnly: true })}
               </Disclaimer>
             )}
             <Disclaimer>

--- a/src/pages/task/taskTabs/buildBaronAndAnnotations/BBComponents.tsx
+++ b/src/pages/task/taskTabs/buildBaronAndAnnotations/BBComponents.tsx
@@ -6,11 +6,8 @@ import { StyledLink } from "components/styles";
 import { getJiraTicketUrl } from "constants/externalResources";
 import { size } from "constants/tokens";
 import { TicketFields } from "gql/generated/types";
-import { useSpruceConfig } from "hooks";
-import { useUserTimeZone } from "hooks/useUserTimeZone";
-import { string } from "utils";
+import { useSpruceConfig, useDateFormat } from "hooks";
 
-const { getDateCopy } = string;
 interface TitleProps {
   margin?: boolean;
 }
@@ -24,7 +21,7 @@ export const JiraTicketRow: React.VFC<JiraTicketRowProps> = ({
   fields,
 }) => {
   const annotationAnalytics = useAnnotationAnalytics();
-  const tz = useUserTimeZone();
+  const getDateCopy = useDateFormat();
   const spruceConfig = useSpruceConfig();
   const jiraHost = spruceConfig?.jira?.host;
   const url = getJiraTicketUrl(jiraHost, jiraKey);
@@ -48,10 +45,10 @@ export const JiraTicketRow: React.VFC<JiraTicketRowProps> = ({
 
       <BottomMetaDataWrapper data-cy={`${jiraKey}-metadata`}>
         <Disclaimer>
-          Created: {getDateCopy(created, { dateOnly: true, tz })}{" "}
+          Created: {getDateCopy(created, { dateOnly: true })}{" "}
         </Disclaimer>
         <Disclaimer>
-          Updated: {getDateCopy(updated, { dateOnly: true, tz })}{" "}
+          Updated: {getDateCopy(updated, { dateOnly: true })}{" "}
         </Disclaimer>
         <Disclaimer>
           {assigneeDisplayName

--- a/src/pages/task/taskTabs/logs/logTypes/TaskEventLogLine.tsx
+++ b/src/pages/task/taskTabs/logs/logTypes/TaskEventLogLine.tsx
@@ -3,15 +3,14 @@ import { StyledLink, StyledRouterLink } from "components/styles";
 import { getHostRoute } from "constants/routes";
 import { size } from "constants/tokens";
 import { TaskEventLogEntry } from "gql/generated/types";
-import { useUserTimeZone } from "hooks/useUserTimeZone";
-import { getDateCopy } from "utils/string";
+import { useDateFormat } from "hooks";
 
 export const TaskEventLogLine: React.VFC<TaskEventLogEntry> = ({
   timestamp,
   eventType,
   data,
 }) => {
-  const tz = useUserTimeZone();
+  const getDateCopy = useDateFormat();
   const { hostId, status, userId, jiraIssue, jiraLink, priority } = data;
   const hostLink = getHostRoute(hostId);
   let message: JSX.Element;
@@ -76,7 +75,7 @@ export const TaskEventLogLine: React.VFC<TaskEventLogEntry> = ({
     case "TASK_SCHEDULED":
       message = (
         <span className="cy-event-scheduled">
-          Scheduled at {getDateCopy(timestamp, { tz })}
+          Scheduled at {getDateCopy(timestamp)}
         </span>
       );
       break;
@@ -96,9 +95,7 @@ export const TaskEventLogLine: React.VFC<TaskEventLogEntry> = ({
 
   return (
     <Row>
-      <Timestamp className="cy-event-ts">
-        {getDateCopy(timestamp, { tz })}
-      </Timestamp>
+      <Timestamp className="cy-event-ts">{getDateCopy(timestamp)}</Timestamp>
       {message}
     </Row>
   );

--- a/src/pages/version/Metadata.tsx
+++ b/src/pages/version/Metadata.tsx
@@ -11,13 +11,13 @@ import {
   getVersionRoute,
 } from "constants/routes";
 import { VersionQuery } from "gql/generated/types";
-import { useUserTimeZone } from "hooks/useUserTimeZone";
+import { useDateFormat } from "hooks";
 import { ProjectTriggerLevel } from "types/triggers";
 import { string } from "utils";
 import ManifestBlob from "./ManifestBlob";
 import { ParametersModal } from "./ParametersModal";
 
-const { msToDuration, getDateCopy, shortenGithash } = string;
+const { msToDuration, shortenGithash } = string;
 
 interface Props {
   loading: boolean;
@@ -25,7 +25,7 @@ interface Props {
 }
 
 export const Metadata: React.VFC<Props> = ({ loading, version }) => {
-  const tz = useUserTimeZone();
+  const getDateCopy = useDateFormat();
   const {
     author,
     revision,
@@ -70,9 +70,9 @@ export const Metadata: React.VFC<Props> = ({ loading, version }) => {
       </P2>
       <P2>Makespan: {makespan && msToDuration(makespan)}</P2>
       <P2>Time taken: {timeTaken && msToDuration(timeTaken)}</P2>
-      <P2>Submitted at: {createTime && getDateCopy(createTime, { tz })}</P2>
-      <P2>Started: {startTime && getDateCopy(startTime, { tz })}</P2>
-      <P2>Finished: {finishTime && getDateCopy(finishTime, { tz })}</P2>
+      <P2>Submitted at: {createTime && getDateCopy(createTime)}</P2>
+      <P2>Started: {startTime && getDateCopy(startTime)}</P2>
+      <P2>Finished: {finishTime && getDateCopy(finishTime)}</P2>
       <P2>{`Submitted by: ${author}`}</P2>
       {isPatch ? (
         <P2>

--- a/src/utils/string/index.ts
+++ b/src/utils/string/index.ts
@@ -100,10 +100,11 @@ export const omitTypename = (object) =>
     key === "__typename" ? undefined : value
   );
 
-type DateCopyOptions = {
+export type DateCopyOptions = {
   tz?: string;
   dateOnly?: boolean;
   omitSeconds?: boolean;
+  dateFormat?: string;
 };
 
 // Will return a time in the users local timezone when one is not provided
@@ -114,15 +115,17 @@ export const getDateCopy = (
   if (!time) {
     return "";
   }
-  const { tz, dateOnly, omitSeconds } = options || {};
-  const dateFormat = dateOnly
-    ? "MMM d, yyyy"
-    : `MMM d, yyyy, h:mm${omitSeconds ? "" : ":ss"} aa`;
+  const { tz, dateOnly, omitSeconds, dateFormat } = options || {
+    dateFormat: "MMM d, yyyy",
+  };
+  const finalDateFormat = dateOnly
+    ? dateFormat
+    : `${dateFormat}, h:mm${omitSeconds ? "" : ":ss"} aa`;
   if (tz) {
-    return format(utcToZonedTime(time, tz), dateFormat);
+    return format(utcToZonedTime(time, tz), finalDateFormat);
   }
 
-  return format(new Date(time), dateFormat);
+  return format(new Date(time), finalDateFormat);
 };
 
 export const copyToClipboard = (str: string) => {


### PR DESCRIPTION
EVG-15841

### Description
Adds an option in the profile settings to allow users to specify a custom date format which all dates will be rendered with. 
* Refactor the profile tab to use SpruceForm as a bonus.
* Adds a bunch of custom formats.
* Add a hook to fetch the data necessary to specify a date format. 

I opted not to allow users to specify a custom format since there is a risk of using an invalid format string which would result in `date-fns` throwing an error instead i supplied a variety of options.

### Screenshots
<img width="960" alt="image" src="https://user-images.githubusercontent.com/4605522/186024726-9a3c5727-a919-4f0e-9a76-a52fc1d9d197.png">

<img width="260" alt="image" src="https://user-images.githubusercontent.com/4605522/186024760-f28faacb-3d07-4ff9-85e5-57065c2e0b40.png">
<img width="258" alt="image" src="https://user-images.githubusercontent.com/4605522/186024809-411d18c8-5fb7-4a27-86fc-1361331f4132.png">
<img width="231" alt="image" src="https://user-images.githubusercontent.com/4605522/186024879-0a0e5752-2864-4423-9e48-9e1d95600a3f.png">



### Evergreen PR
https://github.com/evergreen-ci/evergreen/pull/5887