### PR TITLE
EVG-18898 upgrade e2e test to 6.0

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -444,7 +444,7 @@ buildvariants:
       - ubuntu2004-large
     expansions:
       goroot: /opt/golang/go1.19
-      mongodb_url_2004: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2004-5.0.14.tgz
+      mongodb_url_2004: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2204-6.0.5.tgz
       node_version: 16.17.0
     modules:
       - evergreen


### PR DESCRIPTION
[EVG-18898](https://jira.mongodb.org/browse/EVG-18898)

### Description
Hopefully the last time for a while. Let's move testing to 6.0 to make sure it works before we up the version in prod.

### Screenshots
N/A

### Testing
Let's see if the e2e test passes in this PR.

### Evergreen PR
https://github.com/evergreen-ci/evergreen/pull/6340
