### PR TITLE
EVG-18452: Accept null input for dateCutoff

### DIFF
--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -1983,7 +1983,7 @@ export type TriggerAlias = {
   alias: Scalars["String"];
   buildVariantRegex: Scalars["String"];
   configFile: Scalars["String"];
-  dateCutoff: Scalars["Int"];
+  dateCutoff?: Maybe<Scalars["Int"]>;
   level: Scalars["String"];
   project: Scalars["String"];
   status: Scalars["String"];
@@ -1994,7 +1994,7 @@ export type TriggerAliasInput = {
   alias: Scalars["String"];
   buildVariantRegex: Scalars["String"];
   configFile: Scalars["String"];
-  dateCutoff: Scalars["Int"];
+  dateCutoff?: InputMaybe<Scalars["Int"]>;
   level: Scalars["String"];
   project: Scalars["String"];
   status: Scalars["String"];
@@ -2671,7 +2671,7 @@ export type ProjectSettingsFragment = {
         buildVariantRegex: string;
         taskRegex: string;
         status: string;
-        dateCutoff: number;
+        dateCutoff?: Maybe<number>;
         configFile: string;
         alias: string;
       }>
@@ -2810,7 +2810,7 @@ export type RepoSettingsFragment = {
       buildVariantRegex: string;
       taskRegex: string;
       status: string;
-      dateCutoff: number;
+      dateCutoff?: Maybe<number>;
       configFile: string;
       alias: string;
     }>;
@@ -3075,7 +3075,7 @@ export type ProjectEventSettingsFragment = {
         buildVariantRegex: string;
         taskRegex: string;
         status: string;
-        dateCutoff: number;
+        dateCutoff?: Maybe<number>;
         configFile: string;
         alias: string;
       }>
@@ -3161,7 +3161,7 @@ export type ProjectTriggersSettingsFragment = {
       buildVariantRegex: string;
       taskRegex: string;
       status: string;
-      dateCutoff: number;
+      dateCutoff?: Maybe<number>;
       configFile: string;
       alias: string;
     }>
@@ -3175,7 +3175,7 @@ export type RepoTriggersSettingsFragment = {
     buildVariantRegex: string;
     taskRegex: string;
     status: string;
-    dateCutoff: number;
+    dateCutoff?: Maybe<number>;
     configFile: string;
     alias: string;
   }>;
@@ -4676,7 +4676,7 @@ export type ProjectEventLogsQuery = {
               buildVariantRegex: string;
               taskRegex: string;
               status: string;
-              dateCutoff: number;
+              dateCutoff?: Maybe<number>;
               configFile: string;
               alias: string;
             }>
@@ -4832,7 +4832,7 @@ export type ProjectEventLogsQuery = {
               buildVariantRegex: string;
               taskRegex: string;
               status: string;
-              dateCutoff: number;
+              dateCutoff?: Maybe<number>;
               configFile: string;
               alias: string;
             }>
@@ -4992,7 +4992,7 @@ export type ProjectSettingsQuery = {
           buildVariantRegex: string;
           taskRegex: string;
           status: string;
-          dateCutoff: number;
+          dateCutoff?: Maybe<number>;
           configFile: string;
           alias: string;
         }>
@@ -5183,7 +5183,7 @@ export type RepoEventLogsQuery = {
               buildVariantRegex: string;
               taskRegex: string;
               status: string;
-              dateCutoff: number;
+              dateCutoff?: Maybe<number>;
               configFile: string;
               alias: string;
             }>
@@ -5339,7 +5339,7 @@ export type RepoEventLogsQuery = {
               buildVariantRegex: string;
               taskRegex: string;
               status: string;
-              dateCutoff: number;
+              dateCutoff?: Maybe<number>;
               configFile: string;
               alias: string;
             }>
@@ -5493,7 +5493,7 @@ export type RepoSettingsQuery = {
         buildVariantRegex: string;
         taskRegex: string;
         status: string;
-        dateCutoff: number;
+        dateCutoff?: Maybe<number>;
         configFile: string;
         alias: string;
       }>;

--- a/src/pages/projectSettings/tabs/ProjectTriggersTab/getFormSchema.ts
+++ b/src/pages/projectSettings/tabs/ProjectTriggersTab/getFormSchema.ts
@@ -29,10 +29,11 @@ export const getFormSchema = (
               default: "",
               minLength: 1,
             },
-            dateCutoff: {
-              type: "number" as "number",
-              title: "Date Cutoff",
-              minimum: 0,
+            configFile: {
+              type: "string" as "string",
+              title: "Config File",
+              default: "",
+              minLength: 1,
             },
             level: {
               type: "string" as "string",
@@ -73,6 +74,11 @@ export const getFormSchema = (
                 },
               ],
             },
+            dateCutoff: {
+              type: ["number", "null"],
+              title: "Date Cutoff",
+              minimum: 0,
+            },
             buildVariantRegex: {
               type: "string" as "string",
               title: "Variant Regex",
@@ -82,12 +88,6 @@ export const getFormSchema = (
               type: "string" as "string",
               title: "Task Regex",
               default: "",
-            },
-            configFile: {
-              type: "string" as "string",
-              title: "Config File",
-              default: "",
-              minLength: 1,
             },
             alias: {
               type: "string" as "string",
@@ -117,16 +117,20 @@ export const getFormSchema = (
         project: {
           "ui:data-cy": "project-input",
         },
-        dateCutoff: {
-          "ui:description":
-            "Commits older than this number of days will not invoke trigger.",
-          "ui:optional": true,
+        configFile: {
+          "ui:data-cy": "config-file-input",
+          "ui:placeholder": ".evergreen.yml",
         },
         level: {
           "ui:allowDeselect": false,
         },
         status: {
           "ui:allowDeselect": false,
+        },
+        dateCutoff: {
+          "ui:description":
+            "Commits older than this number of days will not invoke trigger.",
+          "ui:optional": true,
         },
         buildVariantRegex: {
           "ui:description":
@@ -137,10 +141,6 @@ export const getFormSchema = (
           "ui:description":
             "Only matching tasks in the upstream project will invoke trigger.",
           "ui:optional": true,
-        },
-        configFile: {
-          "ui:data-cy": "config-file-input",
-          "ui:placeholder": ".evergreen.yml",
         },
         alias: {
           "ui:description":

--- a/src/pages/projectSettings/tabs/ProjectTriggersTab/transformers.ts
+++ b/src/pages/projectSettings/tabs/ProjectTriggersTab/transformers.ts
@@ -59,7 +59,7 @@ export const formToGql: FormToGqlFunction<Tab> = (
           buildVariantRegex: trigger.buildVariantRegex,
           taskRegex: trigger.taskRegex,
           status: trigger.status,
-          dateCutoff: trigger.dateCutoff || 0,
+          dateCutoff: trigger.dateCutoff,
           configFile: trigger.configFile,
           alias: trigger.alias,
         }))

--- a/src/pages/projectSettings/tabs/ProjectTriggersTab/types.ts
+++ b/src/pages/projectSettings/tabs/ProjectTriggersTab/types.ts
@@ -2,7 +2,7 @@ import { ProjectType } from "../utils";
 
 type FormTrigger = {
   project: string;
-  dateCutoff: number;
+  dateCutoff: number | null;
   level: string;
   status: string;
   buildVariantRegex: string;


### PR DESCRIPTION
EVG-18452

### Description
<!-- add description, context, thought process, etc -->
- Support omitting input for dateCutoff field within new project triggers since this field is nullable
- Also reorder inputs so that required fields appear before optional inputs

### Testing
- Codegen will fail until the linked Evergreen PR is merged

### Evergreen PR
<!-- link to a corresponding Evergreen PR if applicable -->
https://github.com/evergreen-ci/evergreen/pull/6235