### PR TITLE
EVG-18584 upgrade go version for evergreen

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -443,7 +443,7 @@ buildvariants:
     run_on:
       - ubuntu2004-large
     expansions:
-      goroot: /opt/golang/go1.16
+      goroot: /opt/golang/go1.19
       mongodb_url_2004: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2004-5.0.14.tgz
       node_version: 16.17.0
     modules:


### PR DESCRIPTION
[EVG-18584](https://jira.mongodb.org/browse/EVG-18584)

### Description
https://github.com/evergreen-ci/evergreen/pull/6285 will update the go version for evergreen to go1.19. In order for the e2e test to be able to build evergreen, it needs to be running a version of go greater than or equal to evergreen's version. I'd like to merge this before the evergreen PR so the e2e task doesn't break when the evergreen changes merge.

### Screenshots
N/A

### Testing
Hopefully the e2e test will pass on this PR 😄 

### Evergreen PR
https://github.com/evergreen-ci/evergreen/pull/6285
