### PR TITLE
EVG-17691: Add repo link to project settings pages

### DIFF
--- a/cypress/integration/projectSettings/project_settings.ts
+++ b/cypress/integration/projectSettings/project_settings.ts
@@ -141,6 +141,10 @@ describe("Repo Settings", () => {
     cy.dataCy("attach-repo-button").should("not.exist");
   });
 
+  it("Does not show a 'Go to repo settings' link on page", () => {
+    cy.dataCy("attached-repo-link").should("not.exist");
+  });
+
   it("Sets a display name", () => {
     cy.dataCy("display-name-input").type("evg");
   });
@@ -553,6 +557,12 @@ describe("Project Settings when defaulting to repo", () => {
   describe("General Settings page", () => {
     it("Should not have the save button enabled on load", () => {
       cy.dataCy("save-settings-button").should("be.disabled");
+    });
+
+    it("Shows a link to the repo", () => {
+      cy.dataCy("attached-repo-link")
+        .should("have.attr", "href")
+        .and("eq", getGeneralRoute(repo));
     });
 
     it("Preserves edits to the form when navigating between settings tabs and does not show a warning modal", () => {

--- a/cypress/integration/projectSettings/project_settings.ts
+++ b/cypress/integration/projectSettings/project_settings.ts
@@ -562,7 +562,7 @@ describe("Project Settings when defaulting to repo", () => {
     it("Shows a link to the repo", () => {
       cy.dataCy("attached-repo-link")
         .should("have.attr", "href")
-        .and("eq", getGeneralRoute(repo));
+        .and("eq", `/${getGeneralRoute(repo)}`);
     });
 
     it("Preserves edits to the form when navigating between settings tabs and does not show a warning modal", () => {

--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "camelcase": "^6.1.0",
     "colors": "1.4.0",
     "css-loader": "4.3.0",
-    "cypress": "10.3.1",
+    "cypress": "10.10.0",
     "eslint": "8.19.0",
     "eslint-config-airbnb": "19.0.4",
     "eslint-config-prettier": "8.5.0",

--- a/src/pages/projectSettings/Header.tsx
+++ b/src/pages/projectSettings/Header.tsx
@@ -1,6 +1,10 @@
 import styled from "@emotion/styled";
-import { H2, Disclaimer } from "@leafygreen-ui/typography";
-import { ProjectSettingsTabRoutes } from "constants/routes";
+import { H2 } from "@leafygreen-ui/typography";
+import { StyledRouterLink } from "components/styles";
+import {
+  getProjectSettingsRoute,
+  ProjectSettingsTabRoutes,
+} from "constants/routes";
 import { size } from "constants/tokens";
 import { getTabTitle } from "./getTabTitle";
 import { HeaderButtons } from "./HeaderButtons";
@@ -8,20 +12,30 @@ import { readOnlyTabs, WritableTabRoutes } from "./tabs/types";
 import { ProjectType } from "./tabs/utils";
 
 interface Props {
+  attachedRepoId?: string;
   id: string;
   projectType: ProjectType;
   tab: ProjectSettingsTabRoutes;
 }
 
-export const Header: React.VFC<Props> = ({ id, projectType, tab }) => {
-  const { title, subtitle } = getTabTitle(tab);
+export const Header: React.VFC<Props> = ({
+  attachedRepoId,
+  id,
+  projectType,
+  tab,
+}) => {
+  const { title } = getTabTitle(tab);
   const saveable = !(readOnlyTabs as ReadonlyArray<string>).includes(tab);
 
   return (
     <Container>
       <TitleContainer>
         <H2 data-cy="project-settings-tab-title">{title}</H2>
-        {subtitle && <Subtitle>{subtitle}</Subtitle>}
+        {projectType === ProjectType.AttachedProject && (
+          <StyledRouterLink to={getProjectSettingsRoute(attachedRepoId, tab)}>
+            <strong>Go to repo settings</strong>
+          </StyledRouterLink>
+        )}
       </TitleContainer>
       {saveable && (
         <HeaderButtons
@@ -35,6 +49,7 @@ export const Header: React.VFC<Props> = ({ id, projectType, tab }) => {
 };
 
 const Container = styled.div`
+  align-items: start;
   display: flex;
   justify-content: space-between;
   margin-bottom: ${size.l};
@@ -42,8 +57,4 @@ const Container = styled.div`
 
 const TitleContainer = styled.div`
   margin-right: ${size.s};
-`;
-
-const Subtitle = styled(Disclaimer)`
-  padding-top: ${size.s};
 `;

--- a/src/pages/projectSettings/Header.tsx
+++ b/src/pages/projectSettings/Header.tsx
@@ -32,7 +32,10 @@ export const Header: React.VFC<Props> = ({
       <TitleContainer>
         <H2 data-cy="project-settings-tab-title">{title}</H2>
         {projectType === ProjectType.AttachedProject && (
-          <StyledRouterLink to={getProjectSettingsRoute(attachedRepoId, tab)}>
+          <StyledRouterLink
+            to={getProjectSettingsRoute(attachedRepoId, tab)}
+            data-cy="attached-repo-link"
+          >
             <strong>Go to repo settings</strong>
           </StyledRouterLink>
         )}

--- a/src/pages/projectSettings/Tabs.tsx
+++ b/src/pages/projectSettings/Tabs.tsx
@@ -55,7 +55,12 @@ export const ProjectSettingsTabs: React.VFC<Props> = ({
 
   return (
     <Container>
-      <Header id={projectId || repoId} projectType={projectType} tab={tab} />
+      <Header
+        attachedRepoId={projectData?.projectRef?.repoRefId}
+        id={projectId || repoId}
+        projectType={projectType}
+        tab={tab}
+      />
       <Routes>
         <Route
           path={ProjectSettingsTabRoutes.General}

--- a/src/pages/projectSettings/getTabTitle.ts
+++ b/src/pages/projectSettings/getTabTitle.ts
@@ -2,7 +2,7 @@ import { ProjectSettingsTabRoutes } from "constants/routes";
 
 export const getTabTitle = (
   tab: ProjectSettingsTabRoutes = ProjectSettingsTabRoutes.General
-): { title: string; subtitle?: string } => {
+): { title: string } => {
   const defaultTitle = {
     title: "General Settings",
   };

--- a/src/pages/projectSettings/tabs/VariablesTab/PromoteVariablesModal.tsx
+++ b/src/pages/projectSettings/tabs/VariablesTab/PromoteVariablesModal.tsx
@@ -106,7 +106,8 @@ export const PromoteVariablesModal: React.VFC<Props> = ({
     >
       <Body>
         Variables will be moved to the repo to which this project is attached,
-        allowing them to be used by all attached projects.
+        allowing them to be used by all attached projects. They will be deleted
+        from this project.
       </Body>
       <SelectAllContainer>
         <Button onClick={handleSelectAll} size={Size.XSmall}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -9254,10 +9254,10 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
-cypress@10.3.1:
-  version "10.3.1"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-10.3.1.tgz#7fab4ef43481c05a9a17ebe9a0ec860e15b95a19"
-  integrity sha512-As9HrExjAgpgjCnbiQCuPdw5sWKx5HUJcK2EOKziu642akwufr/GUeqL5UnCPYXTyyibvEdWT/pSC2qnGW/e5w==
+cypress@10.10.0:
+  version "10.10.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-10.10.0.tgz#fd671297b2ca3e64dfffd55fe3857c388cfbb695"
+  integrity sha512-bU8r44x1NIYAUNNXt3CwJpLOVth7HUv2hUhYCxZmgZ1IugowDvuHNpevnoZRQx1KKOEisLvIJW+Xen5Pjn41pg==
   dependencies:
     "@cypress/request" "^2.88.10"
     "@cypress/xvfb" "^1.2.4"
@@ -9278,7 +9278,7 @@ cypress@10.3.1:
     dayjs "^1.10.4"
     debug "^4.3.2"
     enquirer "^2.3.6"
-    eventemitter2 "^6.4.3"
+    eventemitter2 "6.4.7"
     execa "4.1.0"
     executable "^4.1.1"
     extract-zip "2.0.1"
@@ -10767,10 +10767,10 @@ event-target-shim@^5.0.0:
   resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
   integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
 
-eventemitter2@^6.4.3:
-  version "6.4.5"
-  resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-6.4.5.tgz#97380f758ae24ac15df8353e0cc27f8b95644655"
-  integrity sha512-bXE7Dyc1i6oQElDG0jMRZJrRAn9QR2xyyFGmBdZleNmyQX0FqGYmhZIrIrpPfm/w//LTo4tVQGOGQcGCb5q9uw==
+eventemitter2@6.4.7:
+  version "6.4.7"
+  resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-6.4.7.tgz#a7f6c4d7abf28a14c1ef3442f21cb306a054271d"
+  integrity sha512-tYUSVOGeQPKt/eC1ABfhHy5Xd96N3oIijJvN3O9+TsC28T5V9yX9oEfEK5faP0EFSNVOG97qtAS68GBrQB2hDg==
 
 eventemitter3@^4.0.0:
   version "4.0.7"


### PR DESCRIPTION
EVG-17691

### Description
<!-- add description, context, thought process, etc -->
- On attached project pages, add link to repo settings. The page will open on the same tab that the project was viewing.
- Remove unused subtitle field from project settings pages
- Upgrade Cypress to 10.10.0. This version fixes a bug that prevented Cypress from running locally using Firefox: https://github.com/cypress-io/cypress/issues/23897
- Bonus: add additional text to promote variables modal to indicate that vars will be deleted (follow up to https://github.com/evergreen-ci/spruce/pull/1465)

### Screenshots
<img width="990" alt="image" src="https://user-images.githubusercontent.com/9298431/196742796-ef14e48b-4cdd-4754-b96b-94dd39e737d0.png">

### Testing
- Add Cypress tests (flaky tests are failing)