### PR TITLE
EVG-17064: Remove document.execCommand usage

### DIFF
--- a/src/pages/spawn/spawnHost/SpawnHostTableActions.tsx
+++ b/src/pages/spawn/spawnHost/SpawnHostTableActions.tsx
@@ -45,41 +45,48 @@ export const CopySSHCommandButton: React.VFC<{
   }, [hasCopied]);
 
   return (
-    <StyledTooltip
-      align="top"
-      justify="middle"
-      data-cy="copy-ssh-tooltip"
-      trigger={
-        // Wrapper is necessary because disabled elements cannot trigger mouse events.
-        <div data-cy="copy-ssh-button-wrapper">
-          <PaddedButton
-            data-cy="copy-ssh-button"
-            disabled={!canSSH}
-            leftGlyph={<Icon glyph="Copy" />}
-            // @ts-expect-error
-            onClick={(event: React.MouseEvent) => {
-              event.stopPropagation();
-              copyToClipboard(sshCommand);
-              spawnAnalytics.sendEvent({ name: "Copy SSH Command" });
-              setHasCopied(!hasCopied);
-            }}
-            size={Size.XSmall}
-          >
-            <Label>SSH Command</Label>
-          </PaddedButton>
-        </div>
-      }
+    // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+    <span
+      onClick={(e) => {
+        e.stopPropagation();
+      }}
     >
-      {hasCopied ? (
-        <Center>Copied!</Center>
-      ) : (
-        <Center>
-          {canSSH
-            ? `Must be on VPN to connect to host`
-            : `Host must be running in order to SSH`}
-        </Center>
-      )}
-    </StyledTooltip>
+      <StyledTooltip
+        align="top"
+        justify="middle"
+        data-cy="copy-ssh-tooltip"
+        trigger={
+          // Wrapper is necessary because disabled elements cannot trigger mouse events.
+          <div data-cy="copy-ssh-button-wrapper">
+            <PaddedButton
+              data-cy="copy-ssh-button"
+              disabled={!canSSH}
+              leftGlyph={<Icon glyph="Copy" />}
+              // @ts-expect-error
+              onClick={(event: React.MouseEvent) => {
+                event.stopPropagation();
+                copyToClipboard(sshCommand);
+                spawnAnalytics.sendEvent({ name: "Copy SSH Command" });
+                setHasCopied(!hasCopied);
+              }}
+              size={Size.XSmall}
+            >
+              <Label>SSH Command</Label>
+            </PaddedButton>
+          </div>
+        }
+      >
+        {hasCopied ? (
+          <Center>Copied!</Center>
+        ) : (
+          <Center>
+            {canSSH
+              ? `Must be on VPN to connect to host`
+              : `Host must be running in order to SSH`}
+          </Center>
+        )}
+      </StyledTooltip>
+    </span>
   );
 };
 

--- a/src/pages/spawn/spawnHost/SpawnHostTableActions.tsx
+++ b/src/pages/spawn/spawnHost/SpawnHostTableActions.tsx
@@ -38,55 +38,48 @@ export const CopySSHCommandButton: React.VFC<{
 
   const canSSH = hostStatus !== HostStatus.Terminated && !!hostUrl;
   const [hasCopied, setHasCopied] = useState(false);
-  const [openTooltip, setOpenTooltip] = useState(false);
+
   useEffect(() => {
     const timeout = setTimeout(() => setHasCopied(false), 10 * SECOND);
     return () => clearTimeout(timeout);
   }, [hasCopied]);
 
   return (
-    // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
-    <div
-      onClick={(e: React.MouseEvent) => e.stopPropagation()}
-      onMouseEnter={() => {
-        setOpenTooltip(true);
-      }}
-      onMouseLeave={() => {
-        setOpenTooltip(false);
-      }}
-    >
-      <StyledTooltip
-        align="top"
-        justify="middle"
-        open={openTooltip}
-        data-cy="copy-ssh-tooltip"
-        trigger={
-          <PaddedButton // @ts-expect-error
-            onClick={() => {
+    <StyledTooltip
+      align="top"
+      justify="middle"
+      data-cy="copy-ssh-tooltip"
+      trigger={
+        // Wrapper is necessary because disabled elements cannot trigger mouse events.
+        <div data-cy="copy-ssh-button-wrapper">
+          <PaddedButton
+            data-cy="copy-ssh-button"
+            disabled={!canSSH}
+            leftGlyph={<Icon glyph="Copy" />}
+            // @ts-expect-error
+            onClick={(event: React.MouseEvent) => {
+              event.stopPropagation();
               copyToClipboard(sshCommand);
               spawnAnalytics.sendEvent({ name: "Copy SSH Command" });
               setHasCopied(!hasCopied);
             }}
             size={Size.XSmall}
-            data-cy="copy-ssh-button"
-            leftGlyph={<Icon glyph="Copy" />}
-            disabled={!canSSH}
           >
             <Label>SSH Command</Label>
           </PaddedButton>
-        }
-      >
-        {hasCopied ? (
-          <Center>Copied!</Center>
-        ) : (
-          <Center>
-            {canSSH
-              ? `Must be on VPN to connect to host`
-              : `Host must be running in order to SSH`}
-          </Center>
-        )}
-      </StyledTooltip>
-    </div>
+        </div>
+      }
+    >
+      {hasCopied ? (
+        <Center>Copied!</Center>
+      ) : (
+        <Center>
+          {canSSH
+            ? `Must be on VPN to connect to host`
+            : `Host must be running in order to SSH`}
+        </Center>
+      )}
+    </StyledTooltip>
   );
 };
 

--- a/src/test_utils/index.tsx
+++ b/src/test_utils/index.tsx
@@ -4,6 +4,7 @@ import type {
   RenderOptions,
   BoundFunctions,
 } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { createMemoryHistory } from "history";
 import {
   Route,
@@ -105,4 +106,5 @@ export {
   customRender as render,
   renderWithRouterMatch,
   customWithin as within,
+  userEvent,
 };

--- a/src/utils/string/index.ts
+++ b/src/utils/string/index.ts
@@ -130,13 +130,8 @@ export const getDateCopy = (
   return format(new Date(time), finalDateFormat);
 };
 
-export const copyToClipboard = (str: string) => {
-  const el = document.createElement("textarea");
-  el.value = str;
-  document.body.appendChild(el);
-  el.select();
-  document.execCommand("copy");
-  document.body.removeChild(el);
+export const copyToClipboard = (textToCopy: string) => {
+  navigator.clipboard.writeText(textToCopy);
 };
 
 export const sortFunctionString = (a, b, key) => {


### PR DESCRIPTION
EVG-17064

### Description
This PR removes the deprecated `document.execCommand` from Spruce. It also removes the `div` wrapper we had on the LG Tooltip in `SpawnHostTableActions` because it seems like the original problem went away.

I also exported `userEvent` from our test_utils file because that's how Parsley does it and I feel like the reason we aren't using it is because of the extra import we have to do... in a future ticket we can update this import statement in the test files.

### Screenshots
- N/A

### Testing
- Updated `SpawnHostTableActions.test.tsx`

