### PR TITLE
EVG-18163 Use node version defined in evergreen expansions

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -74,7 +74,7 @@ functions:
       working_dir: spruce
       background: true
       script: |
-        export PATH=/opt/nodejs/node-v16.13.0-linux-x64/bin:$PATH
+        export PATH=${node_path}
         yarn serve
 
   
@@ -83,7 +83,7 @@ functions:
     params:
       working_dir: spruce
       script: |
-        export PATH=/opt/nodejs/node-v16.13.0-linux-x64/bin:$PATH
+        export PATH=${node_path}
         yarn
 
   yarn-test:
@@ -91,7 +91,7 @@ functions:
     params:
       working_dir: spruce
       script: |
-        export PATH=/opt/nodejs/node-v16.13.0-linux-x64/bin:$PATH
+        export PATH=${node_path}
         yarn test --reporters=default --reporters=jest-junit --testPathIgnorePatterns=storybook.test.ts
 
   yarn-eslint:
@@ -99,7 +99,7 @@ functions:
     params:
       working_dir: spruce
       script: |
-        export PATH=/opt/nodejs/node-v16.13.0-linux-x64/bin:$PATH
+        export PATH=${node_path}
         yarn eslint:strict
 
   yarn-tsc:
@@ -107,7 +107,7 @@ functions:
     params:
       working_dir: spruce
       script: |
-        export PATH=/opt/nodejs/node-v16.13.0-linux-x64/bin:$PATH
+        export PATH=${node_path}
         yarn check-types
 
   yarn-build:
@@ -115,7 +115,7 @@ functions:
     params:
       working_dir: spruce
       script: |
-        export PATH=/opt/nodejs/node-v16.13.0-linux-x64/bin:$PATH
+        export PATH=${node_path}
         yarn build:local
 
   yarn-build-storybook:
@@ -123,7 +123,7 @@ functions:
     params:
       working_dir: spruce
       script: |
-        export PATH=/opt/nodejs/node-v16.13.0-linux-x64/bin:$PATH
+        export PATH=${node_path}
         yarn build-storybook
     
   yarn-snapshot:
@@ -131,7 +131,7 @@ functions:
     params:
       working_dir: spruce
       script: |
-        export PATH=/opt/nodejs/node-v16.13.0-linux-x64/bin:$PATH
+        export PATH=${node_path}
         yarn test --reporters="jest-junit" --reporters="default" --testPathPattern="storybook.test.ts"
 
   check-codegen:
@@ -140,7 +140,7 @@ functions:
       working_dir: spruce
       shell: bash
       script: |
-        export PATH=/opt/nodejs/node-v16.13.0-linux-x64/bin:$PATH
+        export PATH=${node_path}
         chmod +x check_codegen.sh
         ./check_codegen.sh
 
@@ -159,7 +159,7 @@ functions:
     params:
       working_dir: spruce
       script: |
-        export PATH=/opt/nodejs/node-v16.13.0-linux-x64/bin:$PATH
+        export PATH=${node_path}
         yarn cy:run --browser /tmp/chrome-linux/chrome --record --key ${cypress_record_key} --reporter junit
         
   copy-cmdrc:
@@ -326,7 +326,7 @@ functions:
     params:
       working_dir: spruce
       script: |
-        export PATH=/opt/nodejs/node-v16.13.0-linux-x64/bin:$PATH
+        export PATH=${node_path}
         BUCKET=${bucket} AWS_ACCESS_KEY_ID=${aws_key} AWS_SECRET_ACCESS_KEY=${aws_secret}  yarn deploy; yarn upload-source-maps;
 
   build-prod:
@@ -334,7 +334,7 @@ functions:
     params:
       working_dir: spruce
       script: |
-        export PATH=/opt/nodejs/node-v16.13.0-linux-x64/bin:$PATH
+        export PATH=${node_path}
         chmod +x appVersion.sh
         . ./appVersion.sh
         echo "Building Production version: $REACT_APP_VERSION"


### PR DESCRIPTION
EVG-18163

### Description
Fixes the invalid node version errors causing spruce builds to fail

