### PR TITLE
EVG-18789 upgrade ubuntu to 20.04

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -438,10 +438,10 @@ tasks:
 
 
 buildvariants:
-  - name: ubuntu1604
-    display_name: Ubuntu 16.04
+  - name: ubuntu2004
+    display_name: Ubuntu 20.04
     run_on:
-    - ubuntu1604-large
+    - ubuntu2004-large
     modules:
       - evergreen
     tasks:


### PR DESCRIPTION
[EVG-18789](https://jira.mongodb.org/browse/EVG-18789)

### Description
We're moving evergreen's self-tests to Ubuntu 20.04, so let's move Spruce too. We're also updating the DB version for evergreen, but that's configured from Spruce's project variables.

### Screenshots
N/A

### Testing
Let's see how it lands 😄 

### Evergreen PR
https://github.com/evergreen-ci/evergreen/pull/6204
