### PR TITLE
EVG-19669 Fix broken spruce deploys

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -361,14 +361,6 @@ functions:
 
         echo "Done populating"
 
-  deploy-to-prod:
-    command: shell.exec
-    params:
-      working_dir: spruce
-      script: |
-        ${PREPARE_SHELL}
-        BUCKET=${bucket} AWS_ACCESS_KEY_ID=${aws_key} AWS_SECRET_ACCESS_KEY=${aws_secret}  yarn deploy; yarn upload-source-maps;
-
   build-prod:
     command: shell.exec
     params:
@@ -380,6 +372,15 @@ functions:
         echo "Building Production version: $REACT_APP_VERSION"
         yarn build:prod
   
+  upload-to-prod-s3:
+    command: shell.exec
+    params:
+      working_dir: spruce
+      shell: bash
+      script: |
+        ${PREPARE_SHELL}
+        REACT_APP_BUGSNAG_API_KEY=${REACT_APP_BUGSNAG_API_KEY} BUCKET=${bucket} AWS_ACCESS_KEY_ID=${aws_key} AWS_SECRET_ACCESS_KEY=${aws_secret}  yarn deploy:do-not-use;
+
   send-email:
     command: shell.exec
     params:
@@ -447,7 +448,7 @@ tasks:
       - func: setup-credentials
       - func: sym-link
       - func: build-prod
-      - func: deploy-to-prod
+      - func: upload-to-prod-s3
       - func: send-email
 
 buildvariants:


### PR DESCRIPTION
EVG-19669

### Description
The old command used `yarn deploy` which was removed from the package.json and was silently failing. Updated to use `yarn deploy:do-not-use` which calls a script that manages uploading the artifacts. 

