### PR TITLE
EVG-18597: Wrap text in tooltips on history pages

### DIFF
--- a/src/components/HistoryTable/HistoryTableIcon/index.tsx
+++ b/src/components/HistoryTable/HistoryTableIcon/index.tsx
@@ -28,7 +28,6 @@ export const HistoryTableIcon: React.VFC<HistoryTableIconProps> = ({
     condition={inactive || failingTests.length > 0}
     wrapper={(children) => (
       <Tooltip
-        usePortal={false}
         align="right"
         justify="middle"
         enabled={!inactive && !!failingTests.length}
@@ -36,14 +35,14 @@ export const HistoryTableIcon: React.VFC<HistoryTableIconProps> = ({
         trigger={children}
         triggerEvent="hover"
       >
-        <TestNameContainer data-cy="test-tooltip">
+        <div data-cy="test-tooltip">
           {failingTests.map((testName) => (
             <TestName key={testName}>{testName}</TestName>
           ))}
           {loadingTestResults && (
             <Skeleton active data-cy="history-tooltip-skeleton" />
           )}
-        </TestNameContainer>
+        </div>
       </Tooltip>
     )}
   >
@@ -60,10 +59,6 @@ export const HistoryTableIcon: React.VFC<HistoryTableIconProps> = ({
     </Container>
   </ConditionalWrapper>
 );
-
-const TestNameContainer = styled.div`
-  white-space: nowrap;
-`;
 
 interface ContainerProps {
   onClick?: () => void;


### PR DESCRIPTION
EVG-18597

### Description
This PR makes it so that the text wraps in the tooltips on the history pages.

### Screenshots
<img width="319" alt="Screen Shot 2022-12-19 at 1 01 15 PM" src="https://user-images.githubusercontent.com/47064971/208491230-6b20a2aa-c142-42cc-b22c-a2a83e0d0623.png">

### Testing
* Existing tests should pass.


