### PR TITLE
EVG-18333: Remove unit test skips

### DIFF
--- a/cypress/integration/projectSettings/project_settings.ts
+++ b/cypress/integration/projectSettings/project_settings.ts
@@ -127,12 +127,6 @@ describe("Repo Settings", () => {
     cy.visit(destination);
   });
 
-  it("clicking the New Project button opens the new project modal", () => {
-    cy.dataCy("new-project-button").click();
-    cy.dataCy("create-project-modal").should("be.visible");
-    cy.get('button[aria-label="Close modal"]').click();
-  });
-
   it("Should not have the save button enabled on load", () => {
     cy.dataCy("save-settings-button").should("be.disabled");
   });
@@ -949,28 +943,6 @@ describe("Attaching Spruce to a repo", () => {
       });
       cy.dataCy("cq-card").dataCy("error-banner").should("exist");
     });
-  });
-});
-
-describe("New Project button for project", () => {
-  beforeEach(() => {
-    cy.login();
-    cy.visit(getGeneralRoute(project));
-    cy.dataCy("new-project-menu").should("not.exist");
-    cy.dataCy("new-project-button").click();
-    cy.dataCy("new-project-menu").should("be.visible");
-  });
-
-  it("clicking the 'Create New Project' menu button opens the create project modal and closes the menu", () => {
-    cy.dataCy("create-project-button").click();
-    cy.dataCy("new-project-menu").should("not.exist");
-    cy.dataCy("create-project-modal").should("be.visible");
-  });
-
-  it("clicking the 'Duplicate Project' menu button opens the create project modal and closes the menu", () => {
-    cy.dataCy("copy-project-button").click();
-    cy.dataCy("new-project-menu").should("not.exist");
-    cy.dataCy("copy-project-modal").should("be.visible");
   });
 });
 

--- a/src/pages/projectSettings/CreateDuplicateProjectButton.test.tsx
+++ b/src/pages/projectSettings/CreateDuplicateProjectButton.test.tsx
@@ -53,9 +53,7 @@ describe("createDuplicateProjectField", () => {
     expect(screen.queryByDataCy("new-project-button")).not.toBeInTheDocument();
   });
 
-  // Flakiness will be addressed in EVG-18333
-  // eslint-disable-next-line jest/no-disabled-tests
-  describe.skip("when looking at a repo", () => {
+  describe("when looking at a repo", () => {
     it("clicking the button opens the new project modal", async () => {
       const { Component } = RenderFakeToastContext(
         <Button projectType={ProjectType.Repo} />
@@ -83,9 +81,7 @@ describe("createDuplicateProjectField", () => {
       );
     });
 
-    // Flakiness will be addressed in EVG-18333
-    // eslint-disable-next-line jest/no-disabled-tests
-    it.skip("clicking the 'Create New Project' button opens the create project modal and closes the menu", async () => {
+    it("clicking the 'Create New Project' button opens the create project modal and closes the menu", async () => {
       const { Component } = RenderFakeToastContext(<Button />);
       render(<Component />);
 
@@ -101,9 +97,7 @@ describe("createDuplicateProjectField", () => {
       expect(screen.queryByDataCy("new-project-menu")).not.toBeInTheDocument();
     });
 
-    // Flakiness will be addressed in EVG-18333
-    // eslint-disable-next-line jest/no-disabled-tests
-    it.skip("clicking the 'Duplicate Project' button opens the create project modal and closes the menu", async () => {
+    it("clicking the 'Duplicate Project' button opens the create project modal and closes the menu", async () => {
       const { Component } = RenderFakeToastContext(<Button />);
       render(<Component />);
 


### PR DESCRIPTION
EVG-18333

### Description
<!-- add description, context, thought process, etc -->
- Updating all packages to run on the same version of LeafyGreen provider seems to have eliminated the unit test timeouts we were seeing
- Reintroduce unit tests and remove duplicate Cypress tests.