### PR TITLE
EVG-17198: Include system/setup failure icons on project health page

### DIFF
--- a/src/pages/commits/utils.ts
+++ b/src/pages/commits/utils.ts
@@ -163,6 +163,10 @@ const FAILED_STATUSES = [
   TaskStatus.TaskTimedOut,
   TaskStatus.TestTimedOut,
   TaskStatus.KnownIssue,
+  TaskStatus.SetupFailed,
+  TaskStatus.SystemFailed,
+  TaskStatus.SystemTimedOut,
+  TaskStatus.SystemUnresponsive,
   TaskStatus.Aborted,
 ];
 


### PR DESCRIPTION
EVG-17198

### Description
<!-- add description, context, thought process, etc -->
- Expand definition of "failed" for project health page to include system & setup failure statuses in order to show their icons.

### Screenshots
<!-- add screenshots of visible changes -->
<img width="182" alt="image" src="https://user-images.githubusercontent.com/9298431/227024336-fb6f4f27-5f10-40a2-996c-29186ef2ca60.png">