### PR TITLE
EVG-19279 Add help text to project settings admin section

### DIFF
--- a/src/pages/projectSettings/tabs/AccessTab/getFormSchema.ts
+++ b/src/pages/projectSettings/tabs/AccessTab/getFormSchema.ts
@@ -68,11 +68,16 @@ export const getFormSchema = (
 });
 
 const getAdminsDescription = (projectType: ProjectType): string => {
+  let description = "";
   if (projectType === ProjectType.Repo) {
-    return "Admins for this repo will be able to edit repo settings and any attached branches’ settings.";
+    description =
+      "Admins for this repo will be able to edit repo settings and any attached branches’ settings.";
+  } else if (projectType === ProjectType.AttachedProject) {
+    description =
+      "Admins for this branch will be able to edit branch settings and view repo settings.";
+  } else {
+    description =
+      "Admins for this branch will be able to edit branch settings.";
   }
-  if (projectType === ProjectType.AttachedProject) {
-    return "Admins for this branch will be able to edit branch settings and view repo settings.";
-  }
-  return "Admins for this branch will be able to edit branch settings.";
+  return `${description} All admins will have access to create new projects on Evergreen.`;
 };

--- a/src/pages/projectSettings/tabs/AccessTab/getFormSchema.ts
+++ b/src/pages/projectSettings/tabs/AccessTab/getFormSchema.ts
@@ -68,16 +68,13 @@ export const getFormSchema = (
 });
 
 const getAdminsDescription = (projectType: ProjectType): string => {
-  let description = "";
-  if (projectType === ProjectType.Repo) {
-    description =
-      "Admins for this repo will be able to edit repo settings and any attached branches’ settings.";
-  } else if (projectType === ProjectType.AttachedProject) {
-    description =
-      "Admins for this branch will be able to edit branch settings and view repo settings.";
-  } else {
-    description =
-      "Admins for this branch will be able to edit branch settings.";
-  }
+  const descriptions = {
+    [ProjectType.Repo]:
+      "Admins for this repo will be able to edit repo settings and any attached branches’ settings.",
+    [ProjectType.AttachedProject]:
+      "Admins for this branch will be able to edit branch settings and view repo settings.",
+    default: "Admins for this branch will be able to edit branch settings.",
+  };
+  const description = descriptions[projectType] || descriptions.default;
   return `${description} All admins will have access to create new projects on Evergreen.`;
 };


### PR DESCRIPTION
EVG-19279

### Description
Add an extra line saying that admins will have access to create projects

### Screenshots
<img width="759" alt="image" src="https://user-images.githubusercontent.com/26491602/228680588-75e0fd46-6fec-4cc2-a3aa-e9f10fee3fee.png">

### Testing
saw that text changed

