### PR TITLE
EVG-16280 Add TaskQueue Link to navbar

### DIFF
--- a/src/analytics/navbar/useNavbarAnalytics.ts
+++ b/src/analytics/navbar/useNavbarAnalytics.ts
@@ -18,7 +18,8 @@ type Action =
   | { name: "Click Project Patches Link" }
   | { name: "Click EVG Wiki Link" }
   | { name: "Click Preferences Link" }
-  | { name: "Click Notifications Link" };
+  | { name: "Click Notifications Link" }
+  | { name: "Click Task Queue Link" };
 
 interface P extends Properties {}
 interface Analytics extends A<Action> {}

--- a/src/components/Header/AuxiliaryDropdown.tsx
+++ b/src/components/Header/AuxiliaryDropdown.tsx
@@ -7,6 +7,7 @@ import {
   routes,
   getProjectPatchesRoute,
   getProjectSettingsRoute,
+  getTaskQueueRoute,
 } from "constants/routes";
 import { GetSpruceConfigQuery } from "gql/generated/types";
 import { GET_SPRUCE_CONFIG } from "gql/queries";
@@ -48,6 +49,11 @@ export const AuxiliaryDropdown = () => {
       to: getProjectPatchesRoute(mostRecentProject),
       text: "Project Patches",
       onClick: () => sendEvent({ name: "Click Project Patches Link" }),
+    },
+    {
+      text: "Task Queue",
+      to: getTaskQueueRoute(""),
+      onClick: () => sendEvent({ name: "Click Task Queue Link" }),
     },
   ];
 


### PR DESCRIPTION
EVG-16280

### Description
Adds a link to the task queue page to the navbar.



### Screenshots
<img width="639" alt="image" src="https://user-images.githubusercontent.com/4605522/206220636-a8f54439-ab49-48bc-b158-afbb6ef4afb1.png">

