### PR TITLE
EVG-14070: Show current task label if host is capable of running tasks

### DIFF
--- a/src/pages/host/Metadata.tsx
+++ b/src/pages/host/Metadata.tsx
@@ -1,5 +1,6 @@
 import { ApolloError } from "@apollo/client";
 import styled from "@emotion/styled";
+import { palette } from "@leafygreen-ui/palette";
 import { formatDistanceToNow } from "date-fns";
 import {
   MetadataCard,
@@ -10,7 +11,7 @@ import { StyledLink } from "components/styles";
 import { getTaskRoute } from "constants/routes";
 import { HostQuery } from "gql/generated/types";
 import { environmentalVariables } from "utils";
-
+const { gray } = palette;
 const { getUiUrl } = environmentalVariables;
 
 export const Metadata: React.VFC<{
@@ -70,7 +71,7 @@ export const Metadata: React.VFC<{
 };
 
 const Italic = styled.i`
-  color: silver;
+  color: ${gray.light1};
 `;
 
 const MCI_USER = "mci";


### PR DESCRIPTION
[EVG-14070](https://jira.mongodb.org/browse/EVG-14070)

### Description
A [StartedBy](https://github.com/evergreen-ci/evergreen/blob/main/model/host/host.go#L98) field equal to `mci` indicates that the Host is capable of running a task.
