### PR TITLE
EVG-16156: Disable spawn button if public key name is required and missing

### DIFF
--- a/src/components/Spawn/spawnHostModal/utils.test.ts
+++ b/src/components/Spawn/spawnHostModal/utils.test.ts
@@ -90,9 +90,50 @@ describe("validateSpawnHostForm", () => {
     expect(
       validateSpawnHostForm({
         ...validForm,
+        publicKeySection: {
+          useExisting: true,
+          publicKeyNameDropdown: "key val",
+        },
+      })
+    ).toBe(true);
+    expect(
+      validateSpawnHostForm({
+        ...validForm,
         publicKeySection: { useExisting: false, newPublicKey: "key val" },
       })
     ).toBe(true);
+  });
+  it("a public key name is required when 'Save Public Key' is checked", () => {
+    expect(
+      validateSpawnHostForm({
+        ...validForm,
+        publicKeySection: {
+          useExisting: false,
+          newPublicKey: "ssh-rsa new-key",
+        },
+      })
+    ).toBe(true);
+    expect(
+      validateSpawnHostForm({
+        ...validForm,
+        publicKeySection: {
+          useExisting: false,
+          newPublicKey: "ssh-rsa new-key",
+          savePublicKey: true,
+          newPublicKeyName: "new key",
+        },
+      })
+    ).toBe(true);
+    expect(
+      validateSpawnHostForm({
+        ...validForm,
+        publicKeySection: {
+          useExisting: false,
+          newPublicKey: "ssh-rsa new-key",
+          savePublicKey: true,
+        },
+      })
+    ).toBe(false);
   });
   it("a user data script must be provided when the option is selected", () => {
     expect(

--- a/src/components/Spawn/spawnHostModal/utils.test.ts
+++ b/src/components/Spawn/spawnHostModal/utils.test.ts
@@ -110,15 +110,6 @@ describe("validateSpawnHostForm", () => {
         publicKeySection: {
           useExisting: false,
           newPublicKey: "ssh-rsa new-key",
-        },
-      })
-    ).toBe(true);
-    expect(
-      validateSpawnHostForm({
-        ...validForm,
-        publicKeySection: {
-          useExisting: false,
-          newPublicKey: "ssh-rsa new-key",
           savePublicKey: true,
           newPublicKeyName: "new key",
         },

--- a/src/components/Spawn/spawnHostModal/utils.ts
+++ b/src/components/Spawn/spawnHostModal/utils.ts
@@ -22,24 +22,37 @@ export const validateSpawnHostForm = (
   }: FormState,
   isMigration?: boolean
 ) => {
-  const isValidHomeVolumeDetails =
+  const hasDistro = !!distro?.value;
+  const hasRegion = !!region;
+  const hasPublicKey = publicKeySection?.useExisting
+    ? !!publicKeySection?.publicKeyNameDropdown
+    : !!publicKeySection?.newPublicKey;
+  const hasValidKeyName = publicKeySection?.savePublicKey
+    ? !!publicKeySection?.newPublicKeyName
+    : true;
+  const hasValidUserdataScript = userdataScriptSection?.runUserdataScript
+    ? !!userdataScriptSection?.userdataScript
+    : true;
+  const hasValidSetupScript = setupScriptSection?.defineSetupScriptCheckbox
+    ? !!setupScriptSection?.setupScript
+    : true;
+  const hasValidHomeVolumeDetails =
     isMigration ||
     (homeVolumeDetails?.selectExistingVolume
       ? !!homeVolumeDetails?.volumeSelect
       : !!homeVolumeDetails?.volumeSize);
+  const hasValidExpiration = expirationDetails?.noExpiration
+    ? true
+    : !!expirationDetails?.expiration;
+
   return (
-    !!distro?.value &&
-    !!region &&
-    (publicKeySection?.useExisting
-      ? !!publicKeySection?.publicKeyNameDropdown
-      : !!publicKeySection?.newPublicKey) &&
-    (userdataScriptSection?.runUserdataScript
-      ? !!userdataScriptSection?.userdataScript
-      : true) &&
-    (setupScriptSection?.defineSetupScriptCheckbox
-      ? !!setupScriptSection?.setupScript
-      : true) &&
-    (distro?.isVirtualWorkstation ? isValidHomeVolumeDetails : true) &&
-    (expirationDetails?.noExpiration ? true : !!expirationDetails?.expiration)
+    hasDistro &&
+    hasRegion &&
+    hasPublicKey &&
+    hasValidKeyName &&
+    hasValidUserdataScript &&
+    hasValidSetupScript &&
+    (distro?.isVirtualWorkstation ? hasValidHomeVolumeDetails : true) &&
+    hasValidExpiration
   );
 };

--- a/src/components/Spawn/spawnHostModal/utils.ts
+++ b/src/components/Spawn/spawnHostModal/utils.ts
@@ -27,7 +27,7 @@ export const validateSpawnHostForm = (
   const hasPublicKey = publicKeySection?.useExisting
     ? !!publicKeySection?.publicKeyNameDropdown
     : !!publicKeySection?.newPublicKey;
-  const hasValidKeyName = publicKeySection?.savePublicKey
+  const hasValidPublicKeyName = publicKeySection?.savePublicKey
     ? !!publicKeySection?.newPublicKeyName
     : true;
   const hasValidUserdataScript = userdataScriptSection?.runUserdataScript
@@ -49,7 +49,7 @@ export const validateSpawnHostForm = (
     hasDistro &&
     hasRegion &&
     hasPublicKey &&
-    hasValidKeyName &&
+    hasValidPublicKeyName &&
     hasValidUserdataScript &&
     hasValidSetupScript &&
     (distro?.isVirtualWorkstation ? hasValidHomeVolumeDetails : true) &&


### PR DESCRIPTION
EVG-16156

### Description
This PR disables the Spawn button when the "Save Public Key" option is checked yet no public key name is provided. Note that I didn't modify the behavior for the Edit Spawn Host modal because it depends on [EVG-18014](https://jira.mongodb.org/browse/EVG-18014).

Currently we show a toast error which works fine, but the ticket seems to imply that we should disable the button instead. If the current behavior is preferred, I can just close this pull request.

### Screenshots
Current behavior (show error toast):

<img width="1109" alt="Screen Shot 2022-11-15 at 11 48 12 AM" src="https://user-images.githubusercontent.com/47064971/202003858-a1b5549d-4da8-4ccd-8030-94ad23281c73.png">

New behavior (disable button):

<img width="739" alt="Screen Shot 2022-11-15 at 1 43 10 PM" src="https://user-images.githubusercontent.com/47064971/202003916-320a3ae2-bbb6-4787-93e6-75a7efabeef4.png">

### Testing
- Added tests to `spawnHostModal/utils.test.ts`
