### PR TITLE
EVG-19746 Hide Host in side panel for container tasks

### DIFF
--- a/src/pages/task/metadata/index.tsx
+++ b/src/pages/task/metadata/index.tsx
@@ -231,7 +231,7 @@ export const Metadata: React.VFC<Props> = ({
       {ami && (
         <MetadataItem data-cy="task-metadata-ami">AMI: {ami}</MetadataItem>
       )}
-      {!isContainerTask && (
+      {!isContainerTask && hostId && (
         <MetadataItem>
           Host:{" "}
           <StyledLink


### PR DESCRIPTION
EVG-19746

### Description
Sometimes we might show the `Host` label in a task metadata for container tasks that have not been assigned a podId yet. This adds an additional guard to ensure that a hostId also exists.

