### PR TITLE
EVG-18252 Add a toggle to surface inactive tasks on the version page and the waterfall

### DIFF
--- a/src/components/InactiveTasksToggle/index.tsx
+++ b/src/components/InactiveTasksToggle/index.tsx
@@ -1,0 +1,42 @@
+import Checkbox from "@leafygreen-ui/checkbox";
+import Cookies from "js-cookie";
+import { useLocation } from "react-router-dom";
+import { INCLUDE_INACTIVE_TASKS } from "constants/cookies";
+import { useUpdateURLQueryParams } from "hooks";
+import { parseQueryString } from "utils/queryString";
+
+const inactiveTaskQueryParam = "includeInactiveTasks";
+interface InactiveTasksToggleProps {
+  onChange?: (value: boolean) => void;
+}
+const InactiveTasksToggle: React.VFC<InactiveTasksToggleProps> = ({
+  onChange = () => undefined,
+}) => {
+  const { search } = useLocation();
+  const parsed = parseQueryString(search);
+  const updateQueryParams = useUpdateURLQueryParams();
+
+  const includeInactiveTasks =
+    parsed[inactiveTaskQueryParam] !== undefined
+      ? parsed[inactiveTaskQueryParam] === "true"
+      : Cookies.get(INCLUDE_INACTIVE_TASKS) === "true";
+
+  const handleOnChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { checked } = e.target;
+    updateQueryParams({
+      [inactiveTaskQueryParam]: checked.toString(),
+    });
+    Cookies.set(INCLUDE_INACTIVE_TASKS, checked.toString());
+    onChange(checked);
+  };
+
+  return (
+    <Checkbox
+      label="Include Inactive tasks"
+      checked={Boolean(includeInactiveTasks)}
+      onChange={handleOnChange}
+    />
+  );
+};
+
+export { InactiveTasksToggle, inactiveTaskQueryParam };

--- a/src/constants/cookies.ts
+++ b/src/constants/cookies.ts
@@ -9,3 +9,5 @@ export const COMMIT_CHART_TYPE_VIEW_OPTIONS_ACCORDION =
   "commit-chart-view-options-accordion";
 export const DISABLE_QUERY_POLLING = "disable-query-polling";
 export const SEEN_MIGRATE_GUIDE_CUE = "seen-migrate-guide-cue";
+export const INCLUDE_INACTIVE_MAINLINE_COMMIT_TASKS =
+  "include-inactive-mainline-commit-tasks";

--- a/src/constants/cookies.ts
+++ b/src/constants/cookies.ts
@@ -9,5 +9,4 @@ export const COMMIT_CHART_TYPE_VIEW_OPTIONS_ACCORDION =
   "commit-chart-view-options-accordion";
 export const DISABLE_QUERY_POLLING = "disable-query-polling";
 export const SEEN_MIGRATE_GUIDE_CUE = "seen-migrate-guide-cue";
-export const INCLUDE_INACTIVE_MAINLINE_COMMIT_TASKS =
-  "include-inactive-mainline-commit-tasks";
+export const INCLUDE_INACTIVE_TASKS = "include-inactive-tasks";

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -3844,6 +3844,7 @@ export type BuildBaronQuery = {
 
 export type GetBuildVariantStatsQueryVariables = Exact<{
   id: Scalars["String"];
+  includeInactiveTasks: Scalars["Boolean"];
 }>;
 
 export type GetBuildVariantStatsQuery = {

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -95,6 +95,7 @@ export type BuildBaronSettingsInput = {
  */
 export type BuildVariantOptions = {
   includeBaseTasks?: InputMaybe<Scalars["Boolean"]>;
+  includeInactiveTasks?: InputMaybe<Scalars["Boolean"]>;
   statuses?: InputMaybe<Array<Scalars["String"]>>;
   tasks?: InputMaybe<Array<Scalars["String"]>>;
   variants?: InputMaybe<Array<Scalars["String"]>>;

--- a/src/gql/queries/get-build-variant-stats.graphql
+++ b/src/gql/queries/get-build-variant-stats.graphql
@@ -1,7 +1,9 @@
-query GetBuildVariantStats($id: String!) {
+query GetBuildVariantStats($id: String!, $includeInactiveTasks: Boolean!) {
   version(id: $id) {
     id
-    buildVariantStats(options: {}) {
+    buildVariantStats(
+      options: { includeInactiveTasks: $includeInactiveTasks }
+    ) {
       variant
       displayName
       statusCounts {

--- a/src/pages/Commits.tsx
+++ b/src/pages/Commits.tsx
@@ -7,15 +7,13 @@ import { useProjectHealthAnalytics } from "analytics/projectHealth/useProjectHea
 import FilterBadges, {
   useFilterBadgeQueryParams,
 } from "components/FilterBadges";
+import { inactiveTaskQueryParam } from "components/InactiveTasksToggle";
 import { ProjectSelect } from "components/ProjectSelect";
 import { PageWrapper } from "components/styles";
 import { ALL_VALUE } from "components/TreeSelect";
 import TupleSelect from "components/TupleSelect";
 import WelcomeModal from "components/WelcomeModal";
-import {
-  CURRENT_PROJECT,
-  INCLUDE_INACTIVE_MAINLINE_COMMIT_TASKS,
-} from "constants/cookies";
+import { CURRENT_PROJECT, INCLUDE_INACTIVE_TASKS } from "constants/cookies";
 import { DEFAULT_POLL_INTERVAL } from "constants/index";
 import { getCommitsRoute } from "constants/routes";
 import { size } from "constants/tokens";
@@ -97,9 +95,9 @@ export const Commits = () => {
   );
   const skipOrderNumber = parseInt(skipOrderNumberParam, 10) || undefined;
   const includeInactiveTasks =
-    getString(parsed[ProjectFilterOptions.InactiveTasks]) !== ""
-      ? getString(parsed[ProjectFilterOptions.InactiveTasks]) === "true"
-      : Cookies.get(INCLUDE_INACTIVE_MAINLINE_COMMIT_TASKS) === "true";
+    getString(parsed[inactiveTaskQueryParam]) !== ""
+      ? getString(parsed[inactiveTaskQueryParam]) === "true"
+      : Cookies.get(INCLUDE_INACTIVE_TASKS) === "true";
   const filterState = {
     statuses: statusFilters,
     variants: variantFilters,

--- a/src/pages/Commits.tsx
+++ b/src/pages/Commits.tsx
@@ -36,6 +36,7 @@ import { array, queryString, validators } from "utils";
 import { CommitsWrapper } from "./commits/CommitsWrapper";
 import CommitTypeSelect from "./commits/commitTypeSelect";
 import { PaginationButtons } from "./commits/PaginationButtons";
+import { SettingsButton } from "./commits/SettingsButton";
 import { StatusSelect } from "./commits/StatusSelect";
 import {
   getMainlineCommitsQueryVariables,
@@ -165,7 +166,7 @@ export const Commits = () => {
           <ElementWrapper width="20">
             <CommitTypeSelect />
           </ElementWrapper>
-          <ElementWrapper width="25">
+          <ElementWrapper width="20">
             <ProjectSelect
               selectedProjectIdentifier={projectId}
               getRoute={getCommitsRoute}
@@ -175,6 +176,9 @@ export const Commits = () => {
                 });
               }}
             />
+          </ElementWrapper>
+          <ElementWrapper width="5">
+            <SettingsButton />
           </ElementWrapper>
         </HeaderWrapper>
         <BadgeWrapper>

--- a/src/pages/Commits.tsx
+++ b/src/pages/Commits.tsx
@@ -12,7 +12,10 @@ import { PageWrapper } from "components/styles";
 import { ALL_VALUE } from "components/TreeSelect";
 import TupleSelect from "components/TupleSelect";
 import WelcomeModal from "components/WelcomeModal";
-import { CURRENT_PROJECT } from "constants/cookies";
+import {
+  CURRENT_PROJECT,
+  INCLUDE_INACTIVE_MAINLINE_COMMIT_TASKS,
+} from "constants/cookies";
 import { DEFAULT_POLL_INTERVAL } from "constants/index";
 import { getCommitsRoute } from "constants/routes";
 import { size } from "constants/tokens";
@@ -93,11 +96,16 @@ export const Commits = () => {
     parsed[MainlineCommitQueryParams.SkipOrderNumber]
   );
   const skipOrderNumber = parseInt(skipOrderNumberParam, 10) || undefined;
+  const includeInactiveTasks =
+    getString(parsed[ProjectFilterOptions.InactiveTasks]) !== ""
+      ? getString(parsed[ProjectFilterOptions.InactiveTasks]) === "true"
+      : Cookies.get(INCLUDE_INACTIVE_MAINLINE_COMMIT_TASKS) === "true";
   const filterState = {
     statuses: statusFilters,
     variants: variantFilters,
     tasks: taskFilters,
     requesters: requesterFilters,
+    includeInactiveTasks,
   };
   const variables = getMainlineCommitsQueryVariables({
     mainlineCommitOptions: {

--- a/src/pages/commits/SettingsButton/index.tsx
+++ b/src/pages/commits/SettingsButton/index.tsx
@@ -1,54 +1,24 @@
-import React from "react";
 import styled from "@emotion/styled";
 import Button from "@leafygreen-ui/button";
-import Checkbox from "@leafygreen-ui/checkbox";
 import { Menu, MenuItem } from "@leafygreen-ui/menu";
 import { Label } from "@leafygreen-ui/typography";
-import Cookies from "js-cookie";
-import { useLocation } from "react-router-dom";
 import Icon from "components/Icon";
-import { INCLUDE_INACTIVE_MAINLINE_COMMIT_TASKS } from "constants/cookies";
-import { useUpdateURLQueryParams } from "hooks";
-import { ProjectFilterOptions } from "types/commits";
-import { parseQueryString } from "utils/queryString";
+import { InactiveTasksToggle } from "components/InactiveTasksToggle";
 
-const SettingsButton = () => {
-  const { search } = useLocation();
-  const updateQueryParams = useUpdateURLQueryParams();
-  const parsed = parseQueryString(search);
-
-  const includeInactiveTasks =
-    parsed[ProjectFilterOptions.InactiveTasks] !== undefined
-      ? parsed[ProjectFilterOptions.InactiveTasks] === "true"
-      : Cookies.get(INCLUDE_INACTIVE_MAINLINE_COMMIT_TASKS) === "true";
-
-  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const { checked } = e.target;
-    updateQueryParams({
-      [ProjectFilterOptions.InactiveTasks]: checked.toString(),
-    });
-    Cookies.set(INCLUDE_INACTIVE_MAINLINE_COMMIT_TASKS, checked.toString());
-  };
-
-  return (
-    <Container>
-      <Label htmlFor="project-task-status-select">Settings</Label>
-      <Menu
-        align="bottom"
-        justify="start"
-        trigger={<Button leftGlyph={<Icon glyph="Settings" />} />}
-      >
-        <MenuItem>
-          <Checkbox
-            label="Include Inactive tasks"
-            checked={Boolean(includeInactiveTasks)}
-            onChange={onChange}
-          />
-        </MenuItem>
-      </Menu>
-    </Container>
-  );
-};
+const SettingsButton = () => (
+  <Container>
+    <Label htmlFor="project-task-status-select">Settings</Label>
+    <Menu
+      align="bottom"
+      justify="start"
+      trigger={<Button leftGlyph={<Icon glyph="Settings" />} />}
+    >
+      <MenuItem>
+        <InactiveTasksToggle />
+      </MenuItem>
+    </Menu>
+  </Container>
+);
 
 const Container = styled.div`
   display: flex;

--- a/src/pages/commits/SettingsButton/index.tsx
+++ b/src/pages/commits/SettingsButton/index.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import styled from "@emotion/styled";
+import Button from "@leafygreen-ui/button";
+import Checkbox from "@leafygreen-ui/checkbox";
+import { Menu, MenuItem } from "@leafygreen-ui/menu";
+import { Label } from "@leafygreen-ui/typography";
+import Cookies from "js-cookie";
+import { useLocation } from "react-router-dom";
+import Icon from "components/Icon";
+import { INCLUDE_INACTIVE_MAINLINE_COMMIT_TASKS } from "constants/cookies";
+import { useUpdateURLQueryParams } from "hooks";
+import { ProjectFilterOptions } from "types/commits";
+import { parseQueryString } from "utils/queryString";
+
+const SettingsButton = () => {
+  const { search } = useLocation();
+  const updateQueryParams = useUpdateURLQueryParams();
+  const parsed = parseQueryString(search);
+
+  const includeInactiveTasks =
+    parsed[ProjectFilterOptions.InactiveTasks] !== undefined
+      ? parsed[ProjectFilterOptions.InactiveTasks] === "true"
+      : Cookies.get(INCLUDE_INACTIVE_MAINLINE_COMMIT_TASKS) === "true";
+
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { checked } = e.target;
+    updateQueryParams({
+      [ProjectFilterOptions.InactiveTasks]: checked.toString(),
+    });
+    Cookies.set(INCLUDE_INACTIVE_MAINLINE_COMMIT_TASKS, checked.toString());
+  };
+
+  return (
+    <Container>
+      <Label htmlFor="project-task-status-select">Settings</Label>
+      <Menu
+        align="bottom"
+        justify="start"
+        trigger={<Button leftGlyph={<Icon glyph="Settings" />} />}
+      >
+        <MenuItem>
+          <Checkbox
+            label="Include Inactive tasks"
+            checked={Boolean(includeInactiveTasks)}
+            onChange={onChange}
+          />
+        </MenuItem>
+      </Menu>
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+export { SettingsButton };

--- a/src/pages/commits/utils.test.ts
+++ b/src/pages/commits/utils.test.ts
@@ -15,6 +15,7 @@ describe("getFilterStatus", () => {
         tasks: ["task1"],
         variants: ["variant1"],
         requesters: ["requester1"],
+        includeInactiveTasks: false,
       })
     ).toStrictEqual({
       hasFilters: true,
@@ -29,6 +30,7 @@ describe("getFilterStatus", () => {
         tasks: [],
         variants: [],
         requesters: [],
+        includeInactiveTasks: false,
       })
     ).toStrictEqual({
       hasFilters: false,
@@ -43,6 +45,7 @@ describe("getFilterStatus", () => {
         tasks: ["task1"],
         variants: [],
         requesters: [],
+        includeInactiveTasks: false,
       })
     ).toStrictEqual({
       hasFilters: true,
@@ -69,6 +72,7 @@ describe("getMainlineCommitsQueryVariables", () => {
             tasks: [],
             variants: [],
             requesters: [],
+            includeInactiveTasks: false,
           },
         }).mainlineCommitsOptions
       ).toStrictEqual({
@@ -92,6 +96,7 @@ describe("getMainlineCommitsQueryVariables", () => {
             tasks: ["test1"],
             variants: [],
             requesters: [],
+            includeInactiveTasks: false,
           },
         }).mainlineCommitsOptions
       ).toStrictEqual({
@@ -113,6 +118,7 @@ describe("getMainlineCommitsQueryVariables", () => {
             tasks: [],
             variants: [],
             requesters: [],
+            includeInactiveTasks: false,
           },
         }).mainlineCommitsOptions
       ).toStrictEqual({
@@ -134,6 +140,7 @@ describe("getMainlineCommitsQueryVariables", () => {
             tasks: ["test1"],
             variants: [],
             requesters: [],
+            includeInactiveTasks: false,
           },
         }).mainlineCommitsOptions
       ).toStrictEqual({
@@ -155,6 +162,7 @@ describe("getMainlineCommitsQueryVariables", () => {
             tasks: [],
             variants: ["test1"],
             requesters: [],
+            includeInactiveTasks: false,
           },
         }).mainlineCommitsOptions
       ).toStrictEqual({
@@ -180,6 +188,7 @@ describe("getMainlineCommitsQueryVariables", () => {
             tasks: [],
             variants: [],
             requesters: [],
+            includeInactiveTasks: false,
           },
         }).buildVariantOptions
       ).toStrictEqual({
@@ -187,6 +196,7 @@ describe("getMainlineCommitsQueryVariables", () => {
         variants: [],
         statuses: [],
         includeBaseTasks: false,
+        includeInactiveTasks: false,
       });
       expect(
         getMainlineCommitsQueryVariables({
@@ -200,6 +210,7 @@ describe("getMainlineCommitsQueryVariables", () => {
             tasks: [],
             variants: [],
             requesters: [],
+            includeInactiveTasks: false,
           },
         }).buildVariantOptions
       ).toStrictEqual({
@@ -207,6 +218,7 @@ describe("getMainlineCommitsQueryVariables", () => {
         variants: [],
         statuses: [TaskStatus.Failed],
         includeBaseTasks: false,
+        includeInactiveTasks: false,
       });
       expect(
         getMainlineCommitsQueryVariables({
@@ -220,6 +232,7 @@ describe("getMainlineCommitsQueryVariables", () => {
             tasks: ["task1"],
             variants: [],
             requesters: [],
+            includeInactiveTasks: false,
           },
         }).buildVariantOptions
       ).toStrictEqual({
@@ -227,6 +240,7 @@ describe("getMainlineCommitsQueryVariables", () => {
         variants: [],
         statuses: [],
         includeBaseTasks: false,
+        includeInactiveTasks: false,
       });
     });
   });
@@ -244,12 +258,14 @@ describe("getMainlineCommitsQueryVariables", () => {
             tasks: [],
             variants: [],
             requesters: [],
+            includeInactiveTasks: false,
           },
         }).buildVariantOptionsForGraph
       ).toStrictEqual({
         tasks: [],
         variants: [],
         statuses: [],
+        includeInactiveTasks: false,
       });
     });
     it("should apply all filters when they are provided", () => {
@@ -265,12 +281,14 @@ describe("getMainlineCommitsQueryVariables", () => {
             tasks: [],
             variants: [],
             requesters: [],
+            includeInactiveTasks: false,
           },
         }).buildVariantOptionsForGraph
       ).toStrictEqual({
         tasks: [],
         variants: [],
         statuses: [TaskStatus.Failed],
+        includeInactiveTasks: false,
       });
       expect(
         getMainlineCommitsQueryVariables({
@@ -284,12 +302,14 @@ describe("getMainlineCommitsQueryVariables", () => {
             tasks: ["task1"],
             variants: [],
             requesters: [],
+            includeInactiveTasks: false,
           },
         }).buildVariantOptionsForGraph
       ).toStrictEqual({
         tasks: ["task1"],
         variants: [],
         statuses: [],
+        includeInactiveTasks: false,
       });
       expect(
         getMainlineCommitsQueryVariables({
@@ -303,12 +323,14 @@ describe("getMainlineCommitsQueryVariables", () => {
             tasks: [],
             variants: ["variant1"],
             requesters: [],
+            includeInactiveTasks: false,
           },
         }).buildVariantOptionsForGraph
       ).toStrictEqual({
         tasks: [],
         variants: ["variant1"],
         statuses: [],
+        includeInactiveTasks: false,
       });
     });
   });
@@ -326,6 +348,7 @@ describe("getMainlineCommitsQueryVariables", () => {
             tasks: [],
             variants: [],
             requesters: [],
+            includeInactiveTasks: false,
           },
         }).buildVariantOptionsForTaskIcons
       ).toStrictEqual({
@@ -333,6 +356,7 @@ describe("getMainlineCommitsQueryVariables", () => {
         variants: [],
         statuses: FAILED_STATUSES,
         includeBaseTasks: false,
+        includeInactiveTasks: false,
       });
     });
     it("should not return any task icons when a non failing status filter is applied", () => {
@@ -348,6 +372,7 @@ describe("getMainlineCommitsQueryVariables", () => {
             tasks: [],
             variants: [],
             requesters: [],
+            includeInactiveTasks: false,
           },
         }).buildVariantOptionsForTaskIcons
       ).toStrictEqual({
@@ -355,6 +380,7 @@ describe("getMainlineCommitsQueryVariables", () => {
         variants: [],
         statuses: [],
         includeBaseTasks: false,
+        includeInactiveTasks: false,
       });
     });
     it("should only show failing task icons when there are multiple statuses with mixed failing and non failing statuses", () => {
@@ -370,6 +396,7 @@ describe("getMainlineCommitsQueryVariables", () => {
             tasks: [],
             variants: [],
             requesters: [],
+            includeInactiveTasks: false,
           },
         }).buildVariantOptionsForTaskIcons
       ).toStrictEqual({
@@ -377,6 +404,7 @@ describe("getMainlineCommitsQueryVariables", () => {
         variants: [],
         statuses: [TaskStatus.Failed],
         includeBaseTasks: false,
+        includeInactiveTasks: false,
       });
     });
     it("should return all matching tasks when a task filter is applied regardless of status", () => {
@@ -392,6 +420,7 @@ describe("getMainlineCommitsQueryVariables", () => {
             tasks: ["task1"],
             variants: [],
             requesters: [],
+            includeInactiveTasks: false,
           },
         }).buildVariantOptionsForTaskIcons
       ).toStrictEqual({
@@ -399,6 +428,7 @@ describe("getMainlineCommitsQueryVariables", () => {
         variants: [],
         statuses: [],
         includeBaseTasks: false,
+        includeInactiveTasks: false,
       });
       expect(
         getMainlineCommitsQueryVariables({
@@ -412,6 +442,7 @@ describe("getMainlineCommitsQueryVariables", () => {
             tasks: ["task1"],
             variants: [],
             requesters: [],
+            includeInactiveTasks: false,
           },
         }).buildVariantOptionsForTaskIcons
       ).toStrictEqual({
@@ -419,6 +450,7 @@ describe("getMainlineCommitsQueryVariables", () => {
         variants: [],
         statuses: [TaskStatus.Succeeded],
         includeBaseTasks: false,
+        includeInactiveTasks: false,
       });
     });
     it("should only return failing tasks when a variant filter is applied with no other filters", () => {
@@ -434,6 +466,7 @@ describe("getMainlineCommitsQueryVariables", () => {
             tasks: [],
             variants: ["variant1"],
             requesters: [],
+            includeInactiveTasks: false,
           },
         }).buildVariantOptionsForTaskIcons
       ).toStrictEqual({
@@ -441,6 +474,7 @@ describe("getMainlineCommitsQueryVariables", () => {
         variants: ["variant1"],
         statuses: FAILED_STATUSES,
         includeBaseTasks: false,
+        includeInactiveTasks: false,
       });
     });
   });
@@ -459,12 +493,15 @@ describe("getMainlineCommitsQueryVariables", () => {
             tasks: [],
             variants: [],
             requesters: [],
+            includeInactiveTasks: false,
           },
         }).buildVariantOptionsForGroupedTasks
       ).toStrictEqual({
         tasks: [impossibleMatch],
         statuses: [],
         variants: [],
+        includeBaseTasks: false,
+        includeInactiveTasks: false,
       });
     });
     it("should group statuses when a non failing status filter is applied", () => {
@@ -480,12 +517,15 @@ describe("getMainlineCommitsQueryVariables", () => {
             tasks: [],
             variants: [],
             requesters: [],
+            includeInactiveTasks: false,
           },
         }).buildVariantOptionsForGroupedTasks
       ).toStrictEqual({
         tasks: [],
         variants: [],
         statuses: [TaskStatus.Succeeded],
+        includeBaseTasks: false,
+        includeInactiveTasks: false,
       });
     });
     it("should not return groupings for failing statuses if there are multiple statuses", () => {
@@ -501,12 +541,15 @@ describe("getMainlineCommitsQueryVariables", () => {
             tasks: [],
             variants: [],
             requesters: [],
+            includeInactiveTasks: false,
           },
         }).buildVariantOptionsForGroupedTasks
       ).toStrictEqual({
         tasks: [],
         variants: [],
         statuses: [TaskStatus.Succeeded],
+        includeBaseTasks: false,
+        includeInactiveTasks: false,
       });
     });
     it("should not return groupings for failing statuses if there are only failing statuses", () => {
@@ -522,12 +565,15 @@ describe("getMainlineCommitsQueryVariables", () => {
             tasks: [],
             variants: [],
             requesters: [],
+            includeInactiveTasks: false,
           },
         }).buildVariantOptionsForGroupedTasks
       ).toStrictEqual({
         tasks: [impossibleMatch],
         variants: [],
         statuses: [],
+        includeBaseTasks: false,
+        includeInactiveTasks: false,
       });
     });
     it("should not group failing statuses when there are other filters applied", () => {
@@ -543,12 +589,15 @@ describe("getMainlineCommitsQueryVariables", () => {
             tasks: [],
             variants: ["variant1"],
             requesters: [],
+            includeInactiveTasks: false,
           },
         }).buildVariantOptionsForGroupedTasks
       ).toStrictEqual({
         tasks: [],
         variants: ["variant1"],
         statuses: ALL_NON_FAILING_STATUSES,
+        includeBaseTasks: false,
+        includeInactiveTasks: false,
       });
     });
     it("should not return any task groupings if there are task filters applied", () => {
@@ -564,12 +613,15 @@ describe("getMainlineCommitsQueryVariables", () => {
             tasks: ["task1"],
             variants: [],
             requesters: [],
+            includeInactiveTasks: false,
           },
         }).buildVariantOptionsForGroupedTasks
       ).toStrictEqual({
         tasks: [impossibleMatch],
         variants: [],
         statuses: [],
+        includeBaseTasks: false,
+        includeInactiveTasks: false,
       });
       expect(
         getMainlineCommitsQueryVariables({
@@ -583,12 +635,15 @@ describe("getMainlineCommitsQueryVariables", () => {
             tasks: ["task1"],
             variants: [],
             requesters: [],
+            includeInactiveTasks: false,
           },
         }).buildVariantOptionsForGroupedTasks
       ).toStrictEqual({
         tasks: [impossibleMatch],
         variants: [],
         statuses: [],
+        includeBaseTasks: false,
+        includeInactiveTasks: false,
       });
     });
   });

--- a/src/pages/commits/utils.ts
+++ b/src/pages/commits/utils.ts
@@ -9,6 +9,7 @@ interface FilterState {
   tasks: string[];
   variants: string[];
   requesters: string[];
+  includeInactiveTasks: boolean;
 }
 interface MainlineCommitOptions {
   projectID: string;
@@ -53,13 +54,14 @@ const generateBuildVariantOptionsFromState = (
   state: CommitsPageReducerState
 ) => {
   const { filterState } = state;
-  const { statuses, tasks, variants } = filterState;
+  const { statuses, tasks, variants, includeInactiveTasks } = filterState;
 
   const buildVariantOptions = {
     tasks,
     variants,
     statuses,
     includeBaseTasks: false,
+    includeInactiveTasks,
   };
 
   return buildVariantOptions;
@@ -92,6 +94,7 @@ const generateBuildVariantOptionsForTaskIconsFromState = (
     variants: filterState.variants,
     statuses: statusesToShow,
     includeBaseTasks: false,
+    includeInactiveTasks: filterState.includeInactiveTasks,
   };
   return buildVariantOptions;
 };
@@ -129,6 +132,8 @@ const generateBuildVariantOptionsForGroupedTasksFromState = (
     tasks: shouldShowGroupedTaskIcons ? filterState.tasks : [impossibleMatch],
     variants: filterState.variants,
     statuses: statusesToShow,
+    includeBaseTasks: false,
+    includeInactiveTasks: filterState.includeInactiveTasks,
   };
 
   return groupedBuildVariantOptions;
@@ -142,6 +147,7 @@ const generateBuildVariantOptionsForGraphFromState = (
     statuses: filterState.statuses,
     tasks: filterState.tasks,
     variants: filterState.variants,
+    includeInactiveTasks: filterState.includeInactiveTasks,
   };
   return buildVariantOptionsForGraph;
 };

--- a/src/pages/version/ActionButtons.tsx
+++ b/src/pages/version/ActionButtons.tsx
@@ -1,4 +1,6 @@
+import { MenuItem } from "@leafygreen-ui/menu";
 import { ButtonDropdown } from "components/ButtonDropdown";
+import { InactiveTasksToggle } from "components/InactiveTasksToggle";
 import { LinkToReconfigurePage } from "components/LinkToReconfigurePage";
 import {
   ScheduleTasks,
@@ -50,6 +52,9 @@ export const ActionButtons: React.VFC<ActionButtonProps> = ({
       key="enqueue"
       disabled={!canEnqueueToCommitQueue}
     />,
+    <MenuItem key="inactiveTasksToggle">
+      <InactiveTasksToggle />
+    </MenuItem>,
   ];
 
   return (

--- a/src/pages/version/useQueryVariables.ts
+++ b/src/pages/version/useQueryVariables.ts
@@ -1,3 +1,6 @@
+import Cookies from "js-cookie";
+import { inactiveTaskQueryParam } from "components/InactiveTasksToggle";
+import { INCLUDE_INACTIVE_TASKS } from "constants/cookies";
 import {
   VersionTasksQueryVariables,
   SortOrder,
@@ -15,6 +18,11 @@ export const useQueryVariables = (
   versionId: string
 ): VersionTasksQueryVariables => {
   const queryParams = parseQueryString(search);
+  const includeInactiveTasks =
+    getString(queryParams[inactiveTaskQueryParam]) !== ""
+      ? getString(queryParams[inactiveTaskQueryParam]) === "true"
+      : Cookies.get(INCLUDE_INACTIVE_TASKS) === "true";
+
   const {
     [PatchTasksQueryParams.Duration]: duration,
     [PatchTasksQueryParams.Sorts]: sorts,
@@ -44,6 +52,7 @@ export const useQueryVariables = (
       sorts: sortsToApply,
       page: getPageFromSearch(search),
       limit: getLimitFromSearch(search),
+      includeEmptyActivation: includeInactiveTasks,
     },
   };
 };

--- a/src/types/commits.ts
+++ b/src/types/commits.ts
@@ -6,6 +6,7 @@ export enum ProjectFilterOptions {
   Task = "taskNames",
   Status = "statuses",
   Test = "tests",
+  InactiveTasks = "includeInactiveTasks",
 }
 
 export enum ChartToggleQueryParams {


### PR DESCRIPTION
EVG-18252

### Description
This change adds a toggle to commits page and version pages that toggles a param to include inactive tasks in the views. This setting is also sticky and persists it to a cookie. 

### Screenshots
Before:
<img width="1501" alt="image" src="https://user-images.githubusercontent.com/4605522/201692781-71c365a2-15f6-41ba-b08b-1129e0e00172.png">
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/4605522/201692919-2fac1b82-41aa-4558-abab-c8aecd8ed7af.png">

After:
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/4605522/201693088-6dc440e8-82e9-4e2d-8633-21a399601df7.png">

<img width="1504" alt="image" src="https://user-images.githubusercontent.com/4605522/201692987-9bcad7b1-7ae7-416e-a016-b9340865b945.png">

### Evergreen PR
https://github.com/evergreen-ci/evergreen/pull/6064

