### PR TITLE
EVG-18781: Safely search for patches by number

### DIFF
--- a/cypress/integration/myPatches/my_patches.ts
+++ b/cypress/integration/myPatches/my_patches.ts
@@ -45,6 +45,12 @@ describe("My Patches Page", () => {
     cy.dataCy("patch-description-input").clear();
   });
 
+  it("Inputting a number successfully searches patches", () => {
+    cy.dataCy("patch-description-input").type(3186);
+    cy.dataCy("patch-card").should("have.length", "1");
+    cy.dataCy("patch-description-input").clear();
+  });
+
   it("Searching for a nonexistent patch shows 'No patches found'", () => {
     cy.dataCy("patch-description-input").type("satenarstharienht");
     cy.dataCy("no-patches-found").contains("No patches found");

--- a/src/components/PatchesPage/index.tsx
+++ b/src/components/PatchesPage/index.tsx
@@ -124,7 +124,7 @@ export const usePatchesInputFromSearch = (search: string): PatchesInput => {
   );
   const statuses = rawStatuses.filter((v) => v && v !== ALL_PATCH_STATUS);
   return {
-    patchName,
+    patchName: `${patchName}`,
     statuses,
     page: getPageFromSearch(search),
     limit: getLimitFromSearch(search),


### PR DESCRIPTION
EVG-18781

### Description
<!-- add description, context, thought process, etc -->
- Stringify query used to filter patch names so that numbers don't throw an error

### Testing
<!-- add a description of how you tested it -->
- Update e2e test