### PR TITLE
EVG-19322: E2E test references new unactivated CQ patch

### DIFF
--- a/cypress/integration/version/routes.ts
+++ b/cypress/integration/version/routes.ts
@@ -3,7 +3,7 @@ const versions = {
   1: "i-dont-exist", // non existent patch
   2: "52a630633ff1227909000021", // patch 2
   3: "5e6bb9e23066155a993e0f1a", // unconfigured patch
-  4: "5e94c2dfe3c3312519b59480", // unactivated patch on commit queue
+  4: "642de18d2a60edf48b34a8c7", // unactivated patch on commit queue
   5: "evergreen_33016573166a36bd5f46b4111151899d5c4e95b1", // basecommit for versions[0]
   6: "5e4ff3abe3c3317e352062e4",
 };

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -46,6 +46,7 @@ export type Annotation = {
   createdIssues?: Maybe<Array<Maybe<IssueLink>>>;
   id: Scalars["String"];
   issues?: Maybe<Array<Maybe<IssueLink>>>;
+  metadataLinks?: Maybe<Array<Maybe<MetadataLink>>>;
   note?: Maybe<Note>;
   suspectedIssues?: Maybe<Array<Maybe<IssueLink>>>;
   taskExecution: Scalars["Int"];
@@ -540,6 +541,7 @@ export type LogkeeperBuild = {
   buildNum: Scalars["Int"];
   builder: Scalars["String"];
   id: Scalars["String"];
+  task: Task;
   taskExecution: Scalars["Int"];
   taskId: Scalars["String"];
   tests: Array<LogkeeperTest>;
@@ -602,6 +604,18 @@ export enum MetStatus {
   Started = "STARTED",
   Unmet = "UNMET",
 }
+
+export type MetadataLink = {
+  __typename?: "MetadataLink";
+  source?: Maybe<Source>;
+  text: Scalars["String"];
+  url: Scalars["String"];
+};
+
+export type MetadataLinkInput = {
+  text: Scalars["String"];
+  url: Scalars["String"];
+};
 
 export type Module = {
   __typename?: "Module";
@@ -668,6 +682,7 @@ export type Mutation = {
   schedulePatchTasks?: Maybe<Scalars["String"]>;
   scheduleTasks: Array<Task>;
   scheduleUndispatchedBaseTasks?: Maybe<Array<Task>>;
+  setAnnotationMetadataLinks: Scalars["Boolean"];
   setPatchPriority?: Maybe<Scalars["String"]>;
   setTaskPriority: Task;
   spawnHost: Host;
@@ -859,6 +874,12 @@ export type MutationScheduleTasksArgs = {
 
 export type MutationScheduleUndispatchedBaseTasksArgs = {
   patchId: Scalars["String"];
+};
+
+export type MutationSetAnnotationMetadataLinksArgs = {
+  apiMetadataLinks: Array<MetadataLinkInput>;
+  execution: Scalars["Int"];
+  taskId: Scalars["String"];
 };
 
 export type MutationSetPatchPriorityArgs = {


### PR DESCRIPTION
EVG-19322

### Description
<!-- add description, context, thought process, etc -->
- Since https://github.com/evergreen-ci/evergreen/pull/6382 introduces a version for patch `5e94c2dfe3c3312519b59480`, it is no longer unactivated. I added another patch there that is unactivated; we should now use it in the e2e test that checks that unactivated patches redirect to the commit queue.

### Testing
<!-- add a description of how you tested it -->
- Verified locally on Cypress

### Evergreen PR
<!-- link to a corresponding Evergreen PR if applicable -->
https://github.com/evergreen-ci/evergreen/pull/6382