### PR TITLE
EVG-18710: Add font-smoothing property

### DIFF
--- a/src/components/styles/GlobalStyles.tsx
+++ b/src/components/styles/GlobalStyles.tsx
@@ -40,6 +40,8 @@ const globalStyles = css`
     font-family: ${fontFamilies.default};
     font-size: 13px;
     margin: 0;
+    -webkit-font-smoothing: antialiased; /* Chrome, Safari */
+    -moz-osx-font-smoothing: grayscale; /* Firefox */
   }
 
   // TODO: Remove when fixed: https://jira.mongodb.org/browse/EVG-18184


### PR DESCRIPTION
EVG-18710

### Description
<!-- add description, context, thought process, etc -->
- Apply [font smoothing](https://css-tricks.com/understanding-web-fonts-getting/#aa-font-smoothing), which is used by Atlas and I think improves legibility of our sans serif font.
- Preview on [beta](https://spruce-beta.corp.mongodb.com/)