### PR TITLE
EVG-17947: Modify stepback modal to require build variant and task

### DIFF
--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -1032,6 +1032,7 @@ export type Project = {
   repotrackerDisabled?: Maybe<Scalars["Boolean"]>;
   restricted?: Maybe<Scalars["Boolean"]>;
   spawnHostScriptPath: Scalars["String"];
+  stepbackDisabled?: Maybe<Scalars["Boolean"]>;
   taskAnnotationSettings: TaskAnnotationSettings;
   taskSync: TaskSyncOptions;
   tracksPushEvents?: Maybe<Scalars["Boolean"]>;
@@ -1133,6 +1134,7 @@ export type ProjectInput = {
   repotrackerDisabled?: InputMaybe<Scalars["Boolean"]>;
   restricted?: InputMaybe<Scalars["Boolean"]>;
   spawnHostScriptPath?: InputMaybe<Scalars["String"]>;
+  stepbackDisabled?: InputMaybe<Scalars["Boolean"]>;
   taskAnnotationSettings?: InputMaybe<TaskAnnotationSettingsInput>;
   taskSync?: InputMaybe<TaskSyncOptionsInput>;
   tracksPushEvents?: InputMaybe<Scalars["Boolean"]>;
@@ -1453,6 +1455,7 @@ export type RepoRef = {
   repotrackerDisabled: Scalars["Boolean"];
   restricted: Scalars["Boolean"];
   spawnHostScriptPath: Scalars["String"];
+  stepbackDisabled: Scalars["Boolean"];
   taskAnnotationSettings: TaskAnnotationSettings;
   taskSync: RepoTaskSyncOptions;
   tracksPushEvents: Scalars["Boolean"];
@@ -1494,6 +1497,7 @@ export type RepoRefInput = {
   repotrackerDisabled?: InputMaybe<Scalars["Boolean"]>;
   restricted?: InputMaybe<Scalars["Boolean"]>;
   spawnHostScriptPath?: InputMaybe<Scalars["String"]>;
+  stepbackDisabled?: InputMaybe<Scalars["Boolean"]>;
   taskAnnotationSettings?: InputMaybe<TaskAnnotationSettingsInput>;
   taskSync?: InputMaybe<TaskSyncOptionsInput>;
   tracksPushEvents?: InputMaybe<Scalars["Boolean"]>;

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -556,6 +556,8 @@ export type Mutation = {
   copyProject: Project;
   createProject: Project;
   createPublicKey: Array<PublicKey>;
+  deactivateStepbackTask: Scalars["Boolean"];
+  /** @deprecated deactivateStepbackTasks is deprecated. Use deactivateStepbackTask instead. */
   deactivateStepbackTasks: Scalars["Boolean"];
   defaultSectionToRepo?: Maybe<Scalars["String"]>;
   detachProjectFromRepo: Project;
@@ -639,6 +641,12 @@ export type MutationCreateProjectArgs = {
 
 export type MutationCreatePublicKeyArgs = {
   publicKeyInput: PublicKeyInput;
+};
+
+export type MutationDeactivateStepbackTaskArgs = {
+  buildVariantName: Scalars["String"];
+  projectId: Scalars["String"];
+  taskName: Scalars["String"];
 };
 
 export type MutationDeactivateStepbackTasksArgs = {
@@ -3278,6 +3286,16 @@ export type CreatePublicKeyMutationVariables = Exact<{
 
 export type CreatePublicKeyMutation = {
   createPublicKey: Array<{ key: string; name: string }>;
+};
+
+export type DeactivateStepbackTaskMutationVariables = Exact<{
+  projectId: Scalars["String"];
+  buildVariantName: Scalars["String"];
+  taskName: Scalars["String"];
+}>;
+
+export type DeactivateStepbackTaskMutation = {
+  deactivateStepbackTask: boolean;
 };
 
 export type DeactivateStepbackTasksMutationVariables = Exact<{

--- a/src/gql/mutations/deactivate-stepback-task.graphql
+++ b/src/gql/mutations/deactivate-stepback-task.graphql
@@ -1,0 +1,11 @@
+mutation DeactivateStepbackTask(
+  $projectId: String!
+  $buildVariantName: String!
+  $taskName: String!
+) {
+  deactivateStepbackTask(
+    projectId: $projectId
+    buildVariantName: $buildVariantName
+    taskName: $taskName
+  )
+}

--- a/src/gql/mutations/deactivate-stepback-tasks.graphql
+++ b/src/gql/mutations/deactivate-stepback-tasks.graphql
@@ -1,3 +1,0 @@
-mutation DeactivateStepbackTasks($projectId: String!) {
-  deactivateStepbackTasks(projectId: $projectId)
-}

--- a/src/gql/mutations/index.ts
+++ b/src/gql/mutations/index.ts
@@ -8,6 +8,7 @@ import CLEAR_MY_SUBSCRIPTIONS from "./clear-my-subscriptions.graphql";
 import COPY_PROJECT from "./copy-project.graphql";
 import CREATE_PROJECT from "./create-project.graphql";
 import CREATE_PUBLIC_KEY from "./create-public-key.graphql";
+import DEACTIVATE_STEPBACK_TASK from "./deactivate-stepback-task.graphql";
 import DEACTIVATE_STEPBACK_TASKS from "./deactivate-stepback-tasks.graphql";
 import DEFAULT_SECTION_TO_REPO from "./default-section-to-repo.graphql";
 import DETACH_PROJECT_FROM_REPO from "./detach-project-from-repo.graphql";
@@ -59,6 +60,7 @@ export {
   COPY_PROJECT,
   CREATE_PROJECT,
   CREATE_PUBLIC_KEY,
+  DEACTIVATE_STEPBACK_TASK,
   DEACTIVATE_STEPBACK_TASKS,
   DEFAULT_SECTION_TO_REPO,
   DETACH_PROJECT_FROM_REPO,

--- a/src/gql/mutations/index.ts
+++ b/src/gql/mutations/index.ts
@@ -9,7 +9,6 @@ import COPY_PROJECT from "./copy-project.graphql";
 import CREATE_PROJECT from "./create-project.graphql";
 import CREATE_PUBLIC_KEY from "./create-public-key.graphql";
 import DEACTIVATE_STEPBACK_TASK from "./deactivate-stepback-task.graphql";
-import DEACTIVATE_STEPBACK_TASKS from "./deactivate-stepback-tasks.graphql";
 import DEFAULT_SECTION_TO_REPO from "./default-section-to-repo.graphql";
 import DETACH_PROJECT_FROM_REPO from "./detach-project-from-repo.graphql";
 import DETACH_VOLUME from "./detach-volume.graphql";
@@ -61,7 +60,6 @@ export {
   CREATE_PROJECT,
   CREATE_PUBLIC_KEY,
   DEACTIVATE_STEPBACK_TASK,
-  DEACTIVATE_STEPBACK_TASKS,
   DEFAULT_SECTION_TO_REPO,
   DETACH_PROJECT_FROM_REPO,
   DETACH_VOLUME,

--- a/src/pages/projectSettings/tabs/GeneralTab/Fields/DeactivateStepbackTaskField.test.tsx
+++ b/src/pages/projectSettings/tabs/GeneralTab/Fields/DeactivateStepbackTaskField.test.tsx
@@ -8,11 +8,11 @@ import {
   userEvent,
   waitFor,
 } from "test_utils";
-import { DeactivateStepbackTasksField } from ".";
+import { DeactivateStepbackTaskField } from ".";
 
 const Field = () => (
   <MockedProvider mocks={[deactivateStepbackTaskMock]}>
-    <DeactivateStepbackTasksField
+    <DeactivateStepbackTaskField
       {...({} as unknown as FieldProps)}
       uiSchema={{
         options: {
@@ -23,7 +23,7 @@ const Field = () => (
   </MockedProvider>
 );
 
-describe("deactivateStepbackTasks", () => {
+describe("deactivateStepbackTask", () => {
   it("renders the button properly", () => {
     const { Component } = RenderFakeToastContext(<Field />);
     render(<Component />);

--- a/src/pages/projectSettings/tabs/GeneralTab/Fields/DeactivateStepbackTaskField.tsx
+++ b/src/pages/projectSettings/tabs/GeneralTab/Fields/DeactivateStepbackTaskField.tsx
@@ -26,7 +26,7 @@ const Modal: React.VFC<ModalProps> = ({ closeModal, open, projectId }) => {
   );
   const [hasError, setHasError] = useState(true);
 
-  const [deactivateStepbackTasks, { loading }] = useMutation<
+  const [deactivateStepbackTask, { loading }] = useMutation<
     DeactivateStepbackTaskMutation,
     DeactivateStepbackTaskMutationVariables
   >(DEACTIVATE_STEPBACK_TASK, {
@@ -42,7 +42,7 @@ const Modal: React.VFC<ModalProps> = ({ closeModal, open, projectId }) => {
 
   const onConfirm = () => {
     const { buildVariantName, taskName } = formState;
-    deactivateStepbackTasks({
+    deactivateStepbackTask({
       variables: {
         projectId,
         buildVariantName,
@@ -76,7 +76,7 @@ const Modal: React.VFC<ModalProps> = ({ closeModal, open, projectId }) => {
   );
 };
 
-export const DeactivateStepbackTasksField: Field = ({ uiSchema }) => {
+export const DeactivateStepbackTaskField: Field = ({ uiSchema }) => {
   const {
     options: { projectId },
   } = uiSchema;

--- a/src/pages/projectSettings/tabs/GeneralTab/Fields/DeactivateStepbackTasksField.test.tsx
+++ b/src/pages/projectSettings/tabs/GeneralTab/Fields/DeactivateStepbackTasksField.test.tsx
@@ -35,7 +35,7 @@ describe("deactivateStepbackTasks", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("clicking on the button opens the modal, with the fields being empty and confirm button disabled", async () => {
+  it("clicking on the button opens the modal with the confirm button disabled by default", async () => {
     const { Component } = RenderFakeToastContext(<Field />);
     render(<Component />);
     userEvent.click(screen.getByDataCy("deactivate-stepback-button"));
@@ -75,7 +75,7 @@ describe("deactivateStepbackTasks", () => {
 
     await waitFor(() => {
       expect(dispatchToast.success).toHaveBeenCalledWith(
-        "Stepback tasks deactivated."
+        "Stepback task was deactivated."
       );
     });
   });

--- a/src/pages/projectSettings/tabs/GeneralTab/Fields/DeactivateStepbackTasksField.test.tsx
+++ b/src/pages/projectSettings/tabs/GeneralTab/Fields/DeactivateStepbackTasksField.test.tsx
@@ -1,0 +1,98 @@
+import { MockedProvider } from "@apollo/client/testing";
+import { FieldProps } from "@rjsf/core";
+import { RenderFakeToastContext } from "context/__mocks__/toast";
+import { DEACTIVATE_STEPBACK_TASK } from "gql/mutations";
+import {
+  renderWithRouterMatch as render,
+  screen,
+  userEvent,
+  waitFor,
+} from "test_utils";
+import { DeactivateStepbackTasksField } from ".";
+
+const Field = () => (
+  <MockedProvider mocks={[deactivateStepbackTaskMock]}>
+    <DeactivateStepbackTasksField
+      {...({} as unknown as FieldProps)}
+      uiSchema={{
+        options: {
+          projectId: "evergreen",
+        },
+      }}
+    />
+  </MockedProvider>
+);
+
+describe("deactivateStepbackTasks", () => {
+  it("renders the button properly", () => {
+    const { Component } = RenderFakeToastContext(<Field />);
+    render(<Component />);
+    expect(
+      screen.getByDataCy("deactivate-stepback-button")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByDataCy("deactivate-stepback-modal")
+    ).not.toBeInTheDocument();
+  });
+
+  it("clicking on the button opens the modal, with the fields being empty and confirm button disabled", async () => {
+    const { Component } = RenderFakeToastContext(<Field />);
+    render(<Component />);
+    userEvent.click(screen.getByDataCy("deactivate-stepback-button"));
+    await waitFor(() => {
+      expect(
+        screen.getByDataCy("deactivate-stepback-modal")
+      ).toBeInTheDocument();
+    });
+    expect(screen.getByDataCy("deactivate-variant-name-input")).toHaveValue("");
+    expect(screen.getByDataCy("deactivate-task-name-input")).toHaveValue("");
+    const confirmButton = screen.getByRole("button", {
+      name: "Confirm",
+    });
+    expect(confirmButton).toBeDisabled();
+  });
+
+  it("filling out all of the fields should enable the confirm button", async () => {
+    const { Component, dispatchToast } = RenderFakeToastContext(<Field />);
+    render(<Component />);
+    userEvent.click(screen.getByDataCy("deactivate-stepback-button"));
+    await waitFor(() => {
+      expect(
+        screen.getByDataCy("deactivate-stepback-modal")
+      ).toBeInTheDocument();
+    });
+
+    userEvent.type(
+      screen.getByDataCy("deactivate-variant-name-input"),
+      "ubuntu1604"
+    );
+    userEvent.type(screen.getByDataCy("deactivate-task-name-input"), "js-test");
+    const confirmButton = screen.getByRole("button", {
+      name: "Confirm",
+    });
+    expect(confirmButton).toBeEnabled();
+    userEvent.click(confirmButton);
+
+    await waitFor(() => {
+      expect(dispatchToast.success).toHaveBeenCalledWith(
+        "Stepback tasks deactivated."
+      );
+    });
+  });
+});
+
+const deactivateStepbackTaskMock = {
+  request: {
+    query: DEACTIVATE_STEPBACK_TASK,
+    variables: {
+      projectId: "evergreen",
+      buildVariantName: "ubuntu1604",
+      taskName: "js-test",
+    },
+  },
+  result: {
+    data: {
+      deactivateStepbackTask: true,
+    },
+  },
+};

--- a/src/pages/projectSettings/tabs/GeneralTab/Fields/DeactivateStepbackTasksField.tsx
+++ b/src/pages/projectSettings/tabs/GeneralTab/Fields/DeactivateStepbackTasksField.tsx
@@ -31,7 +31,7 @@ const Modal: React.VFC<ModalProps> = ({ closeModal, open, projectId }) => {
     DeactivateStepbackTaskMutationVariables
   >(DEACTIVATE_STEPBACK_TASK, {
     onCompleted() {
-      dispatchToast.success(`Stepback task was deactivated.`);
+      dispatchToast.success("Stepback task was deactivated.");
     },
     onError(err) {
       dispatchToast.error(
@@ -59,10 +59,10 @@ const Modal: React.VFC<ModalProps> = ({ closeModal, open, projectId }) => {
       onConfirm={onConfirm}
       open={open}
       submitDisabled={hasError || loading}
-      title="Deactivate Scheduled Stepback Tasks"
+      title="Deactivate Scheduled Stepback Task"
       data-cy="deactivate-stepback-modal"
     >
-      <p>Will deactivate running stepback tasks for the specified task.</p>
+      <p>Will deactivate a specific running stepback task.</p>
       <SpruceForm
         formData={formState}
         onChange={({ formData, errors }) => {
@@ -94,11 +94,9 @@ export const DeactivateStepbackTasksField: Field = ({ uiSchema }) => {
         />
       )}
       <ElementWrapper>
-        <Label htmlFor={id}>
-          Deactivate Currently Scheduled Stepback Tasks
-        </Label>
+        <Label htmlFor={id}>Deactivate Currently Scheduled Stepback Task</Label>
         <Description>
-          This will not turn off future stepbacks for the project.
+          This will not turn off future stepbacks for the task.
         </Description>
         <div>
           <Button

--- a/src/pages/projectSettings/tabs/GeneralTab/Fields/DeactivateStepbackTasksField.tsx
+++ b/src/pages/projectSettings/tabs/GeneralTab/Fields/DeactivateStepbackTasksField.tsx
@@ -62,10 +62,7 @@ const Modal: React.VFC<ModalProps> = ({ closeModal, open, projectId }) => {
       title="Deactivate Scheduled Stepback Tasks"
       data-cy="deactivate-stepback-modal"
     >
-      <p>
-        Specify the build variant and task for which you want to deactivate the
-        stepback process.
-      </p>
+      <p>Will deactivate running stepback tasks for the specified task.</p>
       <SpruceForm
         formData={formState}
         onChange={({ formData, errors }) => {

--- a/src/pages/projectSettings/tabs/GeneralTab/Fields/DeactivateStepbackTasksField.tsx
+++ b/src/pages/projectSettings/tabs/GeneralTab/Fields/DeactivateStepbackTasksField.tsx
@@ -31,11 +31,11 @@ const Modal: React.VFC<ModalProps> = ({ closeModal, open, projectId }) => {
     DeactivateStepbackTaskMutationVariables
   >(DEACTIVATE_STEPBACK_TASK, {
     onCompleted() {
-      dispatchToast.success("Stepback tasks deactivated.");
+      dispatchToast.success(`Stepback task was deactivated.`);
     },
     onError(err) {
       dispatchToast.error(
-        `There was an error deactivating stepback tasks: ${err.message}`
+        `There was an error deactivating the stepback task: ${err.message}`
       );
     },
   });
@@ -141,9 +141,11 @@ const deactivateStepbackForm = {
   uiSchema: {
     buildVariantName: {
       "ui:data-cy": "deactivate-variant-name-input",
+      "ui:placeholder": "ex. ubuntu1604",
     },
     taskName: {
       "ui:data-cy": "deactivate-task-name-input",
+      "ui:placeholder": "ex. dist",
     },
   },
 };

--- a/src/pages/projectSettings/tabs/GeneralTab/Fields/RepoConfigField.test.tsx
+++ b/src/pages/projectSettings/tabs/GeneralTab/Fields/RepoConfigField.test.tsx
@@ -1,6 +1,5 @@
 import { MockedProvider } from "@apollo/client/testing";
 import { FieldProps } from "@rjsf/core";
-import userEvent from "@testing-library/user-event";
 import { RenderFakeToastContext } from "context/__mocks__/toast";
 import {
   ATTACH_PROJECT_TO_REPO,
@@ -9,9 +8,9 @@ import {
 } from "gql/mutations";
 import { GET_GITHUB_ORGS } from "gql/queries";
 import {
-  fireEvent,
   renderWithRouterMatch as render,
   screen,
+  userEvent,
   waitFor,
 } from "test_utils";
 import { ProjectType } from "../../utils";
@@ -110,7 +109,7 @@ describe("repoConfigField", () => {
     expect(
       screen.queryByDataCy("attach-repo-disabled-tooltip")
     ).not.toBeInTheDocument();
-    fireEvent.mouseEnter(screen.queryByDataCy("attach-repo-button"));
+    userEvent.hover(screen.queryByDataCy("attach-repo-button-wrapper"));
     await waitFor(() => {
       expect(
         screen.queryByDataCy("attach-repo-disabled-tooltip")
@@ -133,7 +132,7 @@ describe("repoConfigField", () => {
     expect(
       screen.queryByDataCy("attach-repo-disabled-tooltip")
     ).not.toBeInTheDocument();
-    fireEvent.mouseEnter(screen.queryByDataCy("attach-repo-button"));
+    userEvent.hover(screen.queryByDataCy("attach-repo-button-wrapper"));
     await waitFor(() => {
       expect(
         screen.queryByDataCy("attach-repo-disabled-tooltip")
@@ -163,7 +162,7 @@ describe("repoConfigField", () => {
     expect(screen.queryByDataCy("move-repo-modal")).not.toBeInTheDocument();
 
     await screen.findByDataCy("move-repo-button");
-    fireEvent.click(screen.queryByDataCy("move-repo-button"));
+    userEvent.click(screen.queryByDataCy("move-repo-button"));
     await waitFor(() =>
       expect(screen.queryByDataCy("move-repo-modal")).toBeVisible()
     );
@@ -238,7 +237,7 @@ describe("repoConfigField", () => {
 
       expect(screen.queryByDataCy("attach-repo-modal")).not.toBeInTheDocument();
       const attachRepoButton = screen.queryByDataCy("attach-repo-button");
-      fireEvent.click(attachRepoButton);
+      userEvent.click(attachRepoButton);
       await waitFor(() =>
         expect(screen.queryByDataCy("attach-repo-modal")).toBeVisible()
       );
@@ -266,7 +265,7 @@ describe("repoConfigField", () => {
       );
       render(<Component />);
 
-      fireEvent.click(screen.queryByText("Attach"));
+      userEvent.click(screen.queryByText("Attach"));
       await waitFor(() => expect(dispatchToast.error).not.toHaveBeenCalled());
       await waitFor(() => {
         expect(dispatchToast.success).toHaveBeenCalledWith(
@@ -293,7 +292,7 @@ describe("repoConfigField", () => {
       );
       render(<Component />);
 
-      fireEvent.click(screen.queryByText("Detach"));
+      userEvent.click(screen.queryByText("Detach"));
       await waitFor(() => expect(dispatchToast.error).not.toHaveBeenCalled());
       await waitFor(() => {
         expect(dispatchToast.success).toHaveBeenCalledWith(

--- a/src/pages/projectSettings/tabs/GeneralTab/Fields/RepoConfigField.tsx
+++ b/src/pages/projectSettings/tabs/GeneralTab/Fields/RepoConfigField.tsx
@@ -77,7 +77,7 @@ export const RepoConfigField: Field = ({
                 </Tooltip>
               )}
             >
-              <ButtonWrapper>
+              <ButtonWrapper data-cy="attach-repo-button-wrapper">
                 <Button
                   size="small"
                   onClick={() => setAttachModalOpen(true)}

--- a/src/pages/projectSettings/tabs/GeneralTab/Fields/index.tsx
+++ b/src/pages/projectSettings/tabs/GeneralTab/Fields/index.tsx
@@ -1,5 +1,5 @@
-import { DeactivateStepbackTasksField } from "./DeactivateStepbackTasksField";
+import { DeactivateStepbackTaskField } from "./DeactivateStepbackTaskField";
 import { RepoConfigField } from "./RepoConfigField";
 import { RepotrackerField } from "./RepotrackerField";
 
-export { DeactivateStepbackTasksField, RepoConfigField, RepotrackerField };
+export { DeactivateStepbackTaskField, RepoConfigField, RepotrackerField };

--- a/src/pages/projectSettings/tabs/GeneralTab/getFormSchema.tsx
+++ b/src/pages/projectSettings/tabs/GeneralTab/getFormSchema.tsx
@@ -5,7 +5,7 @@ import { versionControlDocumentationUrl } from "constants/externalResources";
 import { GetFormSchema } from "../types";
 import { form, ProjectType } from "../utils";
 import {
-  DeactivateStepbackTasksField,
+  DeactivateStepbackTaskField,
   RepoConfigField,
   RepotrackerField,
 } from "./Fields";
@@ -22,7 +22,7 @@ export const getFormSchema = (
   repoData?: FormState
 ): ReturnType<GetFormSchema> => ({
   fields: {
-    deactivateStepbackTasks: DeactivateStepbackTasksField,
+    deactivateStepbackTask: DeactivateStepbackTaskField,
     repoConfigField: RepoConfigField,
     repotrackerField: RepotrackerField,
   },
@@ -333,7 +333,7 @@ export const getFormSchema = (
             "When unscheduled, tasks from previous revisions will be unscheduled when the equivalent task in a newer commit finishes successfully.",
         },
         deactivateStepback: {
-          "ui:field": "deactivateStepbackTasks",
+          "ui:field": "deactivateStepbackTask",
           "ui:showLabel": false,
           options: { projectId },
         },


### PR DESCRIPTION
EVG-17947

### Description
This PR makes it so that we call the new mutation resolver for deactivating stepback tasks. The new resolver requires both a build variant name and a task name, so these fields were added to the Deactivate Stepback Modal.

### Screenshots
(Not sure about the wording here, and if we should possibly provide placeholders as an example.)

<img width="699" alt="Screen Shot 2022-11-16 at 11 55 08 AM" src="https://user-images.githubusercontent.com/47064971/202249317-84bde289-29ab-4ab8-a151-7ad082686990.png">

### Testing
- Wrote test file `DeactivateStepbackTasksField.test.tsx`
- Changed `fireEvent` => `userEvent` in `RepoConfigField.test.tsx` just because it was close by
- [Patch with module](https://spruce.mongodb.com/version/63751e593e8e863310325cdd/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)

### Evergreen PR
- evergreen-ci/evergreen/pull/6068