### PR TITLE
EVG-18118: Display fallback project for repo patches

### DIFF
--- a/src/components/PatchesPage/PatchCard.tsx
+++ b/src/components/PatchesPage/PatchCard.tsx
@@ -49,10 +49,34 @@ export const PatchCard: React.VFC<Props> = ({
 }) => {
   const createDate = new Date(createTime);
   const getDateCopy = useDateFormat();
-  const { taskStatusStats, id: versionId } = versionFull || {};
+  const { taskStatusStats, id: versionId, projectMetadata } = versionFull || {};
   const { stats } = groupStatusesByUmbrellaStatus(
     taskStatusStats?.counts ?? []
   );
+
+  let patchProject = null;
+  if (pageType === "project") {
+    patchProject = (
+      <StyledRouterLink
+        to={getUserPatchesRoute(author)}
+        data-cy="user-patches-link"
+      >
+        <strong>{authorDisplayName}</strong>
+      </StyledRouterLink>
+    );
+  } else {
+    patchProject = projectIdentifier ? (
+      <StyledRouterLink
+        to={getProjectPatchesRoute(projectIdentifier)}
+        data-cy="project-patches-link"
+      >
+        <strong>{projectIdentifier}</strong>
+      </StyledRouterLink>
+    ) : (
+      `${projectMetadata.owner}/${projectMetadata.repo}`
+    );
+  }
+
   const badges = stats?.map(({ count, umbrellaStatus, statusCounts }) => (
     <GroupedTaskStatusBadge
       status={umbrellaStatus}
@@ -76,21 +100,7 @@ export const PatchCard: React.VFC<Props> = ({
         </DescriptionLink>
         <TimeAndProject>
           {getDateCopy(createDate)} {pageType === "project" ? "by" : "on"}{" "}
-          {pageType === "project" ? (
-            <StyledRouterLink
-              to={getUserPatchesRoute(author)}
-              data-cy="user-patches-link"
-            >
-              <b>{authorDisplayName}</b>
-            </StyledRouterLink>
-          ) : (
-            <StyledRouterLink
-              to={getProjectPatchesRoute(projectIdentifier)}
-              data-cy="project-patches-link"
-            >
-              <b>{projectIdentifier}</b>
-            </StyledRouterLink>
-          )}
+          {patchProject}
         </TimeAndProject>
       </Left>
       <Center>

--- a/src/gql/fragments/patchesPage.graphql
+++ b/src/gql/fragments/patchesPage.graphql
@@ -17,6 +17,10 @@ fragment PatchesPagePatches on Patches {
         }
       }
       status
+      projectMetadata {
+        owner
+        repo
+      }
     }
     canEnqueueToCommitQueue
   }

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -2423,6 +2423,7 @@ export type PatchesPagePatchesFragment = {
       taskStatusStats?: Maybe<{
         counts?: Maybe<Array<{ status: string; count: number }>>;
       }>;
+      projectMetadata?: Maybe<{ owner: string; repo: string }>;
     }>;
   }>;
 };
@@ -6150,6 +6151,7 @@ export type ProjectPatchesQuery = {
           taskStatusStats?: Maybe<{
             counts?: Maybe<Array<{ status: string; count: number }>>;
           }>;
+          projectMetadata?: Maybe<{ owner: string; repo: string }>;
         }>;
       }>;
     };
@@ -6220,6 +6222,7 @@ export type UserPatchesQuery = {
           taskStatusStats?: Maybe<{
             counts?: Maybe<Array<{ status: string; count: number }>>;
           }>;
+          projectMetadata?: Maybe<{ owner: string; repo: string }>;
         }>;
       }>;
     };

--- a/src/pages/version/Metadata.tsx
+++ b/src/pages/version/Metadata.tsx
@@ -64,9 +64,13 @@ export const Metadata: React.VFC<Props> = ({ loading, version }) => {
     >
       <P2>
         Project:{" "}
-        <StyledRouterLink to={getProjectPatchesRoute(projectIdentifier)}>
-          {projectIdentifier}
-        </StyledRouterLink>
+        {projectIdentifier ? (
+          <StyledRouterLink to={getProjectPatchesRoute(projectIdentifier)}>
+            {projectIdentifier}
+          </StyledRouterLink>
+        ) : (
+          `${owner}/${repo}`
+        )}
       </P2>
       <P2>Makespan: {makespan && msToDuration(makespan)}</P2>
       <P2>Time taken: {timeTaken && msToDuration(timeTaken)}</P2>


### PR DESCRIPTION
EVG-18118

### Description
<!-- add description, context, thought process, etc -->
- For patches attached to a repo instead of a project, display `owner/repo` since no project name exists. These don't link anywhere because we don't support a repo patches page.

### Screenshots
<!-- add screenshots of visible changes -->
**Before:**
My patches:
<img width="998" alt="image" src="https://user-images.githubusercontent.com/9298431/198680566-35f6ef40-3ac5-42aa-a0a2-982424efccdd.png">
Patch page:
<img width="296" alt="image" src="https://user-images.githubusercontent.com/9298431/198680608-632e9f80-5a09-44f9-b11c-8f3f128ed756.png">

**After:**
My patches:
<img width="1002" alt="image" src="https://user-images.githubusercontent.com/9298431/198680476-3e41c54c-6a1f-4dad-b2f4-a1061ab74af0.png">
Patch page:
<img width="297" alt="image" src="https://user-images.githubusercontent.com/9298431/198680512-6061d6e9-31fa-48b8-91ac-705f509e6619.png">