### PR TITLE
EVG-15510: Replace antd tooltips with LeafyGreen tooltips

### DIFF
--- a/src/components/Spawn/ExpirationField.tsx
+++ b/src/components/Spawn/ExpirationField.tsx
@@ -1,7 +1,8 @@
 import styled from "@emotion/styled";
 import Checkbox from "@leafygreen-ui/checkbox";
-import { Tooltip } from "antd";
+import Tooltip from "@leafygreen-ui/tooltip";
 import { set } from "date-fns";
+import { ConditionalWrapper } from "components/ConditionalWrapper";
 import DatePicker from "components/DatePicker";
 import { InputLabel } from "components/styles";
 import TimePicker from "components/TimePicker";
@@ -26,12 +27,11 @@ interface ExpirationFieldProps {
 export const ExpirationField: React.VFC<ExpirationFieldProps> = ({
   onChange,
   data,
-  isVolume,
   targetItem,
 }) => {
   const spruceConfig = useSpruceConfig();
   const disableExpirationCheckbox = useDisableSpawnExpirationCheckbox(
-    isVolume,
+    true,
     targetItem
   );
   const { expiration: expirationString, noExpiration } = data;
@@ -57,8 +57,14 @@ export const ExpirationField: React.VFC<ExpirationFieldProps> = ({
   };
 
   const disabledDate = (current) => current < Date.now();
-  const { unexpirableHostsPerUser, unexpirableVolumesPerUser } =
-    spruceConfig?.spawnHost ?? {};
+  const { unexpirableVolumesPerUser } = spruceConfig?.spawnHost ?? {};
+
+  const disabledExpirationCopy = getNoExpirationCheckboxTooltipCopy({
+    disableExpirationCheckbox,
+    isVolume: true,
+    limit: unexpirableVolumesPerUser,
+  });
+
   return (
     <SectionContainer>
       <SectionLabel weight="medium">Expiration</SectionLabel>
@@ -89,14 +95,18 @@ export const ExpirationField: React.VFC<ExpirationFieldProps> = ({
         </FlexColumnContainer>
         <PaddedBody> or </PaddedBody>
         <FlexColumnContainer>
-          <Tooltip
-            title={getNoExpirationCheckboxTooltipCopy({
-              disableExpirationCheckbox,
-              isVolume,
-              limit: isVolume
-                ? unexpirableVolumesPerUser
-                : unexpirableHostsPerUser,
-            })}
+          <ConditionalWrapper
+            condition={disableExpirationCheckbox}
+            wrapper={(children) => (
+              <Tooltip
+                align="top"
+                justify="middle"
+                trigger={<span>{children}</span>}
+                triggerEvent="hover"
+              >
+                {disabledExpirationCopy}
+              </Tooltip>
+            )}
           >
             <span>
               <PaddedCheckbox
@@ -109,7 +119,7 @@ export const ExpirationField: React.VFC<ExpirationFieldProps> = ({
                 }
               />
             </span>
-          </Tooltip>
+          </ConditionalWrapper>
         </FlexColumnContainer>
       </FormContainer>
     </SectionContainer>

--- a/src/components/Spawn/ExpirationField.tsx
+++ b/src/components/Spawn/ExpirationField.tsx
@@ -20,7 +20,6 @@ export interface ExpirationDateType {
 interface ExpirationFieldProps {
   data: ExpirationDateType;
   onChange: (data: ExpirationDateType) => void;
-  isVolume: boolean;
   targetItem?: MyHost | MyVolume;
 }
 

--- a/src/pages/spawn/spawnVolume/spawnVolumeButton/SpawnVolumeModal.tsx
+++ b/src/pages/spawn/spawnVolume/spawnVolumeButton/SpawnVolumeModal.tsx
@@ -128,7 +128,6 @@ export const SpawnVolumeModal: React.VFC<SpawnVolumeModalProps> = ({
           expiration: state.expiration,
           noExpiration: state.noExpiration,
         }}
-        isVolume
         onChange={(expData) => dispatch({ type: "editExpiration", ...expData })}
       />
       <SectionContainer>

--- a/src/pages/spawn/spawnVolume/spawnVolumeButton/spawnVolumeModal/SizeSelector.tsx
+++ b/src/pages/spawn/spawnVolume/spawnVolumeButton/spawnVolumeModal/SizeSelector.tsx
@@ -10,11 +10,11 @@ interface Props {
 
 export const SizeSelector: React.VFC<Props> = ({ value, onChange, limit }) => (
   <SectionContainer>
-    <div>
+    <div style={{ width: 200 }}>
       <SectionLabel weight="medium">Volume Size</SectionLabel>
-      <Description>The max volume size is {limit} GiB.</Description>
+      <Description>The max spawnable volume size is {limit} GiB.</Description>
     </div>
-    <ModalContent style={{ width: 200 }}>
+    <ModalContent>
       <TextInput
         label="Size (GB)"
         data-cy="volumeSize"

--- a/src/pages/spawn/spawnVolume/spawnVolumeButton/spawnVolumeModal/SizeSelector.tsx
+++ b/src/pages/spawn/spawnVolume/spawnVolumeButton/spawnVolumeModal/SizeSelector.tsx
@@ -1,5 +1,5 @@
 import TextInput from "@leafygreen-ui/text-input";
-import { Tooltip } from "antd";
+import { Description } from "@leafygreen-ui/typography";
 import { ModalContent, SectionContainer, SectionLabel } from "components/Spawn";
 
 interface Props {
@@ -10,21 +10,22 @@ interface Props {
 
 export const SizeSelector: React.VFC<Props> = ({ value, onChange, limit }) => (
   <SectionContainer>
-    <SectionLabel weight="medium">Volume Size</SectionLabel>
-    <ModalContent>
-      <Tooltip title={`Max Spawnable Volume Size is ${limit} GiB`}>
-        <TextInput
-          label="Size (GB)"
-          data-cy="volumeSize"
-          id="volumeSize"
-          min={0}
-          max={limit}
-          style={{ width: "100px" }}
-          value={value.toString()}
-          onChange={(e) => onChange(parseInt(e.target.value, 10))}
-          type="number"
-        />
-      </Tooltip>
+    <div>
+      <SectionLabel weight="medium">Volume Size</SectionLabel>
+      <Description>The max volume size is {limit} GiB.</Description>
+    </div>
+    <ModalContent style={{ width: 200 }}>
+      <TextInput
+        label="Size (GB)"
+        data-cy="volumeSize"
+        id="volumeSize"
+        min={0}
+        max={limit}
+        style={{ width: 200 }}
+        value={value.toString()}
+        onChange={(e) => onChange(parseInt(e.target.value, 10))}
+        type="number"
+      />
     </ModalContent>
   </SectionContainer>
 );

--- a/src/pages/spawn/spawnVolume/spawnVolumeTable/spawnVolumeTableActions/UnmountButton.tsx
+++ b/src/pages/spawn/spawnVolume/spawnVolumeTable/spawnVolumeTableActions/UnmountButton.tsx
@@ -1,6 +1,6 @@
 import { useQuery, useMutation } from "@apollo/client";
 import Button, { Size } from "@leafygreen-ui/button";
-import { Tooltip } from "antd";
+import Tooltip from "@leafygreen-ui/tooltip";
 import { useSpawnAnalytics } from "analytics/spawn/useSpawnAnalytics";
 import { ConditionalWrapper } from "components/ConditionalWrapper";
 import { Popconfirm } from "components/Popconfirm";
@@ -52,8 +52,13 @@ export const UnmountButton: React.VFC<Props> = ({ volume }) => {
     <ConditionalWrapper
       condition={isHomeVolume}
       wrapper={(children) => (
-        <Tooltip title="Cannot unmount home volume">
-          <span>{children}</span>
+        <Tooltip
+          align="top"
+          justify="middle"
+          trigger={<span>{children}</span>}
+          triggerEvent="hover"
+        >
+          Cannot unmount home volume
         </Tooltip>
       )}
       altWrapper={(children) => (

--- a/src/pages/spawn/spawnVolume/spawnVolumeTable/spawnVolumeTableActions/editButton/EditVolumeModal.tsx
+++ b/src/pages/spawn/spawnVolume/spawnVolumeTable/spawnVolumeTableActions/editButton/EditVolumeModal.tsx
@@ -105,13 +105,12 @@ export const EditVolumeModal: React.VFC<Props> = ({
         </ModalContent>
       </SectionContainer>
       <ExpirationField
-        isVolume
-        targetItem={volume}
         data={{
           expiration: state.expiration,
           noExpiration: state.noExpiration,
         }}
         onChange={(expData) => dispatch({ type: "editExpiration", ...expData })}
+        targetItem={volume}
       />
     </ConfirmationModal>
   );


### PR DESCRIPTION
EVG-15510

### Description
This PR replaces `antd` tooltips with LeafyGreen tooltips.

### Screenshots
`UnmountButton` (before)        |  `UnmountButton` (after)
:-------------------------:|:-------------------------:
<img width="275" alt="Screen Shot 2023-01-25 at 3 34 40 PM" src="https://user-images.githubusercontent.com/47064971/214684319-a1965b24-0c1c-4dd9-9bfc-05aa5e6c527c.png">  |  <img width="275" alt="Screen Shot 2023-01-25 at 2 38 14 PM" src="https://user-images.githubusercontent.com/47064971/214684325-3c6b89a8-1f03-45e7-bc34-2cae2e387861.png">

`ExpirationField` (before)        |  `ExpirationField` (after)
:-------------------------:|:-------------------------:
<img width="275" alt="Screen Shot 2023-01-25 at 3 34 24 PM" src="https://user-images.githubusercontent.com/47064971/214684544-450d75e5-558f-461d-b48e-8727d63c3717.png"> |  <img width="275" alt="Screen Shot 2023-01-25 at 3 09 58 PM" src="https://user-images.githubusercontent.com/47064971/214684550-ba5a6bde-f4ab-4ea6-9e52-90c4278be5e3.png">

`SizeSelector` (before)        |  `SizeSelector` (after) - removed tooltip
:-------------------------:|:-------------------------:
<img width="275" alt="Screen Shot 2023-01-25 at 3 34 04 PM" src="https://user-images.githubusercontent.com/47064971/214686734-3b6a4a76-e9e0-4be9-a3f6-5858d6033fc9.png">| <img width="450" alt="Screen Shot 2023-01-25 at 3 42 19 PM" src="https://user-images.githubusercontent.com/47064971/214686798-aabe4ea4-db8d-4dbf-977e-2b60d4db9d20.png">

### Testing
- Existing tests should pass
