### PR TITLE
EVG-17495 Allow clipboard permissions for Trendcharts plugin

### DIFF
--- a/src/components/PerfPlugin/TrendChartsPlugin.tsx
+++ b/src/components/PerfPlugin/TrendChartsPlugin.tsx
@@ -11,6 +11,7 @@ const TrendChartsPlugin: React.VFC<Props> = ({ taskId }) => (
   <StyledIframe
     src={`${getSignalProcessingUrl()}/task/${taskId}/performanceData`}
     title="Task Performance Data"
+    allow="clipboard-read; clipboard-write"
   />
 );
 


### PR DESCRIPTION
EVG-17495

### Description
Adds the [clipboard permissions policy](https://web.dev/async-clipboard/#permissions-policy-integration) to the Trendcharts iframe. 

@anjani-bhat lmk if this looks good i can also deploy it to our beta environment and you should be able to try it out against the prod backend.

