### PR TITLE
EVG-19694: Omit seconds from task and version metadata

### DIFF
--- a/src/pages/task/metadata/index.tsx
+++ b/src/pages/task/metadata/index.tsx
@@ -122,7 +122,10 @@ export const Metadata: React.VFC<Props> = ({
 
       {submittedTime && (
         <MetadataItem data-cy="task-metadata-submitted-at">
-          Submitted at: {getDateCopy(submittedTime)}
+          Submitted at:{" "}
+          <span title={getDateCopy(submittedTime)}>
+            {getDateCopy(submittedTime, { omitSeconds: true })}
+          </span>
         </MetadataItem>
       )}
       {generatedBy && (
@@ -147,14 +150,19 @@ export const Metadata: React.VFC<Props> = ({
       {startTime && (
         <MetadataItem>
           Started:{" "}
-          <span data-cy="task-metadata-started">{getDateCopy(startTime)}</span>
+          <span data-cy="task-metadata-started" title={getDateCopy(startTime)}>
+            {getDateCopy(startTime, { omitSeconds: true })}
+          </span>
         </MetadataItem>
       )}
       {finishTime && (
         <MetadataItem>
           Finished:{" "}
-          <span data-cy="task-metadata-finished">
-            {getDateCopy(finishTime)}
+          <span
+            data-cy="task-metadata-finished"
+            title={getDateCopy(finishTime)}
+          >
+            {getDateCopy(finishTime, { omitSeconds: true })}
           </span>
         </MetadataItem>
       )}

--- a/src/pages/version/Metadata.tsx
+++ b/src/pages/version/Metadata.tsx
@@ -90,13 +90,28 @@ export const Metadata: React.VFC<Props> = ({ loading, version }) => {
         Time taken: {timeTaken && msToDuration(timeTaken)}
       </MetadataItem>
       <MetadataItem>
-        Submitted at: {createTime && getDateCopy(createTime)}
+        Submitted at:{" "}
+        {createTime && (
+          <span title={getDateCopy(createTime)}>
+            {getDateCopy(createTime, { omitSeconds: true })}
+          </span>
+        )}
       </MetadataItem>
       <MetadataItem>
-        Started: {startTime && getDateCopy(startTime)}
+        Started:{" "}
+        {startTime && (
+          <span title={getDateCopy(startTime)}>
+            {getDateCopy(startTime, { omitSeconds: true })}
+          </span>
+        )}
       </MetadataItem>
       {finishTime && (
-        <MetadataItem>Finished: {getDateCopy(finishTime)}</MetadataItem>
+        <MetadataItem>
+          Finished:{" "}
+          <span title={getDateCopy(finishTime)}>
+            {getDateCopy(finishTime, { omitSeconds: true })}
+          </span>
+        </MetadataItem>
       )}
       <MetadataItem>{`Submitted by: ${author}`}</MetadataItem>
       {isPatch ? (


### PR DESCRIPTION
EVG-19694

### Description
<!-- add description, context, thought process, etc -->
- Simplify metadata by omitting seconds in the sidebar. Hovering will show seconds via `title` attribute.

### Screenshots
<!-- add screenshots of visible changes -->
<img width="363" alt="image" src="https://user-images.githubusercontent.com/9298431/234051465-956a8233-c693-4d3f-9276-9fbe1b2f5bb9.png">