### PR TITLE
EVG-18546 Switch version outcomes to family 

### DIFF
--- a/src/constants/triggers.ts
+++ b/src/constants/triggers.ts
@@ -133,19 +133,19 @@ export const taskTriggers: Trigger = {
 // VERSION TRIGGERS
 export const versionTriggers: Trigger = {
   [VersionTriggers.VERSION_FINISHES]: {
-    trigger: TriggerType.OUTCOME,
+    trigger: TriggerType.FAMILY_OUTCOME,
     label: "This version finishes",
     resourceType: ResourceType.VERSION,
     payloadResourceIdKey: "id",
   },
   [VersionTriggers.VERSION_FAILS]: {
-    trigger: TriggerType.FAILURE,
+    trigger: TriggerType.FAMILY_FAILURE,
     label: "This version fails",
     resourceType: ResourceType.VERSION,
     payloadResourceIdKey: "id",
   },
   [VersionTriggers.VERSION_SUCCEEDS]: {
-    trigger: TriggerType.SUCCESS,
+    trigger: TriggerType.FAMILY_SUCCESS,
     label: "This version succeeds",
     resourceType: ResourceType.VERSION,
     payloadResourceIdKey: "id",
@@ -205,13 +205,13 @@ export const versionTriggers: Trigger = {
 
 export const projectTriggers: Trigger = {
   [ProjectTriggers.ANY_VERSION_FINISHES]: {
-    trigger: TriggerType.OUTCOME,
+    trigger: TriggerType.FAMILY_OUTCOME,
     resourceType: ResourceType.VERSION,
     label: "Any Version Finishes",
     extraFields: [requesterSubscriberConfig],
   },
   [ProjectTriggers.ANY_VERSION_FAILS]: {
-    trigger: TriggerType.FAILURE,
+    trigger: TriggerType.FAMILY_FAILURE,
     resourceType: ResourceType.VERSION,
     label: "Any Version Fails",
     extraFields: [requesterSubscriberConfig],


### PR DESCRIPTION
[EVG-18546](https://jira.mongodb.org/browse/EVG-18546)
### Description
Right now, [evergreen converts](https://github.com/evergreen-ci/evergreen/blob/main/rest/data/subscription.go#L63) any incoming subscriptions that are a Version type and on an outcome to the family equivalent. Ideally, they should be sent in the family format. 


### Testing
Existing tests

### Evergreen PR
[6131](https://github.com/evergreen-ci/evergreen/pull/6131)
