### PR TITLE
EVG-18143: Upgrade Side Nav

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.36.48",
   "private": true,
   "scripts": {
-    "build-storybook": "build-storybook",
+    "build-storybook": "NODE_OPTIONS=--max-old-space-size=6144 build-storybook",
     "build:beta": "env-cmd -e beta -r env/.cmdrc.json yarn build",
     "build:local": "env-cmd -e local -r env/.cmdrc.json  yarn build",
     "build:prod": "env-cmd -e prod -r env/.cmdrc.json yarn build",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "@leafygreen-ui/radio-group": "7.0.6",
     "@leafygreen-ui/segmented-control": "0.9.1",
     "@leafygreen-ui/select": "3.1.0",
-    "@leafygreen-ui/side-nav": "7.2.1",
+    "@leafygreen-ui/side-nav": "11.0.0",
     "@leafygreen-ui/table": "2.0.7",
     "@leafygreen-ui/tabs": "5.1.4",
     "@leafygreen-ui/text-area": "4.0.3",

--- a/src/pages/Preferences.tsx
+++ b/src/pages/Preferences.tsx
@@ -1,3 +1,4 @@
+import Icon from "@leafygreen-ui/icon";
 import { useParams, Link, Navigate } from "react-router-dom";
 import { usePreferencesAnalytics } from "analytics";
 import {
@@ -20,7 +21,7 @@ export const Preferences: React.VFC = () => {
   return (
     <>
       <SideNav aria-label="Preferences">
-        <SideNavGroup header="Preferences">
+        <SideNavGroup header="Preferences" glyph={<Icon glyph="Settings" />}>
           <SideNavItem
             active={tab === PreferencesTabRoutes.Profile}
             to={getPreferencesRoute(PreferencesTabRoutes.Profile)}

--- a/src/pages/ProjectSettings.tsx
+++ b/src/pages/ProjectSettings.tsx
@@ -207,7 +207,7 @@ const ProjectSettingsNavItem: React.VFC<{
 const tabRouteValues = Object.values(ProjectSettingsTabRoutes);
 
 const ButtonsContainer = styled.div`
-  padding: 0 ${size.xs};
+  margin: 0 ${size.s};
 
   > :not(:last-child) {
     margin-bottom: ${size.xs};

--- a/src/pages/preferences/Card.tsx
+++ b/src/pages/preferences/Card.tsx
@@ -3,8 +3,7 @@ import Card from "@leafygreen-ui/card";
 import { size } from "constants/tokens";
 import { CardType } from "types/leafygreen";
 
-// @ts-expect-error
-export const PreferencesCard: CardType = styled(Card)`
+export const PreferencesCard = styled<CardType>(Card)`
   padding: ${size.m};
 
   :not(:last-of-type) {

--- a/src/pages/preferences/Card.tsx
+++ b/src/pages/preferences/Card.tsx
@@ -1,0 +1,13 @@
+import styled from "@emotion/styled";
+import Card from "@leafygreen-ui/card";
+import { size } from "constants/tokens";
+import { CardType } from "types/leafygreen";
+
+// @ts-expect-error
+export const PreferencesCard: CardType = styled(Card)`
+  padding: ${size.m};
+
+  :not(:last-of-type) {
+    margin-bottom: ${size.m};
+  }
+`;

--- a/src/pages/preferences/PreferencesTabs.tsx
+++ b/src/pages/preferences/PreferencesTabs.tsx
@@ -67,6 +67,7 @@ const getTitle = (
 };
 
 const Container = styled.div`
+  min-width: 600px;
   width: 60%;
 `;
 

--- a/src/pages/preferences/preferencesTabs/CliTab.tsx
+++ b/src/pages/preferences/preferencesTabs/CliTab.tsx
@@ -26,7 +26,7 @@ const list = [
     child: <AuthenticationCard />,
   },
   {
-    title: "Move the authentication file to ~/.evergreen.yml.",
+    title: "Move the authentication file to 〜/.evergreen.yml.",
   },
   {
     title: "Make sure you are good to go!",

--- a/src/pages/preferences/preferencesTabs/NewUITab.tsx
+++ b/src/pages/preferences/preferencesTabs/NewUITab.tsx
@@ -1,8 +1,7 @@
 import { useMutation } from "@apollo/client";
 import styled from "@emotion/styled";
-import Card from "@leafygreen-ui/card";
 import Toggle from "@leafygreen-ui/toggle";
-import { Body } from "@leafygreen-ui/typography";
+import { Label } from "@leafygreen-ui/typography";
 import { Skeleton } from "antd";
 import Cookies from "js-cookie";
 import { usePreferencesAnalytics } from "analytics";
@@ -15,6 +14,7 @@ import {
 } from "gql/generated/types";
 import { UPDATE_USER_SETTINGS } from "gql/mutations";
 import { useUserSettings } from "hooks";
+import { PreferencesCard } from "../Card";
 
 export const NewUITab: React.VFC = () => {
   const { sendEvent } = usePreferencesAnalytics();
@@ -64,44 +64,47 @@ export const NewUITab: React.VFC = () => {
   };
 
   return (
-    <>
-      {/* @ts-expect-error */}
-      <PreferencesCard>
-        <PaddedBody>
-          Direct all inbound links to the new Evergreen UI, whenever possible
-          (e.g. from the CLI, GitHub, etc.).
-        </PaddedBody>
-        <Toggle
+    <PreferencesCard>
+      <PreferenceItem>
+        <StyledToggle
           checked={spruceV1}
           disabled={updateLoading}
           onChange={handleOnChangeNewUI}
           aria-label="Toggle new evergreen ui"
+          id="prefer-spruce"
+          size="small"
         />
-      </PreferencesCard>
-      {/* @ts-expect-error */}
-      <PreferencesCard>
-        <PaddedBody>
-          Allow background polling for active tabs in the current browser.
-        </PaddedBody>
-        <Toggle
+        <Label htmlFor="prefer-spruce">
+          Direct all inbound links to the new Evergreen UI, whenever possible
+          (e.g. from the CLI, GitHub, etc.).
+        </Label>
+      </PreferenceItem>
+      <PreferenceItem>
+        <StyledToggle
           checked={Cookies.get(DISABLE_QUERY_POLLING) !== "true"}
           onChange={handleOnChangePolling}
-          aria-label="Toggle new evergreen ui"
+          aria-label="Toggle background polling"
+          id="polling"
+          size="small"
         />
-      </PreferencesCard>
-    </>
+        <Label htmlFor="polling">
+          Allow background polling for active tabs in the current browser.
+        </Label>
+      </PreferenceItem>
+    </PreferencesCard>
   );
 };
 
 // @ts-expect-error
-const PreferencesCard = styled(Card)`
-  display: flex;
-  flex-direction: column;
-  padding: ${size.m};
-  margin-bottom: ${size.m};
-  width: 100%;
+const StyledToggle = styled(Toggle)`
+  margin-right: ${size.xs};
 `;
 
-const PaddedBody = styled(Body)`
-  padding-bottom: ${size.l};
+const PreferenceItem = styled.div`
+  align-items: center;
+  display: flex;
+
+  :not(:last-of-type) {
+    margin-bottom: ${size.s};
+  }
 `;

--- a/src/pages/preferences/preferencesTabs/NewUITab.tsx
+++ b/src/pages/preferences/preferencesTabs/NewUITab.tsx
@@ -66,7 +66,7 @@ export const NewUITab: React.VFC = () => {
   return (
     <PreferencesCard>
       <PreferenceItem>
-        <StyledToggle
+        <Toggle
           checked={spruceV1}
           disabled={updateLoading}
           onChange={handleOnChangeNewUI}
@@ -80,7 +80,7 @@ export const NewUITab: React.VFC = () => {
         </Label>
       </PreferenceItem>
       <PreferenceItem>
-        <StyledToggle
+        <Toggle
           checked={Cookies.get(DISABLE_QUERY_POLLING) !== "true"}
           onChange={handleOnChangePolling}
           aria-label="Toggle background polling"
@@ -95,14 +95,10 @@ export const NewUITab: React.VFC = () => {
   );
 };
 
-// @ts-expect-error
-const StyledToggle = styled(Toggle)`
-  margin-right: ${size.xs};
-`;
-
 const PreferenceItem = styled.div`
   align-items: center;
   display: flex;
+  gap: ${size.xs};
 
   :not(:last-of-type) {
     margin-bottom: ${size.s};

--- a/src/pages/preferences/preferencesTabs/NotificationsTab.tsx
+++ b/src/pages/preferences/preferencesTabs/NotificationsTab.tsx
@@ -2,7 +2,6 @@ import { useState, useEffect } from "react";
 import { useMutation } from "@apollo/client";
 import styled from "@emotion/styled";
 import Button, { Variant } from "@leafygreen-ui/button";
-import Card from "@leafygreen-ui/card";
 import TextInput from "@leafygreen-ui/text-input";
 import { Skeleton } from "antd";
 import { usePreferencesAnalytics } from "analytics";
@@ -14,6 +13,7 @@ import {
 } from "gql/generated/types";
 import { UPDATE_USER_SETTINGS } from "gql/mutations";
 import { useUserSettings } from "hooks";
+import { PreferencesCard } from "pages/preferences/Card";
 import { string } from "utils";
 import { ClearSubscriptionsCard } from "./notificationTab/ClearSubscriptionsCard";
 import { NotificationField } from "./notificationTab/NotificationField";
@@ -84,8 +84,7 @@ export const NotificationsTab: React.VFC = () => {
 
   const newPayload = omitTypename(notificationStatus);
   return (
-    <div>
-      {/* @ts-expect-error */}
+    <>
       <PreferencesCard>
         <StyledTextInput
           label="Slack Username"
@@ -124,7 +123,7 @@ export const NotificationsTab: React.VFC = () => {
         </Button>
       </PreferencesCard>
       <ClearSubscriptionsCard />
-    </div>
+    </>
   );
 };
 
@@ -152,11 +151,4 @@ const GridField = styled.div`
 const StyledTextInput = styled(TextInput)`
   margin-bottom: ${size.m};
   width: 50%;
-`;
-
-// @ts-expect-error
-const PreferencesCard = styled(Card)`
-  padding: ${size.m};
-  margin-bottom: ${size.m};
-  width: 100%;
 `;

--- a/src/pages/preferences/preferencesTabs/ProfileTab.tsx
+++ b/src/pages/preferences/preferencesTabs/ProfileTab.tsx
@@ -2,12 +2,10 @@ import { useEffect, useState } from "react";
 import { useMutation, useQuery } from "@apollo/client";
 import styled from "@emotion/styled";
 import Button, { Variant } from "@leafygreen-ui/button";
-import Card from "@leafygreen-ui/card";
 import { Skeleton } from "antd";
 import { usePreferencesAnalytics } from "analytics";
 import { SpruceForm } from "components/SpruceForm";
 import { timeZones, dateFormats } from "constants/fieldMaps";
-import { size } from "constants/tokens";
 import { useToastContext } from "context/toast";
 import {
   UpdateUserSettingsMutation,
@@ -18,6 +16,7 @@ import { UPDATE_USER_SETTINGS } from "gql/mutations";
 import { GET_AWS_REGIONS } from "gql/queries";
 import { useUserSettings } from "hooks";
 import { omitTypename } from "utils/string";
+import { PreferencesCard } from "../Card";
 
 export const ProfileTab: React.VFC = () => {
   const { sendEvent } = usePreferencesAnalytics();
@@ -89,96 +88,84 @@ export const ProfileTab: React.VFC = () => {
   }
 
   return (
-    <div>
-      {/* @ts-expect-error */}
-      <PreferencesCard>
-        <ContentWrapper>
-          <SpruceForm
-            onChange={({ formData, errors }) => {
-              setHasErrors(errors.length > 0);
-              setFormState(formData);
-            }}
-            formData={formState}
-            uiSchema={{
-              timezone: {
-                "ui:placeholder": "Select a timezone",
+    <PreferencesCard>
+      <ContentWrapper>
+        <SpruceForm
+          onChange={({ formData, errors }) => {
+            setHasErrors(errors.length > 0);
+            setFormState(formData);
+          }}
+          formData={formState}
+          uiSchema={{
+            timezone: {
+              "ui:placeholder": "Select a timezone",
+            },
+            region: {
+              "ui:placeholder": "Select an AWS region",
+            },
+            githubUser: {
+              lastKnownAs: {
+                "ui:placeholder": "Enter your GitHub username",
               },
-              region: {
-                "ui:placeholder": "Select an AWS region",
-              },
+            },
+            dateFormat: {
+              "ui:placeholder": "Select a date format",
+            },
+          }}
+          schema={{
+            properties: {
               githubUser: {
-                lastKnownAs: {
-                  "ui:placeholder": "Enter your GitHub username",
-                },
-              },
-              dateFormat: {
-                "ui:placeholder": "Select a date format",
-              },
-            }}
-            schema={{
-              properties: {
-                githubUser: {
-                  title: null,
-                  properties: {
-                    lastKnownAs: {
-                      type: "string",
-                      title: "GitHub Username",
-                    },
+                title: null,
+                properties: {
+                  lastKnownAs: {
+                    type: "string",
+                    title: "GitHub Username",
                   },
                 },
-                timezone: {
-                  type: "string",
-                  title: "Timezone",
-                  oneOf: [
-                    ...timeZones.map(({ str, value }) => ({
-                      type: "string" as "string",
-                      title: str,
-                      enum: [value],
-                    })),
-                  ],
-                },
-                region: {
-                  type: "string",
-                  title: "AWS Region",
-                  enum: awsRegions,
-                },
-                dateFormat: {
-                  type: "string",
-                  title: "Date Format",
-                  oneOf: [
-                    ...dateFormats.map(({ str, value }) => ({
-                      type: "string" as "string",
-                      title: str,
-                      enum: [value],
-                    })),
-                  ],
-                },
               },
-            }}
-          />
-          <Button
-            data-cy="save-profile-changes-button"
-            variant={Variant.Primary}
-            disabled={!hasErrors || updateLoading}
-            onClick={handleSubmit}
-          >
-            Save Changes
-          </Button>
-        </ContentWrapper>
-      </PreferencesCard>
-    </div>
+              timezone: {
+                type: "string",
+                title: "Timezone",
+                oneOf: [
+                  ...timeZones.map(({ str, value }) => ({
+                    type: "string" as "string",
+                    title: str,
+                    enum: [value],
+                  })),
+                ],
+              },
+              region: {
+                type: "string",
+                title: "AWS Region",
+                enum: awsRegions,
+              },
+              dateFormat: {
+                type: "string",
+                title: "Date Format",
+                oneOf: [
+                  ...dateFormats.map(({ str, value }) => ({
+                    type: "string" as "string",
+                    title: str,
+                    enum: [value],
+                  })),
+                ],
+              },
+            },
+          }}
+        />
+        <Button
+          data-cy="save-profile-changes-button"
+          variant={Variant.Primary}
+          disabled={!hasErrors || updateLoading}
+          onClick={handleSubmit}
+        >
+          Save Changes
+        </Button>
+      </ContentWrapper>
+    </PreferencesCard>
   );
 };
 
 const ContentWrapper = styled.div`
   width: 50%;
-`;
-
-// @ts-expect-error
-const PreferencesCard = styled(Card)`
-  padding-left: ${size.m};
-  padding-top: ${size.m};
-  padding-bottom: 40px;
-  margin-bottom: 30px;
-  width: 100%;
 `;

--- a/src/pages/preferences/preferencesTabs/cliTab/AuthenticationCard.tsx
+++ b/src/pages/preferences/preferencesTabs/cliTab/AuthenticationCard.tsx
@@ -6,13 +6,13 @@ import { Subtitle } from "@leafygreen-ui/typography";
 import { Skeleton } from "antd";
 import get from "lodash/get";
 import { usePreferencesAnalytics } from "analytics";
-import { SiderCard } from "components/styles";
 import { size } from "constants/tokens";
 import {
   GetUserConfigQuery,
   GetUserConfigQueryVariables,
 } from "gql/generated/types";
 import { GET_USER_CONFIG } from "gql/queries";
+import { PreferencesCard } from "pages/preferences/Card";
 import { request } from "utils";
 
 const { post } = request;
@@ -54,35 +54,27 @@ ui_server_host: "${config.ui_server_host}"
     document.body.removeChild(element);
   };
   return (
-    <>
+    <PreferencesCard>
+      <Subtitle>Authentication</Subtitle>
+      <CodeContainer>
+        <Code language="yaml">{authCode}</Code>
+      </CodeContainer>
       {/* @ts-expect-error */}
-      <Container>
-        <Subtitle>Authentication</Subtitle>
-        <CodeContainer>
-          <Code language="yaml">{authCode}</Code>
-        </CodeContainer>{" "}
-        {/* @ts-expect-error */}
-        <StyledButton variant={Variant.Primary} onClick={downloadFile}>
-          Download File
-        </StyledButton>
-        <Button onClick={resetKey}>Reset Key</Button>
-      </Container>
-    </>
+      <StyledButton variant={Variant.Primary} onClick={downloadFile}>
+        Download File
+      </StyledButton>
+      <Button onClick={resetKey}>Reset Key</Button>
+    </PreferencesCard>
   );
 };
 
-const Container = styled(SiderCard)`
-  padding-left: 20px;
-  padding-top: 20px;
-  padding-bottom: 20px;
-`;
-
 const CodeContainer = styled.div`
-  margin-top: 30px;
-  margin-bottom: 30px;
+  margin: ${size.m} 0;
 `;
 
 // @ts-expect-error
 const StyledButton = styled(Button)`
-  margin-right: ${size.s};
+  :not(:last-of-type) {
+    margin-right: ${size.s};
+  }
 `;

--- a/src/pages/preferences/preferencesTabs/cliTab/AuthenticationCard.tsx
+++ b/src/pages/preferences/preferencesTabs/cliTab/AuthenticationCard.tsx
@@ -59,11 +59,12 @@ ui_server_host: "${config.ui_server_host}"
       <CodeContainer>
         <Code language="yaml">{authCode}</Code>
       </CodeContainer>
-      {/* @ts-expect-error */}
-      <StyledButton variant={Variant.Primary} onClick={downloadFile}>
-        Download File
-      </StyledButton>
-      <Button onClick={resetKey}>Reset Key</Button>
+      <ButtonGroup>
+        <Button variant={Variant.Primary} onClick={downloadFile}>
+          Download File
+        </Button>
+        <Button onClick={resetKey}>Reset Key</Button>
+      </ButtonGroup>
     </PreferencesCard>
   );
 };
@@ -72,9 +73,7 @@ const CodeContainer = styled.div`
   margin: ${size.m} 0;
 `;
 
-// @ts-expect-error
-const StyledButton = styled(Button)`
-  :not(:last-of-type) {
-    margin-right: ${size.s};
-  }
+const ButtonGroup = styled.div`
+  display: flex;
+  gap: ${size.xs};
 `;

--- a/src/pages/preferences/preferencesTabs/cliTab/DownloadCard.tsx
+++ b/src/pages/preferences/preferencesTabs/cliTab/DownloadCard.tsx
@@ -21,6 +21,7 @@ import {
 } from "gql/generated/types";
 import { GET_CLIENT_CONFIG } from "gql/queries";
 import { PreferencesCard } from "pages/preferences/Card";
+import { CardType, SubtitleType } from "types/leafygreen";
 
 export const DownloadCard = () => {
   const { data, loading } = useQuery<
@@ -144,19 +145,17 @@ const filterBinaries = (binary: ClientBinary) =>
 
 const CardGroup = styled.div`
   display: flex;
+  gap: ${size.xs};
   margin-bottom: ${size.s};
 `;
 
 // @ts-expect-error
-const CliDownloadCard = styled(Card)`
+const CliDownloadCard: CardType = styled(Card)`
   display: flex;
   flex-direction: column;
   justify-content: space-between;
   padding: ${size.s};
-  :not(:last-of-type) {
-    margin-right: ${size.xs};
-  }
-` as typeof Card;
+`;
 
 // @ts-expect-error
 const CliDownloadButton = styled(Button)`
@@ -164,9 +163,9 @@ const CliDownloadButton = styled(Button)`
 `;
 
 // @ts-expect-error
-const CliDownloadTitle = styled(Subtitle)`
+const CliDownloadTitle: SubtitleType = styled(Subtitle)`
   font-weight: bold;
-` as typeof Subtitle;
+`;
 
 const CardDescription = styled.div`
   font-size: ${fontSize.m};

--- a/src/pages/preferences/preferencesTabs/cliTab/DownloadCard.tsx
+++ b/src/pages/preferences/preferencesTabs/cliTab/DownloadCard.tsx
@@ -2,8 +2,12 @@ import { useQuery } from "@apollo/client";
 import styled from "@emotion/styled";
 import Button from "@leafygreen-ui/button";
 import Card from "@leafygreen-ui/card";
-import { palette } from "@leafygreen-ui/palette";
-import { Subtitle, Body, Disclaimer } from "@leafygreen-ui/typography";
+import {
+  InlineCode,
+  Subtitle,
+  Body,
+  Disclaimer,
+} from "@leafygreen-ui/typography";
 import { Skeleton } from "antd";
 import { usePreferencesAnalytics } from "analytics";
 import { Accordion } from "components/Accordion";
@@ -16,8 +20,7 @@ import {
   ClientBinary,
 } from "gql/generated/types";
 import { GET_CLIENT_CONFIG } from "gql/queries";
-
-const { gray } = palette;
+import { PreferencesCard } from "pages/preferences/Card";
 
 export const DownloadCard = () => {
   const { data, loading } = useQuery<
@@ -36,16 +39,16 @@ export const DownloadCard = () => {
   );
 
   return (
-    <Container>
+    <PreferencesCard>
       <Subtitle>Command-Line Client</Subtitle>
       <CardDescription>
         <Body>
           View the{" "}
           <StyledLink href={cliDocumentationUrl}>documentation</StyledLink> or
-          run &nbsp;{" "}
+          run <InlineCode>evergreen --help</InlineCode> or{" "}
+          <InlineCode>evergreen [command] --help</InlineCode> for additional
+          assistance.
         </Body>
-        <InlinePre>evergreen --help or evergreen [command] --help</InlinePre>{" "}
-        <Body>for additional assistance.</Body>
       </CardDescription>
       <CardGroup>
         {topBinaries.map((binary) => (
@@ -59,10 +62,10 @@ export const DownloadCard = () => {
           />
         ))}
       </CardGroup>
-      <Accordion title="Show More" toggledTitle="Show Less" showCaret={false}>
+      <Accordion title="Show More" toggledTitle="Show Less">
         <ExpandableLinkContents clientBinaries={otherBinaries} />
       </Accordion>
-    </Container>
+    </PreferencesCard>
   );
 };
 
@@ -91,6 +94,7 @@ const CliDownloadBox: React.VFC<CliDownloadBoxProps> = ({
         href={link}
         disabled={!link} // @ts-expect-error
         as="a"
+        size="small"
       >
         Download
       </CliDownloadButton>
@@ -118,7 +122,7 @@ const ExpandableLinkContents: React.VFC<ExpandableLinkContentsProps> = ({
           key={`link_${binary.url}`}
           href={binary.url}
         >
-          {prettyDisplayNameAccordion[binary.displayName] || binary.displayName}
+          {binary.displayName}
         </StyledLink>
       ))}
     </LinkContainer>
@@ -130,29 +134,16 @@ const descriptions = {
   "OSX ARM 64-bit": "M1 CPU",
 };
 const prettyDisplayNameTop = {
-  "OSX 64-bit": "macOS",
   "OSX ARM 64-bit": "macOS ARM",
   "Windows 64-bit": "Windows",
   "Linux 64-bit": "Linux (64-bit)",
 };
 
-const prettyDisplayNameAccordion = {
-  "Linux 64-bit": "Linux (64-bit, Legacy)",
-};
-
 const filterBinaries = (binary: ClientBinary) =>
-  /darwin_arm64\/|darwin_amd64\/|linux_amd64\/|windows_amd64\//.test(
-    binary.url
-  );
-
-// @ts-expect-error
-const Container = styled(Card)`
-  padding: ${size.m};
-` as typeof Card;
+  /darwin_arm64\/|linux_amd64\/|windows_amd64\//.test(binary.url);
 
 const CardGroup = styled.div`
   display: flex;
-  align-items: space-between;
   margin-bottom: ${size.s};
 `;
 
@@ -162,7 +153,9 @@ const CliDownloadCard = styled(Card)`
   flex-direction: column;
   justify-content: space-between;
   padding: ${size.s};
-  margin-right: ${size.xs};
+  :not(:last-of-type) {
+    margin-right: ${size.xs};
+  }
 ` as typeof Card;
 
 // @ts-expect-error
@@ -177,14 +170,7 @@ const CliDownloadTitle = styled(Subtitle)`
 
 const CardDescription = styled.div`
   font-size: ${fontSize.m};
-  margin-bottom: 40px;
-`;
-
-const InlinePre = styled("pre")`
-  display: inline-block;
-  background-color: ${gray.light3};
-  margin-bottom: 0;
-  overflow: visible;
+  margin-bottom: ${size.m};
 `;
 
 const LinkContainer = styled.div`

--- a/src/pages/preferences/preferencesTabs/cliTab/DownloadCard.tsx
+++ b/src/pages/preferences/preferencesTabs/cliTab/DownloadCard.tsx
@@ -149,8 +149,7 @@ const CardGroup = styled.div`
   margin-bottom: ${size.s};
 `;
 
-// @ts-expect-error
-const CliDownloadCard: CardType = styled(Card)`
+const CliDownloadCard = styled<CardType>(Card)`
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -160,10 +159,10 @@ const CliDownloadCard: CardType = styled(Card)`
 // @ts-expect-error
 const CliDownloadButton = styled(Button)`
   align-self: flex-start;
+  margin-top: ${size.xs};
 `;
 
-// @ts-expect-error
-const CliDownloadTitle: SubtitleType = styled(Subtitle)`
+const CliDownloadTitle = styled<SubtitleType>(Subtitle)`
   font-weight: bold;
 `;
 

--- a/src/pages/preferences/preferencesTabs/cliTab/VerifyCard.tsx
+++ b/src/pages/preferences/preferencesTabs/cliTab/VerifyCard.tsx
@@ -1,15 +1,13 @@
 import { useQuery } from "@apollo/client";
-import styled from "@emotion/styled";
 import Code from "@leafygreen-ui/code";
 import { InlineCode, Body } from "@leafygreen-ui/typography";
 import get from "lodash/get";
-import { SiderCard } from "components/styles";
-import { size } from "constants/tokens";
 import {
   ClientConfigQuery,
   ClientConfigQueryVariables,
 } from "gql/generated/types";
 import { GET_CLIENT_CONFIG } from "gql/queries";
+import { PreferencesCard } from "pages/preferences/Card";
 
 export const VerifyCard = () => {
   const { data } = useQuery<ClientConfigQuery, ClientConfigQueryVariables>(
@@ -18,30 +16,17 @@ export const VerifyCard = () => {
 
   const latestRevision = get(data, "clientConfig.latestRevision", "");
   const verificationCode = `
-"[message='Binary is already up to date - not updating.' revision='${latestRevision}']"`;
+[message='Binary is already up to date - not updating.' revision='${latestRevision}']`;
 
   return (
-    <>
-      {/* @ts-expect-error */}
-      <Container>
-        <Body>
-          At the command line, type{" "}
-          <InlineCode>evergreen get-update</InlineCode>. It should display :
-        </Body>
-        <CodeContainer>
-          <Code copyable={false} language="shell">
-            {verificationCode}
-          </Code>
-        </CodeContainer>
-      </Container>
-    </>
+    <PreferencesCard>
+      <Body>
+        On the command line, type <InlineCode>evergreen get-update</InlineCode>.
+        It should display:
+      </Body>
+      <Code copyable={false} language="shell">
+        {verificationCode}
+      </Code>
+    </PreferencesCard>
   );
 };
-
-const Container = styled(SiderCard)`
-  padding: ${size.m};
-`;
-
-const CodeContainer = styled.div`
-  width: 80%;
-`;

--- a/src/pages/preferences/preferencesTabs/notificationTab/ClearSubscriptionsCard.tsx
+++ b/src/pages/preferences/preferencesTabs/notificationTab/ClearSubscriptionsCard.tsx
@@ -2,7 +2,6 @@ import { useState } from "react";
 import { useMutation } from "@apollo/client";
 import styled from "@emotion/styled";
 import Button, { Variant } from "@leafygreen-ui/button";
-import Card from "@leafygreen-ui/card";
 import { Body } from "@leafygreen-ui/typography";
 import { usePreferencesAnalytics } from "analytics";
 import { size } from "constants/tokens";
@@ -12,6 +11,7 @@ import {
   ClearMySubscriptionsMutationVariables,
 } from "gql/generated/types";
 import { CLEAR_MY_SUBSCRIPTIONS } from "gql/mutations";
+import { PreferencesCard } from "pages/preferences/Card";
 import { PreferencesModal } from "pages/preferences/preferencesTabs/PreferencesModal";
 
 export const ClearSubscriptionsCard: React.VFC = () => {
@@ -41,21 +41,18 @@ export const ClearSubscriptionsCard: React.VFC = () => {
 
   return (
     <>
-      {/* @ts-expect-error */}
       <PreferencesCard>
-        <ContentWrapper>
-          <Body>
-            To clear all subscriptions you have made on individual Version and
-            Task pages.
-          </Body>
-          <StyledClearSubscriptionButton
-            data-cy="clear-subscriptions-button"
-            variant={Variant.Danger} // @ts-expect-error
-            onClick={() => setShowModal(true)}
-          >
-            Clear all previous subscriptions
-          </StyledClearSubscriptionButton>
-        </ContentWrapper>
+        <Body>
+          Clear all subscriptions you have made on individual Version and Task
+          pages:
+        </Body>
+        <StyledClearSubscriptionButton
+          data-cy="clear-subscriptions-button"
+          variant={Variant.Danger} // @ts-expect-error
+          onClick={() => setShowModal(true)}
+        >
+          Clear all previous subscriptions
+        </StyledClearSubscriptionButton>
       </PreferencesCard>
       <PreferencesModal
         visible={showModal}
@@ -77,15 +74,4 @@ export const ClearSubscriptionsCard: React.VFC = () => {
 // @ts-expect-error
 const StyledClearSubscriptionButton = styled(Button)`
   margin-top: ${size.m};
-`;
-
-const ContentWrapper = styled.div`
-  width: 50%;
-`;
-
-// @ts-expect-error
-const PreferencesCard = styled(Card)`
-  padding: ${size.m};
-  margin-bottom: ${size.m};
-  width: 100%;
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4373,7 +4373,7 @@
   dependencies:
     "@leafygreen-ui/palette" "^3.4.4"
 
-"@leafygreen-ui/tooltip@6.3.1", "@leafygreen-ui/tooltip@^6.3.1":
+"@leafygreen-ui/tooltip@6.3.1":
   version "6.3.1"
   resolved "https://registry.yarnpkg.com/@leafygreen-ui/tooltip/-/tooltip-6.3.1.tgz#e36d5f18ecaf9b5eeb719dbe09794fc8253b6662"
   integrity sha512-bwIe7nb4O1A57aP1K/XPFyRlS5egBJ5BfYZHjOD1Qu9+WKIDcC8KWsR6P3hrQOqbi3zdWUG43HDZbJvHqQi45w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3853,6 +3853,15 @@
     "@leafygreen-ui/hooks" "^7.0.0"
     "@leafygreen-ui/lib" "^9.0.0"
 
+"@leafygreen-ui/a11y@^1.3.3":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@leafygreen-ui/a11y/-/a11y-1.3.3.tgz#9a9e72f08a3ea56918c0d37b68cb4bb7afca46e2"
+  integrity sha512-8aFrxq8yvyjN4qQ5ddJPrC2FxvZUwkJHXJ+ozBpDinT+9xmLLlCs4AxY2EZ1tDwt91Vb42NMwZBULVTWKnr45A==
+  dependencies:
+    "@leafygreen-ui/emotion" "^4.0.3"
+    "@leafygreen-ui/hooks" "^7.3.3"
+    "@leafygreen-ui/lib" "^9.5.1"
+
 "@leafygreen-ui/badge@4.0.5":
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/@leafygreen-ui/badge/-/badge-4.0.5.tgz#27cc960d25aba5606d77ec8668ace273f0d988d8"
@@ -3952,7 +3961,7 @@
     "@leafygreen-ui/palette" "^3.2.2"
     "@leafygreen-ui/text-input" "^6.0.4"
 
-"@leafygreen-ui/emotion@4.0.0", "@leafygreen-ui/emotion@^4.0.0":
+"@leafygreen-ui/emotion@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@leafygreen-ui/emotion/-/emotion-4.0.0.tgz#49ce6c4a10dea037f5a9c20621f4dc1f10d915ed"
   integrity sha512-nr2g6OFsy+psaMto3H4HQ1ivM1tCwd9k1bbR5WH4U7YibDagfBekFTwlhohmC/K7hUM/eDVPGw0w4zQyC+BwZg==
@@ -4115,7 +4124,7 @@
   dependencies:
     lodash "^4.17.21"
 
-"@leafygreen-ui/menu@11.0.1", "@leafygreen-ui/menu@^11.0.1":
+"@leafygreen-ui/menu@11.0.1":
   version "11.0.1"
   resolved "https://registry.yarnpkg.com/@leafygreen-ui/menu/-/menu-11.0.1.tgz#4d1232b0dcc199c29263a5b00bb8608391ac3611"
   integrity sha512-JhoTkWcMTPJK1LjaWCP3m5uS7Q2LFqWxLfl1Z1zovzG1jkyl7r+priZUAXC4xpUqcTSZvsaAuZh6MaaBXhibdA==
@@ -4169,12 +4178,31 @@
     lodash "^4.17.21"
     react-transition-group "^4.4.1"
 
+"@leafygreen-ui/popover@^10.0.0":
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/@leafygreen-ui/popover/-/popover-10.0.0.tgz#06b0619dc47ad9cb19a74ce0fba0e1207cb85642"
+  integrity sha512-vQtkvHIlvWL8sZ00DRNzN6wmAH2pGDRDOe/1TVhMGwDAPb/7RetUXIFmYtPBspiTTOV6hU195VzbQ/yNoRdymA==
+  dependencies:
+    "@leafygreen-ui/emotion" "^4.0.3"
+    "@leafygreen-ui/hooks" "^7.3.3"
+    "@leafygreen-ui/lib" "^9.5.1"
+    "@leafygreen-ui/portal" "^4.0.6"
+    react-transition-group "^4.4.1"
+
 "@leafygreen-ui/portal@^4.0.0":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@leafygreen-ui/portal/-/portal-4.0.1.tgz#a1428ea990b73810b33e772dceaa4cf4ca9024ac"
   integrity sha512-H+CBvvStKHx3c8TvU1zhKTa05zPjZR9ezeL2gGPZJyIAH45umiBtAT+7RHnPSj7MSfnp4685RcBNN4DNHrMhxw==
   dependencies:
     "@leafygreen-ui/lib" "^9.0.0"
+
+"@leafygreen-ui/portal@^4.0.6":
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/@leafygreen-ui/portal/-/portal-4.0.6.tgz#0f73b30eaf74b4bb9e413cacc2fee4243b028397"
+  integrity sha512-DNAJRwQgO9a7hsZbSayKgz6ZpRsTWVlziDxchOcoDzFrEiPaq9ve2FATsaM8wET3U0wA0vSDoaGkGOHuf+gNIA==
+  dependencies:
+    "@leafygreen-ui/hooks" "^7.3.3"
+    "@leafygreen-ui/lib" "^9.5.1"
 
 "@leafygreen-ui/radio-box-group@6.1.4":
   version "6.1.4"
@@ -4233,21 +4261,23 @@
     polished "^4.1.3"
     react-is "^17.0.1"
 
-"@leafygreen-ui/side-nav@7.2.1":
-  version "7.2.1"
-  resolved "https://registry.yarnpkg.com/@leafygreen-ui/side-nav/-/side-nav-7.2.1.tgz#44716a113f4db5118ec155b7599435b5782c9f25"
-  integrity sha512-SLDIJ0bepjRS8WdbN5yABaE60B7j0fQgN/rcza+w5zriLH5XZ++qZ1kCVAYIA6Ae5VeScVZIorj/yNAJk/+idg==
+"@leafygreen-ui/side-nav@11.0.0":
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/@leafygreen-ui/side-nav/-/side-nav-11.0.0.tgz#e43aeebd613eb1b6e66e589f9be1015735328a69"
+  integrity sha512-+hAWFi9GbLP6fB/nNHQ3NgJOyOBJlEvGFheeFzSDO+yNi7cSZO4St8HvgF/zUzdB5n2e9CR1f0LTPC3IunUzHw==
   dependencies:
-    "@leafygreen-ui/a11y" "^1.2.2"
-    "@leafygreen-ui/box" "^3.0.6"
-    "@leafygreen-ui/emotion" "4.0.0"
-    "@leafygreen-ui/hooks" "^7.0.0"
-    "@leafygreen-ui/icon" "^11.3.0"
-    "@leafygreen-ui/lib" "^9.0.0"
-    "@leafygreen-ui/menu" "^11.0.1"
-    "@leafygreen-ui/palette" "^3.2.2"
-    "@leafygreen-ui/portal" "^4.0.0"
-    "@leafygreen-ui/tooltip" "^6.3.1"
+    "@leafygreen-ui/a11y" "^1.3.3"
+    "@leafygreen-ui/box" "^3.1.1"
+    "@leafygreen-ui/emotion" "^4.0.3"
+    "@leafygreen-ui/hooks" "^7.3.3"
+    "@leafygreen-ui/icon" "^11.11.1"
+    "@leafygreen-ui/lib" "^9.5.1"
+    "@leafygreen-ui/palette" "^3.4.4"
+    "@leafygreen-ui/portal" "^4.0.6"
+    "@leafygreen-ui/tokens" "^1.3.4"
+    "@leafygreen-ui/tooltip" "^8.0.0"
+    "@leafygreen-ui/typography" "^14.0.0"
+    react-transition-group "^4.4.5"
 
 "@leafygreen-ui/table@2.0.7":
   version "2.0.7"
@@ -4355,7 +4385,22 @@
     "@leafygreen-ui/tokens" "^0.5.3"
     lodash "^4.17.21"
 
-"@leafygreen-ui/typography@14.0.0":
+"@leafygreen-ui/tooltip@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@leafygreen-ui/tooltip/-/tooltip-8.0.0.tgz#ffff07319fc460ae4dcd7fb9ceddbdc37f204df7"
+  integrity sha512-ggv4k/Nr1rMDsM4LYWvs9/m7rFRUq67opypn5o3pm463WtFAtM7hbfYrATwS2tu8mWaYDXW3csO4M7aDURwJiQ==
+  dependencies:
+    "@leafygreen-ui/emotion" "^4.0.3"
+    "@leafygreen-ui/hooks" "^7.3.3"
+    "@leafygreen-ui/icon" "^11.11.1"
+    "@leafygreen-ui/lib" "^9.5.1"
+    "@leafygreen-ui/palette" "^3.4.4"
+    "@leafygreen-ui/popover" "^10.0.0"
+    "@leafygreen-ui/tokens" "^1.3.4"
+    "@leafygreen-ui/typography" "^14.0.0"
+    lodash "^4.17.21"
+
+"@leafygreen-ui/typography@14.0.0", "@leafygreen-ui/typography@^14.0.0":
   version "14.0.0"
   resolved "https://registry.yarnpkg.com/@leafygreen-ui/typography/-/typography-14.0.0.tgz#c8eb9c40578e0aeefbe86405f068adb72411457c"
   integrity sha512-2C7+uwY/52fHYfnRkpVKV203t1qf63mzKAUmT8EupywzMH/qtyRea85CPJIF0EkFDHf2s76gYrLqkbNXshwIJw==
@@ -17286,6 +17331,16 @@ react-transition-group@^4.4.1:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.2.tgz#8b59a56f09ced7b55cbd53c36768b922890d5470"
   integrity sha512-/RNYfRAMlZwDSr6z4zNKV6xu53/e2BuaBbGhbyYIXTrmgu/bGHzmqOs7mJSJBHy9Ud+ApHx3QjrkKSp1pxvlFg==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    dom-helpers "^5.0.1"
+    loose-envify "^1.4.0"
+    prop-types "^15.6.2"
+
+react-transition-group@^4.4.5:
+  version "4.4.5"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.5.tgz#e53d4e3f3344da8521489fbef8f2581d42becdd1"
+  integrity sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==
   dependencies:
     "@babel/runtime" "^7.5.5"
     dom-helpers "^5.0.1"


### PR DESCRIPTION
EVG-18143

### Description
<!-- add description, context, thought process, etc -->
- Upgrade `@leafygreen-ui/side-nav` to the latest version
- Since I was inspecting the user preferences page this seemed like a good time to streamline some styling
  - Replace various styled `Card` components with one `PreferencesCard` component
  - Remove legacy macOS build as a primary CLI option since engineers are no longer receiving non-ARM machines (the build is still available under "Show More")
- Increase Node heap size for storybook task to 6GB — I was seeing a lot of OOM failures on this task. Interestingly, I can reproduce the failure on my machine on Node v16.17, but it passes on v16.13 😮 so this may be related to the recent upgrade to the Node version in Evergreen. I'll circle back to a more permanent solution but for now increasing heap size unblocks us.

### Screenshots
<!-- add screenshots of visible changes -->
<img width="1624" alt="image" src="https://user-images.githubusercontent.com/9298431/199051270-715d21f3-6cff-46b6-b3b1-e4555c2213ad.png">
<img width="1624" alt="image" src="https://user-images.githubusercontent.com/9298431/199051299-bb751746-31b3-4dd3-ba57-2a532b60067b.png">