### PR TITLE
EVG-18309: Add SpruceForm enumDisabled support

### DIFF
--- a/src/components/SpruceForm/Widgets/LeafyGreenWidgets.tsx
+++ b/src/components/SpruceForm/Widgets/LeafyGreenWidgets.tsx
@@ -164,6 +164,7 @@ export const LeafyGreenSelect: React.VFC<
     allowDeselect,
     ariaLabelledBy,
     description,
+    enumDisabled,
     enumOptions,
     "data-cy": dataCy,
     elementWrapperCSS,
@@ -193,12 +194,14 @@ export const LeafyGreenSelect: React.VFC<
           popoverZIndex={zIndex.dropdown}
         >
           {enumOptions.map((o) => {
+            const optionDisabled = enumDisabled?.includes(o.value) ?? false;
+
             // Handle deselect value without errors
             if (o.value === null) {
               return;
             }
             return (
-              <Option key={o.value} value={o.value}>
+              <Option key={o.value} value={o.value} disabled={optionDisabled}>
                 {o.label}
               </Option>
             );
@@ -216,7 +219,12 @@ export const LeafyGreenRadio: React.VFC<EnumSpruceWidgetProps> = ({
   onChange,
   disabled,
 }) => {
-  const { "data-cy": dataCy, enumOptions, elementWrapperCSS } = options;
+  const {
+    "data-cy": dataCy,
+    enumDisabled,
+    enumOptions,
+    elementWrapperCSS,
+  } = options;
   return (
     <ElementWrapper css={elementWrapperCSS}>
       <RadioGroup
@@ -225,11 +233,18 @@ export const LeafyGreenRadio: React.VFC<EnumSpruceWidgetProps> = ({
         onChange={(e) => onChange(e.target.value)}
         data-cy={dataCy}
       >
-        {enumOptions.map((o) => (
-          <Radio key={o.value} value={o.value} disabled={disabled}>
-            {o.label}
-          </Radio>
-        ))}
+        {enumOptions.map((o) => {
+          const optionDisabled = enumDisabled?.includes(o.value) ?? false;
+          return (
+            <Radio
+              key={o.value}
+              value={o.value}
+              disabled={disabled || optionDisabled}
+            >
+              {o.label}
+            </Radio>
+          );
+        })}
       </RadioGroup>
     </ElementWrapper>
   );
@@ -242,6 +257,7 @@ export const LeafyGreenRadioBox: React.VFC<
     "data-cy": dataCy,
     description,
     elementWrapperCSS,
+    enumDisabled,
     enumOptions,
     errors,
     showLabel,
@@ -284,15 +300,18 @@ export const LeafyGreenRadioBox: React.VFC<
         onChange={(e) => onChange(valueMap[e.target.value])}
         data-cy={dataCy}
       >
-        {enumOptions.map((o) => (
-          <StyledRadioBox
-            key={valueMap.indexOf(o.value)}
-            value={valueMap.indexOf(o.value)}
-            disabled={disabled}
-          >
-            {o.label}
-          </StyledRadioBox>
-        ))}
+        {enumOptions.map((o) => {
+          const optionDisabled = enumDisabled?.includes(o.value) ?? false;
+          return (
+            <StyledRadioBox
+              key={valueMap.indexOf(o.value)}
+              value={valueMap.indexOf(o.value)}
+              disabled={disabled || optionDisabled}
+            >
+              {o.label}
+            </StyledRadioBox>
+          );
+        })}
       </RadioBoxGroup>
     </ElementWrapper>
   );
@@ -351,6 +370,7 @@ export const LeafyGreenSegmentedControl: React.VFC<EnumSpruceWidgetProps> = ({
   const {
     "aria-controls": ariaControls,
     "data-cy": dataCy,
+    enumDisabled,
     enumOptions,
     elementWrapperCSS,
   } = options;
@@ -366,15 +386,18 @@ export const LeafyGreenSegmentedControl: React.VFC<EnumSpruceWidgetProps> = ({
         onChange={onChange}
         aria-controls={ariaControls?.join(" ")}
       >
-        {enumOptions.map((o) => (
-          <SegmentedControlOption
-            key={o.value}
-            value={o.value}
-            disabled={isDisabled}
-          >
-            {o.label}
-          </SegmentedControlOption>
-        ))}
+        {enumOptions.map((o) => {
+          const optionDisabled = enumDisabled?.includes(o.value) ?? false;
+          return (
+            <SegmentedControlOption
+              key={o.value}
+              value={o.value}
+              disabled={isDisabled || optionDisabled}
+            >
+              {o.label}
+            </SegmentedControlOption>
+          );
+        })}
       </StyledSegmentedControl>
     </ElementWrapper>
   );

--- a/src/components/SpruceForm/Widgets/types.ts
+++ b/src/components/SpruceForm/Widgets/types.ts
@@ -21,6 +21,7 @@ export interface SpruceWidgetProps extends WidgetProps {
 
 export type EnumSpruceWidgetProps = {
   options: {
+    enumDisabled: string[];
     enumOptions: Array<{
       label: string;
       value: string;


### PR DESCRIPTION
EVG-18309

### Description
<!-- add description, context, thought process, etc -->
- Add support for RJSF's [enumDisabled](https://react-jsonschema-form.readthedocs.io/en/latest/api-reference/uiSchema/#enumdisabled) option
- This models the antd widget's [disabledEnums](https://github.com/evergreen-ci/spruce/blob/main/src/components/SpruceForm/Widgets/AntdWidgets.tsx#L32) property, but the Antd widget will be deprecated in EVG-18126. I will replace usage of this option with `enumDisabled` in that PR.

### Testing
<!-- add a description of how you tested it -->
- Added unit test
