### PR TITLE
EVG-18902 upgrade db version

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -425,7 +425,7 @@ buildvariants:
     run_on:
       - ubuntu2004-large
     expansions:
-      mongodb_url_2004: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2004-4.4.18.tgz
+      mongodb_url_2004: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2004-5.0.14.tgz
       node_version: 16.17.0
     modules:
       - evergreen


### PR DESCRIPTION
[EVG-18902](https://jira.mongodb.org/browse/EVG-18902)

### Description
We upped the db version for evergreen's tests to 5.0 in https://github.com/evergreen-ci/evergreen/commit/03582f54276af29b7d64dc51918c0eb126d8d024. Let's update it here too to validate the e2e test in preparation for [EVG-15892](https://jira.mongodb.org/browse/EVG-15892)
