### PR TITLE
EVG-17549: Use dropdown for project org selection

### DIFF
--- a/cypress/integration/projectSettings/constants.ts
+++ b/cypress/integration/projectSettings/constants.ts
@@ -1,0 +1,18 @@
+const getSettingsRoute = (identifier: string) =>
+  `project/${identifier}/settings`;
+
+export const getGeneralRoute = (identifier: string) =>
+  `${getSettingsRoute(identifier)}/general`;
+
+export const getGithubCommitQueueRoute = (identifier: string) =>
+  `${getSettingsRoute(identifier)}/github-commitqueue`;
+
+export const getNotificationsRoute = (identifier: string) =>
+  `${getSettingsRoute(identifier)}/notifications`;
+
+export const getAccessRoute = (identifier: string) =>
+  `${getSettingsRoute(identifier)}/access`;
+
+export const project = "spruce";
+export const projectUseRepoEnabled = "evergreen";
+export const repo = "602d70a2b2373672ee493184";

--- a/cypress/integration/projectSettings/new_project.ts
+++ b/cypress/integration/projectSettings/new_project.ts
@@ -1,0 +1,50 @@
+import { getGeneralRoute, project } from "./constants";
+
+describe("Duplicating a project", () => {
+  const destination = getGeneralRoute(project);
+
+  before(() => {
+    cy.login();
+    cy.visit(destination);
+  });
+
+  it("Successfully duplicates a project with warnings", () => {
+    cy.dataCy("new-project-button").click();
+    cy.dataCy("new-project-menu").should("be.visible");
+    cy.dataCy("copy-project-button").click();
+    cy.dataCy("copy-project-modal").should("be.visible");
+
+    cy.dataCy("project-name-input").type("copied-project");
+
+    cy.contains("button", "Duplicate").click();
+    cy.validateToast("warning");
+
+    cy.url().should("include", "copied-project");
+  });
+});
+
+describe("Creating a new project", () => {
+  const destination = getGeneralRoute(project);
+
+  before(() => {
+    cy.login();
+    cy.visit(destination);
+  });
+
+  it("Successfully creates a new project", () => {
+    cy.dataCy("new-project-button").click();
+    cy.dataCy("new-project-menu").should("be.visible");
+    cy.dataCy("create-project-button").click();
+    cy.dataCy("create-project-modal").should("be.visible");
+
+    cy.dataCy("project-name-input").type("my-new-project");
+    cy.dataCy("owner-select").contains("evergreen-ci");
+    cy.dataCy("new-repo-input").should("have.value", "spruce");
+    cy.dataCy("new-repo-input").clear().type("new-repo");
+
+    cy.contains("button", "Create Project").click();
+    cy.validateToast("success");
+
+    cy.url().should("include", "my-new-project");
+  });
+});

--- a/cypress/integration/projectSettings/new_project.ts
+++ b/cypress/integration/projectSettings/new_project.ts
@@ -38,7 +38,7 @@ describe("Creating a new project", () => {
     cy.dataCy("create-project-modal").should("be.visible");
 
     cy.dataCy("project-name-input").type("my-new-project");
-    cy.dataCy("owner-select").contains("evergreen-ci");
+    cy.dataCy("new-owner-select").contains("evergreen-ci");
     cy.dataCy("new-repo-input").should("have.value", "spruce");
     cy.dataCy("new-repo-input").clear().type("new-repo");
 

--- a/cypress/integration/projectSettings/project_settings.ts
+++ b/cypress/integration/projectSettings/project_settings.ts
@@ -901,8 +901,7 @@ describe("Attaching Spruce to a repo", () => {
   it("Saves a new repo", () => {
     cy.dataCy("repo-input").clear().type("evergreen");
 
-    // TODO: Re-add test when EVG-16604 is completed.
-    // cy.dataCy("attach-repo-button").should("be.disabled");
+    cy.dataCy("attach-repo-button").should("be.disabled");
 
     cy.dataCy("save-settings-button").click();
     cy.validateToast("success", "Successfully updated project");

--- a/cypress/integration/projectSettings/project_settings.ts
+++ b/cypress/integration/projectSettings/project_settings.ts
@@ -1,17 +1,12 @@
-const getSettingsRoute = (identifier: string) =>
-  `project/${identifier}/settings`;
-const getGeneralRoute = (identifier: string) =>
-  `${getSettingsRoute(identifier)}/general`;
-const getGithubCommitQueueRoute = (identifier: string) =>
-  `${getSettingsRoute(identifier)}/github-commitqueue`;
-const getNotificationsRoute = (identifier: string) =>
-  `${getSettingsRoute(identifier)}/notifications`;
-const getAccessRoute = (identifier: string) =>
-  `${getSettingsRoute(identifier)}/access`;
-
-const project = "spruce";
-const projectUseRepoEnabled = "evergreen";
-const repo = "602d70a2b2373672ee493184";
+import {
+  getAccessRoute,
+  getGeneralRoute,
+  getGithubCommitQueueRoute,
+  getNotificationsRoute,
+  project,
+  projectUseRepoEnabled,
+  repo,
+} from "./constants";
 
 describe("Access page", () => {
   const destination = getAccessRoute(projectUseRepoEnabled);
@@ -976,32 +971,6 @@ describe("Renaming the identifier", () => {
 
   it("Redirects to a new URL", () => {
     cy.url().should("include", "new-identifier");
-  });
-});
-
-describe("Duplicating a project with errors", () => {
-  const destination = getGeneralRoute(project);
-
-  before(() => {
-    cy.login();
-    cy.visit(destination);
-  });
-
-  it("Shows the copy modal when the button and dropdown menu are clicked", () => {
-    cy.dataCy("new-project-button").click();
-    cy.dataCy("new-project-menu").should("be.visible");
-    cy.dataCy("copy-project-button").click();
-    cy.dataCy("copy-project-modal").should("be.visible");
-  });
-
-  it("Successfully copies the project and shows a warning toast", () => {
-    cy.dataCy("project-name-input").type("copied-project");
-    cy.contains("button", "Duplicate").click();
-    cy.validateToast("warning");
-  });
-
-  it("Redirects to a new URL", () => {
-    cy.url().should("include", "copied-project");
   });
 });
 

--- a/src/pages/projectSettings/CreateDuplicateProjectButton.tsx
+++ b/src/pages/projectSettings/CreateDuplicateProjectButton.tsx
@@ -84,12 +84,14 @@ export const CreateDuplicateProjectButton: React.VFC<Props> = ({
           </MenuItem>
         </Menu>
       )}
-      <CreateProjectModal
-        handleClose={() => setCreateModalOpen(false)}
-        open={createModalOpen}
-        owner={owner}
-        repo={repo}
-      />
+      {owner && repo && (
+        <CreateProjectModal
+          handleClose={() => setCreateModalOpen(false)}
+          open={createModalOpen}
+          owner={owner}
+          repo={repo}
+        />
+      )}
       <CopyProjectModal
         handleClose={() => setCopyModalOpen(false)}
         id={id}

--- a/src/pages/projectSettings/CreateProjectModal.test.tsx
+++ b/src/pages/projectSettings/CreateProjectModal.test.tsx
@@ -11,13 +11,6 @@ import {
 import { selectLGOption } from "test_utils/utils";
 import { CreateProjectModal } from "./CreateProjectModal";
 
-// Mock out useNavigate to prevent a warning when the page is redirected to the new project on success.
-const mockedUseNavigate = jest.fn();
-jest.mock("react-router-dom", () => ({
-  ...jest.requireActual("react-router-dom"),
-  useNavigate: () => mockedUseNavigate,
-}));
-
 const defaultOwner = "evergreen-ci";
 const defaultRepo = "spruce";
 
@@ -140,7 +133,7 @@ describe("createProjectField", () => {
     const { Component, dispatchToast } = RenderFakeToastContext(
       <NewProjectModal />
     );
-    render(<Component />);
+    const { history } = render(<Component />);
 
     await waitFor(() =>
       expect(screen.queryByDataCy("create-project-modal")).toBeVisible()
@@ -162,7 +155,9 @@ describe("createProjectField", () => {
     userEvent.click(screen.queryByText("Create Project"));
     await waitFor(() => expect(dispatchToast.success).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(dispatchToast.error).toHaveBeenCalledTimes(0));
-    expect(mockedUseNavigate).toHaveBeenCalledTimes(1);
+    expect(history.location.pathname).toBe(
+      "/project/new-project-name/settings"
+    );
   });
 
   it("form submission succeeds when all fields are updated", async () => {
@@ -189,7 +184,7 @@ describe("createProjectField", () => {
     const { Component, dispatchToast } = RenderFakeToastContext(
       <NewProjectModal mock={mockWithId} />
     );
-    render(<Component />);
+    const { history } = render(<Component />);
 
     await waitFor(() =>
       expect(screen.queryByDataCy("create-project-modal")).toBeVisible()
@@ -212,7 +207,9 @@ describe("createProjectField", () => {
     userEvent.click(screen.queryByText("Create Project"));
     await waitFor(() => expect(dispatchToast.success).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(dispatchToast.error).toHaveBeenCalledTimes(0));
-    expect(mockedUseNavigate).toHaveBeenCalledTimes(1);
+    expect(history.location.pathname).toBe(
+      "/project/new-project-name/settings"
+    );
   });
 });
 

--- a/src/pages/projectSettings/CreateProjectModal.test.tsx
+++ b/src/pages/projectSettings/CreateProjectModal.test.tsx
@@ -11,6 +11,7 @@ import {
 import { selectLGOption } from "test_utils/utils";
 import { CreateProjectModal } from "./CreateProjectModal";
 
+// Mock out useNavigate to prevent a warning when the page is redirected to the new project on success.
 const mockedUseNavigate = jest.fn();
 jest.mock("react-router-dom", () => ({
   ...jest.requireActual("react-router-dom"),
@@ -80,10 +81,10 @@ describe("createProjectField", () => {
       expect(screen.queryByDataCy("create-project-modal")).toBeVisible()
     );
 
-    expect(screen.queryByDataCy("owner-select")).toHaveTextContent(
+    expect(screen.queryByDataCy("new-owner-select")).toHaveTextContent(
       defaultOwner
     );
-    expect(screen.queryByDataCy("repo-input")).toHaveValue(defaultRepo);
+    expect(screen.queryByDataCy("new-repo-input")).toHaveValue(defaultRepo);
   });
 
   it("disables the confirm button when repo field is missing", async () => {
@@ -97,7 +98,7 @@ describe("createProjectField", () => {
       screen.queryByDataCy("project-name-input"),
       "new-project-name-input"
     );
-    userEvent.clear(screen.queryByDataCy("repo-input"));
+    userEvent.clear(screen.queryByDataCy("new-repo-input"));
     expect(
       screen.getByRole("button", {
         name: "Create Project",
@@ -145,9 +146,9 @@ describe("createProjectField", () => {
       expect(screen.queryByDataCy("create-project-modal")).toBeVisible()
     );
 
-    await selectLGOption("owner-select", "10gen");
-    userEvent.clear(screen.queryByDataCy("repo-input"));
-    userEvent.type(screen.queryByDataCy("repo-input"), "new-repo-name");
+    await selectLGOption("new-owner-select", "10gen");
+    userEvent.clear(screen.queryByDataCy("new-repo-input"));
+    userEvent.type(screen.queryByDataCy("new-repo-input"), "new-repo-name");
     userEvent.type(
       screen.queryByDataCy("project-name-input"),
       "new-project-name"
@@ -198,9 +199,9 @@ describe("createProjectField", () => {
       "new-project-name"
     );
     userEvent.type(screen.queryByDataCy("project-id-input"), "new-project-id");
-    await selectLGOption("owner-select", "10gen");
-    userEvent.clear(screen.queryByDataCy("repo-input"));
-    userEvent.type(screen.queryByDataCy("repo-input"), "new-repo-name");
+    await selectLGOption("new-owner-select", "10gen");
+    userEvent.clear(screen.queryByDataCy("new-repo-input"));
+    userEvent.type(screen.queryByDataCy("new-repo-input"), "new-repo-name");
 
     expect(
       screen.getByRole("button", {

--- a/src/pages/projectSettings/CreateProjectModal.test.tsx
+++ b/src/pages/projectSettings/CreateProjectModal.test.tsx
@@ -1,25 +1,37 @@
 import { MockedProvider, MockedResponse } from "@apollo/client/testing";
-import userEvent from "@testing-library/user-event";
 import { RenderFakeToastContext } from "context/toast/__mocks__";
 import { CREATE_PROJECT } from "gql/mutations";
-import { renderWithRouterMatch as render, screen, waitFor } from "test_utils";
+import { GET_GITHUB_ORGS } from "gql/queries";
+import {
+  renderWithRouterMatch as render,
+  screen,
+  userEvent,
+  waitFor,
+} from "test_utils";
+import { selectLGOption } from "test_utils/utils";
 import { CreateProjectModal } from "./CreateProjectModal";
 
-const defaultOwner = "existing_owner";
-const defaultRepo = "existing_repo";
+const mockedUseNavigate = jest.fn();
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockedUseNavigate,
+}));
+
+const defaultOwner = "evergreen-ci";
+const defaultRepo = "spruce";
 
 const NewProjectModal = ({
   mock = createProjectMock,
   open = true,
-  owner,
-  repo,
+  owner = defaultOwner,
+  repo = defaultRepo,
 }: {
   mock?: MockedResponse;
   open?: boolean;
   owner?: string;
   repo?: string;
 }) => (
-  <MockedProvider mocks={[mock]}>
+  <MockedProvider mocks={[getGithubOrgsMock, mock]}>
     <CreateProjectModal
       handleClose={() => {}}
       open={open}
@@ -30,6 +42,10 @@ const NewProjectModal = ({
 );
 
 describe("createProjectField", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it("does not render the modal when open prop is false", () => {
     const { Component } = RenderFakeToastContext(
       <NewProjectModal open={false} />
@@ -41,76 +57,82 @@ describe("createProjectField", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("disables the confirm button on initial render", () => {
+  it("disables the confirm button on initial render", async () => {
     const { Component } = RenderFakeToastContext(<NewProjectModal />);
     render(<Component />);
 
-    expect(screen.queryByText("Project Name")).toBeVisible();
+    await waitFor(() =>
+      expect(screen.queryByDataCy("create-project-modal")).toBeVisible()
+    );
 
-    const confirmButton = screen.getByRole("button", {
-      name: "Create Project",
-    });
-    expect(confirmButton).toBeDisabled();
+    expect(
+      screen.getByRole("button", {
+        name: "Create Project",
+      })
+    ).toBeDisabled();
   });
 
-  it("disables the confirm button when project name field is missing", () => {
+  it("pre-fills the owner and repo", async () => {
     const { Component } = RenderFakeToastContext(<NewProjectModal />);
     render(<Component />);
 
-    expect(screen.queryByText("Project Name")).toBeVisible();
-    userEvent.type(screen.queryByDataCy("repo-input"), "new-repo-name");
-    userEvent.type(screen.queryByDataCy("owner-input"), "new-owner-name");
-    const confirmButton = screen.getByRole("button", {
-      name: "Create Project",
-    });
-    expect(confirmButton).toBeDisabled();
+    await waitFor(() =>
+      expect(screen.queryByDataCy("create-project-modal")).toBeVisible()
+    );
+
+    expect(screen.queryByDataCy("owner-select")).toHaveTextContent(
+      defaultOwner
+    );
+    expect(screen.queryByDataCy("repo-input")).toHaveValue(defaultRepo);
   });
 
-  it("disables the confirm button when repo field is missing", () => {
+  it("disables the confirm button when repo field is missing", async () => {
     const { Component } = RenderFakeToastContext(<NewProjectModal />);
     render(<Component />);
 
-    expect(screen.queryByText("Project Name")).toBeVisible();
+    await waitFor(() =>
+      expect(screen.queryByDataCy("create-project-modal")).toBeVisible()
+    );
     userEvent.type(
       screen.queryByDataCy("project-name-input"),
       "new-project-name-input"
     );
-    userEvent.type(screen.queryByDataCy("owner-input"), "new-owner-name");
-    expect(screen.queryByDataCy("repo-input")).toHaveValue("");
-    const confirmButton = screen.getByRole("button", {
-      name: "Create Project",
-    });
-    expect(confirmButton).toBeDisabled();
+    userEvent.clear(screen.queryByDataCy("repo-input"));
+    expect(
+      screen.getByRole("button", {
+        name: "Create Project",
+      })
+    ).toBeDisabled();
   });
 
-  it("disables the confirm button when owner field is missing", () => {
+  it("disables the confirm button when project name field is missing", async () => {
     const { Component } = RenderFakeToastContext(<NewProjectModal />);
     render(<Component />);
 
-    expect(screen.queryByText("Project Name")).toBeVisible();
-    userEvent.type(
-      screen.queryByDataCy("project-name-input"),
-      "new-project-name-input"
+    await waitFor(() =>
+      expect(screen.queryByDataCy("create-project-modal")).toBeVisible()
     );
-    userEvent.type(screen.queryByDataCy("repo-input"), "new-repo-name");
-    const confirmButton = screen.getByRole("button", {
-      name: "Create Project",
-    });
-    expect(confirmButton).toBeDisabled();
+    expect(screen.queryByDataCy("project-name-input")).toHaveValue("");
+    expect(
+      screen.getByRole("button", {
+        name: "Create Project",
+      })
+    ).toBeDisabled();
   });
 
-  it("disables the confirm button when project name contains a space", () => {
+  it("disables the confirm button when project name contains a space", async () => {
     const { Component } = RenderFakeToastContext(<NewProjectModal />);
     render(<Component />);
 
-    expect(screen.queryByText("Project Name")).toBeVisible();
+    await waitFor(() =>
+      expect(screen.queryByDataCy("create-project-modal")).toBeVisible()
+    );
     userEvent.type(screen.queryByDataCy("project-name-input"), "my test");
-    userEvent.type(screen.queryByDataCy("repo-input"), "new-repo-name");
-    userEvent.type(screen.queryByDataCy("owner-input"), "new-owner-name");
-    const confirmButton = screen.getByRole("button", {
-      name: "Create Project",
-    });
-    expect(confirmButton).toBeDisabled();
+    expect(
+      screen.getByRole("button", {
+        name: "Create Project",
+      })
+    ).toBeDisabled();
   });
 
   it("enables the confirm button if the optional project id is empty", async () => {
@@ -119,21 +141,27 @@ describe("createProjectField", () => {
     );
     render(<Component />);
 
-    expect(screen.queryByText("Project Name")).toBeVisible();
+    await waitFor(() =>
+      expect(screen.queryByDataCy("create-project-modal")).toBeVisible()
+    );
+
+    await selectLGOption("owner-select", "10gen");
+    userEvent.clear(screen.queryByDataCy("repo-input"));
+    userEvent.type(screen.queryByDataCy("repo-input"), "new-repo-name");
     userEvent.type(
       screen.queryByDataCy("project-name-input"),
-      "new-project-name-input"
+      "new-project-name"
     );
-    userEvent.type(screen.queryByDataCy("repo-input"), "new-repo-name");
-    userEvent.type(screen.queryByDataCy("owner-input"), "new-owner-name");
-    const confirmButton = screen.getByRole("button", {
-      name: "Create Project",
-    });
-    expect(confirmButton).toBeEnabled();
+    expect(
+      screen.getByRole("button", {
+        name: "Create Project",
+      })
+    ).toBeEnabled();
 
     userEvent.click(screen.queryByText("Create Project"));
     await waitFor(() => expect(dispatchToast.success).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(dispatchToast.error).toHaveBeenCalledTimes(0));
+    expect(mockedUseNavigate).toHaveBeenCalledTimes(1);
   });
 
   it("form submission succeeds when all fields are updated", async () => {
@@ -142,9 +170,9 @@ describe("createProjectField", () => {
         query: CREATE_PROJECT,
         variables: {
           project: {
-            identifier: "new-project-name-input",
-            id: "new-project-id-input",
-            owner: "new-owner-name",
+            id: "new-project-id",
+            identifier: "new-project-name",
+            owner: "10gen",
             repo: "new-repo-name",
           },
         },
@@ -152,7 +180,7 @@ describe("createProjectField", () => {
       result: {
         data: {
           createProject: {
-            identifier: "new-project-name-input",
+            identifier: "new-project-name",
           },
         },
       },
@@ -162,37 +190,28 @@ describe("createProjectField", () => {
     );
     render(<Component />);
 
-    expect(screen.queryByText("Project Name")).toBeVisible();
+    await waitFor(() =>
+      expect(screen.queryByDataCy("create-project-modal")).toBeVisible()
+    );
     userEvent.type(
       screen.queryByDataCy("project-name-input"),
-      "new-project-name-input"
+      "new-project-name"
     );
-    userEvent.type(
-      screen.queryByDataCy("project-id-input"),
-      "new-project-id-input"
-    );
+    userEvent.type(screen.queryByDataCy("project-id-input"), "new-project-id");
+    await selectLGOption("owner-select", "10gen");
+    userEvent.clear(screen.queryByDataCy("repo-input"));
     userEvent.type(screen.queryByDataCy("repo-input"), "new-repo-name");
-    userEvent.type(screen.queryByDataCy("owner-input"), "new-owner-name");
 
-    const confirmButton = screen.getByRole("button", {
-      name: "Create Project",
-    });
-    expect(confirmButton).toBeEnabled();
+    expect(
+      screen.getByRole("button", {
+        name: "Create Project",
+      })
+    ).toBeEnabled();
 
     userEvent.click(screen.queryByText("Create Project"));
     await waitFor(() => expect(dispatchToast.success).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(dispatchToast.error).toHaveBeenCalledTimes(0));
-  });
-
-  it("pre-fills the owner and repo when available", () => {
-    const { Component } = RenderFakeToastContext(
-      <NewProjectModal owner={defaultOwner} repo={defaultRepo} />
-    );
-    render(<Component />);
-
-    expect(screen.queryByText("Project Name")).toBeVisible();
-    expect(screen.queryByDataCy("owner-input")).toHaveValue(defaultOwner);
-    expect(screen.queryByDataCy("repo-input")).toHaveValue(defaultRepo);
+    expect(mockedUseNavigate).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -201,8 +220,8 @@ const createProjectMock = {
     query: CREATE_PROJECT,
     variables: {
       project: {
-        identifier: "new-project-name-input",
-        owner: "new-owner-name",
+        identifier: "new-project-name",
+        owner: "10gen",
         repo: "new-repo-name",
       },
     },
@@ -210,7 +229,20 @@ const createProjectMock = {
   result: {
     data: {
       createProject: {
-        identifier: "new-project-name-input",
+        identifier: "new-project-name",
+      },
+    },
+  },
+};
+
+const getGithubOrgsMock = {
+  request: {
+    query: GET_GITHUB_ORGS,
+  },
+  result: {
+    data: {
+      spruceConfig: {
+        githubOrgs: ["evergreen-ci", "10gen"],
       },
     },
   },

--- a/src/pages/projectSettings/CreateProjectModal.tsx
+++ b/src/pages/projectSettings/CreateProjectModal.tsx
@@ -41,7 +41,9 @@ export const CreateProjectModal: React.VFC<Props> = ({
   });
   const [hasError, setHasError] = useState(true);
 
-  const { data } = useQuery<GetGithubOrgsQuery>(GET_GITHUB_ORGS);
+  const { data } = useQuery<GetGithubOrgsQuery>(GET_GITHUB_ORGS, {
+    skip: !open,
+  });
   const { spruceConfig: { githubOrgs = [] } = {} } = data ?? {};
 
   const form = modalFormDefinition(githubOrgs);
@@ -131,11 +133,11 @@ const modalFormDefinition = (githubOrgs: string[]) => ({
     projectName: projectName.uiSchema,
     projectId: projectId.uiSchema,
     owner: {
-      "ui:data-cy": "owner-select",
+      "ui:data-cy": "new-owner-select",
       "ui:allowDeselect": false,
     },
     repo: {
-      "ui:data-cy": "repo-input",
+      "ui:data-cy": "new-repo-input",
     },
   },
 });

--- a/src/pages/projectSettings/tabs/GeneralTab/Fields/RepoConfigField.tsx
+++ b/src/pages/projectSettings/tabs/GeneralTab/Fields/RepoConfigField.tsx
@@ -53,13 +53,23 @@ export const RepoConfigField: Field = ({
         <>
           <ButtonRow>
             {isAttachedProject && !!githubOrgs.length && (
-              <Button
-                onClick={() => setMoveModalOpen(true)}
-                size="small"
-                data-cy="move-repo-button"
-              >
-                Move to New Repo
-              </Button>
+              <>
+                <Button
+                  onClick={() => setMoveModalOpen(true)}
+                  size="small"
+                  data-cy="move-repo-button"
+                >
+                  Move to New Repo
+                </Button>
+                <MoveRepoModal
+                  githubOrgs={githubOrgs}
+                  handleClose={() => setMoveModalOpen(false)}
+                  open={moveModalOpen}
+                  projectId={projectId}
+                  repoName={repoName}
+                  repoOwner={repoOwner}
+                />
+              </>
             )}
             <ConditionalWrapper
               condition={ownerOrRepoHasChanges}
@@ -91,14 +101,6 @@ export const RepoConfigField: Field = ({
               </ButtonWrapper>
             </ConditionalWrapper>
           </ButtonRow>
-          <MoveRepoModal
-            githubOrgs={githubOrgs}
-            handleClose={() => setMoveModalOpen(false)}
-            open={moveModalOpen}
-            projectId={projectId}
-            repoName={repoName}
-            repoOwner={repoOwner}
-          />
           <AttachDetachModal
             handleClose={() => setAttachModalOpen(false)}
             open={attachModalOpen}

--- a/src/test_utils/index.tsx
+++ b/src/test_utils/index.tsx
@@ -61,6 +61,7 @@ const renderWithRouterMatch = (
           }
           path={path}
         />
+        <Route element={<div>Not Found</div>} path="*" />
       </Routes>
     </HistoryRouter>
   );


### PR DESCRIPTION
EVG-17549

### Description
<!-- add description, context, thought process, etc -->
- Update Create Project and Move Project modals to use dropdown for selecting which GitHub org should be used.

### Screenshots
<!-- add screenshots of visible changes -->
<img width="1519" alt="image" src="https://user-images.githubusercontent.com/9298431/215122946-630e7cca-d36f-4e03-ac6e-c95647040407.png">

<img width="1519" alt="image" src="https://user-images.githubusercontent.com/9298431/215123069-fce626e6-8a09-4e35-ac69-6ca7a8be3db5.png">

### Testing
<!-- add a description of how you tested it -->

### Evergreen PR
<!-- link to a corresponding Evergreen PR if applicable -->
