### PR TITLE
EVG-14252: Conditionally disable setup script and project setup script

### DIFF
--- a/cypress/integration/spawn/host.ts
+++ b/cypress/integration/spawn/host.ts
@@ -210,6 +210,33 @@ describe("Navigating to Spawn Host page", () => {
         ).click();
         cy.dataCy("setup-script-text-area").should("be.visible");
       });
+
+      it("Conditionally disables setup script and project setup script checkboxes based on the other's value", () => {
+        cy.visit(
+          `/spawn/host?spawnHost=True&distroId=${distroId}&taskId=${hostTaskId}`
+        );
+        // Checking setup script should disable project setup script.
+        cy.dataCy("setup-script-checkbox").check({ force: true });
+        cy.dataCy("project-setup-script-checkbox").should(
+          "have.attr",
+          "aria-disabled",
+          "true"
+        );
+        // Unchecking setup script should reenable project setup script.
+        cy.dataCy("setup-script-checkbox").uncheck({ force: true });
+        cy.dataCy("project-setup-script-checkbox").should(
+          "have.attr",
+          "aria-disabled",
+          "false"
+        );
+        // Checking project setup script should disable setup script.
+        cy.dataCy("project-setup-script-checkbox").check({ force: true });
+        cy.dataCy("setup-script-checkbox").should(
+          "have.attr",
+          "aria-disabled",
+          "true"
+        );
+      });
       const label1 = "Use project-specific setup script defined at /path";
       const label2 = "Load from task sync";
       const label3 = "Also start any hosts this task started (if applicable)";

--- a/src/components/Spawn/spawnHostModal/getFormSchema.tsx
+++ b/src/components/Spawn/spawnHostModal/getFormSchema.tsx
@@ -29,6 +29,8 @@ interface Props {
   userAwsRegion?: string;
   volumes: MyVolumesQuery["myVolumes"];
   isMigration: boolean;
+  useSetupScript?: boolean;
+  useProjectSetupScript?: boolean;
 }
 
 export const getFormSchema = ({
@@ -43,6 +45,8 @@ export const getFormSchema = ({
   userAwsRegion,
   volumes,
   isMigration,
+  useSetupScript = false,
+  useProjectSetupScript = false,
 }: Props): ReturnType<GetFormSchema> => {
   const {
     displayName: taskDisplayName,
@@ -449,6 +453,10 @@ export const getFormSchema = ({
         },
       },
       setupScriptSection: {
+        defineSetupScriptCheckbox: {
+          "ui:disabled": useProjectSetupScript,
+          "ui:data-cy": "setup-script-checkbox",
+        },
         setupScript: {
           "ui:widget": LeafyGreenTextArea,
           "ui:elementWrapperCSS": textAreaWrapperClassName,
@@ -487,6 +495,8 @@ export const getFormSchema = ({
               hasValidTask && project?.spawnHostScriptPath
                 ? widgets.CheckboxWidget
                 : "hidden",
+            "ui:disabled": useSetupScript,
+            "ui:data-cy": "project-setup-script-checkbox",
             "ui:elementWrapperCSS": childCheckboxCSS,
           },
           taskSync: {

--- a/src/components/SpruceForm/Widgets/LeafyGreenWidgets.tsx
+++ b/src/components/SpruceForm/Widgets/LeafyGreenWidgets.tsx
@@ -117,7 +117,7 @@ export const LeafyGreenCheckBox: React.VFC<SpruceWidgetProps> = ({
         data-cy={dataCy}
         checked={value}
         label={
-          <CheckboxLabel>
+          <>
             {customLabel || label}
             {tooltipDescription && (
               <Tooltip
@@ -133,7 +133,7 @@ export const LeafyGreenCheckBox: React.VFC<SpruceWidgetProps> = ({
                 {tooltipDescription}
               </Tooltip>
             )}
-          </CheckboxLabel>
+          </>
         }
         onChange={(e) => onChange(e.target.checked)}
         disabled={disabled || readonly}
@@ -141,11 +141,6 @@ export const LeafyGreenCheckBox: React.VFC<SpruceWidgetProps> = ({
     </ElementWrapper>
   );
 };
-
-const CheckboxLabel = styled.div`
-  display: flex;
-  align-items: center;
-`;
 
 const IconContainer = styled.span`
   margin-left: ${size.xxs};

--- a/src/components/SpruceForm/__snapshots__/SpruceForm.stories.storyshot
+++ b/src/components/SpruceForm/__snapshots__/SpruceForm.stories.storyshot
@@ -169,7 +169,7 @@ exports[`storybook Storyshots Components/Spruce Form Example 1 1`] = `
                           className="css-12pm1mq-MaxWidthContainer eevpusu0"
                         >
                           <div
-                            className="leafygreen-ui-1iyoj2o css-1kbcljo-StyledTextInput eevpusu8"
+                            className="leafygreen-ui-1iyoj2o css-1kbcljo-StyledTextInput eevpusu7"
                           >
                             <label
                               className="leafygreen-ui-ly82bp"
@@ -221,7 +221,7 @@ exports[`storybook Storyshots Components/Spruce Form Example 1 1`] = `
                           className="css-12pm1mq-MaxWidthContainer eevpusu0"
                         >
                           <div
-                            className="leafygreen-ui-1iyoj2o css-1kbcljo-StyledTextInput eevpusu8"
+                            className="leafygreen-ui-1iyoj2o css-1kbcljo-StyledTextInput eevpusu7"
                           >
                             <label
                               className="leafygreen-ui-ly82bp"
@@ -407,11 +407,7 @@ exports[`storybook Storyshots Components/Spruce Form Example 2 1`] = `
                 <span
                   className="leafygreen-ui-1qufm80"
                 >
-                  <div
-                    className="css-9o8rvd-CheckboxLabel eevpusu6"
-                  >
-                    Mark distro as a cluster (jobs are not run on this host, used for special purposes).
-                  </div>
+                  Mark distro as a cluster (jobs are not run on this host, used for special purposes).
                 </span>
               </label>
             </div>
@@ -452,11 +448,7 @@ exports[`storybook Storyshots Components/Spruce Form Example 2 1`] = `
                 <span
                   className="leafygreen-ui-1qufm80"
                 >
-                  <div
-                    className="css-9o8rvd-CheckboxLabel eevpusu6"
-                  >
-                    Disable shallow clone for this distro.
-                  </div>
+                  Disable shallow clone for this distro.
                 </span>
               </label>
             </div>
@@ -497,11 +489,7 @@ exports[`storybook Storyshots Components/Spruce Form Example 2 1`] = `
                 <span
                   className="leafygreen-ui-1qufm80"
                 >
-                  <div
-                    className="css-9o8rvd-CheckboxLabel eevpusu6"
-                  >
-                    Disable queueing this distro. Tasks already in the task queue will be removed.
-                  </div>
+                  Disable queueing this distro. Tasks already in the task queue will be removed.
                 </span>
               </label>
             </div>
@@ -542,11 +530,7 @@ exports[`storybook Storyshots Components/Spruce Form Example 2 1`] = `
                 <span
                   className="leafygreen-ui-1qufm80"
                 >
-                  <div
-                    className="css-9o8rvd-CheckboxLabel eevpusu6"
-                  >
-                    Decommission hosts of this distro for this update
-                  </div>
+                  Decommission hosts of this distro for this update
                 </span>
               </label>
             </div>
@@ -684,11 +668,7 @@ exports[`storybook Storyshots Components/Spruce Form Example 3 1`] = `
                 <span
                   className="leafygreen-ui-1qufm80"
                 >
-                  <div
-                    className="css-9o8rvd-CheckboxLabel eevpusu6"
-                  >
-                    This is the only visible page element
-                  </div>
+                  This is the only visible page element
                 </span>
               </label>
             </div>

--- a/src/pages/spawn/spawnHost/spawnHostButton/SpawnHostModal.tsx
+++ b/src/pages/spawn/spawnHost/spawnHostButton/SpawnHostModal.tsx
@@ -82,6 +82,8 @@ export const SpawnHostModal: React.VFC<SpawnHostModalProps> = ({
     isMigration: false,
     isVirtualWorkstation: !!formState?.distro?.isVirtualWorkstation,
     spawnTaskData: spawnTaskData?.task,
+    useSetupScript: !!formState?.setupScriptSection?.defineSetupScriptCheckbox,
+    useProjectSetupScript: !!formState?.loadData?.runProjectSpecificSetupScript,
   });
 
   if (loadingFormData) {


### PR DESCRIPTION
EVG-14252

### Description
This PR prevents users from submitting the `Spawn host from task` form with both the setup script and project setup script checked. Only one of these values can be checked at a time.

It also removes a style I had applied to the `CheckboxWidget` which was incorrect.

### Screenshots
Check setup script        |  Check project setup script
:-------------------------:|:-------------------------:
 <img width="560" alt="Screen Shot 2022-12-07 at 3 32 18 PM" src="https://user-images.githubusercontent.com/47064971/206289560-dae257a1-3174-4f96-8bea-17a1c7a22261.png"> |  <img width="563" alt="Screen Shot 2022-12-07 at 3 32 11 PM" src="https://user-images.githubusercontent.com/47064971/206289554-d4d5f362-09c4-4e97-a20b-59ded63aca9e.png"> 

### Testing
- Added test in `spawn/host.ts` (Cypress)
