### PR TITLE
EVG-17985 Upload source maps from the correct directory

### DIFF
--- a/upload-bugsnag-sourcemaps.js
+++ b/upload-bugsnag-sourcemaps.js
@@ -4,6 +4,6 @@ browser.uploadMultiple({
   apiKey: process.env.REACT_APP_BUGSNAG_API_KEY,
   detectAppVersion: true,
   overwrite: true,
-  directory: "./build/static/js",
-  baseUrl: process.env.REACT_APP_SPRUCE_URL,
+  directory: "./build/assets",
+  baseUrl: `${process.env.REACT_APP_SPRUCE_URL}/assets`,
 });


### PR DESCRIPTION
EVG-17985

### Description
@SupaJoon  caught that we weren't uploading source maps to bugsnag which may have been the cause of our mystery errors. This updates the script to upload them correctly

### Testing
Ran the script locally and ensured source maps were uploaded.
