### PR TITLE
EVG-19304 Memoize useQueryParams return type

### DIFF
--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -1107,6 +1107,7 @@ export type PodEventLogData = {
   newStatus?: Maybe<Scalars["String"]>;
   oldStatus?: Maybe<Scalars["String"]>;
   reason?: Maybe<Scalars["String"]>;
+  task?: Maybe<Task>;
   taskExecution?: Maybe<Scalars["Int"]>;
   taskID?: Maybe<Scalars["String"]>;
   taskStatus?: Maybe<Scalars["String"]>;

--- a/src/hooks/useQueryParam/index.ts
+++ b/src/hooks/useQueryParam/index.ts
@@ -11,7 +11,9 @@ const useQueryParams = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const setQueryString = useCallback(
     (params: { [key: string]: any }) => {
-      const stringifiedQuery = stringifyQuery(params);
+      const stringifiedQuery = stringifyQuery(params, {
+        skipEmptyString: false,
+      });
       setSearchParams(new URLSearchParams(stringifiedQuery), { replace: true });
     },
     [setSearchParams]

--- a/src/hooks/useQueryParam/index.ts
+++ b/src/hooks/useQueryParam/index.ts
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import { useSearchParams } from "react-router-dom";
 import { conditionalToArray } from "utils/array";
 import {
@@ -17,7 +17,11 @@ const useQueryParams = () => {
     [setSearchParams]
   );
 
-  return [parseQueryString(searchParams.toString()), setQueryString] as const;
+  const parsedQueryString = useMemo(
+    () => parseQueryString(searchParams.toString()),
+    [searchParams]
+  );
+  return [parsedQueryString, setQueryString] as const;
 };
 
 /**

--- a/src/utils/queryString/stringifyQuery.test.ts
+++ b/src/utils/queryString/stringifyQuery.test.ts
@@ -37,10 +37,20 @@ describe("stringifyQueryAsValue", () => {
     const result = stringifyQueryAsValue({ foo: ["bar", "baz"], qux: null });
     expect(result).toBe("foo=bar,baz");
   });
-  it("should preserve empty strings", () => {
-    let result = stringifyQueryAsValue({ foo: "", bar: null });
+  it("should skip empty strings", () => {
+    const result = stringifyQueryAsValue({ foo: "", bar: null });
+    expect(result).toBe("");
+  });
+  it("should preserve empty strings if skipEmptyString is passed in", () => {
+    let result = stringifyQueryAsValue(
+      { foo: "", bar: null },
+      { skipEmptyString: false }
+    );
     expect(result).toBe("foo=");
-    result = stringifyQueryAsValue({ foo: "", bar: 21 });
+    result = stringifyQueryAsValue(
+      { foo: "", bar: 21 },
+      { skipEmptyString: false }
+    );
     expect(result).toBe("bar=21&foo=");
   });
 });

--- a/src/utils/queryString/stringifyQuery.ts
+++ b/src/utils/queryString/stringifyQuery.ts
@@ -1,12 +1,17 @@
-import { stringify } from "query-string";
+import { stringify, StringifyOptions } from "query-string";
 
 export const stringifyQuery = (object: { [key: string]: any }) =>
   stringify(object, {
     arrayFormat: "comma",
   });
 
-export const stringifyQueryAsValue = (object: { [key: string]: any }) =>
+export const stringifyQueryAsValue = (
+  object: { [key: string]: any },
+  options: StringifyOptions = {}
+) =>
   stringify(object, {
     arrayFormat: "comma",
     skipNull: true,
+    skipEmptyString: true,
+    ...options,
   });


### PR DESCRIPTION
EVG-19304

### Description
Eliminates a render caused by `parseQueryString(searchParams.toString())` returning a new reference each time.


