### PR TITLE
EVG-18226: Fix destructuring error in task action buttons

### DIFF
--- a/src/pages/task/ActionButtons.tsx
+++ b/src/pages/task/ActionButtons.tsx
@@ -62,9 +62,10 @@ export const ActionButtons: React.VFC<Props> = ({
     requester,
     canSchedule,
     versionMetadata,
-  } = task;
+  } = task || {};
 
   const { isPatch, order } = versionMetadata || {};
+  const { identifier: projectIdentifier } = project || {};
   const isPatchOnCommitQueue = requester === commitQueueRequester;
 
   const dispatchToast = useToastContext();
@@ -273,7 +274,7 @@ export const ActionButtons: React.VFC<Props> = ({
               onClick={() => {
                 taskAnalytics.sendEvent({ name: "Click See History Button" });
               }}
-              to={getTaskHistoryRoute(project.identifier, displayName, {
+              to={getTaskHistoryRoute(projectIdentifier, displayName, {
                 selectedCommit: !isPatch && order,
               })}
               disabled={displayName === mergeTaskName}


### PR DESCRIPTION
[EVG-18226](https://jira.mongodb.org/browse/EVG-18226)

### Description
It seems like we occasionally encounter a destructuring error because we assume the task is always defined, when it's possible the task hasn't been fully fetched yet.

### Screenshots
- N/A

### Testing
- Manually set the task to be `undefined` and checked that no errors would be thrown


