### PR TITLE
EVG-17958: Update project cookie when visiting project pages

### DIFF
--- a/cypress/integration/project/patches.ts
+++ b/cypress/integration/project/patches.ts
@@ -1,6 +1,7 @@
-const route = "/project/evergreen/patches";
-
 describe("Project Patches Page", () => {
+  const route = "/project/evergreen/patches";
+  const projectCookie = "mci-project-cookie";
+
   before(() => {
     cy.login();
     cy.preserveCookies();
@@ -18,5 +19,12 @@ describe("Project Patches Page", () => {
     cy.dataCy("user-patches-link").first().click();
     cy.location("pathname").should("eq", "/user/admin/patches");
     cy.dataCy("patch-card").should("exist");
+  });
+
+  it("Should update the project cookie when visiting a specific project", () => {
+    cy.clearCookie(projectCookie);
+    cy.visit("/project/evergreen/patches");
+    cy.dataCy("patch-card").should("exist");
+    cy.getCookie(projectCookie).should("have.property", "value", "evergreen");
   });
 });

--- a/cypress/integration/projectHealth/route.ts
+++ b/cypress/integration/projectHealth/route.ts
@@ -1,12 +1,14 @@
 describe("Mainline Commits page route", () => {
-  it("Should default to the project saved in the mci-project-cookie when a project does not exist in the url.", () => {
-    cy.setCookie("mci-project-cookie", "spruce");
+  const projectCookie = "mci-project-cookie";
+
+  it("Should default to the project saved in the mci-project-cookie when a project does not exist in the url", () => {
+    cy.setCookie(projectCookie, "spruce");
     cy.visit("/commits");
     cy.location("pathname").should("eq", "/commits/spruce");
   });
 
-  it("Should default to the project in the SpruceConfig query when a project does not exist in URL nor mci-project-cookie.", () => {
-    cy.clearCookie("mci-project-cookie");
+  it("Should default to the project in the SpruceConfig query when a project does not exist in URL and project cookie is unset", () => {
+    cy.clearCookie(projectCookie);
     cy.visit("/commits");
     cy.location("pathname").should("eq", "/commits/evergreen");
   });
@@ -15,17 +17,16 @@ describe("Mainline Commits page route", () => {
     cy.visit("/commits/spruce");
     cy.dataCy("project-select").click();
     cy.contains("evergreen smoke test").click();
-    cy.getCookie("mci-project-cookie").should(
-      "have.property",
-      "value",
-      "evergreen"
-    );
+    cy.getCookie(projectCookie).should("have.property", "value", "evergreen");
     cy.dataCy("project-select").click();
     cy.contains("System Performance").click();
-    cy.getCookie("mci-project-cookie").should(
-      "have.property",
-      "value",
-      "sys-perf"
-    );
+    cy.getCookie(projectCookie).should("have.property", "value", "sys-perf");
+  });
+
+  it("Should update the project cookie when visiting a specific project", () => {
+    cy.clearCookie(projectCookie);
+    cy.visit("/commits/spruce");
+    cy.dataCy("commit-chart-container").should("be.visible");
+    cy.getCookie(projectCookie).should("have.property", "value", "spruce");
   });
 });

--- a/src/pages/Commits.tsx
+++ b/src/pages/Commits.tsx
@@ -116,6 +116,9 @@ export const Commits = () => {
     skip: !projectId,
     variables,
     pollInterval: DEFAULT_POLL_INTERVAL,
+    onCompleted: () => {
+      Cookies.set(CURRENT_PROJECT, projectId);
+    },
     onError: (e) =>
       dispatchToast.error(`There was an error loading the page: ${e.message}`),
   });

--- a/src/pages/ProjectPatches.tsx
+++ b/src/pages/ProjectPatches.tsx
@@ -1,11 +1,13 @@
 import { useEffect } from "react";
 import { useQuery } from "@apollo/client";
+import Cookies from "js-cookie";
 import { useLocation, useParams } from "react-router-dom";
 import { useProjectPatchesAnalytics } from "analytics/patches/useProjectPatchesAnalytics";
 import {
   PatchesPage,
   getPatchesInputFromURLSearch,
 } from "components/PatchesPage";
+import { CURRENT_PROJECT } from "constants/cookies";
 import { DEFAULT_POLL_INTERVAL } from "constants/index";
 import { useToastContext } from "context/toast";
 import {
@@ -21,6 +23,8 @@ const { parseQueryString } = queryString;
 
 export const ProjectPatches = () => {
   const dispatchToast = useToastContext();
+  const analyticsObject = useProjectPatchesAnalytics();
+
   const { id: projectId } = useParams<{ id: string }>();
   const { search } = useLocation();
   const parsed = parseQueryString(search);
@@ -37,7 +41,6 @@ export const ProjectPatches = () => {
       });
     }
   }, [parsed, updateQueryParams]);
-  const analyticsObject = useProjectPatchesAnalytics();
 
   const { data, refetch, startPolling, stopPolling, loading } = useQuery<
     ProjectPatchesQuery,
@@ -51,6 +54,9 @@ export const ProjectPatches = () => {
       },
     },
     pollInterval: DEFAULT_POLL_INTERVAL,
+    onCompleted: () => {
+      Cookies.set(CURRENT_PROJECT, projectId);
+    },
     onError: (err) => {
       dispatchToast.error(
         `Error while fetching project patches: ${err.message}`


### PR DESCRIPTION
EVG-17958

### Description
This PR updates the project cookie when visiting the project patches page or the project waterfall page. I made it so that the cookie is only updated if the GraphQL query is successful, because it would be kind of sad if I accidentally typed `spruuce` into the URL and my cookie was automatically set to `spruuce`.

### Screenshots
- No visible changes.

### Testing
- Added test in `project/patches.ts` (Cypress)
- Added test in `projectHealth/route.ts` (Cypress)

