### PR TITLE
EVG-19228 Fix bug causing query params to be cleared when resizing mainline commits

### DIFF
--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -1107,6 +1107,7 @@ export type PodEventLogData = {
   newStatus?: Maybe<Scalars["String"]>;
   oldStatus?: Maybe<Scalars["String"]>;
   reason?: Maybe<Scalars["String"]>;
+  task?: Maybe<Task>;
   taskExecution?: Maybe<Scalars["Int"]>;
   taskID?: Maybe<Scalars["String"]>;
   taskStatus?: Maybe<Scalars["String"]>;

--- a/src/hooks/useQueryParam/useQueryParam.test.tsx
+++ b/src/hooks/useQueryParam/useQueryParam.test.tsx
@@ -103,6 +103,25 @@ describe("useQueryParam", () => {
       });
       expect(result.current.queryParam).toBe("test2");
     });
+    it("should handle empty strings", () => {
+      const wrapper: React.FC<{ children: React.ReactNode }> = ({
+        children,
+      }) => (
+        <MemoryRouter initialEntries={["/?search="]}>{children}</MemoryRouter>
+      );
+      const { result } = renderHook(() => useQueryJointHook("search", "test"), {
+        wrapper,
+      });
+      expect(result.current.queryParam).toBe("");
+      act(() => {
+        result.current.setQueryParam("test2");
+      });
+      expect(result.current.queryParam).toBe("test2");
+      act(() => {
+        result.current.setQueryParam("");
+      });
+      expect(result.current.queryParam).toBe("");
+    });
   });
   describe("should handle numbers", () => {
     it("when a default is provided", () => {

--- a/src/hooks/useQueryParam/useQueryParam.test.tsx
+++ b/src/hooks/useQueryParam/useQueryParam.test.tsx
@@ -103,7 +103,7 @@ describe("useQueryParam", () => {
       });
       expect(result.current.queryParam).toBe("test2");
     });
-    it("should handle empty strings", () => {
+    it("should preserve empty strings", () => {
       const wrapper: React.FC<{ children: React.ReactNode }> = ({
         children,
       }) => (

--- a/src/utils/queryString/stringifyQuery.test.ts
+++ b/src/utils/queryString/stringifyQuery.test.ts
@@ -1,0 +1,46 @@
+import { stringifyQuery, stringifyQueryAsValue } from "./stringifyQuery";
+
+describe("stringifyQuery", () => {
+  it("should return an empty string for an empty object", () => {
+    const result = stringifyQuery({});
+    expect(result).toBe("");
+  });
+
+  it("should return a string with one key-value pair for an object with one property", () => {
+    const result = stringifyQuery({ foo: "bar" });
+    expect(result).toBe("foo=bar");
+  });
+
+  it("should handle objects with multiple properties", () => {
+    const result = stringifyQuery({ foo: "bar", baz: 42 });
+    expect(result).toBe("baz=42&foo=bar");
+  });
+
+  it("should handle array properties with comma notation", () => {
+    const result = stringifyQuery({ foo: ["bar", "baz"] });
+    expect(result).toBe("foo=bar,baz");
+  });
+});
+
+describe("stringifyQueryAsValue", () => {
+  it("should skip null properties", () => {
+    const result = stringifyQueryAsValue({ foo: "bar", baz: null });
+    expect(result).toBe("foo=bar");
+  });
+
+  it("should handle objects with multiple properties", () => {
+    const result = stringifyQueryAsValue({ foo: "bar", baz: 42 });
+    expect(result).toBe("baz=42&foo=bar");
+  });
+
+  it("should handle array properties with comma notation", () => {
+    const result = stringifyQueryAsValue({ foo: ["bar", "baz"], qux: null });
+    expect(result).toBe("foo=bar,baz");
+  });
+  it("should preserve empty strings", () => {
+    let result = stringifyQueryAsValue({ foo: "", bar: null });
+    expect(result).toBe("foo=");
+    result = stringifyQueryAsValue({ foo: "", bar: 21 });
+    expect(result).toBe("bar=21&foo=");
+  });
+});

--- a/src/utils/queryString/stringifyQuery.ts
+++ b/src/utils/queryString/stringifyQuery.ts
@@ -9,5 +9,4 @@ export const stringifyQueryAsValue = (object: { [key: string]: any }) =>
   stringify(object, {
     arrayFormat: "comma",
     skipNull: true,
-    skipEmptyString: true,
   });


### PR DESCRIPTION
EVG-19228

### Description
This was caused by a parameter that removed empty strings. 
I'll make this change on parsley as well.
### Screenshots



https://user-images.githubusercontent.com/4605522/229576634-cdc28bc0-97bc-4ae6-b326-362562b89d4e.mov

