### PR TITLE
EVG-18272: Adjust CSS for project settings side nav

### DIFF
--- a/src/components/ProjectSelect/ProjectOptionGroup.tsx
+++ b/src/components/ProjectSelect/ProjectOptionGroup.tsx
@@ -86,8 +86,8 @@ const ProjectContainer = styled.div`
 `;
 
 const OptionGroupContainer = styled.div`
-  word-break: break-word;
   padding: ${size.xs};
+  word-break: break-word;
 `;
 
 const hoverStyles = css`

--- a/src/components/ProjectSelect/ProjectOptionGroup.tsx
+++ b/src/components/ProjectSelect/ProjectOptionGroup.tsx
@@ -79,15 +79,15 @@ const ProjectContainer = styled.div`
   justify-content: space-between;
   align-items: center;
   cursor: pointer;
-  padding: ${size.xs};
+  padding: ${size.xxs} ${size.xxs} ${size.xxs} ${size.xs};
   :hover {
     background-color: ${gray.light1};
   }
 `;
 
 const OptionGroupContainer = styled.div`
-  padding: ${size.xs};
   word-break: break-word;
+  padding: ${size.xs};
 `;
 
 const hoverStyles = css`

--- a/src/pages/ProjectSettings.tsx
+++ b/src/pages/ProjectSettings.tsx
@@ -110,7 +110,7 @@ export const ProjectSettings: React.VFC = () => {
 
   return (
     <ProjectSettingsProvider>
-      <SideNav aria-label="Project Settings">
+      <SideNav aria-label="Project Settings" widthOverride={250}>
         <ButtonsContainer>
           <ProjectSelect
             selectedProjectIdentifier={projectLabel}


### PR DESCRIPTION
EVG-18272

### Description
This PR just adjusts some CSS. Users reported that because the `SideNav` was so small, it was hard to scroll and read through the projects in the `SearchableDropdown`.

### Screenshots
(Screenshots are from beta to show that the changes will work with LeafyGreen updates.)

`SideNav`        |  `SearchableDropdown`
:-------------------------:|:-------------------------:
<img width="246" alt="Screen Shot 2022-12-06 at 4 27 40 PM" src="https://user-images.githubusercontent.com/47064971/206027134-7e484288-b81f-4a0d-a19a-17032ffb4c9d.png">  |  <img width="239" alt="Screen Shot 2022-12-06 at 4 28 02 PM" src="https://user-images.githubusercontent.com/47064971/206027144-dd9c1279-5f82-476d-8a3a-a8cbdc13789f.png">

