### PR TITLE
EVG-17417: Fix destructuring error in VersionTaskPageBreadcrumbs

### DIFF
--- a/src/components/VersionTaskPageBreadcrumbs/VersionTaskPageBreadcrumbs.test.tsx
+++ b/src/components/VersionTaskPageBreadcrumbs/VersionTaskPageBreadcrumbs.test.tsx
@@ -128,6 +128,7 @@ describe("versionTaskPageBreadcrumbs", () => {
       "href",
       getVersionRoute("123")
     );
+    expect(screen.getByText("task-1")).toBeInTheDocument();
   });
 });
 

--- a/src/components/VersionTaskPageBreadcrumbs/index.tsx
+++ b/src/components/VersionTaskPageBreadcrumbs/index.tsx
@@ -1,10 +1,7 @@
 import styled from "@emotion/styled";
-import { useBreadcrumbAnalytics, BreadcrumbAnalytics } from "analytics";
 import Breadcrumbs, { Breadcrumb } from "components/Breadcrumbs";
-import { getVersionRoute, getCommitsRoute } from "constants/routes";
 import { size } from "constants/tokens";
-import { useGetUserPatchesPageTitleAndLink } from "hooks";
-import { shortenGithash } from "utils/string";
+import { useBreadcrumbRoot, useBreadcrumbVersion } from "hooks";
 
 interface Props {
   taskName?: string;
@@ -24,101 +21,21 @@ const VersionTaskPageBreadcrumbs: React.VFC<Props> = ({
   patchNumber,
   taskName,
 }) => {
-  const breadcrumbAnalytics = useBreadcrumbAnalytics();
-  const breadcrumbRoot = useBreadcrumbRoot(versionMetadata);
+  const { isPatch, author, projectIdentifier } = versionMetadata ?? {};
+  const breadcrumbRoot = useBreadcrumbRoot(isPatch, author, projectIdentifier);
+  const breadcrumbVersion = useBreadcrumbVersion(versionMetadata, patchNumber);
+
   const breadcrumbs: Breadcrumb[] = [
     breadcrumbRoot,
-    getMainlineCommitOrPatchBreadcrumb(
-      versionMetadata,
-      patchNumber,
-      breadcrumbAnalytics
-    ),
+    breadcrumbVersion,
+    ...(taskName ? [{ text: taskName }] : []),
   ];
-  if (taskName) {
-    breadcrumbs.push({
-      text: taskName,
-    });
-  }
+
   return (
     <Container>
       <Breadcrumbs breadcrumbs={breadcrumbs} />
     </Container>
   );
-};
-
-const getMainlineCommitOrPatchBreadcrumb = (
-  versionMetadata: {
-    id: string;
-    revision: string;
-    isPatch: boolean;
-  },
-  patchNumber: number,
-  breadcrumbAnalytics: BreadcrumbAnalytics
-) => {
-  const { id, isPatch, revision } = versionMetadata;
-
-  const patchBreadcrumb = {
-    to: getVersionRoute(id),
-    text: `Patch ${patchNumber}`,
-    onClick: () => {
-      breadcrumbAnalytics.sendEvent({
-        name: "Click Link",
-        link: "version",
-      });
-    },
-    "data-cy": "bc-patch",
-  };
-
-  const commitBreadcrumb = {
-    to: getVersionRoute(id),
-    text: shortenGithash(revision),
-    onClick: () => {
-      breadcrumbAnalytics.sendEvent({
-        name: "Click Link",
-        link: "version",
-      });
-    },
-    "data-cy": "bc-version",
-  };
-
-  return isPatch ? patchBreadcrumb : commitBreadcrumb;
-};
-
-const useBreadcrumbRoot = ({
-  isPatch,
-  author,
-  projectIdentifier,
-}: {
-  isPatch: boolean;
-  author: string;
-  projectIdentifier: string;
-}) => {
-  const breadcrumbAnalytics = useBreadcrumbAnalytics();
-
-  const { title: userPatchesPageTitle, link: userPatchesPageLink } =
-    useGetUserPatchesPageTitleAndLink(author, !isPatch) || {};
-  return isPatch
-    ? {
-        text: userPatchesPageTitle,
-        to: userPatchesPageLink,
-        onClick: () => {
-          breadcrumbAnalytics.sendEvent({
-            name: "Click Link",
-            link: "myPatches",
-          });
-        },
-      }
-    : {
-        to: getCommitsRoute(projectIdentifier),
-        text: projectIdentifier,
-        onClick: () => {
-          breadcrumbAnalytics.sendEvent({
-            name: "Click Link",
-            link: "waterfall",
-          });
-        },
-        "data-cy": "bc-waterfall",
-      };
 };
 
 const Container = styled.div`

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -21,3 +21,5 @@ export { useUpsertQueryParams } from "./useUpsertQueryParams";
 export { useSpruceConfig } from "./useSpruceConfig";
 export { useUserSettings } from "./useUserSettings";
 export { useDateFormat } from "./useDateFormat";
+export { useBreadcrumbRoot } from "./useBreadcrumbRoot";
+export { useBreadcrumbVersion } from "./useBreadcrumbVersion";

--- a/src/hooks/tests/useBreadcrumbRoot.test.tsx
+++ b/src/hooks/tests/useBreadcrumbRoot.test.tsx
@@ -1,0 +1,53 @@
+import { MockedProvider } from "@apollo/client/testing";
+import { renderHook } from "@testing-library/react-hooks";
+import { GET_OTHER_USER } from "gql/queries";
+import { useBreadcrumbRoot } from "hooks";
+
+const Provider = ({ children }) => (
+  <MockedProvider mocks={mocks}>{children}</MockedProvider>
+);
+
+describe("useBreadcrumbRoot", () => {
+  it("returns the correct breadcrumb root when the version is a patch", async () => {
+    const { result, waitForNextUpdate } = renderHook(
+      () => useBreadcrumbRoot(true, "admin", "spruce"),
+      { wrapper: Provider }
+    );
+    await waitForNextUpdate();
+
+    expect(result.current.to).toBe("/user/admin/patches");
+    expect(result.current.text).toBe("My Patches");
+  });
+
+  it("returns the correct breadcrumb root when the version is a commit", async () => {
+    const { result, waitForNextUpdate } = renderHook(
+      () => useBreadcrumbRoot(false, "admin", "spruce"),
+      { wrapper: Provider }
+    );
+    await waitForNextUpdate();
+
+    expect(result.current.to).toBe("/commits/spruce");
+    expect(result.current.text).toBe("spruce");
+  });
+});
+
+const mocks = [
+  {
+    request: {
+      query: GET_OTHER_USER,
+      variables: {
+        userId: "admin",
+      },
+    },
+    result: {
+      data: {
+        otherUser: {
+          userId: "admin",
+          displayName: "Evergreen Admin",
+          __typename: "User",
+        },
+        currentUser: { userId: "admin", __typename: "User" },
+      },
+    },
+  },
+];

--- a/src/hooks/tests/useBreadcrumbVersion.test.tsx
+++ b/src/hooks/tests/useBreadcrumbVersion.test.tsx
@@ -1,13 +1,13 @@
 import { MockedProvider } from "@apollo/client/testing";
 import { renderHook } from "@testing-library/react-hooks";
-import { GET_OTHER_USER } from "gql/queries";
+import { GET_USER } from "gql/queries";
 import { useBreadcrumbVersion } from "hooks";
 
 const Provider = ({ children }) => (
   <MockedProvider mocks={mocks}>{children}</MockedProvider>
 );
 
-describe("useBreadcrumbRoot", () => {
+describe("useBreadcrumbVersion", () => {
   it("returns the correct breadcrumb when the version is a patch", async () => {
     const { result, waitForNextUpdate } = renderHook(
       () =>
@@ -42,19 +42,16 @@ describe("useBreadcrumbRoot", () => {
 const mocks = [
   {
     request: {
-      query: GET_OTHER_USER,
-      variables: {
-        userId: "admin",
-      },
+      query: GET_USER,
+      variables: {},
     },
     result: {
       data: {
-        otherUser: {
+        user: {
           userId: "admin",
-          displayName: "Evergreen Admin",
-          __typename: "User",
+          displayName: "admin",
+          emailAddress: "admin@admin.com",
         },
-        currentUser: { userId: "admin", __typename: "User" },
       },
     },
   },

--- a/src/hooks/tests/useBreadcrumbVersion.test.tsx
+++ b/src/hooks/tests/useBreadcrumbVersion.test.tsx
@@ -1,0 +1,61 @@
+import { MockedProvider } from "@apollo/client/testing";
+import { renderHook } from "@testing-library/react-hooks";
+import { GET_OTHER_USER } from "gql/queries";
+import { useBreadcrumbVersion } from "hooks";
+
+const Provider = ({ children }) => (
+  <MockedProvider mocks={mocks}>{children}</MockedProvider>
+);
+
+describe("useBreadcrumbRoot", () => {
+  it("returns the correct breadcrumb when the version is a patch", async () => {
+    const { result, waitForNextUpdate } = renderHook(
+      () =>
+        useBreadcrumbVersion(
+          { id: "patch_id", revision: "evg123spruce456", isPatch: true },
+          1234
+        ),
+      { wrapper: Provider }
+    );
+    await waitForNextUpdate();
+
+    expect(result.current.to).toBe("/version/patch_id/tasks");
+    expect(result.current.text).toBe("Patch 1234");
+  });
+
+  it("returns the correct breadcrumb when the version is a commit", async () => {
+    const { result, waitForNextUpdate } = renderHook(
+      () =>
+        useBreadcrumbVersion(
+          { id: "commit_id", revision: "evg123spruce456", isPatch: false },
+          1234
+        ),
+      { wrapper: Provider }
+    );
+    await waitForNextUpdate();
+
+    expect(result.current.to).toBe("/version/commit_id/tasks");
+    expect(result.current.text).toBe("evg123s");
+  });
+});
+
+const mocks = [
+  {
+    request: {
+      query: GET_OTHER_USER,
+      variables: {
+        userId: "admin",
+      },
+    },
+    result: {
+      data: {
+        otherUser: {
+          userId: "admin",
+          displayName: "Evergreen Admin",
+          __typename: "User",
+        },
+        currentUser: { userId: "admin", __typename: "User" },
+      },
+    },
+  },
+];

--- a/src/hooks/useBreadcrumbRoot.ts
+++ b/src/hooks/useBreadcrumbRoot.ts
@@ -1,0 +1,37 @@
+import { useBreadcrumbAnalytics } from "analytics";
+import { getCommitsRoute } from "constants/routes";
+import { useGetUserPatchesPageTitleAndLink } from "hooks";
+
+export const useBreadcrumbRoot = (
+  isPatch: boolean,
+  author: string,
+  projectIdentifier: string
+) => {
+  const breadcrumbAnalytics = useBreadcrumbAnalytics();
+
+  const { title: userPatchesPageTitle, link: userPatchesPageLink } =
+    useGetUserPatchesPageTitleAndLink(author, !isPatch) ?? {};
+
+  return isPatch
+    ? {
+        to: userPatchesPageLink,
+        text: userPatchesPageTitle,
+        onClick: () => {
+          breadcrumbAnalytics.sendEvent({
+            name: "Click Link",
+            link: "myPatches",
+          });
+        },
+      }
+    : {
+        to: getCommitsRoute(projectIdentifier),
+        text: projectIdentifier,
+        onClick: () => {
+          breadcrumbAnalytics.sendEvent({
+            name: "Click Link",
+            link: "waterfall",
+          });
+        },
+        "data-cy": "bc-waterfall",
+      };
+};

--- a/src/hooks/useBreadcrumbVersion.ts
+++ b/src/hooks/useBreadcrumbVersion.ts
@@ -1,0 +1,42 @@
+import { useBreadcrumbAnalytics } from "analytics";
+import { getVersionRoute } from "constants/routes";
+import { shortenGithash } from "utils/string";
+
+export const useBreadcrumbVersion = (
+  versionMetadata: {
+    id: string;
+    revision: string;
+    isPatch: boolean;
+  },
+  patchNumber: number
+) => {
+  const breadcrumbAnalytics = useBreadcrumbAnalytics();
+
+  const { id, isPatch, revision } = versionMetadata ?? {};
+
+  const patchBreadcrumb = {
+    to: getVersionRoute(id),
+    text: `Patch ${patchNumber}`,
+    onClick: () => {
+      breadcrumbAnalytics.sendEvent({
+        name: "Click Link",
+        link: "version",
+      });
+    },
+    "data-cy": "bc-patch",
+  };
+
+  const commitBreadcrumb = {
+    to: getVersionRoute(id),
+    text: shortenGithash(revision),
+    onClick: () => {
+      breadcrumbAnalytics.sendEvent({
+        name: "Click Link",
+        link: "version",
+      });
+    },
+    "data-cy": "bc-version",
+  };
+
+  return isPatch ? patchBreadcrumb : commitBreadcrumb;
+};

--- a/src/pages/Version.tsx
+++ b/src/pages/Version.tsx
@@ -167,10 +167,12 @@ export const VersionPage: React.VFC = () => {
 
   return (
     <PageWrapper data-cy="version-page">
-      <VersionTaskPageBreadcrumbs
-        versionMetadata={version}
-        patchNumber={patchNumber}
-      />
+      {version && (
+        <VersionTaskPageBreadcrumbs
+          versionMetadata={version}
+          patchNumber={patchNumber}
+        />
+      )}
       <PageTitle
         loading={false}
         title={linkifiedMessage || `Version ${order}`}


### PR DESCRIPTION
EVG-17417

### Description
This PR attempts to address the destructuring error we keep encountering in `useBreadcrumbRoot`. I refactored the code around `VersionTaskPageBreadcrumbs` to hopefully make it easier to understand, and added some guards.

I'm not 100% sure this will work, so once this is merged I'll keep this ticket in Blocked to see if it had any real effect.

### Screenshots
- No visible changes

### Testing
- Moved hooks that were initially in `VersionTaskPageBreadcrumbs.tsx` to `hooks/useBreadcrumbRoot.ts` and `hooks/useBreadcrumbVersion.ts`
- Added tests for each of these hooks
