### PR TITLE
EVG-18555: Add function to wait for Evergreen in e2e task

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -60,6 +60,13 @@ functions:
         SETTINGS_OVERRIDE: file
         GOROOT: /opt/golang/go1.16
 
+  wait-for-evergreen:
+    command: shell.exec
+    type: setup
+    params:
+      working_dir: spruce
+      script: ./scripts/wait-for-evergreen.sh
+
   sym-link:
     command: shell.exec
     params:
@@ -413,6 +420,7 @@ tasks:
     - func: yarn-build
     - func: yarn-serve
     - func: install-chrome
+    - func: wait-for-evergreen
     - func: run-cypress-tests
     
   - name: send_email

--- a/scripts/wait-for-evergreen.sh
+++ b/scripts/wait-for-evergreen.sh
@@ -1,0 +1,9 @@
+# This script waits for Evergreen to be up and running.
+
+# Listen on port 9090 for Evergreen.
+echo "Waiting for Evergreen to be up and running..."
+while ! nc -z localhost 9090; do
+    sleep 1
+done
+
+echo "Evergreen is up and running!"


### PR DESCRIPTION
EVG-18555

### Description
This PR adds a script to wait for Evergreen (copied from Parsley) so that the Cypress tests will pass.

### Testing
- e2e tests should pass.

