### PR TITLE
EVG-19058: Remove build baron language on settings page

### DIFF
--- a/src/pages/projectSettings/tabs/PluginsTab/getFormSchema.ts
+++ b/src/pages/projectSettings/tabs/PluginsTab/getFormSchema.ts
@@ -29,7 +29,7 @@ export const getFormSchema = (
       },
       buildBaronSettings: {
         type: "object" as "object",
-        title: "Build Baron and Task Annotations",
+        title: "Ticket Creation",
         properties: {
           taskAnnotationSettings: {
             title: "",
@@ -61,7 +61,7 @@ export const getFormSchema = (
           useBuildBaron: {
             type: "boolean" as "boolean",
             oneOf: radioBoxOptions([
-              "Build Baron Ticket Search and Create",
+              "JIRA Ticket Search and Create",
               "Custom Ticket Creation",
             ]),
           },


### PR DESCRIPTION
EVG-19058

### Description
<!-- add description, context, thought process, etc -->
- Remove Build Baron language on plugins settings page since the settings are not necessarily BB related

### Screenshots
<!-- add screenshots of visible changes -->
<img width="636" alt="image" src="https://user-images.githubusercontent.com/9298431/232853878-2d9d064d-c9d7-48fd-beca-34c749c78b36.png">