### PR TITLE
EVG-12490 Fix the commit queue position being zero index 

### DIFF
--- a/src/components/CodeChanges/CodeChanges.tsx
+++ b/src/components/CodeChanges/CodeChanges.tsx
@@ -15,6 +15,7 @@ import {
 import { GET_CODE_CHANGES } from "gql/queries";
 import { SubtitleType } from "types/leafygreen";
 import { commits } from "utils";
+import { convertZeroToOneIndex } from "utils/numbers";
 
 const { bucketByCommit, shouldPreserveCommits } = commits;
 
@@ -60,7 +61,7 @@ export const CodeChanges: React.VFC = () => {
             return (
               <CodeChangeModuleContainer key={`code_change_${description}`}>
                 <CommitContainer>
-                  <CommitTitle>Commit {idx + 1}</CommitTitle>
+                  <CommitTitle>Commit {convertZeroToOneIndex(idx)}</CommitTitle>
                   {description && <Description>{description}</Description>}
                 </CommitContainer>
                 <CodeChangesTable fileDiffs={sortedFileDiffs} />

--- a/src/components/CodeChanges/CodeChanges.tsx
+++ b/src/components/CodeChanges/CodeChanges.tsx
@@ -15,7 +15,7 @@ import {
 import { GET_CODE_CHANGES } from "gql/queries";
 import { SubtitleType } from "types/leafygreen";
 import { commits } from "utils";
-import { convertZeroToOneIndex } from "utils/numbers";
+import { formatZeroIndexForDisplay } from "utils/numbers";
 
 const { bucketByCommit, shouldPreserveCommits } = commits;
 
@@ -61,7 +61,9 @@ export const CodeChanges: React.VFC = () => {
             return (
               <CodeChangeModuleContainer key={`code_change_${description}`}>
                 <CommitContainer>
-                  <CommitTitle>Commit {convertZeroToOneIndex(idx)}</CommitTitle>
+                  <CommitTitle>
+                    Commit {formatZeroIndexForDisplay(idx)}
+                  </CommitTitle>
                   {description && <Description>{description}</Description>}
                 </CommitContainer>
                 <CodeChangesTable fileDiffs={sortedFileDiffs} />

--- a/src/components/Table/TaskLink.tsx
+++ b/src/components/Table/TaskLink.tsx
@@ -1,7 +1,7 @@
 import { Body } from "@leafygreen-ui/typography";
 import { StyledRouterLink, WordBreak } from "components/styles";
 import { getTaskRoute } from "constants/routes";
-import { convertZeroToOneIndex } from "utils/numbers";
+import { formatZeroIndexForDisplay } from "utils/numbers";
 
 interface TaskLinkProps {
   execution?: number;
@@ -20,7 +20,7 @@ export const TaskLink: React.VFC<TaskLinkProps> = ({
   <StyledRouterLink onClick={() => onClick(taskId)} to={getTaskRoute(taskId)}>
     <WordBreak>{taskName}</WordBreak>
     {showTaskExecutionLabel && (
-      <Body>Execution {convertZeroToOneIndex(execution)}</Body>
+      <Body>Execution {formatZeroIndexForDisplay(execution)}</Body>
     )}
   </StyledRouterLink>
 );

--- a/src/components/Table/TaskLink.tsx
+++ b/src/components/Table/TaskLink.tsx
@@ -1,7 +1,7 @@
 import { Body } from "@leafygreen-ui/typography";
 import { StyledRouterLink, WordBreak } from "components/styles";
 import { getTaskRoute } from "constants/routes";
-import { executionAsDisplay } from "utils/task";
+import { convertZeroToOneIndex } from "utils/numbers";
 
 interface TaskLinkProps {
   execution?: number;
@@ -20,7 +20,7 @@ export const TaskLink: React.VFC<TaskLinkProps> = ({
   <StyledRouterLink onClick={() => onClick(taskId)} to={getTaskRoute(taskId)}>
     <WordBreak>{taskName}</WordBreak>
     {showTaskExecutionLabel && (
-      <Body>Execution {executionAsDisplay(execution)}</Body>
+      <Body>Execution {convertZeroToOneIndex(execution)}</Body>
     )}
   </StyledRouterLink>
 );

--- a/src/pages/CommitQueue.tsx
+++ b/src/pages/CommitQueue.tsx
@@ -13,6 +13,7 @@ import {
   CommitQueueQueryVariables,
 } from "gql/generated/types";
 import { GET_COMMIT_QUEUE } from "gql/queries";
+import { convertZeroToOneIndex } from "utils/numbers";
 import { CommitQueueCard } from "./commitqueue/CommitQueueCard";
 
 const { gray } = palette;
@@ -56,7 +57,7 @@ export const CommitQueue: React.VFC = () => {
           <CommitQueueCard
             key={issue}
             issue={issue}
-            index={i + 1}
+            index={convertZeroToOneIndex(i)}
             title={patch?.description}
             author={patch?.author}
             patchId={patch?.id}

--- a/src/pages/CommitQueue.tsx
+++ b/src/pages/CommitQueue.tsx
@@ -13,7 +13,7 @@ import {
   CommitQueueQueryVariables,
 } from "gql/generated/types";
 import { GET_COMMIT_QUEUE } from "gql/queries";
-import { convertZeroToOneIndex } from "utils/numbers";
+import { formatZeroIndexForDisplay } from "utils/numbers";
 import { CommitQueueCard } from "./commitqueue/CommitQueueCard";
 
 const { gray } = palette;
@@ -57,7 +57,7 @@ export const CommitQueue: React.VFC = () => {
           <CommitQueueCard
             key={issue}
             issue={issue}
-            index={convertZeroToOneIndex(i)}
+            index={formatZeroIndexForDisplay(i)}
             title={patch?.description}
             author={patch?.author}
             patchId={patch?.id}

--- a/src/pages/preferences/preferencesTabs/cliTab/NodeList.tsx
+++ b/src/pages/preferences/preferencesTabs/cliTab/NodeList.tsx
@@ -1,6 +1,7 @@
 import styled from "@emotion/styled";
 import { palette } from "@leafygreen-ui/palette";
 import { zIndex } from "constants/tokens";
+import { convertZeroToOneIndex } from "utils/numbers";
 import { NodeType, Node } from "./nodeList/Node";
 
 const { gray } = palette;
@@ -14,7 +15,7 @@ export const NodeList: React.VFC<NodeListProps> = ({ list }) => (
         key={node.title}
         title={node.title}
         child={node.child}
-        stepNumber={index + 1}
+        stepNumber={convertZeroToOneIndex(index)}
       />
     ))}
   </NodeContainer>

--- a/src/pages/preferences/preferencesTabs/cliTab/NodeList.tsx
+++ b/src/pages/preferences/preferencesTabs/cliTab/NodeList.tsx
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 import { palette } from "@leafygreen-ui/palette";
 import { zIndex } from "constants/tokens";
-import { convertZeroToOneIndex } from "utils/numbers";
+import { formatZeroIndexForDisplay } from "utils/numbers";
 import { NodeType, Node } from "./nodeList/Node";
 
 const { gray } = palette;
@@ -15,7 +15,7 @@ export const NodeList: React.VFC<NodeListProps> = ({ list }) => (
         key={node.title}
         title={node.title}
         child={node.child}
-        stepNumber={convertZeroToOneIndex(index)}
+        stepNumber={formatZeroIndexForDisplay(index)}
       />
     ))}
   </NodeContainer>

--- a/src/pages/task/executionDropdown/ExecutionSelector.tsx
+++ b/src/pages/task/executionDropdown/ExecutionSelector.tsx
@@ -10,7 +10,7 @@ import {
 } from "gql/generated/types";
 import { GET_TASK_ALL_EXECUTIONS } from "gql/queries";
 import { useDateFormat } from "hooks";
-import { convertZeroToOneIndex } from "utils/numbers";
+import { formatZeroIndexForDisplay } from "utils/numbers";
 
 interface ExecutionSelectProps {
   id: string;
@@ -41,7 +41,7 @@ export const ExecutionSelect: React.VFC<ExecutionSelectProps> = ({
       disabled={executionsLoading}
       key={currentExecution}
       data-cy="execution-select"
-      value={`Execution ${convertZeroToOneIndex(currentExecution)}${
+      value={`Execution ${formatZeroIndexForDisplay(currentExecution)}${
         currentExecution === latestExecution ? " (latest)" : ""
       }`}
       onChange={(selected: number | null) => {
@@ -49,7 +49,7 @@ export const ExecutionSelect: React.VFC<ExecutionSelectProps> = ({
       }}
     >
       {allExecutions?.map((singleExecution) => {
-        const optionText = `Execution ${convertZeroToOneIndex(
+        const optionText = `Execution ${formatZeroIndexForDisplay(
           singleExecution.execution
         )} - ${getDateCopy(
           singleExecution.activatedTime ?? singleExecution.ingestTime

--- a/src/pages/task/executionDropdown/ExecutionSelector.tsx
+++ b/src/pages/task/executionDropdown/ExecutionSelector.tsx
@@ -10,7 +10,7 @@ import {
 } from "gql/generated/types";
 import { GET_TASK_ALL_EXECUTIONS } from "gql/queries";
 import { useDateFormat } from "hooks";
-import { executionAsDisplay } from "utils/task";
+import { convertZeroToOneIndex } from "utils/numbers";
 
 interface ExecutionSelectProps {
   id: string;
@@ -41,7 +41,7 @@ export const ExecutionSelect: React.VFC<ExecutionSelectProps> = ({
       disabled={executionsLoading}
       key={currentExecution}
       data-cy="execution-select"
-      value={`Execution ${executionAsDisplay(currentExecution)}${
+      value={`Execution ${convertZeroToOneIndex(currentExecution)}${
         currentExecution === latestExecution ? " (latest)" : ""
       }`}
       onChange={(selected: number | null) => {
@@ -49,7 +49,7 @@ export const ExecutionSelect: React.VFC<ExecutionSelectProps> = ({
       }}
     >
       {allExecutions?.map((singleExecution) => {
-        const optionText = `Execution ${executionAsDisplay(
+        const optionText = `Execution ${convertZeroToOneIndex(
           singleExecution.execution
         )} - ${getDateCopy(
           singleExecution.activatedTime ?? singleExecution.ingestTime

--- a/src/pages/taskQueue/TaskQueueTable.tsx
+++ b/src/pages/taskQueue/TaskQueueTable.tsx
@@ -18,6 +18,7 @@ import {
 import { DISTRO_TASK_QUEUE } from "gql/queries";
 import { usePrevious } from "hooks";
 import { string } from "utils";
+import { convertZeroToOneIndex } from "utils/numbers";
 
 const { msToDuration } = string;
 
@@ -69,7 +70,9 @@ export const TaskQueueTable = () => {
       dataIndex: "number",
       key: "number",
       className: "cy-task-queue-col-index",
-      render: (...[, , index]) => <Body weight="medium">{index + 1}</Body>,
+      render: (...[, , index]) => (
+        <Body weight="medium">{convertZeroToOneIndex(index)}</Body>
+      ),
     },
     {
       title: "Task",

--- a/src/pages/taskQueue/TaskQueueTable.tsx
+++ b/src/pages/taskQueue/TaskQueueTable.tsx
@@ -18,7 +18,7 @@ import {
 import { DISTRO_TASK_QUEUE } from "gql/queries";
 import { usePrevious } from "hooks";
 import { string } from "utils";
-import { convertZeroToOneIndex } from "utils/numbers";
+import { formatZeroIndexForDisplay } from "utils/numbers";
 
 const { msToDuration } = string;
 
@@ -71,7 +71,7 @@ export const TaskQueueTable = () => {
       key: "number",
       className: "cy-task-queue-col-index",
       render: (...[, , index]) => (
-        <Body weight="medium">{convertZeroToOneIndex(index)}</Body>
+        <Body weight="medium">{formatZeroIndexForDisplay(index)}</Body>
       ),
     },
     {

--- a/src/pages/version/Metadata.tsx
+++ b/src/pages/version/Metadata.tsx
@@ -17,6 +17,7 @@ import { VersionQuery } from "gql/generated/types";
 import { useDateFormat } from "hooks";
 import { ProjectTriggerLevel } from "types/triggers";
 import { string } from "utils";
+import { convertZeroIndex } from "utils/numbers";
 import ManifestBlob from "./ManifestBlob";
 import { ParametersModal } from "./ParametersModal";
 
@@ -137,7 +138,7 @@ export const Metadata: React.VFC<Props> = ({ loading, version }) => {
             data-cy="commit-queue-position"
             to={getCommitQueueRoute(project)}
           >
-            Commit queue position: {commitQueuePosition}
+            Commit queue position: {convertZeroIndex(commitQueuePosition)}
           </StyledRouterLink>
         </MetadataItem>
       )}

--- a/src/pages/version/Metadata.tsx
+++ b/src/pages/version/Metadata.tsx
@@ -17,7 +17,7 @@ import { VersionQuery } from "gql/generated/types";
 import { useDateFormat } from "hooks";
 import { ProjectTriggerLevel } from "types/triggers";
 import { string } from "utils";
-import { convertZeroIndex } from "utils/numbers";
+import { convertZeroToOneIndex } from "utils/numbers";
 import ManifestBlob from "./ManifestBlob";
 import { ParametersModal } from "./ParametersModal";
 
@@ -138,7 +138,7 @@ export const Metadata: React.VFC<Props> = ({ loading, version }) => {
             data-cy="commit-queue-position"
             to={getCommitQueueRoute(project)}
           >
-            Commit queue position: {convertZeroIndex(commitQueuePosition)}
+            Commit queue position: {convertZeroToOneIndex(commitQueuePosition)}
           </StyledRouterLink>
         </MetadataItem>
       )}

--- a/src/pages/version/Metadata.tsx
+++ b/src/pages/version/Metadata.tsx
@@ -17,7 +17,7 @@ import { VersionQuery } from "gql/generated/types";
 import { useDateFormat } from "hooks";
 import { ProjectTriggerLevel } from "types/triggers";
 import { string } from "utils";
-import { convertZeroToOneIndex } from "utils/numbers";
+import { formatZeroIndexForDisplay } from "utils/numbers";
 import ManifestBlob from "./ManifestBlob";
 import { ParametersModal } from "./ParametersModal";
 
@@ -138,7 +138,8 @@ export const Metadata: React.VFC<Props> = ({ loading, version }) => {
             data-cy="commit-queue-position"
             to={getCommitQueueRoute(project)}
           >
-            Commit queue position: {convertZeroToOneIndex(commitQueuePosition)}
+            Commit queue position:{" "}
+            {formatZeroIndexForDisplay(commitQueuePosition)}
           </StyledRouterLink>
         </MetadataItem>
       )}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -8,7 +8,6 @@ import * as queryString from "./queryString";
 import * as request from "./request";
 import * as statuses from "./statuses";
 import * as string from "./string";
-import * as task from "./task";
 import * as url from "./url";
 import * as validators from "./validators";
 
@@ -23,7 +22,6 @@ export {
   request,
   statuses,
   string,
-  task,
   url,
   validators,
 };

--- a/src/utils/numbers/index.ts
+++ b/src/utils/numbers/index.ts
@@ -29,6 +29,9 @@ const toPercent = (value: string | number): number => {
   return parseFloat(value) * 100;
 };
 
-const convertZeroToOneIndex = (value: number): number => value + 1;
+/**
+ * `formatForDisplay` - Formats a zero-indexed number for display in the UI.
+ */
+const formatZeroIndexForDisplay = (value: number): number => value + 1;
 
-export { toDecimal, toPercent, convertZeroToOneIndex };
+export { toDecimal, toPercent, formatZeroIndexForDisplay };

--- a/src/utils/numbers/index.ts
+++ b/src/utils/numbers/index.ts
@@ -29,6 +29,6 @@ const toPercent = (value: string | number): number => {
   return parseFloat(value) * 100;
 };
 
-const convertZeroIndex = (value: number): number => value + 1;
+const convertZeroToOneIndex = (value: number): number => value + 1;
 
-export { toDecimal, toPercent, convertZeroIndex };
+export { toDecimal, toPercent, convertZeroToOneIndex };

--- a/src/utils/numbers/index.ts
+++ b/src/utils/numbers/index.ts
@@ -29,4 +29,6 @@ const toPercent = (value: string | number): number => {
   return parseFloat(value) * 100;
 };
 
-export { toDecimal, toPercent };
+const convertZeroIndex = (value: number): number => value + 1;
+
+export { toDecimal, toPercent, convertZeroIndex };

--- a/src/utils/numbers/index.ts
+++ b/src/utils/numbers/index.ts
@@ -30,7 +30,7 @@ const toPercent = (value: string | number): number => {
 };
 
 /**
- * `formatForDisplay` - Formats a zero-indexed number for display in the UI.
+ * formatZeroIndexForDisplay Formats a zero-indexed number for display in the UI.
  */
 const formatZeroIndexForDisplay = (value: number): number => value + 1;
 

--- a/src/utils/task.ts
+++ b/src/utils/task.ts
@@ -1,3 +1,0 @@
-// in a task's back-end state, the execution will be 0-indexed,
-// but will be 1-indexed wherever it is visible to users
-export const executionAsDisplay = (execution: number) => execution + 1;


### PR DESCRIPTION
[EVG-12490](https://jira.mongodb.org/browse/EVG-12490)
### Description
The commit queue position was displayed as 0 index, which didn't match how it was displayed in the commit queue itself. 

I added a function to convert zero to one index and used it in other parts of the codebase where it seems appropriate. 

