### PR TITLE
EVG-16434: Use projectIdentifier in place of projectID where appropriate

### DIFF
--- a/src/analytics/patches/useProjectPatchesAnalytics.ts
+++ b/src/analytics/patches/useProjectPatchesAnalytics.ts
@@ -23,7 +23,7 @@ export const useProjectPatchesAnalytics = (): Analytics => {
     addPageAction<Action, P>(action, {
       object: "ProjectPatches",
       userId,
-      projectId: projectIdentifier,
+      projectIdentifier,
     });
   };
 

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -214,11 +214,11 @@ export const getProjectSettingsRoute = (
   return `${paths.project}/${projectId}/${PageNames.Settings}/${tab}`;
 };
 
-export const getCommitQueueRoute = (projectId: string) =>
-  `${paths.commitQueue}/${projectId}`;
+export const getCommitQueueRoute = (projectIdentifier: string) =>
+  `${paths.commitQueue}/${projectIdentifier}`;
 
-export const getCommitsRoute = (projectId: string = "") =>
-  `${paths.commits}/${projectId}`;
+export const getCommitsRoute = (projectIdentifier: string = "") =>
+  `${paths.commits}/${projectIdentifier}`;
 
 const getHistoryRoute = (
   basePath: string,

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -501,7 +501,8 @@ export type MainlineCommits = {
  */
 export type MainlineCommitsOptions = {
   limit?: InputMaybe<Scalars["Int"]>;
-  projectID: Scalars["String"];
+  projectID?: InputMaybe<Scalars["String"]>;
+  projectIdentifier?: InputMaybe<Scalars["String"]>;
   requesters?: InputMaybe<Array<Scalars["String"]>>;
   shouldCollapse?: InputMaybe<Scalars["Boolean"]>;
   skipOrderNumber?: InputMaybe<Scalars["Int"]>;
@@ -1276,12 +1277,14 @@ export type QueryBuildBaronArgs = {
 };
 
 export type QueryBuildVariantsForTaskNameArgs = {
-  projectId: Scalars["String"];
+  projectId?: InputMaybe<Scalars["String"]>;
+  projectIdentifier?: InputMaybe<Scalars["String"]>;
   taskName: Scalars["String"];
 };
 
 export type QueryCommitQueueArgs = {
-  id: Scalars["String"];
+  id?: InputMaybe<Scalars["String"]>;
+  projectIdentifier?: InputMaybe<Scalars["String"]>;
 };
 
 export type QueryDistroTaskQueueArgs = {
@@ -1333,7 +1336,8 @@ export type QueryPatchArgs = {
 };
 
 export type QueryProjectArgs = {
-  projectId: Scalars["String"];
+  projectId?: InputMaybe<Scalars["String"]>;
+  projectIdentifier?: InputMaybe<Scalars["String"]>;
 };
 
 export type QueryProjectEventsArgs = {
@@ -1377,7 +1381,8 @@ export type QueryTaskLogsArgs = {
 
 export type QueryTaskNamesForBuildVariantArgs = {
   buildVariant: Scalars["String"];
-  projectId: Scalars["String"];
+  projectId?: InputMaybe<Scalars["String"]>;
+  projectIdentifier?: InputMaybe<Scalars["String"]>;
 };
 
 export type QueryTaskTestSampleArgs = {
@@ -3882,7 +3887,7 @@ export type GetBuildVariantStatsQuery = {
 };
 
 export type GetBuildVariantsForTaskNameQueryVariables = Exact<{
-  projectId: Scalars["String"];
+  projectIdentifier: Scalars["String"];
   taskName: Scalars["String"];
 }>;
 
@@ -3988,7 +3993,7 @@ export type CodeChangesQuery = {
 };
 
 export type CommitQueueQueryVariables = Exact<{
-  id: Scalars["String"];
+  projectIdentifier: Scalars["String"];
 }>;
 
 export type CommitQueueQuery = {
@@ -5680,7 +5685,7 @@ export type TaskLogsQuery = {
 };
 
 export type GetTaskNamesForBuildVariantQueryVariables = Exact<{
-  projectId: Scalars["String"];
+  projectIdentifier: Scalars["String"];
   buildVariant: Scalars["String"];
 }>;
 
@@ -6180,7 +6185,7 @@ export type HostsQuery = {
 };
 
 export type ProjectPatchesQueryVariables = Exact<{
-  projectId: Scalars["String"];
+  projectIdentifier: Scalars["String"];
   patchesInput: PatchesInput;
 }>;
 

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -501,6 +501,7 @@ export type MainlineCommits = {
  */
 export type MainlineCommitsOptions = {
   limit?: InputMaybe<Scalars["Int"]>;
+  /** @deprecated projectID is deprecated. Use projectIdentifier instead. */
   projectID?: InputMaybe<Scalars["String"]>;
   projectIdentifier?: InputMaybe<Scalars["String"]>;
   requesters?: InputMaybe<Array<Scalars["String"]>>;

--- a/src/gql/queries/get-build-variants-for-task-name.graphql
+++ b/src/gql/queries/get-build-variants-for-task-name.graphql
@@ -1,5 +1,11 @@
-query GetBuildVariantsForTaskName($projectId: String!, $taskName: String!) {
-  buildVariantsForTaskName(projectId: $projectId, taskName: $taskName) {
+query GetBuildVariantsForTaskName(
+  $projectIdentifier: String!
+  $taskName: String!
+) {
+  buildVariantsForTaskName(
+    projectIdentifier: $projectIdentifier
+    taskName: $taskName
+  ) {
     displayName
     buildVariant
   }

--- a/src/gql/queries/get-commit-queue.graphql
+++ b/src/gql/queries/get-commit-queue.graphql
@@ -1,7 +1,7 @@
 #import "../fragments/moduleCodeChanges.graphql"
 
-query CommitQueue($id: String!) {
-  commitQueue(id: $id) {
+query CommitQueue($projectIdentifier: String!) {
+  commitQueue(projectIdentifier: $projectIdentifier) {
     projectId
     message
     owner

--- a/src/gql/queries/get-last-mainline-commit.graphql
+++ b/src/gql/queries/get-last-mainline-commit.graphql
@@ -5,7 +5,7 @@ query GetLastMainlineCommit(
 ) {
   mainlineCommits(
     options: {
-      projectID: $projectIdentifier
+      projectIdentifier: $projectIdentifier
       limit: 1
       skipOrderNumber: $skipOrderNumber
       shouldCollapse: true

--- a/src/gql/queries/get-task-names-for-build-variant.graphql
+++ b/src/gql/queries/get-task-names-for-build-variant.graphql
@@ -1,3 +1,9 @@
-query GetTaskNamesForBuildVariant($projectId: String!, $buildVariant: String!) {
-  taskNamesForBuildVariant(projectId: $projectId, buildVariant: $buildVariant)
+query GetTaskNamesForBuildVariant(
+  $projectIdentifier: String!
+  $buildVariant: String!
+) {
+  taskNamesForBuildVariant(
+    projectIdentifier: $projectIdentifier
+    buildVariant: $buildVariant
+  )
 }

--- a/src/gql/queries/project-patches.graphql
+++ b/src/gql/queries/project-patches.graphql
@@ -1,11 +1,14 @@
 #import "../fragments/patchesPage.graphql"
 
-query ProjectPatches($projectId: String!, $patchesInput: PatchesInput!) {
-    project(projectId: $projectId) {
-      id
-      displayName
-      patches(patchesInput: $patchesInput) {
-        ...PatchesPagePatches
-      }
+query ProjectPatches(
+  $projectIdentifier: String!
+  $patchesInput: PatchesInput!
+) {
+  project(projectIdentifier: $projectIdentifier) {
+    id
+    displayName
+    patches(patchesInput: $patchesInput) {
+      ...PatchesPagePatches
     }
   }
+}

--- a/src/pages/CommitQueue.tsx
+++ b/src/pages/CommitQueue.tsx
@@ -24,7 +24,7 @@ export const CommitQueue: React.VFC = () => {
     CommitQueueQuery,
     CommitQueueQueryVariables
   >(GET_COMMIT_QUEUE, {
-    variables: { id: projectIdentifier },
+    variables: { projectIdentifier },
     onError: (err) => {
       dispatchToast.error(
         `There was an error loading the commit queue: ${err.message}`

--- a/src/pages/Commits.tsx
+++ b/src/pages/Commits.tsx
@@ -103,7 +103,7 @@ export const Commits = () => {
   };
   const variables = getMainlineCommitsQueryVariables({
     mainlineCommitOptions: {
-      projectID: projectIdentifier,
+      projectIdentifier,
       skipOrderNumber,
       limit: 5,
     },

--- a/src/pages/ProjectPatches.tsx
+++ b/src/pages/ProjectPatches.tsx
@@ -31,7 +31,7 @@ export const ProjectPatches = () => {
     ProjectPatchesQueryVariables
   >(GET_PROJECT_PATCHES, {
     variables: {
-      projectId: projectIdentifier,
+      projectIdentifier,
       patchesInput: {
         ...patchesInput,
         onlyCommitQueue: isCommitQueueCheckboxChecked,

--- a/src/pages/TaskHistory.tsx
+++ b/src/pages/TaskHistory.tsx
@@ -53,7 +53,7 @@ const TaskHistoryContents: React.VFC = () => {
   >(GET_MAINLINE_COMMITS_FOR_HISTORY, {
     variables: {
       mainlineCommitsOptions: {
-        projectID: projectIdentifier,
+        projectIdentifier,
         limit: 10,
         skipOrderNumber: nextPageOrderNumber,
         shouldCollapse: true,
@@ -81,7 +81,7 @@ const TaskHistoryContents: React.VFC = () => {
               }}
             />
             <BuildVariantSelector
-              projectId={projectIdentifier}
+              projectIdentifier={projectIdentifier}
               taskName={taskName}
             />
           </PageHeaderContent>
@@ -110,7 +110,10 @@ const TaskHistoryContents: React.VFC = () => {
           />
         </PaginationFilterWrapper>
         <div>
-          <ColumnHeaders projectId={projectIdentifier} taskName={taskName} />
+          <ColumnHeaders
+            projectIdentifier={projectIdentifier}
+            taskName={taskName}
+          />
 
           <TableWrapper>
             {error && <div>Failed to retrieve mainline commit history.</div>}

--- a/src/pages/VariantHistory.tsx
+++ b/src/pages/VariantHistory.tsx
@@ -52,7 +52,7 @@ const VariantHistoryContents: React.VFC = () => {
   >(GET_MAINLINE_COMMITS_FOR_HISTORY, {
     variables: {
       mainlineCommitsOptions: {
-        projectID: projectIdentifier,
+        projectIdentifier,
         limit: 10,
         skipOrderNumber: nextPageOrderNumber,
         shouldCollapse: true,
@@ -80,7 +80,7 @@ const VariantHistoryContents: React.VFC = () => {
               }}
             />
             <TaskSelector
-              projectId={projectIdentifier}
+              projectIdentifier={projectIdentifier}
               buildVariant={variantName}
             />
           </PageHeaderContent>
@@ -110,7 +110,7 @@ const VariantHistoryContents: React.VFC = () => {
         </PaginationFilterWrapper>
         <div>
           <ColumnHeaders
-            projectId={projectIdentifier}
+            projectIdentifier={projectIdentifier}
             variantName={variantName}
           />
           <TableWrapper>

--- a/src/pages/commits/utils.test.ts
+++ b/src/pages/commits/utils.test.ts
@@ -60,7 +60,7 @@ describe("getMainlineCommitsQueryVariables", () => {
       expect(
         getMainlineCommitsQueryVariables({
           mainlineCommitOptions: {
-            projectID: "projectID",
+            projectIdentifier: "projectIdentifier",
             limit: 5,
             skipOrderNumber: 0,
           },
@@ -73,7 +73,7 @@ describe("getMainlineCommitsQueryVariables", () => {
         }).mainlineCommitsOptions
       ).toStrictEqual({
         limit: 5,
-        projectID: "projectID",
+        projectIdentifier: "projectIdentifier",
         skipOrderNumber: 0,
         shouldCollapse: false,
         requesters: [],
@@ -83,7 +83,7 @@ describe("getMainlineCommitsQueryVariables", () => {
       expect(
         getMainlineCommitsQueryVariables({
           mainlineCommitOptions: {
-            projectID: "projectID",
+            projectIdentifier: "projectIdentifier",
             limit: 5,
             skipOrderNumber: 0,
           },
@@ -96,7 +96,7 @@ describe("getMainlineCommitsQueryVariables", () => {
         }).mainlineCommitsOptions
       ).toStrictEqual({
         limit: 5,
-        projectID: "projectID",
+        projectIdentifier: "projectIdentifier",
         skipOrderNumber: 0,
         shouldCollapse: true,
         requesters: [],
@@ -104,7 +104,7 @@ describe("getMainlineCommitsQueryVariables", () => {
       expect(
         getMainlineCommitsQueryVariables({
           mainlineCommitOptions: {
-            projectID: "projectID",
+            projectIdentifier: "projectIdentifier",
             limit: 5,
             skipOrderNumber: 0,
           },
@@ -117,7 +117,7 @@ describe("getMainlineCommitsQueryVariables", () => {
         }).mainlineCommitsOptions
       ).toStrictEqual({
         limit: 5,
-        projectID: "projectID",
+        projectIdentifier: "projectIdentifier",
         skipOrderNumber: 0,
         shouldCollapse: true,
         requesters: [],
@@ -125,7 +125,7 @@ describe("getMainlineCommitsQueryVariables", () => {
       expect(
         getMainlineCommitsQueryVariables({
           mainlineCommitOptions: {
-            projectID: "projectID",
+            projectIdentifier: "projectIdentifier",
             limit: 5,
             skipOrderNumber: 0,
           },
@@ -138,7 +138,7 @@ describe("getMainlineCommitsQueryVariables", () => {
         }).mainlineCommitsOptions
       ).toStrictEqual({
         limit: 5,
-        projectID: "projectID",
+        projectIdentifier: "projectIdentifier",
         skipOrderNumber: 0,
         shouldCollapse: true,
         requesters: [],
@@ -146,7 +146,7 @@ describe("getMainlineCommitsQueryVariables", () => {
       expect(
         getMainlineCommitsQueryVariables({
           mainlineCommitOptions: {
-            projectID: "projectID",
+            projectIdentifier: "projectIdentifier",
             limit: 5,
             skipOrderNumber: 0,
           },
@@ -159,7 +159,7 @@ describe("getMainlineCommitsQueryVariables", () => {
         }).mainlineCommitsOptions
       ).toStrictEqual({
         limit: 5,
-        projectID: "projectID",
+        projectIdentifier: "projectIdentifier",
         skipOrderNumber: 0,
         shouldCollapse: true,
         requesters: [],
@@ -171,7 +171,7 @@ describe("getMainlineCommitsQueryVariables", () => {
       expect(
         getMainlineCommitsQueryVariables({
           mainlineCommitOptions: {
-            projectID: "projectID",
+            projectIdentifier: "projectIdentifier",
             limit: 5,
             skipOrderNumber: 0,
           },
@@ -191,7 +191,7 @@ describe("getMainlineCommitsQueryVariables", () => {
       expect(
         getMainlineCommitsQueryVariables({
           mainlineCommitOptions: {
-            projectID: "projectID",
+            projectIdentifier: "projectIdentifier",
             limit: 5,
             skipOrderNumber: 0,
           },
@@ -211,7 +211,7 @@ describe("getMainlineCommitsQueryVariables", () => {
       expect(
         getMainlineCommitsQueryVariables({
           mainlineCommitOptions: {
-            projectID: "projectID",
+            projectIdentifier: "projectIdentifier",
             limit: 5,
             skipOrderNumber: 0,
           },
@@ -235,7 +235,7 @@ describe("getMainlineCommitsQueryVariables", () => {
       expect(
         getMainlineCommitsQueryVariables({
           mainlineCommitOptions: {
-            projectID: "projectID",
+            projectIdentifier: "projectIdentifier",
             limit: 5,
             skipOrderNumber: 0,
           },
@@ -256,7 +256,7 @@ describe("getMainlineCommitsQueryVariables", () => {
       expect(
         getMainlineCommitsQueryVariables({
           mainlineCommitOptions: {
-            projectID: "projectID",
+            projectIdentifier: "projectIdentifier",
             limit: 5,
             skipOrderNumber: 0,
           },
@@ -275,7 +275,7 @@ describe("getMainlineCommitsQueryVariables", () => {
       expect(
         getMainlineCommitsQueryVariables({
           mainlineCommitOptions: {
-            projectID: "projectID",
+            projectIdentifier: "projectIdentifier",
             limit: 5,
             skipOrderNumber: 0,
           },
@@ -294,7 +294,7 @@ describe("getMainlineCommitsQueryVariables", () => {
       expect(
         getMainlineCommitsQueryVariables({
           mainlineCommitOptions: {
-            projectID: "projectID",
+            projectIdentifier: "projectIdentifier",
             limit: 5,
             skipOrderNumber: 0,
           },
@@ -317,7 +317,7 @@ describe("getMainlineCommitsQueryVariables", () => {
       expect(
         getMainlineCommitsQueryVariables({
           mainlineCommitOptions: {
-            projectID: "projectID",
+            projectIdentifier: "projectIdentifier",
             limit: 5,
             skipOrderNumber: 0,
           },
@@ -339,7 +339,7 @@ describe("getMainlineCommitsQueryVariables", () => {
       expect(
         getMainlineCommitsQueryVariables({
           mainlineCommitOptions: {
-            projectID: "projectID",
+            projectIdentifier: "projectIdentifier",
             limit: 5,
             skipOrderNumber: 0,
           },
@@ -361,7 +361,7 @@ describe("getMainlineCommitsQueryVariables", () => {
       expect(
         getMainlineCommitsQueryVariables({
           mainlineCommitOptions: {
-            projectID: "projectID",
+            projectIdentifier: "projectIdentifier",
             limit: 5,
             skipOrderNumber: 0,
           },
@@ -383,7 +383,7 @@ describe("getMainlineCommitsQueryVariables", () => {
       expect(
         getMainlineCommitsQueryVariables({
           mainlineCommitOptions: {
-            projectID: "projectID",
+            projectIdentifier: "projectIdentifier",
             limit: 5,
             skipOrderNumber: 0,
           },
@@ -403,7 +403,7 @@ describe("getMainlineCommitsQueryVariables", () => {
       expect(
         getMainlineCommitsQueryVariables({
           mainlineCommitOptions: {
-            projectID: "projectID",
+            projectIdentifier: "projectIdentifier",
             limit: 5,
             skipOrderNumber: 0,
           },
@@ -425,7 +425,7 @@ describe("getMainlineCommitsQueryVariables", () => {
       expect(
         getMainlineCommitsQueryVariables({
           mainlineCommitOptions: {
-            projectID: "projectID",
+            projectIdentifier: "projectIdentifier",
             limit: 5,
             skipOrderNumber: 0,
           },
@@ -450,7 +450,7 @@ describe("getMainlineCommitsQueryVariables", () => {
       expect(
         getMainlineCommitsQueryVariables({
           mainlineCommitOptions: {
-            projectID: "projectID",
+            projectIdentifier: "projectIdentifier",
             limit: 5,
             skipOrderNumber: 0,
           },
@@ -471,7 +471,7 @@ describe("getMainlineCommitsQueryVariables", () => {
       expect(
         getMainlineCommitsQueryVariables({
           mainlineCommitOptions: {
-            projectID: "projectID",
+            projectIdentifier: "projectIdentifier",
             limit: 5,
             skipOrderNumber: 0,
           },
@@ -492,7 +492,7 @@ describe("getMainlineCommitsQueryVariables", () => {
       expect(
         getMainlineCommitsQueryVariables({
           mainlineCommitOptions: {
-            projectID: "projectID",
+            projectIdentifier: "projectIdentifier",
             limit: 5,
             skipOrderNumber: 0,
           },
@@ -513,7 +513,7 @@ describe("getMainlineCommitsQueryVariables", () => {
       expect(
         getMainlineCommitsQueryVariables({
           mainlineCommitOptions: {
-            projectID: "projectID",
+            projectIdentifier: "projectIdentifier",
             limit: 5,
             skipOrderNumber: 0,
           },
@@ -534,7 +534,7 @@ describe("getMainlineCommitsQueryVariables", () => {
       expect(
         getMainlineCommitsQueryVariables({
           mainlineCommitOptions: {
-            projectID: "projectID",
+            projectIdentifier: "projectIdentifier",
             limit: 5,
             skipOrderNumber: 0,
           },
@@ -555,7 +555,7 @@ describe("getMainlineCommitsQueryVariables", () => {
       expect(
         getMainlineCommitsQueryVariables({
           mainlineCommitOptions: {
-            projectID: "projectID",
+            projectIdentifier: "projectIdentifier",
             limit: 5,
             skipOrderNumber: 0,
           },
@@ -574,7 +574,7 @@ describe("getMainlineCommitsQueryVariables", () => {
       expect(
         getMainlineCommitsQueryVariables({
           mainlineCommitOptions: {
-            projectID: "projectID",
+            projectIdentifier: "projectIdentifier",
             limit: 5,
             skipOrderNumber: 0,
           },

--- a/src/pages/commits/utils.ts
+++ b/src/pages/commits/utils.ts
@@ -11,7 +11,7 @@ interface FilterState {
   requesters: string[];
 }
 interface MainlineCommitOptions {
-  projectID: string;
+  projectIdentifier: string;
   limit: number;
   skipOrderNumber: number;
 }

--- a/src/pages/projectSettings/Tabs.tsx
+++ b/src/pages/projectSettings/Tabs.tsx
@@ -106,9 +106,11 @@ export const ProjectSettingsTabs: React.VFC<Props> = ({
                 projectData?.githubWebhooksEnabled ||
                 repoData?.githubWebhooksEnabled
               }
+              identifier={identifier || repoBranch}
               projectData={
                 tabData[ProjectSettingsTabRoutes.GithubCommitQueue].projectData
               }
+              projectId={projectId}
               projectType={projectType}
               repoData={
                 tabData[ProjectSettingsTabRoutes.GithubCommitQueue].repoData

--- a/src/pages/projectSettings/tabs/GithubCommitQueueTab/GithubCommitQueueTab.tsx
+++ b/src/pages/projectSettings/tabs/GithubCommitQueueTab/GithubCommitQueueTab.tsx
@@ -1,7 +1,6 @@
 import { useMemo } from "react";
 import { useQuery } from "@apollo/client";
 import Banner from "@leafygreen-ui/banner";
-import { useParams } from "react-router-dom";
 import { SpruceForm } from "components/SpruceForm";
 import { ValidateProps } from "components/SpruceForm/types";
 import { ProjectSettingsTabRoutes } from "constants/routes";
@@ -35,14 +34,13 @@ const getInitialFormState = (
 
 export const GithubCommitQueueTab: React.VFC<TabProps> = ({
   githubWebhooksEnabled,
+  identifier,
   projectData,
+  projectId,
   projectType,
   repoData,
   versionControlEnabled,
 }) => {
-  const { projectIdentifier: identifier } = useParams<{
-    projectIdentifier: string;
-  }>();
   const { getTab, updateForm } = useProjectSettingsContext();
   const { formData } = getTab(tab);
 
@@ -51,7 +49,7 @@ export const GithubCommitQueueTab: React.VFC<TabProps> = ({
     GithubProjectConflictsQueryVariables
   >(GET_GITHUB_PROJECT_CONFLICTS, {
     skip: projectType === ProjectType.Repo,
-    variables: { projectId: identifier },
+    variables: { projectId },
   });
 
   const initialFormState = useMemo(

--- a/src/pages/projectSettings/tabs/GithubCommitQueueTab/types.ts
+++ b/src/pages/projectSettings/tabs/GithubCommitQueueTab/types.ts
@@ -68,7 +68,9 @@ export interface FormState {
 
 export type TabProps = {
   githubWebhooksEnabled: boolean;
+  identifier: string;
   projectData?: FormState;
+  projectId: string;
   projectType: ProjectType;
   repoData?: FormState;
   versionControlEnabled: boolean;

--- a/src/pages/taskHistory/BuildVariantSelector.tsx
+++ b/src/pages/taskHistory/BuildVariantSelector.tsx
@@ -14,12 +14,12 @@ import { useQueryParam } from "hooks/useQueryParam";
 import { HistoryQueryParams } from "types/history";
 
 interface BuildVariantSelectorProps {
-  projectId: string;
+  projectIdentifier: string;
   taskName: string;
 }
 
 const BuildVariantSelector: React.VFC<BuildVariantSelectorProps> = ({
-  projectId,
+  projectIdentifier,
   taskName,
 }) => {
   const { sendEvent } = useProjectHealthAnalytics({ page: "Task history" });
@@ -33,7 +33,7 @@ const BuildVariantSelector: React.VFC<BuildVariantSelectorProps> = ({
     GetBuildVariantsForTaskNameQueryVariables
   >(GET_BUILD_VARIANTS_FOR_TASK_NAME, {
     variables: {
-      projectId,
+      projectIdentifier,
       taskName,
     },
   });

--- a/src/pages/taskHistory/ColumnHeaders.test.tsx
+++ b/src/pages/taskHistory/ColumnHeaders.test.tsx
@@ -20,7 +20,7 @@ const trimmedVariantName = trimStringFromMiddle(longVariantName, maxLength);
 describe("columnHeaders (Task History)", () => {
   it("renders an initial skeleton for the 7 column headers when loading", () => {
     const { Component } = RenderFakeToastContext(
-      <ColumnHeaders projectId="evergreen" taskName="some_task" />
+      <ColumnHeaders projectIdentifier="evergreen" taskName="some_task" />
     );
     render(<Component />, {
       route: "/task-history/evergreen/some_task",
@@ -32,7 +32,7 @@ describe("columnHeaders (Task History)", () => {
 
   it("renders the column headers properly when not loading", async () => {
     const { Component } = RenderFakeToastContext(
-      <ColumnHeaders projectId="evergreen" taskName="some_task" />
+      <ColumnHeaders projectIdentifier="evergreen" taskName="some_task" />
     );
 
     render(<Component />, {
@@ -61,7 +61,7 @@ describe("columnHeaders (Task History)", () => {
 
   it("should not show more columns then the columnLimit", async () => {
     const { Component } = RenderFakeToastContext(
-      <ColumnHeaders projectId="evergreen" taskName="some_task" />
+      <ColumnHeaders projectIdentifier="evergreen" taskName="some_task" />
     );
     render(<Component />, {
       route: "/task-history/evergreen/some_task",
@@ -91,7 +91,7 @@ describe("columnHeaders (Task History)", () => {
 
   it("should link to corresponding /variant-history/:projectId/:variantName page", async () => {
     const { Component } = RenderFakeToastContext(
-      <ColumnHeaders projectId="evergreen" taskName="some_task" />
+      <ColumnHeaders projectIdentifier="evergreen" taskName="some_task" />
     );
     render(<Component />, {
       route: "/task-history/evergreen/some_task",
@@ -122,7 +122,7 @@ describe("columnHeaders (Task History)", () => {
 
   it("should truncate the variant name only if it is too long", async () => {
     const { Component } = RenderFakeToastContext(
-      <ColumnHeaders projectId="evergreen" taskName="some_task" />
+      <ColumnHeaders projectIdentifier="evergreen" taskName="some_task" />
     );
     render(<Component />, {
       route: "/task-history/evergreen/some_task",
@@ -155,7 +155,7 @@ describe("columnHeaders (Task History)", () => {
 
   it("should show a tooltip with the full name when hovering over a truncated variant name", async () => {
     const { Component } = RenderFakeToastContext(
-      <ColumnHeaders projectId="evergreen" taskName="some_task" />
+      <ColumnHeaders projectIdentifier="evergreen" taskName="some_task" />
     );
     render(<Component />, {
       route: "/task-history/evergreen/some_task",
@@ -192,7 +192,7 @@ const mock = (
   request: {
     query: GET_BUILD_VARIANTS_FOR_TASK_NAME,
     variables: {
-      projectId: "evergreen",
+      projectIdentifier: "evergreen",
       taskName: "some_task",
     },
   },

--- a/src/pages/taskHistory/ColumnHeaders.tsx
+++ b/src/pages/taskHistory/ColumnHeaders.tsx
@@ -24,6 +24,7 @@ interface ColumnHeadersProps {
   projectIdentifier: string;
   taskName: string;
 }
+
 const ColumnHeaders: React.VFC<ColumnHeadersProps> = ({
   projectIdentifier,
   taskName,

--- a/src/pages/taskHistory/ColumnHeaders.tsx
+++ b/src/pages/taskHistory/ColumnHeaders.tsx
@@ -21,11 +21,11 @@ const { useHistoryTable } = context;
 const { LoadingCell, ColumnHeaderCell, LabelCellContainer } = Cell;
 
 interface ColumnHeadersProps {
-  projectId: string;
+  projectIdentifier: string;
   taskName: string;
 }
 const ColumnHeaders: React.VFC<ColumnHeadersProps> = ({
-  projectId,
+  projectIdentifier,
   taskName,
 }) => {
   const { sendEvent } = useProjectHealthAnalytics({ page: "Task history" });
@@ -37,7 +37,7 @@ const ColumnHeaders: React.VFC<ColumnHeadersProps> = ({
     GetBuildVariantsForTaskNameQueryVariables
   >(GET_BUILD_VARIANTS_FOR_TASK_NAME, {
     variables: {
-      projectId,
+      projectIdentifier,
       taskName,
     },
     onCompleted: ({ buildVariantsForTaskName }) => {
@@ -69,7 +69,7 @@ const ColumnHeaders: React.VFC<ColumnHeadersProps> = ({
         return (
           <ColumnHeaderCell
             key={`header_cell_${cell.displayName}`}
-            link={getVariantHistoryRoute(projectId, cell.buildVariant)}
+            link={getVariantHistoryRoute(projectIdentifier, cell.buildVariant)}
             trimmedDisplayName={trimStringFromMiddle(
               cell.displayName,
               maxLength

--- a/src/pages/variantHistory/ColumnHeaders.test.tsx
+++ b/src/pages/variantHistory/ColumnHeaders.test.tsx
@@ -19,7 +19,7 @@ const trimmedTaskName = trimStringFromMiddle(longTaskName, maxLength);
 describe("columnHeaders (Variant History)", () => {
   it("renders an initial skeleton for the 7 column headers when loading", () => {
     const { Component } = RenderFakeToastContext(
-      <ColumnHeaders projectId="evergreen" variantName="some_variant" />
+      <ColumnHeaders projectIdentifier="evergreen" variantName="some_variant" />
     );
     render(<Component />, {
       wrapper: ProviderWrapper,
@@ -29,7 +29,7 @@ describe("columnHeaders (Variant History)", () => {
 
   it("renders the column headers properly when not loading", async () => {
     const { Component } = RenderFakeToastContext(
-      <ColumnHeaders projectId="evergreen" variantName="some_variant" />
+      <ColumnHeaders projectIdentifier="evergreen" variantName="some_variant" />
     );
     render(<Component />, {
       wrapper: ({ children }) =>
@@ -50,7 +50,7 @@ describe("columnHeaders (Variant History)", () => {
 
   it("should link to corresponding /task-history/:projectId/:taskName page", async () => {
     const { Component } = RenderFakeToastContext(
-      <ColumnHeaders projectId="evergreen" variantName="some_variant" />
+      <ColumnHeaders projectIdentifier="evergreen" variantName="some_variant" />
     );
     render(<Component />, {
       wrapper: ({ children }) =>
@@ -73,7 +73,7 @@ describe("columnHeaders (Variant History)", () => {
 
   it("should not show more column headers then the columnLimit", async () => {
     const { Component } = RenderFakeToastContext(
-      <ColumnHeaders projectId="evergreen" variantName="some_variant" />
+      <ColumnHeaders projectIdentifier="evergreen" variantName="some_variant" />
     );
     render(<Component />, {
       wrapper: ({ children }) =>
@@ -94,7 +94,7 @@ describe("columnHeaders (Variant History)", () => {
 
   it("should truncate the task name only if it is too long", async () => {
     const { Component } = RenderFakeToastContext(
-      <ColumnHeaders projectId="evergreen" variantName="some_variant" />
+      <ColumnHeaders projectIdentifier="evergreen" variantName="some_variant" />
     );
     render(<Component />, {
       wrapper: ({ children }) =>
@@ -116,7 +116,7 @@ describe("columnHeaders (Variant History)", () => {
 
   it("should show a tooltip with the full name when hovering over a truncated task name", async () => {
     const { Component } = RenderFakeToastContext(
-      <ColumnHeaders projectId="evergreen" variantName="some_variant" />
+      <ColumnHeaders projectIdentifier="evergreen" variantName="some_variant" />
     );
     render(<Component />, {
       wrapper: ({ children }) =>
@@ -144,7 +144,7 @@ const mock = (
   request: {
     query: GET_TASK_NAMES_FOR_BUILD_VARIANT,
     variables: {
-      projectId: "evergreen",
+      projectIdentifier: "evergreen",
       buildVariant: "some_variant",
     },
   },

--- a/src/pages/variantHistory/ColumnHeaders.tsx
+++ b/src/pages/variantHistory/ColumnHeaders.tsx
@@ -20,12 +20,12 @@ const { useHistoryTable } = context;
 const { useColumns } = hooks;
 const { trimStringFromMiddle } = string;
 interface ColumnHeadersProps {
-  projectId: string;
+  projectIdentifier: string;
   variantName: string;
 }
 
 const ColumnHeaders: React.VFC<ColumnHeadersProps> = ({
-  projectId,
+  projectIdentifier,
   variantName,
 }) => {
   const { sendEvent } = useProjectHealthAnalytics({ page: "Variant history" });
@@ -37,7 +37,7 @@ const ColumnHeaders: React.VFC<ColumnHeadersProps> = ({
     GetTaskNamesForBuildVariantQueryVariables
   >(GET_TASK_NAMES_FOR_BUILD_VARIANT, {
     variables: {
-      projectId,
+      projectIdentifier,
       buildVariant: variantName,
     },
     onCompleted: ({ taskNamesForBuildVariant }) => {
@@ -66,7 +66,7 @@ const ColumnHeaders: React.VFC<ColumnHeadersProps> = ({
         return (
           <ColumnHeaderCell
             key={`header_cell_${vc}`}
-            link={getTaskHistoryRoute(projectId, vc)}
+            link={getTaskHistoryRoute(projectIdentifier, vc)}
             trimmedDisplayName={trimStringFromMiddle(vc, maxLength)}
             fullDisplayName={vc}
             onClick={() => {

--- a/src/pages/variantHistory/ColumnHeaders.tsx
+++ b/src/pages/variantHistory/ColumnHeaders.tsx
@@ -19,6 +19,7 @@ const { LoadingCell, ColumnHeaderCell, LabelCellContainer } = Cell;
 const { useHistoryTable } = context;
 const { useColumns } = hooks;
 const { trimStringFromMiddle } = string;
+
 interface ColumnHeadersProps {
   projectIdentifier: string;
   variantName: string;

--- a/src/pages/variantHistory/TaskSelector.tsx
+++ b/src/pages/variantHistory/TaskSelector.tsx
@@ -11,12 +11,12 @@ import { useQueryParam } from "hooks/useQueryParam";
 import { HistoryQueryParams } from "types/history";
 
 interface TaskSelectorProps {
-  projectId: string;
+  projectIdentifier: string;
   buildVariant: string;
 }
 
 const TaskSelector: React.VFC<TaskSelectorProps> = ({
-  projectId,
+  projectIdentifier,
   buildVariant,
 }) => {
   const { sendEvent } = useProjectHealthAnalytics({ page: "Variant history" });
@@ -31,7 +31,7 @@ const TaskSelector: React.VFC<TaskSelectorProps> = ({
     GetTaskNamesForBuildVariantQueryVariables
   >(GET_TASK_NAMES_FOR_BUILD_VARIANT, {
     variables: {
-      projectId,
+      projectIdentifier,
       buildVariant,
     },
   });


### PR DESCRIPTION
EVG-16434

### Description
This PR makes it so that we use the `projectIdentifier` param rather than `projectID` param for certain GraphQL queries.

### Testing
- Patch with module ([link](https://spruce.mongodb.com/version/63d423fa32f4173896f6a32a/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC))
- On staging

### Evergreen PR
* evergreen-ci/evergreen/pull/6218
