### PR TITLE
EVG-18374: Fix task icon tooltip hover slowness on Project Health

### DIFF
--- a/src/pages/commits/ActiveCommits/buildVariantCard/WaterfallTaskStatusIcon.tsx
+++ b/src/pages/commits/ActiveCommits/buildVariantCard/WaterfallTaskStatusIcon.tsx
@@ -57,6 +57,14 @@ export const WaterfallTaskStatusIcon: React.VFC<
     }
   }, [enabled]);
 
+  useEffect(
+    () => () => {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+    },
+    [] // eslint-disable-line react-hooks/exhaustive-deps
+  );
   return (
     <Tooltip
       align="top"


### PR DESCRIPTION
[EVG-18374](https://jira.mongodb.org/browse/EVG-18374)
### Description
We experienced tooltip slowness because the tooltip visibility was enabled within a timeout. The `timeout` variable was being reset during every render which made setTimeout ineffective. 
<!-- add screenshots of visible changes -->

### Testing
<!-- add a description of how you tested it -->

### Evergreen PR
<!-- link to a corresponding Evergreen PR if applicable -->
