### PR TITLE
EVG-19697: Ensure error/warning arrays exists before checking length

### DIFF
--- a/src/pages/Version.tsx
+++ b/src/pages/Version.tsx
@@ -159,8 +159,8 @@ export const VersionPage: React.VFC = () => {
 
   return (
     <PageWrapper data-cy="version-page">
-      {errors.length > 0 && <ErrorBanner errors={errors} />}
-      {warnings.length > 0 && <WarningBanner warnings={warnings} />}
+      {errors && errors.length > 0 && <ErrorBanner errors={errors} />}
+      {warnings && warnings.length > 0 && <WarningBanner warnings={warnings} />}
       {version && (
         <VersionPageBreadcrumbs
           patchNumber={patchNumber}


### PR DESCRIPTION
EVG-19697

### Description
<!-- add description, context, thought process, etc -->
- Handle [BugSnag error](https://app.bugsnag.com/mongodb/evergreen/errors/6447d32e5c001f00099a5733?event_id=6447d32e00bbae55dec30000&i=sk&m=nw) by ensuring array is defined before accessing its length