### PR TITLE
EVG-19018 Create pod page

### DIFF
--- a/src/components/HostStatusBadge/HostStatusBadge.stories.tsx
+++ b/src/components/HostStatusBadge/HostStatusBadge.stories.tsx
@@ -1,0 +1,32 @@
+import styled from "@emotion/styled";
+import { size } from "constants/tokens";
+import { HostStatus } from "types/host";
+import HostStatusBadge from ".";
+
+export default {
+  title: "Components/Host Status Badges",
+  component: HostStatusBadge,
+};
+
+export const Default = () => {
+  // filter out umbrella statuses
+  const taskStatuses = Object.keys(HostStatus);
+  return (
+    <Container>
+      {taskStatuses.map((status) => (
+        <Wrapper key={`badge_${status}`}>
+          <HostStatusBadge status={HostStatus[status]} />
+        </Wrapper>
+      ))}
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+`;
+const Wrapper = styled.div`
+  padding: ${size.xxs};
+`;

--- a/src/components/HostStatusBadge/__snapshots__/HostStatusBadge.stories.storyshot
+++ b/src/components/HostStatusBadge/__snapshots__/HostStatusBadge.stories.storyshot
@@ -1,0 +1,215 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`storybook Storyshots Components/Host Status Badges Default 1`] = `
+<div
+  className="css-o6c4dw-Container e1or3ep41"
+>
+  <div
+    className="css-11yt18y-Wrapper e1or3ep40"
+  >
+    <div
+      className="css-1rt3rqp-HostStatusWrapper e1bt0ccw0"
+    >
+      <div
+        className="leafygreen-ui-n4itms"
+      >
+        Running
+      </div>
+    </div>
+  </div>
+  <div
+    className="css-11yt18y-Wrapper e1or3ep40"
+  >
+    <div
+      className="css-1rt3rqp-HostStatusWrapper e1bt0ccw0"
+    >
+      <div
+        className="leafygreen-ui-ixbeze"
+      >
+        Starting
+      </div>
+    </div>
+  </div>
+  <div
+    className="css-11yt18y-Wrapper e1or3ep40"
+  >
+    <div
+      className="css-1rt3rqp-HostStatusWrapper e1bt0ccw0"
+    >
+      <div
+        className="leafygreen-ui-ixbeze"
+      >
+        Provisioning
+      </div>
+    </div>
+  </div>
+  <div
+    className="css-11yt18y-Wrapper e1or3ep40"
+  >
+    <div
+      className="css-1rt3rqp-HostStatusWrapper e1bt0ccw0"
+    >
+      <div
+        className="leafygreen-ui-ud6teo"
+      >
+        Terminated
+      </div>
+      <div
+        className="leafygreen-ui-cssveg css-1c025ob-IconWrapper e1g9h96g0"
+        onBlur={[Function]}
+        onFocus={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        <svg
+          aria-label="Info With Circle Icon"
+          className="leafygreen-ui-1xsx4zj css-1bgg0m1-iconMargin"
+          fill="none"
+          height={16}
+          role="img"
+          viewBox="0 0 16 16"
+          width={16}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            clipRule="evenodd"
+            d="M8 15A7 7 0 108 1a7 7 0 000 14zM9 4a1 1 0 11-2 0 1 1 0 012 0zM8 6a1 1 0 011 1v4h.5a.5.5 0 010 1h-3a.5.5 0 010-1H7V7h-.5a.5.5 0 010-1H8z"
+            fill="currentColor"
+            fillRule="evenodd"
+          />
+        </svg>
+      </div>
+    </div>
+  </div>
+  <div
+    className="css-11yt18y-Wrapper e1or3ep40"
+  >
+    <div
+      className="css-1rt3rqp-HostStatusWrapper e1bt0ccw0"
+    >
+      <div
+        className="leafygreen-ui-ohl2hc"
+      >
+        Decommissioned
+      </div>
+    </div>
+  </div>
+  <div
+    className="css-11yt18y-Wrapper e1or3ep40"
+  >
+    <div
+      className="css-1rt3rqp-HostStatusWrapper e1bt0ccw0"
+    >
+      <div
+        className="leafygreen-ui-ohl2hc"
+      >
+        Quarantined
+      </div>
+    </div>
+  </div>
+  <div
+    className="css-11yt18y-Wrapper e1or3ep40"
+  >
+    <div
+      className="css-1rt3rqp-HostStatusWrapper e1bt0ccw0"
+    >
+      <div
+        className="leafygreen-ui-ohl2hc"
+      >
+        Provision Failed
+      </div>
+    </div>
+  </div>
+  <div
+    className="css-11yt18y-Wrapper e1or3ep40"
+  >
+    <div
+      className="css-1rt3rqp-HostStatusWrapper e1bt0ccw0"
+    >
+      <div
+        className="leafygreen-ui-ohl2hc"
+      >
+        Initializing
+      </div>
+    </div>
+  </div>
+  <div
+    className="css-11yt18y-Wrapper e1or3ep40"
+  >
+    <div
+      className="css-1rt3rqp-HostStatusWrapper e1bt0ccw0"
+    >
+      <div
+        className="leafygreen-ui-ohl2hc"
+      >
+        Building
+      </div>
+    </div>
+  </div>
+  <div
+    className="css-11yt18y-Wrapper e1or3ep40"
+  >
+    <div
+      className="css-1rt3rqp-HostStatusWrapper e1bt0ccw0"
+    >
+      <div
+        className="leafygreen-ui-ohl2hc"
+      >
+        Success
+      </div>
+    </div>
+  </div>
+  <div
+    className="css-11yt18y-Wrapper e1or3ep40"
+  >
+    <div
+      className="css-1rt3rqp-HostStatusWrapper e1bt0ccw0"
+    >
+      <div
+        className="leafygreen-ui-ohl2hc"
+      >
+        Stopping
+      </div>
+    </div>
+  </div>
+  <div
+    className="css-11yt18y-Wrapper e1or3ep40"
+  >
+    <div
+      className="css-1rt3rqp-HostStatusWrapper e1bt0ccw0"
+    >
+      <div
+        className="leafygreen-ui-ohl2hc"
+      >
+        Stopped
+      </div>
+    </div>
+  </div>
+  <div
+    className="css-11yt18y-Wrapper e1or3ep40"
+  >
+    <div
+      className="css-1rt3rqp-HostStatusWrapper e1bt0ccw0"
+    >
+      <div
+        className="leafygreen-ui-ohl2hc"
+      >
+        Failed
+      </div>
+    </div>
+  </div>
+  <div
+    className="css-11yt18y-Wrapper e1or3ep40"
+  >
+    <div
+      className="css-1rt3rqp-HostStatusWrapper e1bt0ccw0"
+    >
+      <div
+        className="leafygreen-ui-ohl2hc"
+      >
+        External
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/HostStatusBadge/index.tsx
+++ b/src/components/HostStatusBadge/index.tsx
@@ -12,7 +12,7 @@ interface Props {
   status: HostStatus;
 }
 
-export const HostStatusBadge: React.VFC<Props> = ({ status }) => (
+const HostStatusBadge: React.VFC<Props> = ({ status }) => (
   <HostStatusWrapper>
     <Badge variant={statusToBadgeVariant[status]}>
       {hostStatusToCopy[status]}
@@ -68,3 +68,5 @@ const HostStatusWrapper = styled.div`
 const iconMargin = css`
   margin-left: ${size.xxs};
 `;
+
+export default HostStatusBadge;

--- a/src/components/PodStatusBadge/PodStatusBadge.stories.tsx
+++ b/src/components/PodStatusBadge/PodStatusBadge.stories.tsx
@@ -1,20 +1,20 @@
 import styled from "@emotion/styled";
 import { size } from "constants/tokens";
-import { HostStatus } from "types/host";
-import HostStatusBadge from ".";
+import { PodStatus } from "types/pod";
+import PodStatusBadge from ".";
 
 export default {
-  title: "Components/Host Status Badges",
-  component: HostStatusBadge,
+  title: "Components/Pod Status Badges",
+  component: PodStatusBadge,
 };
 
 export const Default = () => {
-  const hostStatuses = Object.keys(HostStatus);
+  const podStatuses = Object.keys(PodStatus);
   return (
     <Container>
-      {hostStatuses.map((status) => (
+      {podStatuses.map((status) => (
         <Wrapper key={`badge_${status}`}>
-          <HostStatusBadge status={HostStatus[status]} />
+          <PodStatusBadge status={PodStatus[status]} />
         </Wrapper>
       ))}
     </Container>

--- a/src/components/PodStatusBadge/__snapshots__/PodStatusBadge.stories.storyshot
+++ b/src/components/PodStatusBadge/__snapshots__/PodStatusBadge.stories.storyshot
@@ -1,0 +1,73 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`storybook Storyshots Components/Pod Status Badges Default 1`] = `
+<div
+  className="css-o6c4dw-Container e1enphh91"
+>
+  <div
+    className="css-11yt18y-Wrapper e1enphh90"
+  >
+    <div
+      className="css-c3r44f-PodStatusWrapper e19l1his0"
+    >
+      <div
+        className="leafygreen-ui-ixbeze"
+      >
+        Initializing
+      </div>
+    </div>
+  </div>
+  <div
+    className="css-11yt18y-Wrapper e1enphh90"
+  >
+    <div
+      className="css-c3r44f-PodStatusWrapper e19l1his0"
+    >
+      <div
+        className="leafygreen-ui-ixbeze"
+      >
+        Starting
+      </div>
+    </div>
+  </div>
+  <div
+    className="css-11yt18y-Wrapper e1enphh90"
+  >
+    <div
+      className="css-c3r44f-PodStatusWrapper e19l1his0"
+    >
+      <div
+        className="leafygreen-ui-n4itms"
+      >
+        Running
+      </div>
+    </div>
+  </div>
+  <div
+    className="css-11yt18y-Wrapper e1enphh90"
+  >
+    <div
+      className="css-c3r44f-PodStatusWrapper e19l1his0"
+    >
+      <div
+        className="leafygreen-ui-ohl2hc"
+      >
+        Decommissioned
+      </div>
+    </div>
+  </div>
+  <div
+    className="css-11yt18y-Wrapper e1enphh90"
+  >
+    <div
+      className="css-c3r44f-PodStatusWrapper e19l1his0"
+    >
+      <div
+        className="leafygreen-ui-ud6teo"
+      >
+        Terminated
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/PodStatusBadge/__snapshots__/PodStatusBadge.stories.storyshot
+++ b/src/components/PodStatusBadge/__snapshots__/PodStatusBadge.stories.storyshot
@@ -13,19 +13,6 @@ exports[`storybook Storyshots Components/Pod Status Badges Default 1`] = `
       <div
         className="leafygreen-ui-ixbeze"
       >
-        Initializing
-      </div>
-    </div>
-  </div>
-  <div
-    className="css-11yt18y-Wrapper e1enphh90"
-  >
-    <div
-      className="css-c3r44f-PodStatusWrapper e19l1his0"
-    >
-      <div
-        className="leafygreen-ui-ixbeze"
-      >
         Starting
       </div>
     </div>
@@ -40,6 +27,19 @@ exports[`storybook Storyshots Components/Pod Status Badges Default 1`] = `
         className="leafygreen-ui-n4itms"
       >
         Running
+      </div>
+    </div>
+  </div>
+  <div
+    className="css-11yt18y-Wrapper e1enphh90"
+  >
+    <div
+      className="css-c3r44f-PodStatusWrapper e19l1his0"
+    >
+      <div
+        className="leafygreen-ui-ohl2hc"
+      >
+        Initializing
       </div>
     </div>
   </div>

--- a/src/components/PodStatusBadge/index.tsx
+++ b/src/components/PodStatusBadge/index.tsx
@@ -17,7 +17,7 @@ const PodStatusBadge: React.VFC<Props> = ({ status }) => (
 
 const statusToBadgeVariant = {
   [PodStatus.Decommissioned]: Variant.LightGray,
-  [PodStatus.Initializing]: Variant.Yellow,
+  [PodStatus.Initializing]: Variant.LightGray,
   [PodStatus.Running]: Variant.Green,
   [PodStatus.Starting]: Variant.Yellow,
   [PodStatus.Terminated]: Variant.Red,

--- a/src/components/PodStatusBadge/index.tsx
+++ b/src/components/PodStatusBadge/index.tsx
@@ -1,0 +1,39 @@
+import styled from "@emotion/styled";
+import Badge, { Variant } from "@leafygreen-ui/badge";
+
+import { PodStatus } from "types/pod";
+
+interface Props {
+  status: PodStatus;
+}
+
+const PodStatusBadge: React.VFC<Props> = ({ status }) => (
+  <PodStatusWrapper>
+    <Badge variant={statusToBadgeVariant[status]}>
+      {podStatusToCopy[status]}
+    </Badge>
+  </PodStatusWrapper>
+);
+
+const statusToBadgeVariant = {
+  [PodStatus.Decommissioned]: Variant.LightGray,
+  [PodStatus.Initializing]: Variant.Yellow,
+  [PodStatus.Running]: Variant.Green,
+  [PodStatus.Starting]: Variant.Yellow,
+  [PodStatus.Terminated]: Variant.Red,
+};
+
+const podStatusToCopy = {
+  [PodStatus.Decommissioned]: "Decommissioned",
+  [PodStatus.Initializing]: "Initializing",
+  [PodStatus.Running]: "Running",
+  [PodStatus.Starting]: "Starting",
+  [PodStatus.Terminated]: "Terminated",
+};
+
+const PodStatusWrapper = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+export default PodStatusBadge;

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -5576,6 +5576,35 @@ export type PatchQuery = {
   };
 };
 
+export type PodQueryVariables = Exact<{
+  podId: Scalars["String"];
+}>;
+
+export type PodQuery = {
+  __typename?: "Query";
+  pod: {
+    __typename?: "Pod";
+    id: string;
+    status: string;
+    type: string;
+    taskContainerCreationOpts: {
+      __typename?: "TaskContainerCreationOpts";
+      arch: string;
+      cpu: number;
+      memoryMB: number;
+      os: string;
+      image: string;
+      workingDir: string;
+    };
+    task?: Maybe<{
+      __typename?: "Task";
+      id: string;
+      execution: number;
+      displayName: string;
+    }>;
+  };
+};
+
 export type ProjectEventLogsQueryVariables = Exact<{
   identifier: Scalars["String"];
   limit?: InputMaybe<Scalars["Int"]>;

--- a/src/gql/queries/get-pod.graphql
+++ b/src/gql/queries/get-pod.graphql
@@ -1,0 +1,20 @@
+query Pod($podId: String!) {
+  pod(podId: $podId) {
+    id
+    status
+    taskContainerCreationOpts {
+      arch
+      cpu
+      memoryMB
+      os
+      image
+      workingDir
+    }
+    task {
+      id
+      execution
+      displayName
+    }
+    type
+  }
+}

--- a/src/gql/queries/index.ts
+++ b/src/gql/queries/index.ts
@@ -36,6 +36,7 @@ import GET_OTHER_USER from "./get-other-user.graphql";
 import GET_PATCH_CONFIGURE from "./get-patch-configure.graphql";
 import GET_PATCH_TASK_STATUSES from "./get-patch-task-statuses.graphql";
 import GET_PATCH from "./get-patch.graphql";
+import GET_POD from "./get-pod.graphql";
 import GET_PROJECT_EVENT_LOGS from "./get-project-event-logs.graphql";
 import GET_PROJECT_SETTINGS from "./get-project-settings.graphql";
 import GET_PROJECTS from "./get-projects.graphql";
@@ -111,6 +112,7 @@ export {
   GET_PATCH_CONFIGURE,
   GET_PATCH_TASK_STATUSES,
   GET_PATCH,
+  GET_POD,
   GET_PROJECT_EVENT_LOGS,
   GET_PROJECT_PATCHES,
   GET_PROJECT_SETTINGS,

--- a/src/pages/container/EventsTable/index.tsx
+++ b/src/pages/container/EventsTable/index.tsx
@@ -1,0 +1,28 @@
+import styled from "@emotion/styled";
+import { Subtitle } from "@leafygreen-ui/typography";
+import { Skeleton } from "antd";
+import { SiderCard } from "components/styles";
+import { size } from "constants/tokens";
+
+const EventsTable: React.VFC<{}> = () => (
+  <SiderCard>
+    <TableTitle>
+      {/* @ts-expect-error */}
+      <StyledSubtitle>Recent Events</StyledSubtitle>
+    </TableTitle>
+    <Skeleton active />
+  </SiderCard>
+);
+
+// @ts-expect-error
+const StyledSubtitle = styled(Subtitle)`
+  margin: ${size.s} 0;
+`;
+
+const TableTitle = styled.div`
+  flex-wrap: nowrap;
+  display: flex;
+  justify-content: space-between;
+`;
+
+export default EventsTable;

--- a/src/pages/container/Metadata/index.tsx
+++ b/src/pages/container/Metadata/index.tsx
@@ -1,0 +1,51 @@
+import { ApolloError } from "@apollo/client";
+import { InlineCode } from "@leafygreen-ui/typography";
+import {
+  MetadataCard,
+  MetadataItem,
+  MetadataTitle,
+} from "components/MetadataCard";
+import { StyledRouterLink } from "components/styles";
+import { getTaskRoute } from "constants/routes";
+import { PodQuery } from "gql/generated/types";
+
+const Metadata: React.VFC<{
+  loading: boolean;
+  pod: PodQuery["pod"];
+  error: ApolloError;
+}> = ({ loading, pod, error }) => {
+  const { taskContainerCreationOpts, type, task } = pod ?? {};
+  const { arch, cpu, memoryMB, os, workingDir } =
+    taskContainerCreationOpts ?? {};
+  const {
+    id: runningTaskId,
+    execution: runningTaskExecution,
+    displayName: runningTaskDisplayName,
+  } = task ?? {};
+
+  const taskLink = getTaskRoute(runningTaskId, {
+    execution: runningTaskExecution,
+  });
+
+  return (
+    <MetadataCard error={error} loading={loading}>
+      <MetadataTitle>Container Details</MetadataTitle>
+      <MetadataItem>
+        Running Task:{" "}
+        <StyledRouterLink to={taskLink}>
+          {runningTaskDisplayName}
+        </StyledRouterLink>
+      </MetadataItem>
+      <MetadataItem>Container Type: {type}</MetadataItem>
+      <MetadataItem>CPU: {cpu}</MetadataItem>
+      <MetadataItem>Memory: {memoryMB} MB</MetadataItem>
+      <MetadataItem>Operating System: {os}</MetadataItem>
+      <MetadataItem>CPU Architecture: {arch}</MetadataItem>
+      <MetadataItem>
+        Working Directory: <InlineCode>{workingDir}</InlineCode>
+      </MetadataItem>
+    </MetadataCard>
+  );
+};
+
+export default Metadata;

--- a/src/pages/container/Metadata/index.tsx
+++ b/src/pages/container/Metadata/index.tsx
@@ -30,12 +30,14 @@ const Metadata: React.VFC<{
   return (
     <MetadataCard error={error} loading={loading}>
       <MetadataTitle>Container Details</MetadataTitle>
-      <MetadataItem>
-        Running Task:{" "}
-        <StyledRouterLink to={taskLink}>
-          {runningTaskDisplayName}
-        </StyledRouterLink>
-      </MetadataItem>
+      {runningTaskId !== "" && (
+        <MetadataItem>
+          Running Task:{" "}
+          <StyledRouterLink to={taskLink}>
+            {runningTaskDisplayName}
+          </StyledRouterLink>
+        </MetadataItem>
+      )}
       <MetadataItem>Container Type: {type}</MetadataItem>
       <MetadataItem>CPU: {cpu}</MetadataItem>
       <MetadataItem>Memory: {memoryMB} MB</MetadataItem>

--- a/src/pages/container/index.tsx
+++ b/src/pages/container/index.tsx
@@ -1,2 +1,55 @@
-const Container = () => <div>container</div>;
+import { useQuery } from "@apollo/client";
+import { useParams } from "react-router-dom";
+import { PageTitle } from "components/PageTitle";
+import PodStatusBadge from "components/PodStatusBadge";
+import {
+  PageLayout,
+  PageSider,
+  PageWrapper,
+  PageContent,
+} from "components/styles";
+import { useToastContext } from "context/toast";
+import { PodQuery, PodQueryVariables } from "gql/generated/types";
+import { GET_POD } from "gql/queries";
+import { PodStatus } from "types/pod";
+import Metadata from "./Metadata";
+
+const Container = () => {
+  const dispatchToast = useToastContext();
+  const { id } = useParams<{ id: string }>();
+  const { data, loading, error } = useQuery<PodQuery, PodQueryVariables>(
+    GET_POD,
+    {
+      variables: { podId: id },
+      onError: (err) => {
+        dispatchToast.error(
+          `There was an error loading the host: ${err.message}`
+        );
+      },
+    }
+  );
+  const { pod } = data || {};
+  const { id: podId, status } = pod || {};
+  return (
+    <PageWrapper data-cy="host-page">
+      <PageTitle
+        title={`Container: ${podId}`}
+        pageTitle="Container: {id}"
+        size="large"
+        loading={loading}
+        badge={<PodStatusBadge status={status as PodStatus} />}
+      />
+      <PageLayout>
+        <PageSider width={350}>
+          <Metadata loading={loading} pod={pod} error={error} />
+        </PageSider>
+        <PageLayout>
+          <PageContent>
+            <div>Some Table</div>
+          </PageContent>
+        </PageLayout>
+      </PageLayout>
+    </PageWrapper>
+  );
+};
 export default Container;

--- a/src/pages/container/index.tsx
+++ b/src/pages/container/index.tsx
@@ -12,6 +12,7 @@ import { useToastContext } from "context/toast";
 import { PodQuery, PodQueryVariables } from "gql/generated/types";
 import { GET_POD } from "gql/queries";
 import { PodStatus } from "types/pod";
+import EventsTable from "./EventsTable";
 import Metadata from "./Metadata";
 
 const Container = () => {
@@ -45,7 +46,7 @@ const Container = () => {
         </PageSider>
         <PageLayout>
           <PageContent>
-            <div>Some Table</div>
+            <EventsTable />
           </PageContent>
         </PageLayout>
       </PageLayout>

--- a/src/pages/container/index.tsx
+++ b/src/pages/container/index.tsx
@@ -35,7 +35,7 @@ const Container = () => {
     <PageWrapper data-cy="host-page">
       <PageTitle
         title={`Container: ${podId}`}
-        pageTitle="Container: {id}"
+        pageTitle={`Container: ${podId}`}
         size="large"
         loading={loading}
         badge={<PodStatusBadge status={status as PodStatus} />}

--- a/src/pages/host/index.tsx
+++ b/src/pages/host/index.tsx
@@ -7,7 +7,7 @@ import { useParams, useLocation } from "react-router-dom";
 import { UpdateStatusModal } from "components/Hosts";
 import { Reprovision } from "components/Hosts/Reprovision";
 import { RestartJasper } from "components/Hosts/RestartJasper";
-import { HostStatusBadge } from "components/HostStatusBadge";
+import HostStatusBadge from "components/HostStatusBadge";
 import { PageTitle } from "components/PageTitle";
 import {
   PageWrapper,

--- a/src/pages/spawn/spawnHost/SpawnHostTable.tsx
+++ b/src/pages/spawn/spawnHost/SpawnHostTable.tsx
@@ -4,7 +4,7 @@ import Badge from "@leafygreen-ui/badge";
 import { formatDistanceToNow } from "date-fns";
 import { useLocation } from "react-router-dom";
 import { useSpawnAnalytics } from "analytics";
-import { HostStatusBadge } from "components/HostStatusBadge";
+import HostStatusBadge from "components/HostStatusBadge";
 import { DoesNotExpire, SpawnTable } from "components/Spawn";
 import { StyledRouterLink, WordBreak } from "components/styles";
 import { getHostRoute } from "constants/routes";

--- a/src/types/pod.ts
+++ b/src/types/pod.ts
@@ -1,0 +1,14 @@
+export enum PodStatus {
+  // yellow: pod-starting
+  Initializing = "initializing",
+  Starting = "starting",
+
+  // green: pod-running
+  Running = "running",
+
+  // grey: pod-unreachable
+  Decommissioned = "decommissioned",
+
+  // red: pod-terminated
+  Terminated = "terminated",
+}

--- a/src/types/pod.ts
+++ b/src/types/pod.ts
@@ -1,12 +1,12 @@
 export enum PodStatus {
   // yellow: pod-starting
-  Initializing = "initializing",
   Starting = "starting",
 
   // green: pod-running
   Running = "running",
 
   // grey: pod-unreachable
+  Initializing = "initializing",
   Decommissioned = "decommissioned",
 
   // red: pod-terminated


### PR DESCRIPTION
EVG-19018

### Description
Creates some types used by pods for statuses
Create Pod page, fetch data and render metadata
Render boilerplate placeholder for pod events (Eternal loading skeleton)
### Screenshots
<img width="1476" alt="image" src="https://user-images.githubusercontent.com/4605522/227018717-d278c6f1-9071-4a81-809b-a157531e0078.png">

### Testing
localhost: 
localhost:3000/container/localhost

staging:
<stagingURL>/container/641ae3bd0f40259343a6ffec
