### PR TITLE
EVG-8291 Add pagination to bottom of tasks tables

### DIFF
--- a/src/components/Content/index.tsx
+++ b/src/components/Content/index.tsx
@@ -154,4 +154,10 @@ const FloatingContent = styled.div`
   background-color: white;
   padding: ${size.xs};
   border-radius: ${size.s};
+  transition: opacity 0.2s ease-in-out;
+  opacity: 0.2;
+  :hover {
+    transition: opacity 0.2s ease-in-out;
+    opacity: 1;
+  }
 `;

--- a/src/pages/version/TaskDuration.tsx
+++ b/src/pages/version/TaskDuration.tsx
@@ -96,6 +96,7 @@ const TaskDuration: React.VFC<Props> = ({ taskCount }) => {
 };
 const TableControlWrapper = styled.div`
   padding-top: ${size.xs};
+  margin-bottom: ${size.l};
 `;
 
 export default TaskDuration;

--- a/src/pages/version/TaskDuration.tsx
+++ b/src/pages/version/TaskDuration.tsx
@@ -1,7 +1,9 @@
 import { useEffect } from "react";
 import { useQuery } from "@apollo/client";
+import styled from "@emotion/styled";
 import { useParams, useLocation } from "react-router-dom";
 import { DEFAULT_POLL_INTERVAL } from "constants/index";
+import { size } from "constants/tokens";
 import { useToastContext } from "context/toast";
 import {
   VersionTaskDurationsQuery,
@@ -66,6 +68,7 @@ const TaskDuration: React.VFC<Props> = ({ taskCount }) => {
   const { version } = data || {};
   const { tasks } = version || {};
   const { data: tasksData = [], count = 0 } = tasks || {};
+  const shouldShowBottomTableControl = tasksData.length > 10;
 
   return (
     <>
@@ -77,8 +80,22 @@ const TaskDuration: React.VFC<Props> = ({ taskCount }) => {
         onClear={clearQueryParams}
       />
       <TaskDurationTable tasks={tasksData} loading={loading} />
+      {shouldShowBottomTableControl && (
+        <TableControlWrapper>
+          <TableControl
+            filteredCount={count}
+            taskCount={taskCount}
+            limit={limit}
+            page={page}
+            onClear={clearQueryParams}
+          />
+        </TableControlWrapper>
+      )}
     </>
   );
 };
+const TableControlWrapper = styled.div`
+  padding-top: ${size.xs};
+`;
 
 export default TaskDuration;

--- a/src/pages/version/Tasks.tsx
+++ b/src/pages/version/Tasks.tsx
@@ -103,4 +103,5 @@ export const Tasks: React.VFC<Props> = ({ taskCount }) => {
 
 const TableControlWrapper = styled.div`
   padding-top: ${size.xs};
+  margin-bottom: ${size.l};
 `;

--- a/src/pages/version/Tasks.tsx
+++ b/src/pages/version/Tasks.tsx
@@ -1,7 +1,9 @@
 import { useEffect } from "react";
 import { useQuery } from "@apollo/client";
+import styled from "@emotion/styled";
 import { useParams, useLocation } from "react-router-dom";
 import { DEFAULT_POLL_INTERVAL } from "constants/index";
+import { size } from "constants/tokens";
 import { useToastContext } from "context/toast";
 import {
   VersionTasksQuery,
@@ -69,6 +71,7 @@ export const Tasks: React.VFC<Props> = ({ taskCount }) => {
   const { tasks } = version || {};
   const { data: tasksData = [], count = 0 } = tasks || {};
 
+  const shouldShowBottomTableControl = tasksData.length > 10;
   return (
     <>
       <TableControl
@@ -83,6 +86,21 @@ export const Tasks: React.VFC<Props> = ({ taskCount }) => {
         tasks={tasksData}
         loading={tasksData.length === 0 && loading}
       />
+      {shouldShowBottomTableControl && (
+        <TableControlWrapper>
+          <TableControl
+            filteredCount={count}
+            taskCount={taskCount}
+            limit={limit}
+            page={page}
+            onClear={clearQueryParams}
+          />
+        </TableControlWrapper>
+      )}
     </>
   );
 };
+
+const TableControlWrapper = styled.div`
+  padding-top: ${size.xs};
+`;


### PR DESCRIPTION
EVG-8291

### Description
Adds pagination and table controls to the bottom of the tasks and task duration tables.
Only show the options if the table has > 10 entries to avoid the "small sandwich" look.
I also noticed that the floating buttons on the bottom of the page tend to overlap with the pagination buttons at the bottom so I added transparency to them so they are less obtrusive. 
### Screenshots
<img width="910" alt="image" src="https://user-images.githubusercontent.com/4605522/235524618-ac43c8d8-53d6-4e68-9b82-ca798e7f2367.png">


