### PR TITLE
EVG-17687: Fix null array errors in SearchableDropdown

### DIFF
--- a/cypress/integration/projectHealth/taskHistory.ts
+++ b/cypress/integration/projectHealth/taskHistory.ts
@@ -4,6 +4,14 @@ describe("task history", () => {
     cy.setCookie("has-closed-slack-banner", "true");
   });
 
+  it("shows an error message if mainline commit history could not be retrieved", () => {
+    cy.visit("/task-history/bogus-project/bogus-task");
+    cy.dataCy("loading-cell").should("have.length", 0);
+    cy.contains("Failed to retrieve mainline commit history.").should(
+      "be.visible"
+    );
+  });
+
   it("link from task page should link to the commit and scroll to it", () => {
     cy.visit(`/task/${taskId}`);
     cy.contains("See history").should("exist");

--- a/cypress/integration/projectHealth/variantHistory.ts
+++ b/cypress/integration/projectHealth/variantHistory.ts
@@ -5,6 +5,14 @@ describe("variant history", () => {
     cy.preserveCookies();
   });
 
+  it("shows an error message if mainline commit history could not be retrieved", () => {
+    cy.visit("/variant-history/bogus-project/bogus-variant");
+    cy.dataCy("loading-cell").should("have.length", 0);
+    cy.contains("Failed to retrieve mainline commit history.").should(
+      "be.visible"
+    );
+  });
+
   it("should link to a specific commit from the project health page", () => {
     cy.visit("/commits/spruce");
     cy.dataCy("variant-header").should("exist");

--- a/cypress/integration/projectSettings/project_settings.ts
+++ b/cypress/integration/projectSettings/project_settings.ts
@@ -28,21 +28,22 @@ describe("Access page", () => {
   });
 
   it("Should enable the save button when the General Access value changes", () => {
-    cy.get("label").contains("Private").click();
+    cy.getInputByLabel("Private").parent().click();
     cy.getInputByLabel("Private").should("have.attr", "aria-checked", "true");
     cy.dataCy("save-settings-button").should("be.enabled");
   });
 
   it("Should enable the save button when the General Access value changes", () => {
-    cy.get("label").contains("Private").click();
+    cy.getInputByLabel("Private").parent().click();
     cy.getInputByLabel("Private").should("have.attr", "aria-checked", "true");
     cy.dataCy("save-settings-button").should("be.enabled");
   });
 
   it("Changing settings and clicking the save button produces a success toast and the changes are persisted", () => {
-    cy.get("label").contains("Private").click();
+    cy.getInputByLabel("Private").parent().click();
     cy.getInputByLabel("Private").should("have.attr", "aria-checked", "true");
-    cy.get("label").contains("Unrestricted").click();
+
+    cy.getInputByLabel("Unrestricted").parent().click();
     cy.getInputByLabel("Unrestricted").should(
       "have.attr",
       "aria-checked",

--- a/cypress/integration/projectSettings/project_settings.ts
+++ b/cypress/integration/projectSettings/project_settings.ts
@@ -15,7 +15,7 @@ const repo = "602d70a2b2373672ee493184";
 
 describe("Access page", () => {
   const destination = getAccessRoute(projectUseRepoEnabled);
-  beforeEach(() => {
+  before(() => {
     cy.visit(destination);
   });
 
@@ -55,22 +55,33 @@ describe("Access page", () => {
       .should("have.length", 1)
       .first()
       .type("admin");
-    cy.dataCy("save-settings-button").should("be.enabled").click();
-    cy.validateToast("success", "Successfully updated project");
-    cy.visit(destination);
     cy.get("[aria-label='Username']")
       .should("have.value", "admin")
       .should("exist");
+    cy.dataCy("save-settings-button").should("be.enabled").click();
+    cy.validateToast("success", "Successfully updated project");
   });
 
   it("Deleting a username results in a success toast and the changes are persisted", () => {
     cy.get("[aria-label='Username']").should("have.length", 1);
-    cy.dataCy("delete-item-button").click();
+    cy.dataCy("delete-item-button").should("be.visible").click();
     cy.get("[aria-label='Username']").should("have.length", 0);
     cy.dataCy("save-settings-button").should("be.enabled").click();
     cy.validateToast("success", "Successfully updated project");
+
     cy.reload();
     cy.get("[aria-label='Username']").should("have.length", 0);
+  });
+
+  it("Clicking on 'Default to Repo on Page' selects the 'Default to repo (public)' checkbox and produces a success banner", () => {
+    cy.dataCy("default-to-repo-button").click();
+    cy.dataCy("default-to-repo-modal").contains("Confirm").click();
+    cy.validateToast("success", "Successfully defaulted page to repo");
+    cy.getInputByLabel("Default to repo (public)").should(
+      "have.attr",
+      "aria-checked",
+      "true"
+    );
   });
 
   it("Submitting an invalid admin username produces an error toast", () => {
@@ -84,17 +95,6 @@ describe("Access page", () => {
     cy.validateToast(
       "error",
       "There was an error saving the project: error updating project admin roles: no admin role for project 'spruce' found"
-    );
-  });
-
-  it("Clicking on 'Default to Repo on Page' selects the 'Default to repo (public)' checkbox and produces a success banner", () => {
-    cy.dataCy("default-to-repo-button").click();
-    cy.dataCy("default-to-repo-modal").contains("Confirm").click();
-    cy.validateToast("success", "Successfully defaulted page to repo");
-    cy.getInputByLabel("Default to repo (public)").should(
-      "have.attr",
-      "aria-checked",
-      "true"
     );
   });
 });

--- a/cypress/integration/taskQueue/route.ts
+++ b/cypress/integration/taskQueue/route.ts
@@ -59,6 +59,8 @@ describe("Task Queue", () => {
     cy.dataCy("task-queue-table").should("exist");
     cy.get(".ant-table-row-selected").should("exist");
     cy.get(".ant-table-row-selected").should("contain.text", "13");
+
+    cy.contains("osx-108").should("not.be.visible");
     cy.get(".ant-table-row-selected").should("be.visible");
   });
 

--- a/src/components/SearchableDropdown/index.tsx
+++ b/src/components/SearchableDropdown/index.tsx
@@ -25,7 +25,7 @@ export interface SearchableDropdownProps<T> {
   disabled?: boolean;
   label: string | ReactNode;
   onChange: (value: T | T[]) => void;
-  options: T[] | string[];
+  options?: T[] | string[];
   optionRenderer?: (
     option: T,
     onClick: (selectedV) => void,
@@ -43,7 +43,7 @@ const SearchableDropdown = <T extends {}>({
   disabled = false,
   label,
   onChange,
-  options = [],
+  options,
   optionRenderer,
   searchFunc,
   searchPlaceholder = "search...",
@@ -51,22 +51,19 @@ const SearchableDropdown = <T extends {}>({
   valuePlaceholder = "Select an element",
 }: PropsWithChildren<SearchableDropdownProps<T>>) => {
   const [search, setSearch] = useState("");
-  const [visibleOptions, setVisibleOptions] = useState(options);
+  const [visibleOptions, setVisibleOptions] = useState(options ?? []);
   const DropdownRef = useRef(null);
 
   // Sometimes options come from a query and we have to wait for the query to complete to know what to show in
   // the dropdown. This hook is used to refresh the options.
   useEffect(() => {
-    if (options) {
-      setVisibleOptions(options);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [options.length]);
+    setVisibleOptions(options ?? []);
+  }, [options]);
 
   // Clear search text input and reset visible options to show every option.
   const resetSearch = () => {
     setSearch("");
-    setVisibleOptions(options);
+    setVisibleOptions(options ?? []);
   };
 
   const onClick = (v: T) => {
@@ -116,7 +113,7 @@ const SearchableDropdown = <T extends {}>({
       setSearch(searchTerm);
       let filteredOptions = [];
 
-      if (options.length) {
+      if (options) {
         if (searchFunc) {
           // Alias the array as any to avoid TS error https://github.com/microsoft/TypeScript/issues/36390
           filteredOptions = searchFunc(options as T[], searchTerm);

--- a/src/components/TupleSelect/__snapshots__/TupleSelect.stories.storyshot
+++ b/src/components/TupleSelect/__snapshots__/TupleSelect.stories.storyshot
@@ -31,7 +31,7 @@ exports[`storybook Storyshots Components/TupleSelect Default 1`] = `
           aria-disabled={false}
           aria-expanded={false}
           aria-invalid={false}
-          aria-labelledby="tuple-select-dropdown"
+          aria-labelledby="Tuple Select"
           className="leafygreen-ui-p6v5m8"
           data-testid="leafygreen-ui-select-menubutton"
           disabled={false}
@@ -88,7 +88,7 @@ exports[`storybook Storyshots Components/TupleSelect Default 1`] = `
               className="leafygreen-ui-1i2djk5"
             >
               <input
-                aria-labelledby="tuple-select-input"
+                aria-label="Tuple Search"
                 autoComplete="on"
                 className="leafygreen-ui-1il5lef"
                 data-cy="tuple-select-input"

--- a/src/components/TupleSelect/index.tsx
+++ b/src/components/TupleSelect/index.tsx
@@ -53,7 +53,7 @@ const TupleSelect: React.VFC<TupleSelectProps> = ({
           value={selected}
           onChange={(v) => setSelected(v)}
           data-cy="tuple-select-dropdown"
-          aria-labelledby="tuple-select-dropdown"
+          aria-labelledby="Tuple Select"
           allowDeselect={false}
         >
           {options.map((o) => (

--- a/src/components/TupleSelect/index.tsx
+++ b/src/components/TupleSelect/index.tsx
@@ -68,7 +68,7 @@ const TupleSelect: React.VFC<TupleSelectProps> = ({
         </GroupedSelect>
         <GroupedTextInput
           id="filter-input"
-          aria-labelledby="tuple-select-input"
+          aria-label="Tuple Search"
           data-cy="tuple-select-input"
           value={input}
           type="search"

--- a/src/pages/TaskHistory.tsx
+++ b/src/pages/TaskHistory.tsx
@@ -47,7 +47,7 @@ const TaskHistoryContents: React.VFC = () => {
   const { badges, handleOnRemove, handleClearAll } = useFilterBadgeQueryParams(
     constants.queryParamsToDisplay
   );
-  const { data } = useQuery<
+  const { data, error } = useQuery<
     MainlineCommitsForHistoryQuery,
     MainlineCommitsForHistoryQueryVariables
   >(GET_MAINLINE_COMMITS_FOR_HISTORY, {
@@ -108,17 +108,21 @@ const TaskHistoryContents: React.VFC = () => {
         </PaginationFilterWrapper>
         <div>
           <ColumnHeaders projectId={projectId} taskName={taskName} />
+
           <TableWrapper>
-            <HistoryTable
-              recentlyFetchedCommits={mainlineCommits}
-              loadMoreItems={() => {
-                if (mainlineCommits) {
-                  setNextPageOrderNumber(mainlineCommits.nextPageOrderNumber);
-                }
-              }}
-            >
-              {TaskHistoryRow}
-            </HistoryTable>
+            {error && <div>Failed to retrieve mainline commit history.</div>}
+            {!error && (
+              <HistoryTable
+                recentlyFetchedCommits={mainlineCommits}
+                loadMoreItems={() => {
+                  if (mainlineCommits) {
+                    setNextPageOrderNumber(mainlineCommits.nextPageOrderNumber);
+                  }
+                }}
+              >
+                {TaskHistoryRow}
+              </HistoryTable>
+            )}
           </TableWrapper>
         </div>
       </CenterPage>

--- a/src/pages/VariantHistory.tsx
+++ b/src/pages/VariantHistory.tsx
@@ -46,7 +46,7 @@ const VariantHistoryContents: React.VFC = () => {
   const { badges, handleOnRemove, handleClearAll } = useFilterBadgeQueryParams(
     constants.queryParamsToDisplay
   );
-  const { data } = useQuery<
+  const { data, error } = useQuery<
     MainlineCommitsForHistoryQuery,
     MainlineCommitsForHistoryQueryVariables
   >(GET_MAINLINE_COMMITS_FOR_HISTORY, {
@@ -108,16 +108,19 @@ const VariantHistoryContents: React.VFC = () => {
         <div>
           <ColumnHeaders projectId={projectId} variantName={variantName} />
           <TableWrapper>
-            <HistoryTable
-              recentlyFetchedCommits={mainlineCommits}
-              loadMoreItems={() => {
-                if (mainlineCommits) {
-                  setNextPageOrderNumber(mainlineCommits.nextPageOrderNumber);
-                }
-              }}
-            >
-              {VariantHistoryRow}
-            </HistoryTable>
+            {error && <div>Failed to retrieve mainline commit history.</div>}
+            {!error && (
+              <HistoryTable
+                recentlyFetchedCommits={mainlineCommits}
+                loadMoreItems={() => {
+                  if (mainlineCommits) {
+                    setNextPageOrderNumber(mainlineCommits.nextPageOrderNumber);
+                  }
+                }}
+              >
+                {VariantHistoryRow}
+              </HistoryTable>
+            )}
           </TableWrapper>
         </div>
       </CenterPage>

--- a/src/pages/taskHistory/BuildVariantSelector.tsx
+++ b/src/pages/taskHistory/BuildVariantSelector.tsx
@@ -56,7 +56,7 @@ const BuildVariantSelector: React.VFC<BuildVariantSelectorProps> = ({
     });
   };
 
-  const { buildVariantsForTaskName } = data || {};
+  const { buildVariantsForTaskName = [] } = data || {};
 
   const handleSearch = (options: BuildVariantTuple[], match: string) =>
     options.filter(
@@ -64,6 +64,7 @@ const BuildVariantSelector: React.VFC<BuildVariantSelectorProps> = ({
         option.buildVariant.includes(match) ||
         option.displayName.includes(match)
     );
+
   return (
     <Container>
       <SearchableDropdown

--- a/src/pages/taskHistory/BuildVariantSelector.tsx
+++ b/src/pages/taskHistory/BuildVariantSelector.tsx
@@ -56,7 +56,7 @@ const BuildVariantSelector: React.VFC<BuildVariantSelectorProps> = ({
     });
   };
 
-  const { buildVariantsForTaskName = [] } = data || {};
+  const { buildVariantsForTaskName } = data || {};
 
   const handleSearch = (options: BuildVariantTuple[], match: string) =>
     options.filter(

--- a/src/pages/variantHistory/TaskSelector.tsx
+++ b/src/pages/variantHistory/TaskSelector.tsx
@@ -53,7 +53,8 @@ const TaskSelector: React.VFC<TaskSelectorProps> = ({
     });
   };
 
-  const { taskNamesForBuildVariant = [] } = data || {};
+  const { taskNamesForBuildVariant } = data || {};
+
   return (
     <Container>
       <SearchableDropdown

--- a/src/pages/variantHistory/TaskSelector.tsx
+++ b/src/pages/variantHistory/TaskSelector.tsx
@@ -53,7 +53,7 @@ const TaskSelector: React.VFC<TaskSelectorProps> = ({
     });
   };
 
-  const { taskNamesForBuildVariant } = data || {};
+  const { taskNamesForBuildVariant = [] } = data || {};
   return (
     <Container>
       <SearchableDropdown


### PR DESCRIPTION
EVG-17687

### Description
This PR prevents errors in `BuildVariantSelector` and `TaskSelector` by setting a default array value.

It also stops the commit history from loading forever on the variant history and task history pages if it could not be fetched.

### Screenshots
<img width="1563" alt="Screen Shot 2022-10-24 at 11 53 34 AM" src="https://user-images.githubusercontent.com/47064971/197574953-d1ad221d-d4f1-4aaf-9dfe-ee6b9074c11b.png">

### Testing
- Added tests in `variantHistory.ts` and `taskHistory.ts` (Cypress)

