### PR TITLE
EVG-18506 clarify help text for periodic build

### DIFF
--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -734,6 +734,7 @@ export type MutationRestartJasperArgs = {
 };
 
 export type MutationRestartTaskArgs = {
+  failedOnly?: InputMaybe<Scalars["Boolean"]>;
   taskId: Scalars["String"];
 };
 

--- a/src/pages/projectSettings/tabs/PeriodicBuildsTab/getFormSchema.ts
+++ b/src/pages/projectSettings/tabs/PeriodicBuildsTab/getFormSchema.ts
@@ -12,7 +12,11 @@ export const getFormSchema = (
   fields: {},
   schema: {
     type: "object" as "object",
-    description: "Configure tasks to run at fixed intervals.",
+    description:
+      "Configure tasks to run at a consistent interval within this project. " +
+      "This will create a new version that can be seen on the Spruce commits page, " +
+      "regardless of whether or not a new commit has been pushed since the last interval, " +
+      "as opposed to batchtime which will activate the tasks on existing commit versions.",
     ...overrideRadioBox(
       "periodicBuilds",
       ["Override Repo Commands", "Default to Repo Commands"],


### PR DESCRIPTION
EVG-18506

### Description
Merged https://github.com/evergreen-ci/evergreen/pull/6140/files to make the same change to legacy. This is to help users avoid mixing up periodic build and cron.

### Screenshots
<img width="838" alt="image" src="https://user-images.githubusercontent.com/26798134/207641083-c343f340-d3f0-45fe-8245-c3c4a8be3263.png">

