### PR TITLE
EVG-18449: Fix nested rows in task duration table

### DIFF
--- a/src/pages/version/taskDuration/TaskDurationTable.test.tsx
+++ b/src/pages/version/taskDuration/TaskDurationTable.test.tsx
@@ -1,0 +1,97 @@
+import { MockedProvider } from "@apollo/client/testing";
+import {
+  renderWithRouterMatch as render,
+  screen,
+  userEvent,
+  waitFor,
+  within,
+} from "test_utils";
+import { TaskDurationTable } from "./TaskDurationTable";
+
+describe("taskDurationTable", () => {
+  it("renders all rows", () => {
+    render(
+      <MockedProvider>
+        <TaskDurationTable tasks={tasks} loading={false} />
+      </MockedProvider>
+    );
+    expect(screen.queryAllByDataCy("task-duration-table-row")).toHaveLength(2);
+  });
+
+  it("opens nested row on click", async () => {
+    render(
+      <MockedProvider>
+        <TaskDurationTable tasks={tasks} loading={false} />
+      </MockedProvider>
+    );
+    expect(screen.queryByDataCy("execution-task-row")).not.toBeVisible();
+    const expandRowButton = within(
+      screen.queryAllByDataCy("task-duration-table-row")[0]
+    ).queryByRole("button");
+    userEvent.click(expandRowButton);
+    await waitFor(() => {
+      expect(screen.queryByDataCy("execution-task-row")).toBeVisible();
+    });
+  });
+});
+
+const tasks = [
+  {
+    id: "spruce_ubuntu1604_check_codegen_patch_345da020487255d1b9fb87bed4ceb98397a0c5a5_624af28fa4cf4714c7a6c19a_22_04_04_13_28_48",
+    execution: 0,
+    aborted: false,
+    status: "success",
+    displayName: "check_codegen",
+    buildVariant: "ubuntu1604",
+    buildVariantDisplayName: "Ubuntu 16.04",
+    blocked: false,
+    timeTaken: 6000,
+    executionTasksFull: [
+      {
+        id: "spruce_ubuntu1604_check_codegen_patch_345da020487255d1b9fb87bed4ceb98397a0c5a5_624af28fa4cf4714c7a6c19a_22_04_04_13_28_48",
+        execution: 0,
+        aborted: false,
+        status: "success",
+        displayName:
+          "check_codegen_EXE_really_really_really_really_really_really_really_really_really_really_really_really_really_really_really_really_really_really_really_really_really_really_long_name",
+        buildVariant: "ubuntu1604",
+        buildVariantDisplayName: "Ubuntu 16.04",
+        timeTaken: 4000,
+        baseTask: {
+          id: "spruce_ubuntu1604_check_codegen_345da020487255d1b9fb87bed4ceb98397a0c5a5_22_03_29_15_10_42",
+          execution: 0,
+          status: "success",
+          __typename: "Task",
+        },
+      },
+    ],
+    baseTask: {
+      id: "spruce_ubuntu1604_check_codegen_345da020487255d1b9fb87bed4ceb98397a0c5a5_22_03_29_15_10_42",
+      execution: 0,
+      status: "success",
+      __typename: "Task",
+    },
+    projectIdentifier: "spruce",
+    __typename: "Task",
+  },
+  {
+    id: "spruce_ubuntu1604_compile_patch_345da020487255d1b9fb87bed4ceb98397a0c5a5_624af28fa4cf4714c7a6c19a_22_04_04_13_28_48",
+    execution: 0,
+    aborted: false,
+    status: "success",
+    displayName: "compile",
+    buildVariant: "ubuntu1604",
+    buildVariantDisplayName: "Ubuntu 16.04",
+    blocked: false,
+    executionTasksFull: null,
+    baseTask: {
+      id: "spruce_ubuntu1604_compile_345da020487255d1b9fb87bed4ceb98397a0c5a5_22_03_29_15_10_42",
+      execution: 0,
+      status: "success",
+      __typename: "Task",
+    },
+    projectIdentifier: "spruce",
+    timeTaken: 10000,
+    __typename: "Task",
+  },
+];

--- a/src/pages/version/taskDuration/TaskDurationTable.tsx
+++ b/src/pages/version/taskDuration/TaskDurationTable.tsx
@@ -121,16 +121,7 @@ export const TaskDurationTable: React.VFC<Props> = ({ tasks, loading }) => {
             data-cy="task-duration-table-row"
             task={datum}
             maxTimeTaken={maxTimeTaken}
-          >
-            {datum?.executionTasksFull &&
-              datum?.executionTasksFull.map((task) => (
-                <TaskDurationRow
-                  key={`execution_task_${task.id}`}
-                  task={task}
-                  maxTimeTaken={maxTimeTaken}
-                />
-              ))}
-          </TaskDurationRow>
+          />
         )}
       </Table>
       {loading && (

--- a/src/pages/version/taskDuration/TaskDurationTable.tsx
+++ b/src/pages/version/taskDuration/TaskDurationTable.tsx
@@ -148,6 +148,13 @@ const findMaxTimeTaken = (
 
 const TableWrapper = styled.div`
   border-top: 3px solid ${gray.light2};
+
+  // LeafyGreen applies overflow-x: auto to the table, which causes an overflow-y scrollbar
+  // to appear. Since the table container will expand to fit its contents, we will never
+  // overflow on the Y-axis. Therefore, hide the scroll bar.
+  > div > div:last-of-type {
+    overflow-y: hidden;
+  }
 `;
 
 const StyledTableHeader = styled(TableHeader)`


### PR DESCRIPTION
EVG-18449

### Description
<!-- add description, context, thought process, etc -->
- Updates to LeafyGreen Table prevent nested rows from being wrapped in parent components. To get around this limitation, render execution tasks directly as `Row` and `Cell` components. This should be fixed by LeafyGreen's table overhaul [LG-2231](https://jira.mongodb.org/browse/LG-2231). See [here](https://mongodb.slack.com/archives/CFFA5BS79/p1670426093909309?thread_ts=1651780191.082089&cid=CFFA5BS79) for more details.

### Testing
<!-- add a description of how you tested it -->
- Add unit test