### PR TITLE
EVG-18702: Title prop for log viewer buttons

### DIFF
--- a/src/pages/task/taskTabs/Logs.tsx
+++ b/src/pages/task/taskTabs/Logs.tsx
@@ -104,6 +104,7 @@ export const Logs: React.VFC<Props> = ({ logLinks, taskId, execution }) => {
           <ButtonContainer>
             {parsleyLink && (
               <Button
+                title="High-powered log viewer"
                 data-cy="parsley-log-btn"
                 disabled={noLogs}
                 href={parsleyLink}
@@ -121,6 +122,7 @@ export const Logs: React.VFC<Props> = ({ logLinks, taskId, execution }) => {
             )}
             {lobsterLink && (
               <Button
+                title="Legacy log viewer"
                 data-cy="lobster-log-btn"
                 disabled={noLogs}
                 href={lobsterLink}
@@ -138,6 +140,7 @@ export const Logs: React.VFC<Props> = ({ logLinks, taskId, execution }) => {
             )}
             {htmlLink && (
               <Button
+                title="Plain, colorized log viewer"
                 data-cy="html-log-btn"
                 disabled={noLogs}
                 href={htmlLink}
@@ -155,6 +158,7 @@ export const Logs: React.VFC<Props> = ({ logLinks, taskId, execution }) => {
             )}
             {rawLink && (
               <Button
+                title="Plain text log viewer"
                 data-cy="raw-log-btn"
                 disabled={noLogs}
                 href={rawLink}

--- a/src/pages/task/taskTabs/testsTable/LogsColumn.tsx
+++ b/src/pages/task/taskTabs/testsTable/LogsColumn.tsx
@@ -36,6 +36,7 @@ export const LogsColumn: React.VFC<Props> = ({ testResult, task }) => {
     <ButtonWrapper>
       {urlParsley && (
         <Button
+          title="High-powered log viewer"
           data-cy="test-table-parsley-btn"
           size="xsmall"
           target="_blank"
@@ -53,6 +54,7 @@ export const LogsColumn: React.VFC<Props> = ({ testResult, task }) => {
       )}
       {urlLobster && (
         <Button
+          title="Legacy log viewer"
           data-cy="test-table-lobster-btn"
           size="xsmall"
           target="_blank"
@@ -70,6 +72,7 @@ export const LogsColumn: React.VFC<Props> = ({ testResult, task }) => {
       )}
       {urlHTML && (
         <Button
+          title="Plain, colorized log viewer"
           data-cy="test-table-html-btn"
           size="xsmall"
           target="_blank"
@@ -87,6 +90,7 @@ export const LogsColumn: React.VFC<Props> = ({ testResult, task }) => {
       )}
       {urlRaw && (
         <Button
+          title="Plain text log viewer"
           data-cy="test-table-raw-btn"
           size="xsmall"
           target="_blank"


### PR DESCRIPTION
[EVG-18702](jira.mongodb.com/browse/EVG-18702)
### Description
Add title prop log viewer buttons in the TestsTable and Task Logs Tab
<img width="318" alt="Screen Shot 2023-02-16 at 10 18 45 AM" src="https://user-images.githubusercontent.com/10734386/219410687-7f1feb92-0f74-4da6-92c1-ba761d566282.png">
