### PR TITLE
EVG-5829 Conditionally render AMI for hosts

### DIFF
--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -357,6 +357,7 @@ export type GroupedTaskStatusCount = {
 /** Host models a host, which are used for things like running tasks or as virtual workstations. */
 export type Host = {
   __typename?: "Host";
+  ami?: Maybe<Scalars["String"]>;
   availabilityZone?: Maybe<Scalars["String"]>;
   displayName?: Maybe<Scalars["String"]>;
   distro?: Maybe<DistroInfo>;
@@ -4915,6 +4916,7 @@ export type HostQuery = {
   host?: Maybe<{
     __typename?: "Host";
     distroId?: Maybe<string>;
+    ami?: Maybe<string>;
     lastCommunicationTime?: Maybe<Date>;
     id: string;
     hostUrl: string;

--- a/src/gql/queries/get-host.graphql
+++ b/src/gql/queries/get-host.graphql
@@ -11,6 +11,7 @@ query Host($id: String!) {
       id
       name
     }
+    ami
     lastCommunicationTime
   }
 }

--- a/src/pages/host/Metadata.tsx
+++ b/src/pages/host/Metadata.tsx
@@ -29,6 +29,7 @@ export const Metadata: React.VFC<{
     lastCommunicationTime,
     runningTask,
     uptime,
+    ami,
   } = host ?? {};
 
   const { id: runningTaskId, name: runningTaskName } = runningTask ?? {};
@@ -52,6 +53,7 @@ export const Metadata: React.VFC<{
       </MetadataItem>
       <MetadataItem>Started By: {startedBy}</MetadataItem>
       <MetadataItem>Cloud Provider: {provider}</MetadataItem>
+      {ami && <MetadataItem>AMI: {ami}</MetadataItem>}
       <MetadataItem>
         Distro:{" "}
         <StyledLink data-cy="distro-link" href={distroLink}>


### PR DESCRIPTION
EVG-5829

### Description
Exposes the AMI field for hosts that have one.

### Screenshots
<img width="1501" alt="image" src="https://user-images.githubusercontent.com/4605522/221689436-629fdd15-1b45-4158-a028-18e46f40929b.png">

### Evergreen PR
https://github.com/evergreen-ci/evergreen/pull/6296/files