### PR TITLE
EVG-17080: Address miscellaneous flaky e2e tests

### DIFF
--- a/cypress/integration/hosts/select_hosts.ts
+++ b/cypress/integration/hosts/select_hosts.ts
@@ -15,6 +15,7 @@ describe("Select hosts in hosts page table", () => {
       cy.get(".ant-checkbox-input").should("not.be.disabled");
       cy.get(".ant-checkbox-input").check({ force: true });
     });
+    cy.get(".ant-checkbox-checked").should("have.length", 4);
 
     cy.dataCy("restart-jasper-button").should("not.be.disabled");
     cy.dataCy("update-status-button").should("not.be.disabled");
@@ -23,12 +24,14 @@ describe("Select hosts in hosts page table", () => {
   it("Can restart jasper for selected hosts", () => {
     cy.get(".ant-table-selection-column").within(() => {
       cy.get(".ant-checkbox-input").should("not.be.disabled");
-
       cy.get(".ant-checkbox-input").check({ force: true });
     });
+    cy.get(".ant-checkbox-checked").should("have.length", 4);
 
     cy.dataCy("restart-jasper-button").should("not.be.disabled");
-    cy.dataCy("restart-jasper-button").click();
+    cy.dataCy("restart-jasper-button").should("be.visible").click();
+
+    cy.dataCy("restart-jasper-button-popover").should("be.visible");
     cy.contains("button", "Yes").click();
     cy.validateToast("success");
   });
@@ -36,12 +39,14 @@ describe("Select hosts in hosts page table", () => {
   it("Can reprovision for selected hosts", () => {
     cy.get(".ant-table-selection-column").within(() => {
       cy.get(".ant-checkbox-input").should("not.be.disabled");
-
       cy.get(".ant-checkbox-input").check({ force: true });
     });
+    cy.get(".ant-checkbox-checked").should("have.length", 4);
 
     cy.dataCy("reprovision-button").should("not.be.disabled");
-    cy.dataCy("reprovision-button").click();
+    cy.dataCy("reprovision-button").should("be.visible").click();
+
+    cy.dataCy("reprovision-button-popover").should("be.visible");
     cy.contains("button", "Yes").click();
     cy.validateToast("success", "Marked hosts to reprovision for 0 hosts");
   });

--- a/cypress/integration/hosts/select_hosts.ts
+++ b/cypress/integration/hosts/select_hosts.ts
@@ -1,33 +1,29 @@
 describe("Select hosts in hosts page table", () => {
   const hostsRoute = "/hosts";
 
-  beforeEach(() => {
+  before(() => {
     cy.visit(`${hostsRoute}?distroId=ubuntu1604-large&page=0&statuses=running`);
     cy.dataCy("hosts-table").should("exist");
     cy.dataCy("hosts-table").should("not.have.attr", "data-loading", "true");
   });
 
   it("Selecting hosts shows hosts selection data", () => {
-    cy.dataCy("restart-jasper-button").should("be.disabled");
     cy.dataCy("update-status-button").should("be.disabled");
+    cy.dataCy("restart-jasper-button").should("be.disabled");
+    cy.dataCy("reprovision-button").should("be.disabled");
 
-    cy.get(".ant-table-selection-column").within(() => {
+    cy.get(".ant-table-thead .ant-table-selection-column").within(() => {
       cy.get(".ant-checkbox-input").should("not.be.disabled");
-      cy.get(".ant-checkbox-input").check({ force: true });
+      cy.get(".ant-checkbox-input").check();
     });
     cy.get(".ant-checkbox-checked").should("have.length", 4);
 
-    cy.dataCy("restart-jasper-button").should("not.be.disabled");
     cy.dataCy("update-status-button").should("not.be.disabled");
+    cy.dataCy("restart-jasper-button").should("not.be.disabled");
+    cy.dataCy("reprovision-button").should("not.be.disabled");
   });
 
   it("Can restart jasper for selected hosts", () => {
-    cy.get(".ant-table-selection-column").within(() => {
-      cy.get(".ant-checkbox-input").should("not.be.disabled");
-      cy.get(".ant-checkbox-input").check({ force: true });
-    });
-    cy.get(".ant-checkbox-checked").should("have.length", 4);
-
     cy.dataCy("restart-jasper-button").should("not.be.disabled");
     cy.dataCy("restart-jasper-button").should("be.visible").click();
 
@@ -37,12 +33,6 @@ describe("Select hosts in hosts page table", () => {
   });
 
   it("Can reprovision for selected hosts", () => {
-    cy.get(".ant-table-selection-column").within(() => {
-      cy.get(".ant-checkbox-input").should("not.be.disabled");
-      cy.get(".ant-checkbox-input").check({ force: true });
-    });
-    cy.get(".ant-checkbox-checked").should("have.length", 4);
-
     cy.dataCy("reprovision-button").should("not.be.disabled");
     cy.dataCy("reprovision-button").should("be.visible").click();
 

--- a/cypress/integration/projectSettings/project_settings.ts
+++ b/cypress/integration/projectSettings/project_settings.ts
@@ -351,8 +351,8 @@ describe("Repo Settings", () => {
     });
 
     it("Shows the patch trigger alias", () => {
+      cy.contains("GitHub Trigger Aliases").scrollIntoView();
       cy.dataCy("pta-item").should("have.length", 1);
-      cy.dataCy("pta-item").scrollIntoView();
       cy.contains("my-alias").should("be.visible");
     });
 

--- a/cypress/integration/projectSettings/project_settings.ts
+++ b/cypress/integration/projectSettings/project_settings.ts
@@ -39,7 +39,15 @@ describe("Access page", () => {
 
   it("Changing settings and clicking the save button produces a success toast and the changes are persisted", () => {
     cy.get("label").contains("Private").click();
+    cy.getInputByLabel("Private").should("have.attr", "aria-checked", "true");
+
     cy.get("label").contains("Unrestricted").click();
+    cy.getInputByLabel("Unrestricted").should(
+      "have.attr",
+      "aria-checked",
+      "true"
+    );
+
     cy.contains("Add Username").click();
     cy.get("[aria-label='Username'")
       .should("have.length", 1)
@@ -47,17 +55,8 @@ describe("Access page", () => {
       .type("admin");
     cy.dataCy("save-settings-button").should("be.enabled").click();
     cy.validateToast("success", "Successfully updated project");
+
     cy.visit(destination);
-    cy.get("label")
-      .contains("Private")
-      .closest("label")
-      .get("input")
-      .should("have.attr", "checked", "checked");
-    cy.get("label")
-      .contains("Unrestricted")
-      .closest("label")
-      .get("input")
-      .should("have.attr", "checked", "checked");
     cy.get("[aria-label='Username']")
       .should("have.value", "admin")
       .should("exist");
@@ -89,11 +88,12 @@ describe("Access page", () => {
     cy.dataCy("default-to-repo-button").click();
     cy.dataCy("default-to-repo-modal").contains("Confirm").click();
     cy.validateToast("success", "Successfully defaulted page to repo");
-    cy.get("label")
-      .contains("Default to repo (public)")
-      .closest("label")
-      .get("input")
-      .should("have.attr", "checked", "checked");
+
+    cy.getInputByLabel("Default to repo (public)").should(
+      "have.attr",
+      "aria-checked",
+      "true"
+    );
   });
 });
 

--- a/cypress/integration/projectSettings/project_settings.ts
+++ b/cypress/integration/projectSettings/project_settings.ts
@@ -429,6 +429,7 @@ describe("Project Settings when not defaulting to repo", () => {
       cy.dataCy("var-value-input").type("sample_value");
       cy.dataCy("var-private-input").check({ force: true });
       cy.dataCy("save-settings-button").click();
+      cy.validateToast("success", "Successfully updated project");
     });
 
     it("Should redact and disable private variables on save", () => {
@@ -461,6 +462,7 @@ describe("Project Settings when not defaulting to repo", () => {
       cy.dataCy("var-value-input").first().type("admin_value");
       cy.dataCy("var-admin-input").first().check({ force: true });
       cy.dataCy("save-settings-button").click();
+      cy.validateToast("success", "Successfully updated project");
     });
 
     it("Should show three populated fields when navigating back from another page", () => {
@@ -476,6 +478,7 @@ describe("Project Settings when not defaulting to repo", () => {
       cy.dataCy("delete-item-button").first().click();
       cy.dataCy("delete-item-button").first().click();
       cy.dataCy("save-settings-button").click();
+      cy.validateToast("success", "Successfully updated project");
     });
 
     it("Should show no variables after deleting", () => {
@@ -1024,6 +1027,8 @@ describe("Notifications", () => {
     cy.dataCy("save-settings-button").scrollIntoView();
     cy.dataCy("save-settings-button").should("not.be.disabled");
     cy.dataCy("save-settings-button").click();
+    cy.validateToast("success", "Successfully updated project");
+
     cy.dataCy("save-settings-button").should("be.disabled");
     cy.dataCy("expandable-card").should("exist");
     cy.dataCy("expandable-card").scrollIntoView();
@@ -1031,7 +1036,6 @@ describe("Notifications", () => {
       "contain.text",
       "Version outcome  - mohamed.khelif@mongodb.com"
     );
-    cy.validateToast("success", "Successfully updated project");
   });
   it("should be able to delete a subscription", () => {
     cy.dataCy("expandable-card").should("exist");

--- a/cypress/integration/projectSettings/project_settings.ts
+++ b/cypress/integration/projectSettings/project_settings.ts
@@ -42,7 +42,6 @@ describe("Access page", () => {
   it("Changing settings and clicking the save button produces a success toast and the changes are persisted", () => {
     cy.get("label").contains("Private").click();
     cy.getInputByLabel("Private").should("have.attr", "aria-checked", "true");
-
     cy.get("label").contains("Unrestricted").click();
     cy.getInputByLabel("Unrestricted").should(
       "have.attr",
@@ -57,7 +56,6 @@ describe("Access page", () => {
       .type("admin");
     cy.dataCy("save-settings-button").should("be.enabled").click();
     cy.validateToast("success", "Successfully updated project");
-
     cy.visit(destination);
     cy.get("[aria-label='Username']")
       .should("have.value", "admin")
@@ -70,7 +68,6 @@ describe("Access page", () => {
     cy.get("[aria-label='Username']").should("have.length", 0);
     cy.dataCy("save-settings-button").should("be.enabled").click();
     cy.validateToast("success", "Successfully updated project");
-
     cy.reload();
     cy.get("[aria-label='Username']").should("have.length", 0);
   });
@@ -93,7 +90,6 @@ describe("Access page", () => {
     cy.dataCy("default-to-repo-button").click();
     cy.dataCy("default-to-repo-modal").contains("Confirm").click();
     cy.validateToast("success", "Successfully defaulted page to repo");
-
     cy.getInputByLabel("Default to repo (public)").should(
       "have.attr",
       "aria-checked",

--- a/cypress/integration/projectSettings/project_settings.ts
+++ b/cypress/integration/projectSettings/project_settings.ts
@@ -29,11 +29,13 @@ describe("Access page", () => {
 
   it("Should enable the save button when the General Access value changes", () => {
     cy.get("label").contains("Private").click();
+    cy.getInputByLabel("Private").should("have.attr", "aria-checked", "true");
     cy.dataCy("save-settings-button").should("be.enabled");
   });
 
   it("Should enable the save button when the General Access value changes", () => {
     cy.get("label").contains("Private").click();
+    cy.getInputByLabel("Private").should("have.attr", "aria-checked", "true");
     cy.dataCy("save-settings-button").should("be.enabled");
   });
 
@@ -66,6 +68,9 @@ describe("Access page", () => {
     cy.get("[aria-label='Username']").should("have.length", 1);
     cy.dataCy("delete-item-button").click();
     cy.get("[aria-label='Username']").should("have.length", 0);
+    cy.dataCy("save-settings-button").should("be.enabled").click();
+    cy.validateToast("success", "Successfully updated project");
+
     cy.reload();
     cy.get("[aria-label='Username']").should("have.length", 0);
   });

--- a/cypress/integration/taskQueue/route.ts
+++ b/cypress/integration/taskQueue/route.ts
@@ -58,7 +58,8 @@ describe("Task Queue", () => {
     );
     cy.dataCy("task-queue-table").should("exist");
     cy.get(".ant-table-row-selected").should("exist");
-    cy.get(".ant-table-row-selected").contains("13").should("be.visible");
+    cy.get(".ant-table-row-selected").should("contain.text", "13");
+    cy.get(".ant-table-row-selected").should("be.visible");
   });
 
   it("Task links goes to Spruce for both patches and mainline commits", () => {


### PR DESCRIPTION
EVG-17080

### Description
This PR is more to help me debug than actually solve the flaky test problem. The test currently doesn't scroll the field of interest into view so I can't see what's going on 🙃 

I also added more guards in attempt to fix the flaky reprovision hosts test.

Here's a [patch](https://spruce.mongodb.com/task/spruce_ubuntu1604_e2e_test_patch_10a00b29040b1136e9f0c4bcee9aa5f563230624_634eb42f61837d1f5a044e62_22_10_18_14_12_11/tests?execution=9&sortBy=STATUS&sortDir=ASC) that I ran ten times with no failures, but I could just be lucky.

### Screenshots
- N/A

### Testing
- N/A
