### PR TITLE
EVG-19118 Surface build variant display name on task metadata

### DIFF
--- a/src/gql/fragments/baseTask.graphql
+++ b/src/gql/fragments/baseTask.graphql
@@ -1,8 +1,9 @@
 fragment baseTask on Task {
-    id
-    execution
-    buildVariant
-    displayName
-    revision
-    status
+  id
+  execution
+  buildVariant
+  buildVariantDisplayName
+  displayName
+  revision
+  status
 }

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -2661,6 +2661,7 @@ export type BaseTaskFragment = {
   id: string;
   execution: number;
   buildVariant: string;
+  buildVariantDisplayName?: Maybe<string>;
   displayName: string;
   revision?: Maybe<string>;
   status: string;
@@ -3751,6 +3752,7 @@ export type AbortTaskMutation = {
     id: string;
     execution: number;
     buildVariant: string;
+    buildVariantDisplayName?: Maybe<string>;
     displayName: string;
     revision?: Maybe<string>;
     status: string;
@@ -4129,6 +4131,7 @@ export type RestartTaskMutation = {
     execution: number;
     id: string;
     buildVariant: string;
+    buildVariantDisplayName?: Maybe<string>;
     displayName: string;
     revision?: Maybe<string>;
     status: string;
@@ -4237,6 +4240,7 @@ export type ScheduleTasksMutation = {
     id: string;
     execution: number;
     buildVariant: string;
+    buildVariantDisplayName?: Maybe<string>;
     displayName: string;
     revision?: Maybe<string>;
     status: string;
@@ -7094,6 +7098,7 @@ export type GetTaskQuery = {
     id: string;
     execution: number;
     buildVariant: string;
+    buildVariantDisplayName?: Maybe<string>;
     displayName: string;
     revision?: Maybe<string>;
     status: string;
@@ -7679,6 +7684,7 @@ export type GetSpawnTaskQuery = {
     id: string;
     execution: number;
     buildVariant: string;
+    buildVariantDisplayName?: Maybe<string>;
     displayName: string;
     revision?: Maybe<string>;
     status: string;

--- a/src/pages/task/metadata/__snapshots__/Metadata.stories.storyshot
+++ b/src/pages/task/metadata/__snapshots__/Metadata.stories.storyshot
@@ -31,7 +31,7 @@ exports[`storybook Storyshots Pages/Task/Metadata Base 1`] = `
         <span
           className="leafygreen-ui-1ewnca3"
         >
-          ubuntu1604
+          Ubuntu 16.04
         </span>
       </a>
     </p>
@@ -185,7 +185,7 @@ exports[`storybook Storyshots Pages/Task/Metadata With Abort Message 1`] = `
         <span
           className="leafygreen-ui-1ewnca3"
         >
-          ubuntu1604
+          Ubuntu 16.04
         </span>
       </a>
     </p>
@@ -339,7 +339,7 @@ exports[`storybook Storyshots Pages/Task/Metadata With Dependencies 1`] = `
         <span
           className="leafygreen-ui-1ewnca3"
         >
-          ubuntu1604
+          Ubuntu 16.04
         </span>
       </a>
     </p>

--- a/src/pages/task/metadata/index.tsx
+++ b/src/pages/task/metadata/index.tsx
@@ -62,6 +62,7 @@ export const Metadata: React.VFC<Props> = ({
     priority,
     versionMetadata,
     buildVariant,
+    buildVariantDisplayName,
     details,
     generatedBy,
     generatedByName,
@@ -98,7 +99,7 @@ export const Metadata: React.VFC<Props> = ({
             taskAnalytics.sendEvent({ name: "Click Build Variant Link" })
           }
         >
-          {buildVariant}
+          {buildVariantDisplayName}
         </StyledRouterLink>
       </MetadataItem>
       <MetadataItem data-cy="task-metadata-project">

--- a/src/pages/task/metadata/index.tsx
+++ b/src/pages/task/metadata/index.tsx
@@ -99,7 +99,7 @@ export const Metadata: React.VFC<Props> = ({
             taskAnalytics.sendEvent({ name: "Click Build Variant Link" })
           }
         >
-          {buildVariantDisplayName}
+          {buildVariantDisplayName || buildVariant}
         </StyledRouterLink>
       </MetadataItem>
       <MetadataItem data-cy="task-metadata-project">

--- a/src/pages/task/metadata/taskData.ts
+++ b/src/pages/task/metadata/taskData.ts
@@ -14,6 +14,7 @@ export const taskQuery: GetTaskQuery = {
     },
     blocked: false,
     buildVariant: "ubuntu1604",
+    buildVariantDisplayName: "Ubuntu 16.04",
     canAbort: false,
     canDisable: true,
     canModifyAnnotation: false,


### PR DESCRIPTION
EVG-19118

### Description
Surfaces a tasks build variant display name on the metadata panel
### Screenshots
<img width="309" alt="image" src="https://user-images.githubusercontent.com/4605522/225339684-51166ad8-c8cb-415e-b268-abc9193facf3.png">

