### PR TITLE
EVG-19272: Commit Queue settings page is error-free for new projects

### DIFF
--- a/src/components/SpruceForm/errors.ts
+++ b/src/components/SpruceForm/errors.ts
@@ -34,6 +34,11 @@ export const transformErrors = (errors: AjvError[]) =>
             ...error,
             message: Errors.Invisible,
           };
+        case "oneOf":
+          return {
+            ...error,
+            message: "Please select one of the available options.",
+          };
         case "format":
           switch (error.params.format) {
             case "noSpaces":

--- a/src/pages/projectSettings/tabs/GithubCommitQueueTab/getFormSchema.tsx
+++ b/src/pages/projectSettings/tabs/GithubCommitQueueTab/getFormSchema.tsx
@@ -192,47 +192,75 @@ export const getFormSchema = (
                 repoData?.commitQueue?.enabled
               ),
             },
-            message: {
-              type: "string" as "string",
-              title: "Commit Queue Message",
-            },
-            mergeMethod: {
-              type: "string" as "string",
-              title: "Merge Method",
+          },
+          dependencies: {
+            enabled: {
               oneOf: [
                 {
-                  type: "string" as "string",
-                  title: "Squash",
-                  enum: ["squash"],
+                  properties: {
+                    enabled: {
+                      enum: [false],
+                    },
+
+                    message: {
+                      type: "string" as "string",
+                      title: "Commit Queue Message",
+                    },
+                  },
                 },
                 {
-                  type: "string" as "string",
-                  title: "Merge",
-                  enum: ["merge"],
+                  properties: {
+                    enabled: {
+                      enum: [true],
+                    },
+                    message: {
+                      type: "string" as "string",
+                      title: "Commit Queue Message",
+                    },
+                    mergeMethod: {
+                      type: "string" as "string",
+                      title: "Merge Method",
+                      oneOf: [
+                        {
+                          type: "string" as "string",
+                          title: "Squash",
+                          enum: ["squash"],
+                        },
+                        {
+                          type: "string" as "string",
+                          title: "Merge",
+                          enum: ["merge"],
+                        },
+                        {
+                          type: "string" as "string",
+                          title: "Rebase",
+                          enum: ["rebase"],
+                        },
+                        ...insertIf(
+                          projectType === ProjectType.AttachedProject,
+                          {
+                            type: "string" as "string",
+                            title: `Default to Repo (${repoData?.commitQueue?.mergeMethod})`,
+                            enum: [""],
+                          }
+                        ),
+                      ],
+                    },
+                    patchDefinitions: {
+                      type: "object" as "object",
+                      title: "Commit Queue Patch Definitions",
+                      ...overrideRadioBox(
+                        "commitQueueAliases",
+                        [
+                          "Override Repo Patch Definition",
+                          "Default to Repo Patch Definition",
+                        ],
+                        aliasArray.schema
+                      ),
+                    },
+                  },
                 },
-                {
-                  type: "string" as "string",
-                  title: "Rebase",
-                  enum: ["rebase"],
-                },
-                ...insertIf(projectType === ProjectType.AttachedProject, {
-                  type: "string" as "string",
-                  title: `Default to Repo (${repoData?.commitQueue?.mergeMethod})`,
-                  enum: [""],
-                }),
               ],
-            },
-            patchDefinitions: {
-              type: "object" as "object",
-              title: "Commit Queue Patch Definitions",
-              ...overrideRadioBox(
-                "commitQueueAliases",
-                [
-                  "Override Repo Patch Definition",
-                  "Default to Repo Patch Definition",
-                ],
-                aliasArray.schema
-              ),
             },
           },
         },
@@ -433,20 +461,8 @@ export const getFormSchema = (
         mergeMethod: {
           "ui:allowDeselect": false,
           "ui:data-cy": "merge-method-select",
-          ...hideIf(
-            fieldDisabled(
-              formData?.commitQueue?.enabled,
-              repoData?.commitQueue?.enabled
-            )
-          ),
         },
         patchDefinitions: {
-          ...hideIf(
-            fieldDisabled(
-              formData?.commitQueue?.enabled,
-              repoData?.commitQueue?.enabled
-            )
-          ),
           ...errorStyling(
             formData?.commitQueue?.enabled,
             formData?.commitQueue?.patchDefinitions?.commitQueueAliasesOverride,


### PR DESCRIPTION
EVG-19272

### Description
<!-- add description, context, thought process, etc -->
- Update page schema to use a dependency so that Commit Queue fields that are not currently active/visible (e.g. when CQ is disabled) are not validated
- Improve error message for when commit queue is enabled

### Screenshots
<!-- add screenshots of visible changes -->
<img width="665" alt="image" src="https://user-images.githubusercontent.com/9298431/231287350-59a976fa-b916-4480-b5a3-ab38e15767e6.png">