### PR TITLE
EVG-17352: Remove polling on getVersion lazy query

### DIFF
--- a/src/components/PageTitle.tsx
+++ b/src/components/PageTitle.tsx
@@ -2,12 +2,14 @@ import styled from "@emotion/styled";
 import { H2, Subtitle } from "@leafygreen-ui/typography";
 import { Skeleton } from "antd";
 import { size as tokenSize } from "constants/tokens";
+import { usePageTitle } from "hooks";
 
 type Size = "large" | "medium";
 
 interface Props {
   loading: boolean;
   title: string | JSX.Element | React.ReactNodeArray;
+  pageTitle?: string;
   badge: JSX.Element;
   buttons?: JSX.Element;
   size?: Size;
@@ -36,26 +38,31 @@ export const PageTitle: React.VFC<Props> = ({
   badge,
   buttons,
   size = "medium",
-}) => (
-  <>
-    {loading && (
-      <PageHeader size={size}>
-        <Skeleton active paragraph={{ rows: 0 }} />
-      </PageHeader>
-    )}
-    {!loading && (
-      <PageHeader size={size}>
-        <TitleWrapper size={size}>
-          <TitleTypography size={size}>
-            <span data-cy="page-title">{title}</span>
-            <BadgeWrapper size={size}>{badge}</BadgeWrapper>
-          </TitleTypography>
-        </TitleWrapper>
-        {buttons ?? null}
-      </PageHeader>
-    )}
-  </>
-);
+  pageTitle = "Evergreen",
+}) => {
+  usePageTitle(pageTitle);
+
+  return (
+    <>
+      {loading && (
+        <PageHeader size={size}>
+          <Skeleton active paragraph={{ rows: 0 }} />
+        </PageHeader>
+      )}
+      {!loading && (
+        <PageHeader size={size}>
+          <TitleWrapper size={size}>
+            <TitleTypography size={size}>
+              <span data-cy="page-title">{title}</span>
+              <BadgeWrapper size={size}>{badge}</BadgeWrapper>
+            </TitleTypography>
+          </TitleWrapper>
+          {buttons ?? null}
+        </PageHeader>
+      )}
+    </>
+  );
+};
 
 const BadgeWrapper = styled.div<TitleTypographyProps>`
   display: inline-flex;

--- a/src/hooks/usePolling.ts
+++ b/src/hooks/usePolling.ts
@@ -42,17 +42,17 @@ export const usePolling: usePollingType = (
   }
 
   // If offline and polling, stop polling.
-  if (!isOnline && isPolling && stopPolling) {
+  if (!isOnline && isPolling) {
     setIsPolling(false);
     stopPolling();
   }
   // If not visible and polling, stop polling.
-  if (!isVisible && isPolling && stopPolling) {
+  if (!isVisible && isPolling) {
     setIsPolling(false);
     stopPolling();
   }
   // If online and visible and not polling, start polling.
-  if (isOnline && isVisible && !isPolling && startPolling) {
+  if (isOnline && isVisible && !isPolling) {
     setIsPolling(true);
     startPolling(pollInterval);
     refetch(); // refresh data when returning to tab

--- a/src/pages/CommitQueue.tsx
+++ b/src/pages/CommitQueue.tsx
@@ -14,7 +14,6 @@ import {
   CommitQueueQueryVariables,
 } from "gql/generated/types";
 import { GET_COMMIT_QUEUE } from "gql/queries";
-import { usePageTitle } from "hooks";
 import { CommitQueueCard } from "./commitqueue/CommitQueueCard";
 
 const { gray } = uiColors;
@@ -36,10 +35,11 @@ export const CommitQueue: React.VFC = () => {
 
   const commitQueue = get(data, "commitQueue");
   const queue = get(commitQueue, "queue");
-  usePageTitle(`Commit Queue - ${id}`);
+
   return (
     <PageWrapper>
       <PageTitle
+        pageTitle={`Commit Queue - ${id}`}
         title="Commit Queue"
         badge={
           <Badge variant="darkgray">

--- a/src/pages/Host.tsx
+++ b/src/pages/Host.tsx
@@ -24,7 +24,6 @@ import {
   HostEventsQueryVariables,
 } from "gql/generated/types";
 import { GET_HOST, GET_HOST_EVENTS } from "gql/queries/index";
-import { usePageTitle } from "hooks/usePageTitle";
 import { HostTable } from "pages/host/HostTable";
 import { Metadata } from "pages/host/Metadata";
 import { HostStatus } from "types/host";
@@ -74,8 +73,6 @@ export const Host: React.VFC = () => {
   const [isUpdateStatusModalVisible, setIsUpdateStatusModalVisible] =
     useState<boolean>(false);
 
-  usePageTitle(`Host${hostId ? ` - ${hostId}` : ""}`);
-
   const canRestartJasperOrReprovision =
     host?.status === "running" &&
     (bootstrapMethod === "ssh" || bootstrapMethod === "user-data");
@@ -84,6 +81,7 @@ export const Host: React.VFC = () => {
       {host && (
         <>
           <PageTitle
+            pageTitle={`Host${hostId ? ` - ${hostId}` : ""}`}
             title={`Host: ${hostId}`}
             badge={<HostStatusBadge status={status} />}
             loading={hostMetaDataLoading}

--- a/src/pages/Task.tsx
+++ b/src/pages/Task.tsx
@@ -15,7 +15,7 @@ import { pollInterval } from "constants/index";
 import { useToastContext } from "context/toast";
 import { GetTaskQuery, GetTaskQueryVariables } from "gql/generated/types";
 import { GET_TASK } from "gql/queries";
-import { usePageTitle, usePolling } from "hooks";
+import { usePolling } from "hooks";
 import { useUpdateURLQueryParams } from "hooks/useUpdateURLQueryParams";
 import { PageDoesNotExist } from "pages/404";
 import { RequiredQueryParams, TaskStatus } from "types/task";
@@ -74,8 +74,6 @@ export const Task = () => {
     });
   }
 
-  usePageTitle(`Task${displayName ? ` - ${displayName}` : ""}`);
-
   if (error) {
     return <PageDoesNotExist />;
   }
@@ -89,6 +87,7 @@ export const Task = () => {
         />
       )}
       <PageTitle
+        pageTitle={`Task${displayName ? ` - ${displayName}` : ""}`}
         loading={loading}
         title={displayName}
         badge={

--- a/src/pages/Version.tsx
+++ b/src/pages/Version.tsx
@@ -11,7 +11,6 @@ import {
   PageSider,
 } from "components/styles";
 import VersionTaskPageBreadcrumbs from "components/VersionTaskPageBreadcrumbs";
-import { pollInterval } from "constants/index";
 import { commitQueueAlias } from "constants/patch";
 import { getCommitQueueRoute, getPatchRoute } from "constants/routes";
 import { useToastContext } from "context/toast";
@@ -28,7 +27,7 @@ import {
   GET_IS_PATCH_CONFIGURED,
   GET_HAS_VERSION,
 } from "gql/queries";
-import { usePageTitle, usePolling, useSpruceConfig } from "hooks";
+import { useSpruceConfig } from "hooks";
 import { PageDoesNotExist } from "pages/404";
 import { shortenGithash, githubPRLinkify } from "utils/string";
 import { jiraLinkify } from "utils/string/jiraLinkify";
@@ -40,35 +39,30 @@ import { Tabs } from "./version/Tabs";
 export const VersionPage: React.VFC = () => {
   const spruceConfig = useSpruceConfig();
   const { id } = useParams<{ id: string }>();
-
   const dispatchToast = useToastContext();
 
   const [redirectURL, setRedirectURL] = useState(undefined);
   const [isLoadingData, setIsLoadingData] = useState(true);
 
-  const [
-    getVersion,
-    { data, error: versionError, refetch, startPolling, stopPolling },
-  ] = useLazyQuery<VersionQuery, VersionQueryVariables>(GET_VERSION, {
+  const [getVersion, { data: versionData, error: versionError }] = useLazyQuery<
+    VersionQuery,
+    VersionQueryVariables
+  >(GET_VERSION, {
     variables: { id },
-    pollInterval,
     fetchPolicy: "cache-and-network",
-    onError: (e) => {
+    onError: (error) => {
       dispatchToast.error(
-        `There was an error loading the version: ${e.message}`
+        `There was an error loading the version: ${error.message}`
       );
       setIsLoadingData(false);
     },
   });
-  usePolling(startPolling, stopPolling, refetch, false);
 
   const [getPatch, { data: patchData, error: patchError }] = useLazyQuery<
     IsPatchConfiguredQuery,
     IsPatchConfiguredQueryVariables
   >(GET_IS_PATCH_CONFIGURED, {
-    variables: {
-      id,
-    },
+    variables: { id },
     onError: (error) => {
       dispatchToast.error(
         `There was an error loading this patch: ${error.message}`
@@ -81,9 +75,7 @@ export const VersionPage: React.VFC = () => {
     GetHasVersionQuery,
     GetHasVersionQueryVariables
   >(GET_HAS_VERSION, {
-    variables: {
-      id,
-    },
+    variables: { id },
     onCompleted: ({ hasVersion }) => {
       if (hasVersion) {
         getVersion({ variables: { id } });
@@ -97,14 +89,8 @@ export const VersionPage: React.VFC = () => {
     },
   });
 
-  // This resets the pages states to force showing the loading state when the page is changed on navigation
-  useEffect(() => {
-    setIsLoadingData(true);
-    setRedirectURL(undefined);
-  }, [id]);
-
-  // Decide where to redirect the user based off of whether or not the patch has been activated
-  // If this patch is activated and not on the commit queue we can safely fetch the associated version
+  // Decide where to redirect the user based off of whether or not the patch has been activated.
+  // If the patch is activated and not on the commit queue, we can safely fetch the associated version.
   useEffect(() => {
     if (patchData) {
       const { patch } = patchData;
@@ -121,35 +107,15 @@ export const VersionPage: React.VFC = () => {
     }
   }, [patchData, getVersion, id]);
 
-  // If we have successfully loaded a version we can show the page
+  // If we have successfully loaded a version, we can show the page.
   useEffect(() => {
-    if (data) {
+    if (versionData) {
       setIsLoadingData(false);
     }
-  }, [data]);
-
-  const { version } = data || {};
-  const { status, patch, isPatch, revision, message, order } = version || {};
-
-  const {
-    commitQueuePosition = null,
-    patchNumber,
-    canEnqueueToCommitQueue,
-    childPatches,
-  } = patch || {};
-  const isPatchOnCommitQueue = commitQueuePosition !== null;
-
-  // If a revision exists
-  const versionText = shortenGithash(revision?.length ? revision : id);
-  const title = isPatch ? `Patch - ${patchNumber}` : `Version - ${versionText}`;
-  usePageTitle(title);
+  }, [versionData]);
 
   if (isLoadingData) {
     return <PatchAndTaskFullPageLoad />;
-  }
-
-  if (redirectURL) {
-    return <Navigate to={redirectURL} />;
   }
 
   if (hasVersionError || patchError || versionError) {
@@ -160,6 +126,28 @@ export const VersionPage: React.VFC = () => {
     );
   }
 
+  // If it's a patch, redirect to the proper page.
+  if (redirectURL) {
+    return <Navigate to={redirectURL} />;
+  }
+
+  // If it's a version, proceed with loading the version page.
+  const { version } = versionData || {};
+  const { status, patch, isPatch, revision, message, order } = version || {};
+
+  const {
+    commitQueuePosition = null,
+    patchNumber,
+    canEnqueueToCommitQueue,
+    childPatches,
+  } = patch || {};
+  const isPatchOnCommitQueue = commitQueuePosition !== null;
+
+  const versionText = shortenGithash(revision || id);
+  const pageTitle = isPatch
+    ? `Patch - ${patchNumber}`
+    : `Version - ${versionText}`;
+
   const linkifiedMessage = jiraLinkify(
     githubPRLinkify(message),
     spruceConfig?.jira?.host
@@ -168,12 +156,10 @@ export const VersionPage: React.VFC = () => {
   return (
     <PageWrapper data-cy="version-page">
       <VersionTaskPageBreadcrumbs
-        versionMetadata={version}
         patchNumber={patchNumber}
+        versionMetadata={version}
       />
       <PageTitle
-        loading={false}
-        title={linkifiedMessage || `Version ${order}`}
         badge={<PatchStatusBadge status={status} />}
         buttons={
           <ActionButtons
@@ -185,6 +171,9 @@ export const VersionPage: React.VFC = () => {
             versionId={id}
           />
         }
+        loading={false}
+        pageTitle={pageTitle}
+        title={linkifiedMessage || `Version ${order}`}
       />
       <PageLayout>
         <PageSider>
@@ -194,9 +183,9 @@ export const VersionPage: React.VFC = () => {
         <PageLayout>
           <PageContent>
             <Tabs
-              taskCount={version?.taskCount}
               childPatches={childPatches}
               isPatch={version?.isPatch}
+              taskCount={version?.taskCount}
             />
           </PageContent>
         </PageLayout>


### PR DESCRIPTION
EVG-17352

### Description
`@apollo/client` changed the behavior of `startPolling` and `stopPolling`. It used to be that they would be `undefined` for lazy queries if the query hadn't been called yet, but now they are always defined. This was causing the `getVersion` to be called on component mount.

I ended up removing the polling for the `getVersion` lazy query because it didn't seem necessary.

Also refactored some usage of `usePageTitle` because it helps make `Version.tsx` look cleaner.

### Screenshots
- No visible changes

### Testing
- N/A
