### PR TITLE
EVG-17932 Redirect lobster links to parsley

### DIFF
--- a/src/constants/externalResources.ts
+++ b/src/constants/externalResources.ts
@@ -1,5 +1,6 @@
 import { LogTypes } from "types/task";
 import { environmentalVariables } from "utils";
+import { getParsleyUrl } from "utils/environmentalVariables";
 
 const { getLobsterURL, getUiUrl } = environmentalVariables;
 
@@ -45,6 +46,12 @@ export const getLobsterTaskLink = (
   execution: number
 ) =>
   `${getLobsterURL()}/lobster/evergreen/task/${taskId}/${execution}/${logType}`;
+
+export const getParsleyTaskLogLink = (
+  logType: LogTypes,
+  taskId: string,
+  execution: number
+) => `${getParsleyUrl()}/evergreen/${taskId}/${execution}/${logType}`;
 
 interface GetLobsterTestLogCompleteUrlParams {
   taskId: string;

--- a/src/pages/task/taskTabs/Logs.tsx
+++ b/src/pages/task/taskTabs/Logs.tsx
@@ -1,9 +1,13 @@
 import { useEffect, useState } from "react";
 import queryString from "query-string";
 import { useLocation } from "react-router-dom";
-import { getLobsterTaskLink } from "constants/externalResources";
+import {
+  getLobsterTaskLink,
+  getParsleyTaskLogLink,
+} from "constants/externalResources";
 import { TaskLogLinks } from "gql/generated/types";
 import { LogTypes, QueryParams } from "types/task";
+import { isProduction } from "utils/environmentalVariables";
 import {
   EventLog,
   AgentLog,
@@ -97,7 +101,9 @@ const getLinks = (
   }`;
   return {
     htmlLink,
-    lobsterLink: getLobsterTaskLink(logType, taskId, execution),
+    lobsterLink: isProduction()
+      ? getLobsterTaskLink(logType, taskId, execution)
+      : getParsleyTaskLogLink(logType, taskId, execution),
     rawLink: `${htmlLink}&text=true`,
   };
 };

--- a/src/pages/task/taskTabs/testsTable/LogsColumn.tsx
+++ b/src/pages/task/taskTabs/testsTable/LogsColumn.tsx
@@ -57,7 +57,9 @@ export const LogsColumn: React.VFC<Props> = ({
   const { status, testFile } = testResult;
   const { url: urlHTML, urlRaw, urlLobster } = testResult.logs ?? {};
   const { project, displayName, displayTask, order } = task ?? {};
-  const parsleyLink = urlLobster ? turnTestLogLinkIntoParsleyLink(urlLobster) : turnResmokeTestLogLinkIntoParsleyLink(urlHTML);
+  const parsleyLink = urlLobster
+    ? turnTestLogLinkIntoParsleyLink(urlLobster)
+    : turnResmokeTestLogLinkIntoParsleyLink(urlHTML);
   const filters =
     status === TestStatus.Fail
       ? {

--- a/src/pages/task/taskTabs/testsTable/LogsColumn.tsx
+++ b/src/pages/task/taskTabs/testsTable/LogsColumn.tsx
@@ -57,12 +57,7 @@ export const LogsColumn: React.VFC<Props> = ({
   const { status, testFile } = testResult;
   const { url: urlHTML, urlRaw, urlLobster } = testResult.logs ?? {};
   const { project, displayName, displayTask, order } = task ?? {};
-  let parsleyLink = "";
-  if (urlLobster) {
-    parsleyLink = turnTestLogLinkIntoParsleyLink(urlLobster);
-  } else {
-    parsleyLink = turnResmokeTestLogLinkIntoParsleyLink(urlHTML);
-  }
+  const parsleyLink = urlLobster ? turnTestLogLinkIntoParsleyLink(urlLobster) : turnResmokeTestLogLinkIntoParsleyLink(urlHTML);
   const filters =
     status === TestStatus.Fail
       ? {

--- a/src/pages/task/taskTabs/testsTable/LogsColumn.tsx
+++ b/src/pages/task/taskTabs/testsTable/LogsColumn.tsx
@@ -93,7 +93,7 @@ export const LogsColumn: React.VFC<Props> = ({
           data-cy="test-table-html-btn"
           size="xsmall"
           target="_blank"
-          href={isProduction() ? urlHTML : parsleyLink}
+          href={isProduction() || urlLobster ? urlHTML : parsleyLink}
           onClick={() =>
             taskAnalytics.sendEvent({
               name: "Click Logs HTML Button",

--- a/src/utils/environmentalVariables.ts
+++ b/src/utils/environmentalVariables.ts
@@ -92,6 +92,13 @@ export const getLobsterURL = (): string =>
   process.env.REACT_APP_LOBSTER_URL || "";
 
 /**
+ * `getParsleyUrl()` - Get the Parsley URL from the environment variables
+ * @returns {string} - Returns the Parsley URL.
+ */
+export const getParsleyUrl = (): string =>
+  process.env.REACT_APP_PARSLEY_URL || "";
+
+/**
  * `getAppVersion()` - Get the app release version from the environment variables
  * @returns {string} - Returns the lobster URL.
  */


### PR DESCRIPTION
EVG-17932

### Description
Lobster links will now redirect to parsley on non prod deployments.
Note. This is temporary during development for the production release we will update the links on the evergreen side and return the appropriate link. 

### Testing
Didn't write any tests since this is only used for internal testing

