### PR TITLE
EVG-18623: Wrap task and version links on task queue page

### DIFF
--- a/src/pages/taskQueue/TaskQueueTable.tsx
+++ b/src/pages/taskQueue/TaskQueueTable.tsx
@@ -7,7 +7,7 @@ import { Table } from "antd";
 import { ColumnProps } from "antd/es/table";
 import { useParams, useLocation } from "react-router-dom";
 import { useTaskQueueAnalytics } from "analytics";
-import { StyledRouterLink } from "components/styles";
+import { StyledRouterLink, WordBreak } from "components/styles";
 import { getVersionRoute, getTaskRoute } from "constants/routes";
 import {
   DistroTaskQueueQuery,
@@ -87,7 +87,7 @@ export const TaskQueueTable = () => {
                 taskQueueAnalytics.sendEvent({ name: "Click Task Link" })
               }
             >
-              {displayName}
+              <WordBreak>{displayName}</WordBreak>
             </StyledRouterLink>
           </Body>
           <Body>{buildVariant}</Body>

--- a/src/pages/taskQueue/TaskQueueTable.tsx
+++ b/src/pages/taskQueue/TaskQueueTable.tsx
@@ -109,14 +109,14 @@ export const TaskQueueTable = () => {
       key: "version",
       className: "cy-task-queue-col-version",
       width: "30%",
-      render: (value) => (
+      render: (version) => (
         <StyledRouterLink
-          to={getVersionRoute(value)}
+          to={getVersionRoute(version)}
           onClick={() =>
             taskQueueAnalytics.sendEvent({ name: "Click Version Link" })
           }
         >
-          {value}
+          <WordBreak>{version}</WordBreak>
         </StyledRouterLink>
       ),
     },


### PR DESCRIPTION
EVG-18623

### Description
This PR makes it so that task links are wrapped and don't overflow into the next column of the Task Queue table.

### Screenshots
Before        |  After
:-------------------------:|:-------------------------:
<img width="720" alt="Screen Shot 2022-12-21 at 11 56 19 AM" src="https://user-images.githubusercontent.com/47064971/208963802-1c5ae693-a330-4e77-8209-42de5b4e8f84.png"> | <img width="716" alt="Screen Shot 2022-12-21 at 11 55 57 AM" src="https://user-images.githubusercontent.com/47064971/208963821-ecba72e9-6284-44f1-9ad8-52bee6a67ea9.png">

