### PR TITLE
EVG-17080: Fix e2e failure caused by patch trigger alias

### DIFF
--- a/cypress/integration/commit_queue.ts
+++ b/cypress/integration/commit_queue.ts
@@ -81,11 +81,7 @@ describe("commit queue page", () => {
       cy.visit(INVALID_COMMIT_QUEUE_ROUTE);
     });
     it("visiting a non existent commit queue page should display an error", () => {
-      cy.dataCy("toast").should("exist");
-      cy.dataCy("toast").should(
-        "contain.text",
-        "There was an error loading the commit queue"
-      );
+      cy.validateToast("error", "There was an error loading the commit queue");
     });
   });
 

--- a/cypress/integration/host/host_buttons.ts
+++ b/cypress/integration/host/host_buttons.ts
@@ -6,14 +6,12 @@ describe("Host page restart jasper, reprovision, and update host status buttons"
     cy.dataCy("restart-jasper-button").click();
     cy.contains("button", "Yes").click();
     cy.validateToast("success");
-    cy.get(`[aria-label="Close Message"]`).click();
   });
 
   it("Should show a toast when host is reprovisioned", () => {
     cy.dataCy("reprovision-button").click();
     cy.contains("button", "Yes").click();
     cy.validateToast("success");
-    cy.get(`[aria-label="Close Message"]`).click();
   });
 
   it("Should show and hide the modal for update status", () => {

--- a/cypress/integration/hosts/hosts_sorting.ts
+++ b/cypress/integration/hosts/hosts_sorting.ts
@@ -1,7 +1,3 @@
-const hostsRoute = "/hosts";
-
-const tableRow = "tr.ant-table-row";
-
 const sortByTests = [
   {
     sorterName: "ID",
@@ -153,6 +149,10 @@ const sortDirectionTests = [
 ];
 
 describe("Hosts page sorting", () => {
+  const hostsRoute = "/hosts";
+
+  const tableRow = "tr.ant-table-row";
+
   it("Status sorter is selected by default if no sort params in url", () => {
     cy.visit(hostsRoute);
     cy.get(".cy-task-table-col-STATUS").within(() => {

--- a/cypress/integration/hosts/select_hosts.ts
+++ b/cypress/integration/hosts/select_hosts.ts
@@ -1,6 +1,6 @@
-const hostsRoute = "/hosts";
-
 describe("Select hosts in hosts page table", () => {
+  const hostsRoute = "/hosts";
+
   beforeEach(() => {
     cy.visit(`${hostsRoute}?distroId=ubuntu1604-large&page=0&statuses=running`);
     cy.dataCy("hosts-table").should("exist");
@@ -27,6 +27,7 @@ describe("Select hosts in hosts page table", () => {
       cy.get(".ant-checkbox-input").check({ force: true });
     });
 
+    cy.dataCy("restart-jasper-button").should("not.be.disabled");
     cy.dataCy("restart-jasper-button").click();
     cy.contains("button", "Yes").click();
     cy.validateToast("success");
@@ -39,6 +40,7 @@ describe("Select hosts in hosts page table", () => {
       cy.get(".ant-checkbox-input").check({ force: true });
     });
 
+    cy.dataCy("reprovision-button").should("not.be.disabled");
     cy.dataCy("reprovision-button").click();
     cy.contains("button", "Yes").click();
     cy.validateToast("success", "Marked hosts to reprovision for 0 hosts");

--- a/cypress/integration/hosts/update_status_modal.ts
+++ b/cypress/integration/hosts/update_status_modal.ts
@@ -1,6 +1,6 @@
-const hostsRoute = "/hosts";
-
 describe("Update Status Modal", () => {
+  const hostsRoute = "/hosts";
+
   beforeEach(() => {
     cy.visit(`${hostsRoute}?limit=100&page=0`);
     cy.dataCy("hosts-table").should("exist");

--- a/cypress/integration/projectSettings/project_settings.ts
+++ b/cypress/integration/projectSettings/project_settings.ts
@@ -46,7 +46,7 @@ describe("Access page", () => {
       .first()
       .type("admin");
     cy.dataCy("save-settings-button").should("be.enabled").click();
-    cy.validateToast("success", "Successfully updated project");
+    cy.validateToast("success", "Successfully updated project", true);
     cy.visit(destination);
     cy.get("label")
       .contains("Private")
@@ -81,14 +81,15 @@ describe("Access page", () => {
     cy.dataCy("save-settings-button").should("be.enabled").click();
     cy.validateToast(
       "error",
-      "There was an error saving the project: error updating project admin roles: no admin role for project 'spruce' found"
+      "There was an error saving the project: error updating project admin roles: no admin role for project 'spruce' found",
+      true
     );
   });
 
   it("Clicking on 'Default to Repo on Page' selects the 'Default to repo (public)' checkbox and produces a success banner", () => {
     cy.dataCy("default-to-repo-button").click();
     cy.dataCy("default-to-repo-modal").contains("Confirm").click();
-    cy.validateToast("success", "Successfully defaulted page to repo");
+    cy.validateToast("success", "Successfully defaulted page to repo", true);
     cy.get("label")
       .contains("Default to repo (public)")
       .closest("label")
@@ -147,7 +148,7 @@ describe("Repo Settings", () => {
 
   it("Clicking on save button should show a success toast", () => {
     cy.dataCy("save-settings-button").click();
-    cy.validateToast("success", "Successfully updated repo");
+    cy.validateToast("success", "Successfully updated repo", true);
   });
 
   describe("GitHub/Commit Queue page", () => {
@@ -257,7 +258,7 @@ describe("Repo Settings", () => {
 
     it("Successfully saves the page", () => {
       cy.dataCy("save-settings-button").click();
-      cy.validateToast("success", "Successfully updated repo");
+      cy.validateToast("success", "Successfully updated repo", true);
     });
   });
 
@@ -288,7 +289,7 @@ describe("Repo Settings", () => {
       cy.dataCy("task-tags-input").first().type("alias task tag");
 
       cy.dataCy("save-settings-button").click();
-      cy.validateToast("success", "Successfully updated repo");
+      cy.validateToast("success", "Successfully updated repo", true);
     });
 
     it("Shows the alias name in the card title upon save", () => {
@@ -309,7 +310,7 @@ describe("Repo Settings", () => {
       cy.dataCy("github-trigger-alias-checkbox").check({ force: true });
 
       cy.dataCy("save-settings-button").click();
-      cy.validateToast("success", "Successfully updated repo");
+      cy.validateToast("success", "Successfully updated repo", true);
 
       cy.dataCy("save-settings-button").should("be.disabled");
     });
@@ -331,14 +332,14 @@ describe("Repo Settings", () => {
       cy.dataCy("command-input").eq(1).type("command 2");
 
       cy.dataCy("save-settings-button").click();
-      cy.validateToast("success", "Successfully updated repo");
+      cy.validateToast("success", "Successfully updated repo", true);
     });
 
     it("Reorders the commands", () => {
       cy.dataCy("array-down-button").click();
 
       cy.dataCy("save-settings-button").scrollIntoView().click();
-      cy.validateToast("success", "Successfully updated repo");
+      cy.validateToast("success", "Successfully updated repo", true);
 
       cy.dataCy("command-input").first().should("have.value", "command 2");
       cy.dataCy("command-input").eq(1).should("have.value", "command 1");
@@ -352,10 +353,11 @@ describe("Repo Settings", () => {
 
     it("Shows the patch trigger alias", () => {
       cy.dataCy("pta-item").should("have.length", 1);
+      cy.dataCy("pta-item").scrollIntoView();
+      cy.contains("my-alias").should("be.visible");
     });
 
     it("Hovering over the alias name shows its details", () => {
-      cy.dataCy("pta-item").scrollIntoView();
       cy.dataCy("pta-item").trigger("mouseover");
       cy.dataCy("pta-tooltip").should("be.visible");
       cy.dataCy("pta-tooltip").contains("spruce");
@@ -392,7 +394,7 @@ describe("Project Settings when not defaulting to repo", () => {
       .contains("Attach")
       .parent()
       .click();
-    cy.validateToast("success", "Successfully attached to repo");
+    cy.validateToast("success", "Successfully attached to repo", true);
   });
 
   it("Successfully detaches from repo", () => {
@@ -402,7 +404,7 @@ describe("Project Settings when not defaulting to repo", () => {
       .contains("Detach")
       .parent()
       .click();
-    cy.validateToast("success", "Successfully detached from repo");
+    cy.validateToast("success", "Successfully detached from repo", true);
   });
 
   describe("Variables page", () => {
@@ -490,7 +492,7 @@ describe("Project Settings when not defaulting to repo", () => {
       cy.dataCy("remote-path-input").type("./evergreen.yml");
 
       cy.dataCy("save-settings-button").click();
-      cy.validateToast("success", "Successfully updated project");
+      cy.validateToast("success", "Successfully updated project", true);
     });
 
     it("Shows the saved Git Tag", () => {
@@ -519,7 +521,7 @@ describe("Project Settings when not defaulting to repo", () => {
     it("Saves when a number is entered", () => {
       cy.dataCy("interval-input").clear().type("12");
       cy.dataCy("save-settings-button").click();
-      cy.validateToast("success", "Successfully updated project");
+      cy.validateToast("success", "Successfully updated project", true);
     });
   });
 
@@ -588,13 +590,13 @@ describe("Project Settings when defaulting to repo", () => {
 
     it("Clicking on save button should show a success toast", () => {
       cy.dataCy("save-settings-button").click();
-      cy.validateToast("success", "Successfully updated project");
+      cy.validateToast("success", "Successfully updated project", true);
     });
 
     it("Saves when batch time is updated", () => {
       cy.dataCy("batch-time-input").type("12");
       cy.dataCy("save-settings-button").click();
-      cy.validateToast("success", "Successfully updated project");
+      cy.validateToast("success", "Successfully updated project", true);
     });
   });
 
@@ -705,7 +707,7 @@ describe("Project Settings when defaulting to repo", () => {
 
     it("Returns an error on save because no commit check definitions are defined", () => {
       cy.dataCy("save-settings-button").click();
-      cy.validateToast("error");
+      cy.validateToast("error", undefined, true);
     });
 
     it("Disabling commit checks saves successfully", () => {
@@ -714,7 +716,7 @@ describe("Project Settings when defaulting to repo", () => {
       });
 
       cy.dataCy("save-settings-button").click();
-      cy.validateToast("success", "Successfully updated project");
+      cy.validateToast("success", "Successfully updated project", true);
     });
 
     it("Defaults to repo", () => {
@@ -725,7 +727,7 @@ describe("Project Settings when defaulting to repo", () => {
         .contains("Confirm")
         .parent()
         .click();
-      cy.validateToast("success");
+      cy.validateToast("success", "Successfully defaulted page to repo", true);
     });
 
     it("Again shows the repo's disabled patch definition", () => {
@@ -784,7 +786,7 @@ describe("Project Settings when defaulting to repo", () => {
       cy.dataCy("task-tags-input").first().type("alias task tag 3");
 
       cy.dataCy("save-settings-button").click();
-      cy.validateToast("success", "Successfully updated project");
+      cy.validateToast("success", "Successfully updated project", true);
     });
 
     it("Allows defaulting to repo patch aliases", () => {
@@ -793,7 +795,7 @@ describe("Project Settings when defaulting to repo", () => {
       });
 
       cy.dataCy("save-settings-button").click();
-      cy.validateToast("success", "Successfully updated project");
+      cy.validateToast("success", "Successfully updated project", true);
 
       cy.dataCy("save-settings-button").should("be.disabled");
       cy.dataCy("expandable-card-title").contains("my alias name");
@@ -825,7 +827,7 @@ describe("Project Settings when defaulting to repo", () => {
       cy.getInputByLabel("Override Repo Commands").click({ force: true });
 
       cy.dataCy("save-settings-button").click();
-      cy.validateToast("success", "Successfully updated project");
+      cy.validateToast("success", "Successfully updated project", true);
 
       cy.getInputByLabel("Override Repo Commands").should("be.checked");
     });
@@ -847,7 +849,7 @@ describe("Attaching Spruce to a repo", () => {
     // cy.dataCy("attach-repo-button").should("be.disabled");
 
     cy.dataCy("save-settings-button").click();
-    cy.validateToast("success", "Successfully updated project");
+    cy.validateToast("success", "Successfully updated project", true);
   });
 
   it("Attaches to new repo", () => {
@@ -857,7 +859,7 @@ describe("Attaching Spruce to a repo", () => {
       .contains("Attach")
       .parent()
       .click();
-    cy.validateToast("success", "Successfully attached to repo");
+    cy.validateToast("success", "Successfully attached to repo", true);
   });
 
   describe("GitHub/Commit Queue page", () => {
@@ -912,7 +914,7 @@ describe("Renaming the identifier", () => {
 
   it("Successfully saves", () => {
     cy.dataCy("save-settings-button").click();
-    cy.validateToast("success");
+    cy.validateToast("success", undefined, true);
   });
 
   it("Redirects to a new URL", () => {
@@ -938,7 +940,7 @@ describe("Duplicating a project with errors", () => {
   it("Successfully copies the project and shows a warning toast", () => {
     cy.dataCy("project-name-input").type("copied-project");
     cy.get("button").contains("Duplicate").parent().click();
-    cy.validateToast("warning");
+    cy.validateToast("warning", undefined, true);
   });
 
   it("Redirects to a new URL", () => {
@@ -993,7 +995,7 @@ describe("Notifications", () => {
       "contain.text",
       "Version outcome  - mohamed.khelif@mongodb.com"
     );
-    cy.validateToast("success", undefined, true);
+    cy.validateToast("success", "Successfully updated project", true);
   });
   it("should be able to delete a subscription", () => {
     cy.dataCy("expandable-card").should("exist");
@@ -1003,7 +1005,7 @@ describe("Notifications", () => {
     cy.dataCy("save-settings-button").scrollIntoView();
     cy.dataCy("save-settings-button").should("not.be.disabled");
     cy.dataCy("save-settings-button").click();
-    cy.validateToast("success", undefined, true);
+    cy.validateToast("success", "Successfully updated project", true);
   });
   it("should not be able to combine a jira comment subscription with a task event", () => {
     cy.dataCy("expandable-card").should("not.exist");

--- a/cypress/integration/projectSettings/project_settings.ts
+++ b/cypress/integration/projectSettings/project_settings.ts
@@ -46,7 +46,7 @@ describe("Access page", () => {
       .first()
       .type("admin");
     cy.dataCy("save-settings-button").should("be.enabled").click();
-    cy.validateToast("success", "Successfully updated project", true);
+    cy.validateToast("success", "Successfully updated project");
     cy.visit(destination);
     cy.get("label")
       .contains("Private")
@@ -81,15 +81,14 @@ describe("Access page", () => {
     cy.dataCy("save-settings-button").should("be.enabled").click();
     cy.validateToast(
       "error",
-      "There was an error saving the project: error updating project admin roles: no admin role for project 'spruce' found",
-      true
+      "There was an error saving the project: error updating project admin roles: no admin role for project 'spruce' found"
     );
   });
 
   it("Clicking on 'Default to Repo on Page' selects the 'Default to repo (public)' checkbox and produces a success banner", () => {
     cy.dataCy("default-to-repo-button").click();
     cy.dataCy("default-to-repo-modal").contains("Confirm").click();
-    cy.validateToast("success", "Successfully defaulted page to repo", true);
+    cy.validateToast("success", "Successfully defaulted page to repo");
     cy.get("label")
       .contains("Default to repo (public)")
       .closest("label")
@@ -148,7 +147,7 @@ describe("Repo Settings", () => {
 
   it("Clicking on save button should show a success toast", () => {
     cy.dataCy("save-settings-button").click();
-    cy.validateToast("success", "Successfully updated repo", true);
+    cy.validateToast("success", "Successfully updated repo");
   });
 
   describe("GitHub/Commit Queue page", () => {
@@ -258,7 +257,7 @@ describe("Repo Settings", () => {
 
     it("Successfully saves the page", () => {
       cy.dataCy("save-settings-button").click();
-      cy.validateToast("success", "Successfully updated repo", true);
+      cy.validateToast("success", "Successfully updated repo");
     });
   });
 
@@ -289,7 +288,7 @@ describe("Repo Settings", () => {
       cy.dataCy("task-tags-input").first().type("alias task tag");
 
       cy.dataCy("save-settings-button").click();
-      cy.validateToast("success", "Successfully updated repo", true);
+      cy.validateToast("success", "Successfully updated repo");
     });
 
     it("Shows the alias name in the card title upon save", () => {
@@ -310,7 +309,7 @@ describe("Repo Settings", () => {
       cy.dataCy("github-trigger-alias-checkbox").check({ force: true });
 
       cy.dataCy("save-settings-button").click();
-      cy.validateToast("success", "Successfully updated repo", true);
+      cy.validateToast("success", "Successfully updated repo");
 
       cy.dataCy("save-settings-button").should("be.disabled");
     });
@@ -332,14 +331,14 @@ describe("Repo Settings", () => {
       cy.dataCy("command-input").eq(1).type("command 2");
 
       cy.dataCy("save-settings-button").click();
-      cy.validateToast("success", "Successfully updated repo", true);
+      cy.validateToast("success", "Successfully updated repo");
     });
 
     it("Reorders the commands", () => {
       cy.dataCy("array-down-button").click();
 
       cy.dataCy("save-settings-button").scrollIntoView().click();
-      cy.validateToast("success", "Successfully updated repo", true);
+      cy.validateToast("success", "Successfully updated repo");
 
       cy.dataCy("command-input").first().should("have.value", "command 2");
       cy.dataCy("command-input").eq(1).should("have.value", "command 1");
@@ -394,7 +393,7 @@ describe("Project Settings when not defaulting to repo", () => {
       .contains("Attach")
       .parent()
       .click();
-    cy.validateToast("success", "Successfully attached to repo", true);
+    cy.validateToast("success", "Successfully attached to repo");
   });
 
   it("Successfully detaches from repo", () => {
@@ -404,7 +403,7 @@ describe("Project Settings when not defaulting to repo", () => {
       .contains("Detach")
       .parent()
       .click();
-    cy.validateToast("success", "Successfully detached from repo", true);
+    cy.validateToast("success", "Successfully detached from repo");
   });
 
   describe("Variables page", () => {
@@ -492,7 +491,7 @@ describe("Project Settings when not defaulting to repo", () => {
       cy.dataCy("remote-path-input").type("./evergreen.yml");
 
       cy.dataCy("save-settings-button").click();
-      cy.validateToast("success", "Successfully updated project", true);
+      cy.validateToast("success", "Successfully updated project");
     });
 
     it("Shows the saved Git Tag", () => {
@@ -521,7 +520,7 @@ describe("Project Settings when not defaulting to repo", () => {
     it("Saves when a number is entered", () => {
       cy.dataCy("interval-input").clear().type("12");
       cy.dataCy("save-settings-button").click();
-      cy.validateToast("success", "Successfully updated project", true);
+      cy.validateToast("success", "Successfully updated project");
     });
   });
 
@@ -590,13 +589,13 @@ describe("Project Settings when defaulting to repo", () => {
 
     it("Clicking on save button should show a success toast", () => {
       cy.dataCy("save-settings-button").click();
-      cy.validateToast("success", "Successfully updated project", true);
+      cy.validateToast("success", "Successfully updated project");
     });
 
     it("Saves when batch time is updated", () => {
       cy.dataCy("batch-time-input").type("12");
       cy.dataCy("save-settings-button").click();
-      cy.validateToast("success", "Successfully updated project", true);
+      cy.validateToast("success", "Successfully updated project");
     });
   });
 
@@ -707,7 +706,7 @@ describe("Project Settings when defaulting to repo", () => {
 
     it("Returns an error on save because no commit check definitions are defined", () => {
       cy.dataCy("save-settings-button").click();
-      cy.validateToast("error", undefined, true);
+      cy.validateToast("error");
     });
 
     it("Disabling commit checks saves successfully", () => {
@@ -716,7 +715,7 @@ describe("Project Settings when defaulting to repo", () => {
       });
 
       cy.dataCy("save-settings-button").click();
-      cy.validateToast("success", "Successfully updated project", true);
+      cy.validateToast("success", "Successfully updated project");
     });
 
     it("Defaults to repo", () => {
@@ -727,7 +726,7 @@ describe("Project Settings when defaulting to repo", () => {
         .contains("Confirm")
         .parent()
         .click();
-      cy.validateToast("success", "Successfully defaulted page to repo", true);
+      cy.validateToast("success", "Successfully defaulted page to repo");
     });
 
     it("Again shows the repo's disabled patch definition", () => {
@@ -786,7 +785,7 @@ describe("Project Settings when defaulting to repo", () => {
       cy.dataCy("task-tags-input").first().type("alias task tag 3");
 
       cy.dataCy("save-settings-button").click();
-      cy.validateToast("success", "Successfully updated project", true);
+      cy.validateToast("success", "Successfully updated project");
     });
 
     it("Allows defaulting to repo patch aliases", () => {
@@ -795,7 +794,7 @@ describe("Project Settings when defaulting to repo", () => {
       });
 
       cy.dataCy("save-settings-button").click();
-      cy.validateToast("success", "Successfully updated project", true);
+      cy.validateToast("success", "Successfully updated project");
 
       cy.dataCy("save-settings-button").should("be.disabled");
       cy.dataCy("expandable-card-title").contains("my alias name");
@@ -827,7 +826,7 @@ describe("Project Settings when defaulting to repo", () => {
       cy.getInputByLabel("Override Repo Commands").click({ force: true });
 
       cy.dataCy("save-settings-button").click();
-      cy.validateToast("success", "Successfully updated project", true);
+      cy.validateToast("success", "Successfully updated project");
 
       cy.getInputByLabel("Override Repo Commands").should("be.checked");
     });
@@ -849,7 +848,7 @@ describe("Attaching Spruce to a repo", () => {
     // cy.dataCy("attach-repo-button").should("be.disabled");
 
     cy.dataCy("save-settings-button").click();
-    cy.validateToast("success", "Successfully updated project", true);
+    cy.validateToast("success", "Successfully updated project");
   });
 
   it("Attaches to new repo", () => {
@@ -859,7 +858,7 @@ describe("Attaching Spruce to a repo", () => {
       .contains("Attach")
       .parent()
       .click();
-    cy.validateToast("success", "Successfully attached to repo", true);
+    cy.validateToast("success", "Successfully attached to repo");
   });
 
   describe("GitHub/Commit Queue page", () => {
@@ -914,7 +913,7 @@ describe("Renaming the identifier", () => {
 
   it("Successfully saves", () => {
     cy.dataCy("save-settings-button").click();
-    cy.validateToast("success", undefined, true);
+    cy.validateToast("success", "Successfully updated project");
   });
 
   it("Redirects to a new URL", () => {
@@ -940,7 +939,7 @@ describe("Duplicating a project with errors", () => {
   it("Successfully copies the project and shows a warning toast", () => {
     cy.dataCy("project-name-input").type("copied-project");
     cy.get("button").contains("Duplicate").parent().click();
-    cy.validateToast("warning", undefined, true);
+    cy.validateToast("warning");
   });
 
   it("Redirects to a new URL", () => {
@@ -995,7 +994,7 @@ describe("Notifications", () => {
       "contain.text",
       "Version outcome  - mohamed.khelif@mongodb.com"
     );
-    cy.validateToast("success", "Successfully updated project", true);
+    cy.validateToast("success", "Successfully updated project");
   });
   it("should be able to delete a subscription", () => {
     cy.dataCy("expandable-card").should("exist");
@@ -1005,7 +1004,7 @@ describe("Notifications", () => {
     cy.dataCy("save-settings-button").scrollIntoView();
     cy.dataCy("save-settings-button").should("not.be.disabled");
     cy.dataCy("save-settings-button").click();
-    cy.validateToast("success", "Successfully updated project", true);
+    cy.validateToast("success", "Successfully updated project");
   });
   it("should not be able to combine a jira comment subscription with a task event", () => {
     cy.dataCy("expandable-card").should("not.exist");

--- a/cypress/integration/subscription_modal.ts
+++ b/cypress/integration/subscription_modal.ts
@@ -20,7 +20,7 @@ const testSharedSubscriptionModalFunctionality = (
       cy.dataCy("jira-comment-input").type("EVG-2000");
       cy.dataCy("save-subscription-button").should("not.be.disabled");
       cy.dataCy("save-subscription-button").click();
-      cy.dataCy(toastDataCy).contains(successText);
+      cy.validateToast("success", successText);
     });
 
     describe("Disables save button and displays an error message when populating form with invalid values", () => {
@@ -85,7 +85,7 @@ const testSharedSubscriptionModalFunctionality = (
         errorMessage: "error",
       });
       cy.dataCy("save-subscription-button").click();
-      cy.dataCy(toastDataCy).contains("error");
+      cy.validateToast("error");
     });
 
     it("Hides the modal after clicking the cancel button", () => {
@@ -111,7 +111,6 @@ const testSharedSubscriptionModalFunctionality = (
       cy.clearCookie(triggerCookie);
     });
 
-    const toastDataCy = "toast";
     const successText = "Your subscription has been added";
     const errorTextPercent = "Value should be >= 0";
     const errorTextDuration = "Value should be >= 0";

--- a/cypress/integration/task/execution_task_table.ts
+++ b/cypress/integration/task/execution_task_table.ts
@@ -1,7 +1,7 @@
-const pathExecutionTasks =
-  "/task/mci_ubuntu1604_display_asdf_patch_a1d2c8f70bf5c543de8b9641ac1ec08def1ddb26_5f74d99ab2373627c047c5e5_20_09_30_19_16_47/execution-tasks";
-
 describe("Execution task table", () => {
+  const pathExecutionTasks =
+    "/task/mci_ubuntu1604_display_asdf_patch_a1d2c8f70bf5c543de8b9641ac1ec08def1ddb26_5f74d99ab2373627c047c5e5_20_09_30_19_16_47/execution-tasks";
+
   before(() => {
     cy.login();
     cy.visit(pathExecutionTasks);

--- a/cypress/integration/task/files_tables.ts
+++ b/cypress/integration/task/files_tables.ts
@@ -1,8 +1,8 @@
-const FILES_ROUTE = "/task/evergreen_ubuntu1604_89/files";
-const FILES_ROUTE_WITHOUT_FILES =
-  "/task/evergreen_ubuntu1604_test_model_commitqueue_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48/files ";
-
 describe("files table", () => {
+  const FILES_ROUTE = "/task/evergreen_ubuntu1604_89/files";
+  const FILES_ROUTE_WITHOUT_FILES =
+    "/task/evergreen_ubuntu1604_test_model_commitqueue_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48/files ";
+
   it("File names under name column should link to a new tab", () => {
     cy.visit(FILES_ROUTE);
     cy.dataCy("fileLink").should("have.attr", "target", "_blank");

--- a/cypress/integration/task/task_actions.ts
+++ b/cypress/integration/task/task_actions.ts
@@ -17,7 +17,6 @@ describe("Task Action Buttons", () => {
       cy.dataCy("ellipsis-btn").click();
       cy.dataCy("card-dropdown").should("be.visible");
       cy.dataCy("unschedule-task").click();
-
       cy.validateToast("success", unscheduleSuccessBannerText);
     });
 

--- a/cypress/integration/task/task_actions.ts
+++ b/cypress/integration/task/task_actions.ts
@@ -14,7 +14,6 @@ describe("Task Action Buttons", () => {
     });
 
     it("Clicking Unschedule button should unschedule a task and display a success toast", () => {
-      cy.dataCy("ellipsis-btn").should("be.visible").should("not.be.disabled");
       cy.dataCy("ellipsis-btn").click();
       cy.dataCy("card-dropdown").should("be.visible");
       cy.dataCy("unschedule-task").click();
@@ -22,7 +21,6 @@ describe("Task Action Buttons", () => {
     });
 
     it("Abort button should be disabled on completed tasks", () => {
-      cy.dataCy("ellipsis-btn").should("be.visible").should("not.be.disabled");
       cy.dataCy("ellipsis-btn").click();
       cy.dataCy("card-dropdown").should("be.visible");
       cy.dataCy("abort-task").should("have.attr", "disabled");
@@ -30,43 +28,32 @@ describe("Task Action Buttons", () => {
 
     it("Clicking on set priority, entering a priority value and submitting should result in a success toast.", () => {
       cy.visit(tasks[3]);
-      cy.dataCy("ellipsis-btn").should("be.visible").should("not.be.disabled");
       cy.dataCy("ellipsis-btn").click();
       cy.dataCy("card-dropdown").should("be.visible");
       cy.dataCy("prioritize-task").click();
       cy.dataCy("task-priority-input").clear().type("99");
       cy.get(popconfirmYesClassName).contains("Set").click({ force: true });
-
       cy.validateToast("success", prioritySuccessBannerText);
     });
 
     it("Should be able to abort an incomplete task", () => {
       cy.visit(tasks[2]);
-
-      cy.dataCy("ellipsis-btn").should("be.visible").should("not.be.disabled");
       cy.dataCy("ellipsis-btn").click();
       cy.dataCy("card-dropdown").should("be.visible");
       cy.dataCy("abort-task").click();
-
       cy.validateToast("success", "Task aborted");
     });
 
     it("Should correctly disable/enable the task when clicked", () => {
       cy.visit(tasks[1]);
-
-      cy.dataCy("ellipsis-btn").should("be.visible").should("not.be.disabled");
       cy.dataCy("ellipsis-btn").click();
       cy.dataCy("card-dropdown").should("be.visible");
       cy.dataCy("disable-enable").click();
-      cy.dataCy("ellipsis-btn").click(); // temporary manually close menu button TODO: Remove when PD-1207 is fixed
-
       cy.validateToast("success", "Task was successfully disabled");
 
-      cy.dataCy("ellipsis-btn").should("be.visible").should("not.be.disabled");
       cy.dataCy("ellipsis-btn").click();
       cy.dataCy("card-dropdown").should("be.visible");
       cy.dataCy("disable-enable").click();
-
       cy.validateToast("success", "Priority for task updated to 0");
     });
   });

--- a/cypress/integration/task/task_actions.ts
+++ b/cypress/integration/task/task_actions.ts
@@ -14,6 +14,7 @@ describe("Task Action Buttons", () => {
     });
 
     it("Clicking Unschedule button should unschedule a task and display a success toast", () => {
+      cy.dataCy("ellipsis-btn").should("be.visible").should("not.be.disabled");
       cy.dataCy("ellipsis-btn").click();
       cy.dataCy("card-dropdown").should("be.visible");
       cy.dataCy("unschedule-task").click();
@@ -21,6 +22,7 @@ describe("Task Action Buttons", () => {
     });
 
     it("Abort button should be disabled on completed tasks", () => {
+      cy.dataCy("ellipsis-btn").should("be.visible").should("not.be.disabled");
       cy.dataCy("ellipsis-btn").click();
       cy.dataCy("card-dropdown").should("be.visible");
       cy.dataCy("abort-task").should("have.attr", "disabled");
@@ -41,6 +43,7 @@ describe("Task Action Buttons", () => {
     it("Should be able to abort an incomplete task", () => {
       cy.visit(tasks[2]);
 
+      cy.dataCy("ellipsis-btn").should("be.visible").should("not.be.disabled");
       cy.dataCy("ellipsis-btn").click();
       cy.dataCy("card-dropdown").should("be.visible");
       cy.dataCy("abort-task").click();
@@ -50,6 +53,8 @@ describe("Task Action Buttons", () => {
 
     it("Should correctly disable/enable the task when clicked", () => {
       cy.visit(tasks[1]);
+
+      cy.dataCy("ellipsis-btn").should("be.visible").should("not.be.disabled");
       cy.dataCy("ellipsis-btn").click();
       cy.dataCy("card-dropdown").should("be.visible");
       cy.dataCy("disable-enable").click();
@@ -57,6 +62,7 @@ describe("Task Action Buttons", () => {
 
       cy.validateToast("success", "Task was successfully disabled");
 
+      cy.dataCy("ellipsis-btn").should("be.visible").should("not.be.disabled");
       cy.dataCy("ellipsis-btn").click();
       cy.dataCy("card-dropdown").should("be.visible");
       cy.dataCy("disable-enable").click();

--- a/cypress/integration/task/task_logs.ts
+++ b/cypress/integration/task/task_logs.ts
@@ -1,6 +1,7 @@
-const LOGS_ROUTE =
-  "/task/evergreen_ubuntu1604_test_model_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48/logs";
 describe("task logs", () => {
+  const LOGS_ROUTE =
+    "/task/evergreen_ubuntu1604_test_model_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48/logs";
+
   before(() => {
     cy.login();
     cy.visit(LOGS_ROUTE);

--- a/cypress/integration/version/action_buttons.ts
+++ b/cypress/integration/version/action_buttons.ts
@@ -26,10 +26,8 @@ describe("Action Buttons", () => {
       cy.dataCy("card-dropdown").should("not.exist");
     });
     describe("Version dropdown options", () => {
-      before(() => {
-        cy.dataCy("ellipsis-btn").click();
-      });
       beforeEach(() => {
+        cy.dataCy("ellipsis-btn").click();
         cy.dataCy("card-dropdown").should("be.visible");
       });
 

--- a/cypress/integration/version/routes.ts
+++ b/cypress/integration/version/routes.ts
@@ -8,7 +8,7 @@ const versions = {
   6: "5e4ff3abe3c3317e352062e4",
 };
 
-const versionRoute = (id) => `/version/${id}`;
+const versionRoute = (id: string) => `/version/${id}`;
 
 describe("Version route", () => {
   describe("Redirects", () => {

--- a/cypress/integration/version/subscription_modal.ts
+++ b/cypress/integration/version/subscription_modal.ts
@@ -1,11 +1,10 @@
 import { openSubscriptionModal } from "../../utils/subscriptionModal";
 import { selectAntdOption } from "../../utils";
 
-const regexSelectorRow = "regex-selector-row";
-
 describe("Version Subscription Modal", () => {
   const dataCyToggleModalButton = "notify-patch";
   const route = "/version/5e4ff3abe3c3317e352062e4/tasks";
+  const regexSelectorRow = "regex-selector-row";
 
   describe("Regex selector inputs", () => {
     it("Clicking on 'Add Additional Criteria' adds a regex selector row", () => {

--- a/cypress/integration/version/task_duration.ts
+++ b/cypress/integration/version/task_duration.ts
@@ -1,7 +1,7 @@
-const patch = "5e4ff3abe3c3317e352062e4";
-const TASK_DURATION_ROUTE = `/version/${patch}/task-duration`;
-
 describe("Task Duration Tab", () => {
+  const patch = "5e4ff3abe3c3317e352062e4";
+  const TASK_DURATION_ROUTE = `/version/${patch}/task-duration`;
+
   describe("when interacting with the filters on the page", () => {
     it("updates URL appropriately when task name filter is applied", () => {
       cy.visit(TASK_DURATION_ROUTE);

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -94,6 +94,7 @@ Cypress.Commands.add(
       cy.dataCy("toast").within(() => {
         cy.get("button[aria-label='Close Message']").click();
       });
+      cy.dataCy("toast").should("not.exist");
     }
   }
 );

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -9,12 +9,50 @@ Cypress.Cookies.defaults({
   preserve: TOAST_COOKIE,
 });
 
+type cyGetOptions = Parameters<typeof cy.get>[1];
+
+/* dataCy */
+Cypress.Commands.add("dataCy", (value: string, options: cyGetOptions = {}) => {
+  cy.get(`[data-cy=${value}]`, options);
+});
+
+/* dataRowKey */
+Cypress.Commands.add(
+  "dataRowKey",
+  (value: string, options: cyGetOptions = {}) => {
+    cy.get(`[data-row-key=${value}]`, options);
+  }
+);
+
+/* dataTestId */
+Cypress.Commands.add(
+  "dataTestId",
+  (value: string, options: cyGetOptions = {}) => {
+    cy.get(`[data-test-id=${value}]`, options);
+  }
+);
+
+/* enterLoginCredentials */
 function enterLoginCredentials() {
   cy.get("input[name=username]").type(user.username);
   cy.get("input[name=password]").type(user.password);
   cy.get("button[id=login-submit]").click();
 }
 
+Cypress.Commands.add("enterLoginCredentials", () => {
+  enterLoginCredentials();
+});
+
+/* getInputByLabel */
+Cypress.Commands.add("getInputByLabel", (label: string) => {
+  cy.contains("label", label)
+    .invoke("attr", "for")
+    .then((id) => {
+      cy.get(`#${id}`);
+    });
+});
+
+/* login */
 Cypress.Commands.add("login", () => {
   cy.getCookie(LOGIN_COOKIE).then((c) => {
     if (!c) {
@@ -23,10 +61,7 @@ Cypress.Commands.add("login", () => {
   });
 });
 
-Cypress.Commands.add("enterLoginCredentials", () => {
-  enterLoginCredentials();
-});
-
+/* preserveCookies */
 Cypress.Commands.add("preserveCookies", () => {
   Cypress.Cookies.preserveOnce(
     LOGIN_COOKIE,
@@ -35,27 +70,7 @@ Cypress.Commands.add("preserveCookies", () => {
   );
 });
 
-type cyGetOptions = Parameters<typeof cy.get>[1];
-Cypress.Commands.add("dataCy", (value: string, options: cyGetOptions) =>
-  cy.get(`[data-cy=${value}]`, options)
-);
-Cypress.Commands.add("dataRowKey", (value: string, options: cyGetOptions) =>
-  cy.get(`[data-row-key=${value}]`, options)
-);
-
-Cypress.Commands.add("dataTestId", (value: string, options: cyGetOptions) =>
-  cy.get(`[data-test-id=${value}]`, options)
-);
-
-Cypress.Commands.add("getInputByLabel", (label: string) =>
-  cy
-    .contains("label", label)
-    .invoke("attr", "for")
-    .then((id) => {
-      cy.get(`#${id}`);
-    })
-);
-
+/* toggleTableFilter */
 Cypress.Commands.add("toggleTableFilter", (colNum: number) => {
   cy.get(`.ant-table-thead > tr > :nth-child(${colNum})`)
     .find("[role=button]")
@@ -66,9 +81,10 @@ Cypress.Commands.add("toggleTableFilter", (colNum: number) => {
   );
 });
 
+/* validateToast */
 Cypress.Commands.add(
   "validateToast",
-  (status: string, message?: string, shouldClose?: boolean) => {
+  (status: string, message?: string, shouldClose: boolean = true) => {
     cy.dataCy(`toast`).should("be.visible");
     cy.dataCy("toast").should("have.attr", "data-variant", status);
     if (message) {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -84,7 +84,7 @@ Cypress.Commands.add("toggleTableFilter", (colNum: number) => {
 /* validateToast */
 Cypress.Commands.add(
   "validateToast",
-  (status: string, message?: string, shouldClose: boolean = true) => {
+  (status: string, message: string = "", shouldClose: boolean = true) => {
     cy.dataCy(`toast`).should("be.visible");
     cy.dataCy("toast").should("have.attr", "data-variant", status);
     if (message) {

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -37,27 +37,26 @@ declare global {
        * Custom command to select DOM element by data-cy attribute.
        * @example cy.dataCy('greeting')
        */
-      dataCy(value: string): Chainable<Element>;
+      dataCy(
+        value: string,
+        options?: Parameters<typeof cy.get>[1]
+      ): Chainable<Element>;
       /**
        * Custom command to select DOM element by data-row-key attribute.
        * @example cy.dataRowKey('greeting')
        */
-      dataRowKey(value: string): Chainable<Element>;
+      dataRowKey(
+        value: string,
+        options?: Parameters<typeof cy.get>[1]
+      ): Chainable<Element>;
       /**
        * Custom command to select DOM element by data-test-id attribute.
        * @example cy.dataTestId('greeting')
        */
-      dataTestId(value: string): Chainable<Element>;
-      /**
-       * Custom command to preserve cookie between tests.
-       * @example cy.preserveCookies()
-       */
-      preserveCookies(): void;
-      /**
-       * Custom command to navigate to login page and login.
-       * @example cy.login()
-       */
-      login(): void;
+      dataTestId(
+        value: string,
+        options?: Parameters<typeof cy.get>[1]
+      ): Chainable<Element>;
       /**
        * Custom command to enter credentials in username and password input
        * and then click submit
@@ -69,6 +68,16 @@ declare global {
        * @example cy.getInputBylabel("Some Label")
        */
       getInputByLabel(label: string): Chainable<Element>;
+      /**
+       * Custom command to navigate to login page and login.
+       * @example cy.login()
+       */
+      login(): void;
+      /**
+       * Custom command to preserve cookie between tests.
+       * @example cy.preserveCookies()
+       */
+      preserveCookies(): void;
       /**
        * Custom command to open an antd table filter associated with the
        * the supplied column number


### PR DESCRIPTION
EVG-17080

### Description
(Disclaimer: I don’t know if this is the correct solution. But I ran this test in a [patch](https://spruce.mongodb.com/task/spruce_ubuntu1604_e2e_test_patch_126f75e0b9637086da6925747c8cd7c43c6169cd_63457fbf30661531116aee10_22_10_11_14_37_57/tests?execution=19&sortBy=STATUS&sortDir=ASC) 20 times and the only time it failed was because of an unrelated test.)

This PR makes it so that all toasts in `project_settings.ts` are automatically closed.

I noticed that there would always be a toast covering the `Add to GitHub Trigger Alias` checkbox. Because the toast is covering the checkbox, it's impossible to confirm in the Cypress video whether it has been properly checked or not. I was thinking that the toast might be causing us to sometimes check the checkbox, and sometimes not.

In any case, I think it is a good idea to automatically close the toasts. A lot of the toasts in the project settings say the same thing (e.g. `Successfully updated project`), so we could potentially get false positives because a toast is persisting for several seconds. 

### Screenshots
- No visible changes.

### Testing
- N/A
