### PR TITLE
EVG-16341 followup: Fix e2e test

### DIFF
--- a/cypress/integration/version/task_filters.ts
+++ b/cypress/integration/version/task_filters.ts
@@ -141,7 +141,7 @@ describe("Tasks filters", () => {
               urlSearchParamsAreUpdated({
                 pathname: pathTasks,
                 paramName: urlParam,
-                search: "failed,success",
+                search: "failed-umbrella,failed,known-issue,success",
               });
               waitForTable();
               cy.dataCy("current-task-count").should(
@@ -280,6 +280,7 @@ const assertChecked = (statuses: string[], checked: boolean) => {
 
 /**
  * Function used to select a checkbox option from the table filter dropdown.
+ * Only the first checkbox whose label is a match (i.e. the umbrella group name) will be checked.
  * @param label label of the checkbox option to click on
  * @param checked true if should be checked, false if should be unchecked
  */
@@ -298,6 +299,7 @@ const selectCheckboxOption = (label: string, checked: boolean) => {
             .find('input[type="checkbox"]')
             .uncheck({ force: true, scrollBehavior: false });
         }
+        return false;
       }
     });
 };


### PR DESCRIPTION
EVG-16341

### Description
<!-- add description, context, thought process, etc -->
Renaming the "Failed" task umbrella in [7921cb7](https://github.com/evergreen-ci/spruce/commit/7921cb77989f4c54b8452623424f6d7a177da682#diff-09686debf3a71d22bf34e4110a7bcc5e9b6cf98e9fcf99f949a134cebbabea17) caused Cypress tests to fail as a result of the parent "Failed" status having the same name as its child Failed status.

### Testing
<!-- add a description of how you tested it -->
- Update Cypress tests