### PR TITLE
EVG-18759 Fix webhook naming nit

### DIFF
--- a/src/types/subscription.ts
+++ b/src/types/subscription.ts
@@ -30,7 +30,7 @@ export const projectSubscriptionMethods = [
   ...subscriptionMethods,
   {
     value: NotificationMethods.WEBHOOK,
-    label: "Evergreen Webhook",
+    label: "Webhook",
   },
   {
     value: NotificationMethods.JIRA_ISSUE,


### PR DESCRIPTION
I noticed this in a Slack conversation about the webhook notification. I think this is slightly misleading, since there's nothing specifically "Evergreen" about the webhook, in the same way that we write "Slack message", not "Evergreen Slack message".