### PR TITLE
EVG-19316: Enable @graphql-eslint/naming-convention rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -226,14 +226,13 @@ module.exports = {
       files: ["src/gql/**/*.graphql"],
       extends: "plugin:@graphql-eslint/operations-recommended",
       rules: {
-        "@graphql-eslint/naming-convention": OFF, // This line should be removed as part of EVG-19316.
         "@graphql-eslint/selection-set-depth": OFF,
         "@graphql-eslint/no-deprecated": WARN,
         "@graphql-eslint/alphabetize": [
           ERROR,
           { selections: ["OperationDefinition", "FragmentDefinition"] },
         ],
-        // Following two rules can possibly be removed after ESLint updates.
+        // Allows importing fragments without lint errors.
         "spaced-comment": OFF,
         "@typescript-eslint/spaced-comment": OFF,
       },

--- a/src/analytics/patch/usePatchAnalytics.ts
+++ b/src/analytics/patch/usePatchAnalytics.ts
@@ -2,7 +2,7 @@ import { useQuery } from "@apollo/client";
 import { addPageAction, Properties, Analytics } from "analytics/addPageAction";
 import { useGetUserQuery } from "analytics/useGetUserQuery";
 import {
-  SaveSubscriptionMutationVariables,
+  SaveSubscriptionForUserMutationVariables,
   PatchQuery,
   PatchQueryVariables,
   TaskSortCategory,
@@ -42,7 +42,7 @@ type Action =
   | { name: "Clear all filter" }
   | {
       name: "Add Notification";
-      subscription: SaveSubscriptionMutationVariables["subscription"];
+      subscription: SaveSubscriptionForUserMutationVariables["subscription"];
     }
   | { name: "Toggle Display Task Dropdown"; expanded: boolean }
   | { name: "Click Base Commit Link" }

--- a/src/analytics/projectHealth/useProjectHealthAnalytics.ts
+++ b/src/analytics/projectHealth/useProjectHealthAnalytics.ts
@@ -3,7 +3,7 @@ import {
   Properties,
   Analytics as A,
 } from "analytics/addPageAction";
-import { SaveSubscriptionMutationVariables } from "gql/generated/types";
+import { SaveSubscriptionForUserMutationVariables } from "gql/generated/types";
 
 type pageType = "Commit chart" | "Task history" | "Variant history";
 type Action =
@@ -41,7 +41,7 @@ type Action =
   | { name: "Open Notification Modal" }
   | {
       name: "Add Notification";
-      subscription: SaveSubscriptionMutationVariables["subscription"];
+      subscription: SaveSubscriptionForUserMutationVariables["subscription"];
     };
 
 interface P extends Properties {}

--- a/src/analytics/spawn/useSpawnAnalytics.ts
+++ b/src/analytics/spawn/useSpawnAnalytics.ts
@@ -23,7 +23,7 @@ type Action =
       name: "Spawned a host";
       isMigration: boolean;
       params: Omit<
-        SpawnHostMutationVariables["SpawnHostInput"],
+        SpawnHostMutationVariables["spawnHostInput"],
         "publicKey" | "userDataScript" | "setUpScript"
       >;
     }
@@ -33,11 +33,11 @@ type Action =
   | { name: "Unmount volume"; volumeId: string }
   | {
       name: "Spawned a volume";
-      params: SpawnVolumeMutationVariables["SpawnVolumeInput"];
+      params: SpawnVolumeMutationVariables["spawnVolumeInput"];
     }
   | {
       name: "Edited a Spawn Volume";
-      params: UpdateVolumeMutationVariables["UpdateVolumeInput"];
+      params: UpdateVolumeMutationVariables["updateVolumeInput"];
     }
   | { name: "Opened IDE" };
 

--- a/src/analytics/task/useAnnotationAnalytics.ts
+++ b/src/analytics/task/useAnnotationAnalytics.ts
@@ -6,8 +6,8 @@ import { useGetUserQuery } from "analytics/useGetUserQuery";
 import {
   BuildBaronQuery,
   BuildBaronQueryVariables,
-  GetAnnotationEventDataQuery,
-  GetAnnotationEventDataQueryVariables,
+  AnnotationEventDataQuery,
+  AnnotationEventDataQueryVariables,
 } from "gql/generated/types";
 import { GET_ANNOTATION_EVENT_DATA, GET_BUILD_BARON } from "gql/queries";
 import { RequiredQueryParams } from "types/task";
@@ -42,8 +42,8 @@ export const useAnnotationAnalytics = (): AnnotationAnalytics => {
   const parsed = parseQueryString(location.search);
   const execution = Number(parsed[RequiredQueryParams.Execution]);
   const { data: eventData } = useQuery<
-    GetAnnotationEventDataQuery,
-    GetAnnotationEventDataQueryVariables
+    AnnotationEventDataQuery,
+    AnnotationEventDataQueryVariables
   >(GET_ANNOTATION_EVENT_DATA, {
     variables: { taskId: id, execution },
     fetchPolicy: "cache-first",

--- a/src/analytics/task/useTaskAnalytics.ts
+++ b/src/analytics/task/useTaskAnalytics.ts
@@ -7,9 +7,9 @@ import {
 } from "analytics/addPageAction";
 import { useGetUserQuery } from "analytics/useGetUserQuery";
 import {
-  SaveSubscriptionMutationVariables,
-  GetTaskQuery,
-  GetTaskQueryVariables,
+  SaveSubscriptionForUserMutationVariables,
+  TaskQuery,
+  TaskQueryVariables,
   TaskSortCategory,
   TestSortCategory,
 } from "gql/generated/types";
@@ -54,7 +54,7 @@ type Action =
   | { name: "Open Notification Modal" }
   | {
       name: "Add Notification";
-      subscription: SaveSubscriptionMutationVariables["subscription"];
+      subscription: SaveSubscriptionForUserMutationVariables["subscription"];
     }
   | { name: "Click Base Commit" }
   | { name: "Click Host Link" }
@@ -84,7 +84,7 @@ export const useTaskAnalytics = (): Analytics => {
 
   const parsed = parseQueryString(location.search);
   const execution = Number(parsed[RequiredQueryParams.Execution]);
-  const { data: eventData } = useQuery<GetTaskQuery, GetTaskQueryVariables>(
+  const { data: eventData } = useQuery<TaskQuery, TaskQueryVariables>(
     GET_TASK,
     {
       variables: { taskId: id, execution },

--- a/src/analytics/useGetUserQuery.ts
+++ b/src/analytics/useGetUserQuery.ts
@@ -1,9 +1,9 @@
 import { useQuery } from "@apollo/client";
 import get from "lodash/get";
-import { GetUserQuery } from "gql/generated/types";
+import { UserQuery } from "gql/generated/types";
 import { GET_USER } from "gql/queries";
 
 export const useGetUserQuery = () => {
-  const { data } = useQuery<GetUserQuery>(GET_USER);
+  const { data } = useQuery<UserQuery>(GET_USER);
   return get(data, "user.userId", null);
 };

--- a/src/analytics/version/useVersionAnalytics.ts
+++ b/src/analytics/version/useVersionAnalytics.ts
@@ -2,7 +2,7 @@ import { useQuery } from "@apollo/client";
 import { addPageAction, Properties, Analytics } from "analytics/addPageAction";
 import { useGetUserQuery } from "analytics/useGetUserQuery";
 import {
-  SaveSubscriptionMutationVariables,
+  SaveSubscriptionForUserMutationVariables,
   VersionQuery,
   VersionQueryVariables,
   TaskSortCategory,
@@ -43,7 +43,7 @@ type Action =
   | { name: "Clear all filter" }
   | {
       name: "Add Notification";
-      subscription: SaveSubscriptionMutationVariables["subscription"];
+      subscription: SaveSubscriptionForUserMutationVariables["subscription"];
     }
   | { name: "Toggle Display Task Dropdown"; expanded: boolean }
   | { name: "Click Base Commit Link" }

--- a/src/components/Banners/GithubUsernameBanner.tsx
+++ b/src/components/Banners/GithubUsernameBanner.tsx
@@ -7,7 +7,7 @@ import {
   PreferencesTabRoutes,
   routes,
 } from "constants/routes";
-import { GetUserSettingsQuery } from "gql/generated/types";
+import { UserSettingsQuery } from "gql/generated/types";
 import { GET_USER_SETTINGS } from "gql/queries";
 
 export const GithubUsernameBanner = () => {
@@ -16,7 +16,7 @@ export const GithubUsernameBanner = () => {
   const isPatchesPage = !!matchedPath;
 
   // USER SETTINGS QUERY
-  const { data: userSettingsData } = useQuery<GetUserSettingsQuery>(
+  const { data: userSettingsData } = useQuery<UserSettingsQuery>(
     GET_USER_SETTINGS,
     { skip: !isPatchesPage }
   );

--- a/src/components/Banners/SlackNotificationBanner.tsx
+++ b/src/components/Banners/SlackNotificationBanner.tsx
@@ -12,7 +12,7 @@ import { useToastContext } from "context/toast";
 import {
   UpdateUserSettingsMutation,
   UpdateUserSettingsMutationVariables,
-  GetUserSettingsQuery,
+  UserSettingsQuery,
 } from "gql/generated/types";
 import { UPDATE_USER_SETTINGS } from "gql/mutations";
 import { GET_USER_SETTINGS } from "gql/queries";
@@ -37,12 +37,12 @@ export const SlackNotificationBanner = () => {
       onError: (err) => {
         dispatchToast.error(`Error while saving settings: '${err.message}'`);
       },
-      refetchQueries: ["GetUserSettings"],
+      refetchQueries: ["UserSettings"],
     });
 
   // USER SETTINGS QUERY
   const { data: userSettingsData } =
-    useQuery<GetUserSettingsQuery>(GET_USER_SETTINGS);
+    useQuery<UserSettingsQuery>(GET_USER_SETTINGS);
   const { userSettings } = userSettingsData || {};
   const { slackUsername: defaultSlackUsername, notifications } =
     userSettings || {};

--- a/src/components/Content/index.tsx
+++ b/src/components/Content/index.tsx
@@ -17,7 +17,7 @@ import { redirectRoutes, routes } from "constants/routes";
 import { zIndex, size } from "constants/tokens";
 import { newSpruceUser } from "constants/welcomeModalProps";
 import { useAuthStateContext } from "context/auth";
-import { GetUserQuery, GetUserQueryVariables } from "gql/generated/types";
+import { UserQuery, UserQueryVariables } from "gql/generated/types";
 import { GET_USER } from "gql/queries";
 import { useUserSettings } from "hooks";
 import { useAnnouncementToast } from "hooks/useAnnouncementToast";
@@ -54,7 +54,7 @@ export const Content: React.VFC = () => {
   // this top-level query is required for authentication to work
   // afterware is used at apollo link level to authenticate or deauthenticate user based on response to query
   // therefore this could be any query as long as it is top-level
-  const { data } = useQuery<GetUserQuery, GetUserQueryVariables>(GET_USER);
+  const { data } = useQuery<UserQuery, UserQueryVariables>(GET_USER);
   localStorage.setItem("userId", data?.user?.userId ?? "");
   const { userSettings } = useUserSettings();
 

--- a/src/components/Header/Navbar.tsx
+++ b/src/components/Header/Navbar.tsx
@@ -12,7 +12,7 @@ import { wikiUrl } from "constants/externalResources";
 import { getCommitsRoute, getUserPatchesRoute, routes } from "constants/routes";
 import { size } from "constants/tokens";
 import { useAuthStateContext } from "context/auth";
-import { GetUserQuery, GetSpruceConfigQuery } from "gql/generated/types";
+import { UserQuery, SpruceConfigQuery } from "gql/generated/types";
 import { GET_USER, GET_SPRUCE_CONFIG } from "gql/queries";
 import { useLegacyUIURL } from "hooks";
 import { AuxiliaryDropdown } from "./AuxiliaryDropdown";
@@ -25,7 +25,7 @@ export const Navbar: React.VFC = () => {
   const legacyURL = useLegacyUIURL();
   const { sendEvent } = useNavbarAnalytics();
 
-  const { data: userData } = useQuery<GetUserQuery>(GET_USER);
+  const { data: userData } = useQuery<UserQuery>(GET_USER);
   const { user } = userData || {};
   const { userId } = user || {};
 
@@ -43,12 +43,9 @@ export const Navbar: React.VFC = () => {
 
   const currProject = projectFromUrl ?? Cookies.get(CURRENT_PROJECT);
 
-  const { data: configData } = useQuery<GetSpruceConfigQuery>(
-    GET_SPRUCE_CONFIG,
-    {
-      skip: currProject !== undefined,
-    }
-  );
+  const { data: configData } = useQuery<SpruceConfigQuery>(GET_SPRUCE_CONFIG, {
+    skip: currProject !== undefined,
+  });
 
   const projectIdentifier =
     currProject || configData?.spruceConfig?.ui?.defaultProject;

--- a/src/components/Header/UserDropdown.tsx
+++ b/src/components/Header/UserDropdown.tsx
@@ -1,12 +1,12 @@
 import { useQuery } from "@apollo/client";
 import { useNavbarAnalytics } from "analytics";
 import { PreferencesTabRoutes, getPreferencesRoute } from "constants/routes";
-import { GetUserQuery } from "gql/generated/types";
+import { UserQuery } from "gql/generated/types";
 import { GET_USER } from "gql/queries";
 import { NavDropdown } from "./NavDropdown";
 
 export const UserDropdown = () => {
-  const { data } = useQuery<GetUserQuery>(GET_USER);
+  const { data } = useQuery<UserQuery>(GET_USER);
   const { user } = data || {};
   const { displayName } = user || {};
 

--- a/src/components/HistoryTable/hooks/useTestResults.test.tsx
+++ b/src/components/HistoryTable/hooks/useTestResults.test.tsx
@@ -1,7 +1,7 @@
 import { act, renderHook } from "@testing-library/react-hooks";
 import {
-  GetTaskTestSampleQuery,
-  GetTaskTestSampleQueryVariables,
+  TaskTestSampleQuery,
+  TaskTestSampleQueryVariables,
 } from "gql/generated/types";
 import { GET_TASK_TEST_SAMPLE } from "gql/queries";
 import { ApolloMock } from "types/gql";
@@ -237,8 +237,8 @@ describe("useMergedHookRender - sanity check", () => {
 });
 
 const noFilterData: ApolloMock<
-  GetTaskTestSampleQuery,
-  GetTaskTestSampleQueryVariables
+  TaskTestSampleQuery,
+  TaskTestSampleQueryVariables
 > = {
   request: {
     query: GET_TASK_TEST_SAMPLE,
@@ -269,8 +269,8 @@ const noFilterData: ApolloMock<
 };
 
 const withMatchingFilter: ApolloMock<
-  GetTaskTestSampleQuery,
-  GetTaskTestSampleQueryVariables
+  TaskTestSampleQuery,
+  TaskTestSampleQueryVariables
 > = {
   request: {
     query: GET_TASK_TEST_SAMPLE,
@@ -303,8 +303,8 @@ const withMatchingFilter: ApolloMock<
 };
 
 const withNonMatchingFilter: ApolloMock<
-  GetTaskTestSampleQuery,
-  GetTaskTestSampleQueryVariables
+  TaskTestSampleQuery,
+  TaskTestSampleQueryVariables
 > = {
   request: {
     query: GET_TASK_TEST_SAMPLE,

--- a/src/components/HistoryTable/hooks/useTestResults.ts
+++ b/src/components/HistoryTable/hooks/useTestResults.ts
@@ -1,8 +1,8 @@
 import { useCallback, useState } from "react";
 import { useQuery } from "@apollo/client";
 import {
-  GetTaskTestSampleQuery,
-  GetTaskTestSampleQueryVariables,
+  TaskTestSampleQuery,
+  TaskTestSampleQueryVariables,
   TaskTestResultSample,
 } from "gql/generated/types";
 import { GET_TASK_TEST_SAMPLE } from "gql/queries";
@@ -29,8 +29,8 @@ const useTestResults = (index: number) => {
   }
   const hasDataToQuery = taskIds.length > 0;
   const { loading } = useQuery<
-    GetTaskTestSampleQuery,
-    GetTaskTestSampleQueryVariables
+    TaskTestSampleQuery,
+    TaskTestSampleQueryVariables
   >(GET_TASK_TEST_SAMPLE, {
     variables: {
       tasks: taskIds,

--- a/src/components/Notifications/index.tsx
+++ b/src/components/Notifications/index.tsx
@@ -13,9 +13,9 @@ import { size } from "constants/tokens";
 import { regexDisplayName, regexBuildVariant } from "constants/triggers";
 import { useToastContext } from "context/toast";
 import {
-  SaveSubscriptionMutation,
-  SaveSubscriptionMutationVariables,
-  GetUserQuery,
+  SaveSubscriptionForUserMutation,
+  SaveSubscriptionForUserMutationVariables,
+  UserQuery,
 } from "gql/generated/types";
 import { SAVE_SUBSCRIPTION } from "gql/mutations";
 import { GET_USER } from "gql/queries";
@@ -31,7 +31,7 @@ interface NotificationModalProps {
   onCancel: (e?: React.MouseEvent<HTMLElement, MouseEvent>) => void;
   resourceId: string;
   sendAnalyticsEvent: (
-    subscription: SaveSubscriptionMutationVariables["subscription"]
+    subscription: SaveSubscriptionForUserMutationVariables["subscription"]
   ) => void;
   subscriptionMethods: SubscriptionMethodOption[];
   triggers: Trigger;
@@ -51,8 +51,8 @@ export const NotificationModal: React.VFC<NotificationModalProps> = ({
 }) => {
   const dispatchToast = useToastContext();
   const [saveSubscription] = useMutation<
-    SaveSubscriptionMutation,
-    SaveSubscriptionMutationVariables
+    SaveSubscriptionForUserMutation,
+    SaveSubscriptionForUserMutationVariables
   >(SAVE_SUBSCRIPTION, {
     onCompleted: () => {
       dispatchToast.success("Your subscription has been added");
@@ -65,7 +65,7 @@ export const NotificationModal: React.VFC<NotificationModalProps> = ({
   // Fetch user Slack and email information.
   const { userSettings } = useUserSettings();
   const { slackUsername } = userSettings || {};
-  const { data: userData } = useQuery<GetUserQuery>(GET_USER);
+  const { data: userData } = useQuery<UserQuery>(GET_USER);
   const { user } = userData || {};
   const { emailAddress } = user || {};
 

--- a/src/components/PatchActionButtons/ScheduleTasks.stories.tsx
+++ b/src/components/PatchActionButtons/ScheduleTasks.stories.tsx
@@ -1,8 +1,8 @@
 import { MockedProvider } from "@apollo/client/testing";
 import { StoryObj } from "@storybook/react";
 import {
-  GetUndispatchedTasksQuery,
-  GetUndispatchedTasksQueryVariables,
+  UndispatchedTasksQuery,
+  UndispatchedTasksQueryVariables,
 } from "gql/generated/types";
 import { GET_UNSCHEDULED_TASKS } from "gql/queries";
 import WithToastContext from "test_utils/toast-decorator";
@@ -30,8 +30,8 @@ export const ScheduleTasksEmpty: StoryObj<typeof ScheduleTasks> = {
 };
 
 const mocks: ApolloMock<
-  GetUndispatchedTasksQuery,
-  GetUndispatchedTasksQueryVariables
+  UndispatchedTasksQuery,
+  UndispatchedTasksQueryVariables
 >[] = [
   {
     request: {

--- a/src/components/ProjectSelect/ProjectSelect.stories.tsx
+++ b/src/components/ProjectSelect/ProjectSelect.stories.tsx
@@ -4,10 +4,10 @@ import { getCommitsRoute } from "constants/routes";
 import {
   AddFavoriteProjectMutation,
   AddFavoriteProjectMutationVariables,
-  GetProjectsQuery,
-  GetProjectsQueryVariables,
-  GetViewableProjectRefsQuery,
-  GetViewableProjectRefsQueryVariables,
+  ProjectsQuery,
+  ProjectsQueryVariables,
+  ViewableProjectRefsQuery,
+  ViewableProjectRefsQueryVariables,
   RemoveFavoriteProjectMutation,
   RemoveFavoriteProjectMutationVariables,
 } from "gql/generated/types";
@@ -98,95 +98,94 @@ const removeFavoriteMock: ApolloMock<
   },
 };
 
-const getProjectsMock: ApolloMock<GetProjectsQuery, GetProjectsQueryVariables> =
-  {
-    request: {
-      query: GET_PROJECTS,
+const getProjectsMock: ApolloMock<ProjectsQuery, ProjectsQueryVariables> = {
+  request: {
+    query: GET_PROJECTS,
+  },
+  result: {
+    data: {
+      projects: [
+        {
+          groupDisplayName: "evergreen-ci/evergreen",
+          projects: [
+            {
+              id: "evergreen",
+              identifier: "evergreen",
+              repo: "evergreen",
+              owner: "evergreen-ci",
+              displayName: "evergreen smoke test",
+              isFavorite: false,
+            },
+          ],
+        },
+        {
+          groupDisplayName: "logkeeper/logkeeper",
+          projects: [
+            {
+              id: "logkeeper",
+              identifier: "logkeeper",
+              repo: "logkeeper",
+              owner: "logkeeper",
+              displayName: "logkeeper",
+              isFavorite: false,
+            },
+          ],
+        },
+        {
+          groupDisplayName: "mongodb/mongo",
+          projects: [
+            {
+              id: "sys-perf",
+              identifier: "sys-perf",
+              repo: "mongo",
+              owner: "mongodb",
+              displayName: "System Performance (main)",
+              isFavorite: false,
+            },
+            {
+              id: "performance",
+              identifier: "performance",
+              repo: "mongo",
+              owner: "mongodb",
+              displayName: "MongoDB Microbenchmarks (main)",
+              isFavorite: false,
+            },
+          ],
+        },
+        {
+          groupDisplayName: "mongodb/mongodb",
+          projects: [
+            {
+              id: "mongodb-mongo-master",
+              identifier: "mongodb-mongo-master",
+              repo: "mongodb",
+              owner: "mongodb",
+              displayName: "mongo",
+              isFavorite: false,
+            },
+          ],
+        },
+        {
+          groupDisplayName: "mongodb/mongodb-test",
+          projects: [
+            {
+              id: "mongodb-mongo-test",
+              identifier: "mongodb-mongo-test",
+              repo: "mongodb-test",
+              owner: "mongodb",
+              displayName: "mongo-test",
+              isFavorite: false,
+            },
+          ],
+        },
+      ],
     },
-    result: {
-      data: {
-        projects: [
-          {
-            groupDisplayName: "evergreen-ci/evergreen",
-            projects: [
-              {
-                id: "evergreen",
-                identifier: "evergreen",
-                repo: "evergreen",
-                owner: "evergreen-ci",
-                displayName: "evergreen smoke test",
-                isFavorite: false,
-              },
-            ],
-          },
-          {
-            groupDisplayName: "logkeeper/logkeeper",
-            projects: [
-              {
-                id: "logkeeper",
-                identifier: "logkeeper",
-                repo: "logkeeper",
-                owner: "logkeeper",
-                displayName: "logkeeper",
-                isFavorite: false,
-              },
-            ],
-          },
-          {
-            groupDisplayName: "mongodb/mongo",
-            projects: [
-              {
-                id: "sys-perf",
-                identifier: "sys-perf",
-                repo: "mongo",
-                owner: "mongodb",
-                displayName: "System Performance (main)",
-                isFavorite: false,
-              },
-              {
-                id: "performance",
-                identifier: "performance",
-                repo: "mongo",
-                owner: "mongodb",
-                displayName: "MongoDB Microbenchmarks (main)",
-                isFavorite: false,
-              },
-            ],
-          },
-          {
-            groupDisplayName: "mongodb/mongodb",
-            projects: [
-              {
-                id: "mongodb-mongo-master",
-                identifier: "mongodb-mongo-master",
-                repo: "mongodb",
-                owner: "mongodb",
-                displayName: "mongo",
-                isFavorite: false,
-              },
-            ],
-          },
-          {
-            groupDisplayName: "mongodb/mongodb-test",
-            projects: [
-              {
-                id: "mongodb-mongo-test",
-                identifier: "mongodb-mongo-test",
-                repo: "mongodb-test",
-                owner: "mongodb",
-                displayName: "mongo-test",
-                isFavorite: false,
-              },
-            ],
-          },
-        ],
-      },
-    },
-  };
+  },
+};
 
 const viewableProjectsMock: ApolloMock<
-  GetViewableProjectRefsQuery,
-  GetViewableProjectRefsQueryVariables
+  ViewableProjectRefsQuery,
+  ViewableProjectRefsQueryVariables
 > = {
   request: {
     query: GET_VIEWABLE_PROJECTS,

--- a/src/components/ProjectSelect/ProjectSelect.test.tsx
+++ b/src/components/ProjectSelect/ProjectSelect.test.tsx
@@ -2,10 +2,10 @@ import { MockedProvider } from "@apollo/client/testing";
 import { getCommitsRoute, getProjectSettingsRoute } from "constants/routes";
 import { RenderFakeToastContext } from "context/toast/__mocks__";
 import {
-  GetProjectsQuery,
-  GetProjectsQueryVariables,
-  GetViewableProjectRefsQuery,
-  GetViewableProjectRefsQueryVariables,
+  ProjectsQuery,
+  ProjectsQueryVariables,
+  ViewableProjectRefsQuery,
+  ViewableProjectRefsQueryVariables,
 } from "gql/generated/types";
 import { GET_PROJECTS, GET_VIEWABLE_PROJECTS } from "gql/queries";
 import { renderWithRouterMatch, screen, userEvent, waitFor } from "test_utils";
@@ -247,9 +247,7 @@ describe("projectSelect", () => {
   });
 });
 
-const getProjectsMock: [
-  ApolloMock<GetProjectsQuery, GetProjectsQueryVariables>
-] = [
+const getProjectsMock: [ApolloMock<ProjectsQuery, ProjectsQueryVariables>] = [
   {
     request: {
       query: GET_PROJECTS,
@@ -337,7 +335,7 @@ const getProjectsMock: [
 ];
 
 const getViewableProjectsMock: [
-  ApolloMock<GetViewableProjectRefsQuery, GetViewableProjectRefsQueryVariables>
+  ApolloMock<ViewableProjectRefsQuery, ViewableProjectRefsQueryVariables>
 ] = [
   {
     request: {
@@ -411,7 +409,7 @@ const getViewableProjectsMock: [
 ];
 
 const noDisabledProjectsMock: [
-  ApolloMock<GetViewableProjectRefsQuery, GetViewableProjectRefsQueryVariables>
+  ApolloMock<ViewableProjectRefsQuery, ViewableProjectRefsQueryVariables>
 ] = [
   {
     request: {

--- a/src/components/ProjectSelect/index.tsx
+++ b/src/components/ProjectSelect/index.tsx
@@ -3,10 +3,10 @@ import { useQuery } from "@apollo/client";
 import { useNavigate } from "react-router-dom";
 import SearchableDropdown from "components/SearchableDropdown";
 import {
-  GetProjectsQuery,
-  GetProjectsQueryVariables,
-  GetViewableProjectRefsQuery,
-  GetViewableProjectRefsQueryVariables,
+  ProjectsQuery,
+  ProjectsQueryVariables,
+  ViewableProjectRefsQuery,
+  ViewableProjectRefsQueryVariables,
 } from "gql/generated/types";
 import { GET_PROJECTS, GET_VIEWABLE_PROJECTS } from "gql/queries";
 import { Unpacked } from "types/utils";
@@ -28,14 +28,14 @@ export const ProjectSelect: React.VFC<ProjectSelectProps> = ({
   const navigate = useNavigate();
 
   const { data: projectsData, loading: projectsLoading } = useQuery<
-    GetProjectsQuery,
-    GetProjectsQueryVariables
+    ProjectsQuery,
+    ProjectsQueryVariables
   >(GET_PROJECTS, {
     skip: isProjectSettingsPage,
   });
 
   const { data: viewableProjectsData, loading: viewableProjectsLoading } =
-    useQuery<GetViewableProjectRefsQuery, GetViewableProjectRefsQueryVariables>(
+    useQuery<ViewableProjectRefsQuery, ViewableProjectRefsQueryVariables>(
       GET_VIEWABLE_PROJECTS,
       {
         skip: !isProjectSettingsPage,
@@ -119,13 +119,13 @@ export const ProjectSelect: React.VFC<ProjectSelectProps> = ({
   );
 };
 
-const getFavoriteProjects = (projectGroups: GetProjectsQuery["projects"]) =>
+const getFavoriteProjects = (projectGroups: ProjectsQuery["projects"]) =>
   projectGroups?.flatMap((g) => g.projects.filter((p) => p.isFavorite));
 
 // Split a list of projects into two arrays, one of enabled projects and one of disabled projects
 const filterDisabledProjects = (
   projects: Unpacked<
-    GetViewableProjectRefsQuery["viewableProjectRefs"]
+    ViewableProjectRefsQuery["viewableProjectRefs"]
   >["projects"]
 ) =>
   projects.reduce(
@@ -137,7 +137,7 @@ const filterDisabledProjects = (
   );
 
 type ViewableProjectRef = Unpacked<
-  GetViewableProjectRefsQuery["viewableProjectRefs"]
+  ViewableProjectRefsQuery["viewableProjectRefs"]
 >;
 interface GetProjectsResult {
   groupDisplayName: ViewableProjectRef["groupDisplayName"];
@@ -145,8 +145,8 @@ interface GetProjectsResult {
   repo?: ViewableProjectRef["repo"];
 }
 type GetProjectsType = (
-  projectsData: GetProjectsQuery,
-  viewableProjectsData: GetViewableProjectRefsQuery,
+  projectsData: ProjectsQuery,
+  viewableProjectsData: ViewableProjectRefsQuery,
   isProjectSettingsPage: boolean
 ) => GetProjectsResult[];
 

--- a/src/components/Redirects/ProjectSettingsRedirect.tsx
+++ b/src/components/Redirects/ProjectSettingsRedirect.tsx
@@ -5,15 +5,15 @@ import {
   ProjectSettingsTabRoutes,
 } from "constants/routes";
 import {
-  GetViewableProjectRefsQuery,
-  GetViewableProjectRefsQueryVariables,
+  ViewableProjectRefsQuery,
+  ViewableProjectRefsQueryVariables,
 } from "gql/generated/types";
 import { GET_VIEWABLE_PROJECTS } from "gql/queries";
 
 export const ProjectSettingsRedirect: React.VFC = () => {
   const { data } = useQuery<
-    GetViewableProjectRefsQuery,
-    GetViewableProjectRefsQueryVariables
+    ViewableProjectRefsQuery,
+    ViewableProjectRefsQueryVariables
   >(GET_VIEWABLE_PROJECTS);
 
   if (data) {

--- a/src/components/ScheduleTasksModal/index.tsx
+++ b/src/components/ScheduleTasksModal/index.tsx
@@ -9,8 +9,8 @@ import { ConfirmationModal } from "components/ConfirmationModal";
 import { size } from "constants/tokens";
 import { useToastContext } from "context/toast";
 import {
-  GetUndispatchedTasksQuery,
-  GetUndispatchedTasksQueryVariables,
+  UndispatchedTasksQuery,
+  UndispatchedTasksQueryVariables,
   ScheduleTasksMutation,
   ScheduleTasksMutationVariables,
 } from "gql/generated/types";
@@ -55,12 +55,12 @@ export const ScheduleTasksModal: React.VFC<ScheduleTasksModalProps> = ({
   const [
     loadTaskData,
     { data: taskData, loading: loadingTaskData, called: calledTaskData },
-  ] = useLazyQuery<
-    GetUndispatchedTasksQuery,
-    GetUndispatchedTasksQueryVariables
-  >(GET_UNSCHEDULED_TASKS, {
-    variables: { versionId },
-  });
+  ] = useLazyQuery<UndispatchedTasksQuery, UndispatchedTasksQueryVariables>(
+    GET_UNSCHEDULED_TASKS,
+    {
+      variables: { versionId },
+    }
+  );
   useEffect(() => {
     if (open && !calledTaskData) {
       loadTaskData();

--- a/src/components/ScheduleTasksModal/reducer.ts
+++ b/src/components/ScheduleTasksModal/reducer.ts
@@ -1,4 +1,4 @@
-import { GetUndispatchedTasksQuery } from "gql/generated/types";
+import { UndispatchedTasksQuery } from "gql/generated/types";
 
 interface BVGroupEntry {
   tasks: { id: string; displayName: string }[];
@@ -15,7 +15,7 @@ interface State {
 }
 
 type Action =
-  | { type: "ingestData"; taskData?: GetUndispatchedTasksQuery }
+  | { type: "ingestData"; taskData?: UndispatchedTasksQuery }
   | { type: "toggleTask"; taskId: string }
   | { type: "toggleBuildVariant"; buildVariant: string }
   | { type: "reset" }
@@ -67,7 +67,7 @@ export const initialState: State = {
 };
 
 const getSortedBuildVariantGroups = (
-  data?: GetUndispatchedTasksQuery
+  data?: UndispatchedTasksQuery
 ): BVGroupEntry[] => {
   const bvGroups: BVGroupsInterface = data?.version?.tasks?.data.reduce(
     (acc, task) => {

--- a/src/components/Spawn/editHostModal/getFormSchema.tsx
+++ b/src/components/Spawn/editHostModal/getFormSchema.tsx
@@ -5,7 +5,7 @@ import widgets from "components/SpruceForm/Widgets";
 import { LeafyGreenTextArea } from "components/SpruceForm/Widgets/LeafyGreenWidgets";
 import { InputLabel, StyledLink } from "components/styles";
 import { windowsPasswordRulesURL } from "constants/externalResources";
-import { GetMyPublicKeysQuery, MyVolumesQuery } from "gql/generated/types";
+import { MyPublicKeysQuery, MyVolumesQuery } from "gql/generated/types";
 import { ExpirationRow } from "../ExpirationRow";
 import { getDefaultExpiration } from "../utils";
 import { UserTagRow } from "./FieldTemplates/UserTagRow";
@@ -16,7 +16,7 @@ interface Props {
   canEditSshKeys: boolean;
   disableExpirationCheckbox: boolean;
   instanceTypes: string[];
-  myPublicKeys: GetMyPublicKeysQuery["myPublicKeys"];
+  myPublicKeys: MyPublicKeysQuery["myPublicKeys"];
   noExpirationCheckboxTooltip: string;
   volumes: MyVolumesQuery["myVolumes"];
 }

--- a/src/components/Spawn/editHostModal/transformer.ts
+++ b/src/components/Spawn/editHostModal/transformer.ts
@@ -1,5 +1,5 @@
 import {
-  GetMyPublicKeysQuery,
+  MyPublicKeysQuery,
   EditSpawnHostMutationVariables,
 } from "gql/generated/types";
 import { string } from "utils";
@@ -9,7 +9,7 @@ const { stripNewLines } = string;
 
 interface Props {
   hostId: string;
-  myPublicKeys: GetMyPublicKeysQuery["myPublicKeys"];
+  myPublicKeys: MyPublicKeysQuery["myPublicKeys"];
   formData: FormState;
   oldUserTags: { key: string; value: string }[];
 }

--- a/src/components/Spawn/editHostModal/useLoadFormData.ts
+++ b/src/components/Spawn/editHostModal/useLoadFormData.ts
@@ -1,7 +1,7 @@
 import { useQuery } from "@apollo/client";
 import {
-  GetMyPublicKeysQuery,
-  GetMyPublicKeysQueryVariables,
+  MyPublicKeysQuery,
+  MyPublicKeysQueryVariables,
   InstanceTypesQuery,
   InstanceTypesQueryVariables,
   MyVolumesQuery,
@@ -31,8 +31,8 @@ export const useLoadFormData = (host: MyHost) => {
 
   // QUERY public keys
   const { data: publicKeysData } = useQuery<
-    GetMyPublicKeysQuery,
-    GetMyPublicKeysQueryVariables
+    MyPublicKeysQuery,
+    MyPublicKeysQueryVariables
   >(GET_MY_PUBLIC_KEYS);
 
   const spruceConfig = useSpruceConfig();

--- a/src/components/Spawn/spawnHostModal/getFormSchema.tsx
+++ b/src/components/Spawn/spawnHostModal/getFormSchema.tsx
@@ -4,8 +4,8 @@ import { GetFormSchema } from "components/SpruceForm/types";
 import widgets from "components/SpruceForm/Widgets";
 import { LeafyGreenTextArea } from "components/SpruceForm/Widgets/LeafyGreenWidgets";
 import {
-  GetMyPublicKeysQuery,
-  GetSpawnTaskQuery,
+  MyPublicKeysQuery,
+  SpawnTaskQuery,
   MyVolumesQuery,
 } from "gql/generated/types";
 import { shortenGithash } from "utils/string";
@@ -23,8 +23,8 @@ interface Props {
   distroIdQueryParam?: string;
   isVirtualWorkstation: boolean;
   noExpirationCheckboxTooltip: string;
-  myPublicKeys: GetMyPublicKeysQuery["myPublicKeys"];
-  spawnTaskData?: GetSpawnTaskQuery["task"];
+  myPublicKeys: MyPublicKeysQuery["myPublicKeys"];
+  spawnTaskData?: SpawnTaskQuery["task"];
   userAwsRegion?: string;
   volumes: MyVolumesQuery["myVolumes"];
   isMigration: boolean;

--- a/src/components/Spawn/spawnHostModal/transformer.ts
+++ b/src/components/Spawn/spawnHostModal/transformer.ts
@@ -1,6 +1,6 @@
 import {
-  GetMyPublicKeysQuery,
-  GetSpawnTaskQuery,
+  MyPublicKeysQuery,
+  SpawnTaskQuery,
   SpawnHostMutationVariables,
 } from "gql/generated/types";
 import { stripNewLines } from "utils/string";
@@ -10,8 +10,8 @@ import { validateTask } from "./utils";
 
 interface Props {
   formData: FormState;
-  myPublicKeys: GetMyPublicKeysQuery["myPublicKeys"];
-  spawnTaskData?: GetSpawnTaskQuery["task"];
+  myPublicKeys: MyPublicKeysQuery["myPublicKeys"];
+  spawnTaskData?: SpawnTaskQuery["task"];
   migrateVolumeId?: string;
 }
 export const formToGql = ({
@@ -19,7 +19,7 @@ export const formToGql = ({
   myPublicKeys,
   spawnTaskData,
   migrateVolumeId,
-}: Props): SpawnHostMutationVariables["SpawnHostInput"] => {
+}: Props): SpawnHostMutationVariables["spawnHostInput"] => {
   const {
     expirationDetails,
     homeVolumeDetails,

--- a/src/components/Spawn/spawnHostModal/useLoadFormSchemaData.ts
+++ b/src/components/Spawn/spawnHostModal/useLoadFormSchemaData.ts
@@ -4,9 +4,9 @@ import {
   DistrosQueryVariables,
   AwsRegionsQuery,
   AwsRegionsQueryVariables,
-  GetUserSettingsQuery,
-  GetMyPublicKeysQuery,
-  GetMyPublicKeysQueryVariables,
+  UserSettingsQuery,
+  MyPublicKeysQuery,
+  MyPublicKeysQueryVariables,
   MyVolumesQuery,
   MyHostsQueryVariables,
 } from "gql/generated/types";
@@ -39,14 +39,14 @@ export const useLoadFormSchemaData = (p?: Props) => {
   });
 
   const { data: publicKeysData, loading: publicKeyLoading } = useQuery<
-    GetMyPublicKeysQuery,
-    GetMyPublicKeysQueryVariables
+    MyPublicKeysQuery,
+    MyPublicKeysQueryVariables
   >(GET_MY_PUBLIC_KEYS);
 
   const spruceConfig = useSpruceConfig();
 
   const { data: userSettingsData } =
-    useQuery<GetUserSettingsQuery>(GET_USER_SETTINGS);
+    useQuery<UserSettingsQuery>(GET_USER_SETTINGS);
   const { region: userAwsRegion } = userSettingsData?.userSettings ?? {};
 
   const { data: volumesData, loading: volumesLoading } = useQuery<

--- a/src/components/Spawn/spawnHostModal/utils.ts
+++ b/src/components/Spawn/spawnHostModal/utils.ts
@@ -1,7 +1,7 @@
-import { GetSpawnTaskQuery } from "gql/generated/types";
+import { SpawnTaskQuery } from "gql/generated/types";
 import { FormState } from "./types";
 
-export const validateTask = (taskData: GetSpawnTaskQuery["task"]) => {
+export const validateTask = (taskData: SpawnTaskQuery["task"]) => {
   const {
     displayName: taskDisplayName,
     buildVariant,

--- a/src/components/Spawn/spawnVolumeModal/transformer.ts
+++ b/src/components/Spawn/spawnVolumeModal/transformer.ts
@@ -6,7 +6,7 @@ interface Props {
 }
 export const formToGql = ({
   formData,
-}: Props): SpawnVolumeMutationVariables["SpawnVolumeInput"] => {
+}: Props): SpawnVolumeMutationVariables["spawnVolumeInput"] => {
   const { requiredVolumeInformation, optionalVolumeInformation } =
     formData || {};
 

--- a/src/components/WelcomeModal/WelcomeModal.tsx
+++ b/src/components/WelcomeModal/WelcomeModal.tsx
@@ -60,7 +60,7 @@ const WelcomeModal: React.VFC<WelcomeModalProps> = ({
             },
           },
         },
-        refetchQueries: ["GetUserSettings"],
+        refetchQueries: ["UserSettings"],
       });
     } catch (e) {}
   };

--- a/src/gql/fragments/annotation.graphql
+++ b/src/gql/fragments/annotation.graphql
@@ -1,4 +1,4 @@
-fragment annotation on Annotation {
+fragment Annotation on Annotation {
   createdIssues {
     issueKey
     source {

--- a/src/gql/fragments/annotations/issueLink.graphql
+++ b/src/gql/fragments/annotations/issueLink.graphql
@@ -1,10 +1,10 @@
 #import "./jiraTicket.graphql"
 
-fragment issueLink on IssueLink {
+fragment IssueLink on IssueLink {
   confidenceScore
   issueKey
   jiraTicket {
-    ...jiraTicket
+    ...JiraTicket
   }
   source {
     author

--- a/src/gql/fragments/annotations/jiraTicket.graphql
+++ b/src/gql/fragments/annotations/jiraTicket.graphql
@@ -1,4 +1,4 @@
-fragment jiraTicket on JiraTicket {
+fragment JiraTicket on JiraTicket {
   fields {
     assignedTeam
     assigneeDisplayName

--- a/src/gql/fragments/baseHost.graphql
+++ b/src/gql/fragments/baseHost.graphql
@@ -1,4 +1,4 @@
-fragment baseHost on Host {
+fragment BaseHost on Host {
   hostUrl
   id
   provider

--- a/src/gql/fragments/basePatch.graphql
+++ b/src/gql/fragments/basePatch.graphql
@@ -1,4 +1,4 @@
-fragment basePatch on Patch {
+fragment BasePatch on Patch {
   activated
   alias
   author

--- a/src/gql/fragments/baseSpawnHost.graphql
+++ b/src/gql/fragments/baseSpawnHost.graphql
@@ -1,8 +1,8 @@
 #import "./baseHost.graphql"
 
-fragment baseSpawnHost on Host {
+fragment BaseSpawnHost on Host {
   availabilityZone
-  ...baseHost
+  ...BaseHost
   displayName
   distro {
     id

--- a/src/gql/fragments/baseTask.graphql
+++ b/src/gql/fragments/baseTask.graphql
@@ -1,4 +1,4 @@
-fragment baseTask on Task {
+fragment BaseTask on Task {
   buildVariant
   buildVariantDisplayName
   displayName

--- a/src/gql/fragments/fileDiffs.graphql
+++ b/src/gql/fragments/fileDiffs.graphql
@@ -1,4 +1,4 @@
-fragment fileDiffs on FileDiff {
+fragment FileDiffs on FileDiff {
   additions
   deletions
   description

--- a/src/gql/fragments/logMessage.graphql
+++ b/src/gql/fragments/logMessage.graphql
@@ -1,4 +1,4 @@
-fragment logMessage on LogMessage {
+fragment LogMessage on LogMessage {
   message
   severity
   timestamp

--- a/src/gql/fragments/moduleCodeChanges.graphql
+++ b/src/gql/fragments/moduleCodeChanges.graphql
@@ -1,9 +1,9 @@
 #import "./fileDiffs.graphql"
 
-fragment moduleCodeChange on ModuleCodeChange {
+fragment ModuleCodeChange on ModuleCodeChange {
   branchName
   fileDiffs {
-    ...fileDiffs
+    ...FileDiffs
   }
   htmlLink
   rawLink

--- a/src/gql/fragments/projectSettings/access.graphql
+++ b/src/gql/fragments/projectSettings/access.graphql
@@ -1,9 +1,9 @@
-fragment projectAccessSettings on Project {
+fragment ProjectAccessSettings on Project {
   admins
   restricted
 }
 
-fragment repoAccessSettings on RepoRef {
+fragment RepoAccessSettings on RepoRef {
   admins
   restricted
 }

--- a/src/gql/fragments/projectSettings/aliases.graphql
+++ b/src/gql/fragments/projectSettings/aliases.graphql
@@ -1,4 +1,4 @@
-fragment alias on ProjectAlias {
+fragment Alias on ProjectAlias {
   alias
   gitTag
   id

--- a/src/gql/fragments/projectSettings/containers.graphql
+++ b/src/gql/fragments/projectSettings/containers.graphql
@@ -1,4 +1,4 @@
-fragment projectContainerSettings on Project {
+fragment ProjectContainerSettings on Project {
   containerSizeDefinitions {
     cpu
     memoryMb
@@ -6,7 +6,7 @@ fragment projectContainerSettings on Project {
   }
 }
 
-fragment repoContainerSettings on RepoRef {
+fragment RepoContainerSettings on RepoRef {
   containerSizeDefinitions {
     cpu
     memoryMb

--- a/src/gql/fragments/projectSettings/general.graphql
+++ b/src/gql/fragments/projectSettings/general.graphql
@@ -1,4 +1,4 @@
-fragment projectGeneralSettings on Project {
+fragment ProjectGeneralSettings on Project {
   batchTime
   branch
   deactivatePrevious
@@ -20,7 +20,7 @@ fragment projectGeneralSettings on Project {
   versionControlEnabled
 }
 
-fragment repoGeneralSettings on RepoRef {
+fragment RepoGeneralSettings on RepoRef {
   batchTime
   branch
   deactivatePrevious

--- a/src/gql/fragments/projectSettings/githubCommitQueue.graphql
+++ b/src/gql/fragments/projectSettings/githubCommitQueue.graphql
@@ -1,4 +1,4 @@
-fragment projectGithubSettings on Project {
+fragment ProjectGithubSettings on Project {
   commitQueue {
     enabled
     mergeMethod
@@ -13,7 +13,7 @@ fragment projectGithubSettings on Project {
   prTestingEnabled
 }
 
-fragment repoGithubSettings on RepoRef {
+fragment RepoGithubSettings on RepoRef {
   commitQueue {
     enabled
     mergeMethod
@@ -28,26 +28,26 @@ fragment repoGithubSettings on RepoRef {
   prTestingEnabled
 }
 
-fragment projectGithubCommitQueue on ProjectSettings {
+fragment ProjectGithubCommitQueue on ProjectSettings {
   githubWebhooksEnabled
 
   projectRef {
-    ...projectGithubSettings
+    ...ProjectGithubSettings
   }
 }
 
-fragment repoGithubCommitQueue on RepoSettings {
+fragment RepoGithubCommitQueue on RepoSettings {
   githubWebhooksEnabled
 
   projectRef {
-    ...repoGithubSettings
+    ...RepoGithubSettings
   }
 }
 
-fragment projectEventGithubCommitQueue on ProjectEventSettings {
+fragment ProjectEventGithubCommitQueue on ProjectEventSettings {
   githubWebhooksEnabled
 
   projectRef {
-    ...projectGithubSettings
+    ...ProjectGithubSettings
   }
 }

--- a/src/gql/fragments/projectSettings/index.graphql
+++ b/src/gql/fragments/projectSettings/index.graphql
@@ -10,55 +10,56 @@
 #import "./projectTriggers.graphql"
 #import "./periodicBuilds.graphql"
 #import "./containers.graphql"
-fragment projectSettings on ProjectSettings {
+
+fragment ProjectSettings on ProjectSettings {
   aliases {
-    ...alias
+    ...Alias
   }
-  ...projectGithubCommitQueue
+  ...ProjectGithubCommitQueue
   projectRef {
     id
     identifier
-    ...projectAccessSettings
-    ...projectContainerSettings
-    ...projectGeneralSettings
-    ...projectNotificationSettings
-    ...projectPatchAliasSettings
-    ...projectPeriodicBuildsSettings
-    ...projectPluginsSettings
-    ...projectTriggersSettings
-    ...projectVirtualWorkstationSettings
+    ...ProjectAccessSettings
+    ...ProjectContainerSettings
+    ...ProjectGeneralSettings
+    ...ProjectNotificationSettings
+    ...ProjectPatchAliasSettings
+    ...ProjectPeriodicBuildsSettings
+    ...ProjectPluginsSettings
+    ...ProjectTriggersSettings
+    ...ProjectVirtualWorkstationSettings
     repoRefId
   }
   subscriptions {
-    ...subscriptions
+    ...Subscriptions
   }
   vars {
-    ...variables
+    ...Variables
   }
 }
 
-fragment repoSettings on RepoSettings {
+fragment RepoSettings on RepoSettings {
   aliases {
-    ...alias
+    ...Alias
   }
   projectRef {
     displayName
     id
-    ...repoAccessSettings
-    ...repoContainerSettings
-    ...repoGeneralSettings
-    ...repoNotificationSettings
-    ...repoPatchAliasSettings
-    ...repoPeriodicBuildsSettings
-    ...repoPluginsSettings
-    ...repoTriggersSettings
-    ...repoVirtualWorkstationSettings
+    ...RepoAccessSettings
+    ...RepoContainerSettings
+    ...RepoGeneralSettings
+    ...RepoNotificationSettings
+    ...RepoPatchAliasSettings
+    ...RepoPeriodicBuildsSettings
+    ...RepoPluginsSettings
+    ...RepoTriggersSettings
+    ...RepoVirtualWorkstationSettings
   }
-  ...repoGithubCommitQueue
+  ...RepoGithubCommitQueue
   subscriptions {
-    ...subscriptions
+    ...Subscriptions
   }
   vars {
-    ...variables
+    ...Variables
   }
 }

--- a/src/gql/fragments/projectSettings/index.graphql
+++ b/src/gql/fragments/projectSettings/index.graphql
@@ -11,7 +11,7 @@
 #import "./periodicBuilds.graphql"
 #import "./containers.graphql"
 
-fragment ProjectSettings on ProjectSettings {
+fragment ProjectSettingsFields on ProjectSettings {
   aliases {
     ...Alias
   }
@@ -38,7 +38,7 @@ fragment ProjectSettings on ProjectSettings {
   }
 }
 
-fragment RepoSettings on RepoSettings {
+fragment RepoSettingsFields on RepoSettings {
   aliases {
     ...Alias
   }

--- a/src/gql/fragments/projectSettings/notifications.graphql
+++ b/src/gql/fragments/projectSettings/notifications.graphql
@@ -1,12 +1,12 @@
-fragment projectNotificationSettings on Project {
+fragment ProjectNotificationSettings on Project {
   notifyOnBuildFailure
 }
 
-fragment repoNotificationSettings on RepoRef {
+fragment RepoNotificationSettings on RepoRef {
   notifyOnBuildFailure
 }
 
-fragment subscriptions on ProjectSubscription {
+fragment Subscriptions on ProjectSubscription {
   id
   ownerType
   regexSelectors {

--- a/src/gql/fragments/projectSettings/patchAliases.graphql
+++ b/src/gql/fragments/projectSettings/patchAliases.graphql
@@ -1,4 +1,4 @@
-fragment projectPatchAliasSettings on Project {
+fragment ProjectPatchAliasSettings on Project {
   githubTriggerAliases
   patchTriggerAliases {
     alias
@@ -13,7 +13,7 @@ fragment projectPatchAliasSettings on Project {
   }
 }
 
-fragment repoPatchAliasSettings on RepoRef {
+fragment RepoPatchAliasSettings on RepoRef {
   githubTriggerAliases
   patchTriggerAliases {
     alias

--- a/src/gql/fragments/projectSettings/periodicBuilds.graphql
+++ b/src/gql/fragments/projectSettings/periodicBuilds.graphql
@@ -1,4 +1,4 @@
-fragment projectPeriodicBuildsSettings on Project {
+fragment ProjectPeriodicBuildsSettings on Project {
   periodicBuilds {
     alias
     configFile
@@ -9,7 +9,7 @@ fragment projectPeriodicBuildsSettings on Project {
   }
 }
 
-fragment repoPeriodicBuildsSettings on RepoRef {
+fragment RepoPeriodicBuildsSettings on RepoRef {
   periodicBuilds {
     alias
     configFile

--- a/src/gql/fragments/projectSettings/plugins.graphql
+++ b/src/gql/fragments/projectSettings/plugins.graphql
@@ -1,4 +1,4 @@
-fragment projectPluginsSettings on Project {
+fragment ProjectPluginsSettings on Project {
   buildBaronSettings {
     ticketCreateProject
     ticketSearchProjects
@@ -20,7 +20,7 @@ fragment projectPluginsSettings on Project {
   }
 }
 
-fragment repoPluginsSettings on RepoRef {
+fragment RepoPluginsSettings on RepoRef {
   buildBaronSettings {
     ticketCreateProject
     ticketSearchProjects

--- a/src/gql/fragments/projectSettings/projectEventSettings.graphql
+++ b/src/gql/fragments/projectSettings/projectEventSettings.graphql
@@ -10,30 +10,30 @@
 #import "./projectTriggers.graphql"
 #import "./periodicBuilds.graphql"
 
-fragment projectEventSettings on ProjectEventSettings {
+fragment ProjectEventSettings on ProjectEventSettings {
   aliases {
-    ...alias
+    ...Alias
   }
-  ...projectEventGithubCommitQueue
+  ...ProjectEventGithubCommitQueue
   projectRef {
     hidden
     identifier
-    ...projectAccessSettings
-    ...projectGeneralSettings
-    ...projectNotificationSettings
-    ...projectPatchAliasSettings
-    ...projectPeriodicBuildsSettings
-    ...projectPluginsSettings
-    ...projectTriggersSettings
-    ...projectVirtualWorkstationSettings
+    ...ProjectAccessSettings
+    ...ProjectGeneralSettings
+    ...ProjectNotificationSettings
+    ...ProjectPatchAliasSettings
+    ...ProjectPeriodicBuildsSettings
+    ...ProjectPluginsSettings
+    ...ProjectTriggersSettings
+    ...ProjectVirtualWorkstationSettings
     repoRefId
     tracksPushEvents
     versionControlEnabled
   }
   subscriptions {
-    ...subscriptions
+    ...Subscriptions
   }
   vars {
-    ...variables
+    ...Variables
   }
 }

--- a/src/gql/fragments/projectSettings/projectTriggers.graphql
+++ b/src/gql/fragments/projectSettings/projectTriggers.graphql
@@ -1,4 +1,4 @@
-fragment projectTriggersSettings on Project {
+fragment ProjectTriggersSettings on Project {
   triggers {
     alias
     buildVariantRegex
@@ -11,7 +11,7 @@ fragment projectTriggersSettings on Project {
   }
 }
 
-fragment repoTriggersSettings on RepoRef {
+fragment RepoTriggersSettings on RepoRef {
   triggers {
     alias
     buildVariantRegex

--- a/src/gql/fragments/projectSettings/variables.graphql
+++ b/src/gql/fragments/projectSettings/variables.graphql
@@ -1,4 +1,4 @@
-fragment variables on ProjectVars {
+fragment Variables on ProjectVars {
   adminOnlyVars
   privateVars
   vars

--- a/src/gql/fragments/projectSettings/virtualWorkstation.graphql
+++ b/src/gql/fragments/projectSettings/virtualWorkstation.graphql
@@ -1,4 +1,4 @@
-fragment projectVirtualWorkstationSettings on Project {
+fragment ProjectVirtualWorkstationSettings on Project {
   workstationConfig {
     gitClone
     setupCommands {
@@ -8,7 +8,7 @@ fragment projectVirtualWorkstationSettings on Project {
   }
 }
 
-fragment repoVirtualWorkstationSettings on RepoRef {
+fragment RepoVirtualWorkstationSettings on RepoRef {
   workstationConfig {
     gitClone
     setupCommands {

--- a/src/gql/fragments/upstreamProject.graphql
+++ b/src/gql/fragments/upstreamProject.graphql
@@ -1,4 +1,4 @@
-fragment upstreamProject on Version {
+fragment UpstreamProject on Version {
   upstreamProject {
     project
     repo

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -3021,7 +3021,7 @@ export type ProjectEventGithubCommitQueueFragment = {
   }>;
 };
 
-export type ProjectSettingsFragment = {
+export type ProjectSettingsFieldsFragment = {
   __typename?: "ProjectSettings";
   githubWebhooksEnabled: boolean;
   aliases?: Maybe<
@@ -3230,7 +3230,7 @@ export type ProjectSettingsFragment = {
   }>;
 };
 
-export type RepoSettingsFragment = {
+export type RepoSettingsFieldsFragment = {
   __typename?: "RepoSettings";
   githubWebhooksEnabled: boolean;
   aliases?: Maybe<

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -4154,12 +4154,12 @@ export type EnqueuePatchMutation = {
   enqueuePatch: { __typename?: "Patch"; id: string };
 };
 
-export type BbCreateTicketMutationVariables = Exact<{
+export type BuildBaronCreateTicketMutationVariables = Exact<{
   taskId: Scalars["String"];
   execution?: InputMaybe<Scalars["Int"]>;
 }>;
 
-export type BbCreateTicketMutation = {
+export type BuildBaronCreateTicketMutation = {
   __typename?: "Mutation";
   bbCreateTicket: boolean;
 };
@@ -4374,11 +4374,11 @@ export type SaveRepoSettingsForSectionMutation = {
   };
 };
 
-export type SaveSubscriptionMutationVariables = Exact<{
+export type SaveSubscriptionForUserMutationVariables = Exact<{
   subscription: SubscriptionInput;
 }>;
 
-export type SaveSubscriptionMutation = {
+export type SaveSubscriptionForUserMutation = {
   __typename?: "Mutation";
   saveSubscription: boolean;
 };
@@ -4469,7 +4469,7 @@ export type SetTaskPriorityMutation = {
 };
 
 export type SpawnHostMutationVariables = Exact<{
-  SpawnHostInput?: InputMaybe<SpawnHostInput>;
+  spawnHostInput?: InputMaybe<SpawnHostInput>;
 }>;
 
 export type SpawnHostMutation = {
@@ -4478,7 +4478,7 @@ export type SpawnHostMutation = {
 };
 
 export type SpawnVolumeMutationVariables = Exact<{
-  SpawnVolumeInput: SpawnVolumeInput;
+  spawnVolumeInput: SpawnVolumeInput;
 }>;
 
 export type SpawnVolumeMutation = {
@@ -4541,7 +4541,7 @@ export type UpdateSpawnHostStatusMutation = {
 };
 
 export type UpdateVolumeMutationVariables = Exact<{
-  UpdateVolumeInput: UpdateVolumeInput;
+  updateVolumeInput: UpdateVolumeInput;
 }>;
 
 export type UpdateVolumeMutation = {
@@ -4584,11 +4584,11 @@ export type DistroTaskQueueQuery = {
   }>;
 };
 
-export type GetFailedTaskStatusIconTooltipQueryVariables = Exact<{
+export type FailedTaskStatusIconTooltipQueryVariables = Exact<{
   taskId: Scalars["String"];
 }>;
 
-export type GetFailedTaskStatusIconTooltipQuery = {
+export type FailedTaskStatusIconTooltipQuery = {
   __typename?: "Query";
   taskTests: {
     __typename?: "TaskTestResult";
@@ -4647,12 +4647,12 @@ export type AllLogsQuery = {
   }>;
 };
 
-export type GetAnnotationEventDataQueryVariables = Exact<{
+export type AnnotationEventDataQueryVariables = Exact<{
   taskId: Scalars["String"];
   execution?: InputMaybe<Scalars["Int"]>;
 }>;
 
-export type GetAnnotationEventDataQuery = {
+export type AnnotationEventDataQuery = {
   __typename?: "Query";
   task?: Maybe<{
     __typename?: "Task";
@@ -4726,11 +4726,11 @@ export type GetAnnotationEventDataQuery = {
   }>;
 };
 
-export type GetBaseVersionAndTaskQueryVariables = Exact<{
+export type BaseVersionAndTaskQueryVariables = Exact<{
   taskId: Scalars["String"];
 }>;
 
-export type GetBaseVersionAndTaskQuery = {
+export type BaseVersionAndTaskQuery = {
   __typename?: "Query";
   task?: Maybe<{
     __typename?: "Task";
@@ -4758,12 +4758,12 @@ export type GetBaseVersionAndTaskQuery = {
   }>;
 };
 
-export type GetBuildBaronConfiguredQueryVariables = Exact<{
+export type BuildBaronConfiguredQueryVariables = Exact<{
   taskId: Scalars["String"];
   execution: Scalars["Int"];
 }>;
 
-export type GetBuildBaronConfiguredQuery = {
+export type BuildBaronConfiguredQuery = {
   __typename?: "Query";
   buildBaron: { __typename?: "BuildBaron"; buildBaronConfigured: boolean };
 };
@@ -4801,11 +4801,11 @@ export type BuildBaronQuery = {
   };
 };
 
-export type GetBuildVariantStatsQueryVariables = Exact<{
+export type BuildVariantStatsQueryVariables = Exact<{
   id: Scalars["String"];
 }>;
 
-export type GetBuildVariantStatsQuery = {
+export type BuildVariantStatsQuery = {
   __typename?: "Query";
   version: {
     __typename?: "Version";
@@ -4825,12 +4825,12 @@ export type GetBuildVariantStatsQuery = {
   };
 };
 
-export type GetBuildVariantsForTaskNameQueryVariables = Exact<{
+export type BuildVariantsForTaskNameQueryVariables = Exact<{
   projectIdentifier: Scalars["String"];
   taskName: Scalars["String"];
 }>;
 
-export type GetBuildVariantsForTaskNameQuery = {
+export type BuildVariantsForTaskNameQuery = {
   __typename?: "Query";
   buildVariantsForTaskName?: Maybe<
     Array<
@@ -4996,11 +4996,11 @@ export type CommitQueueQuery = {
   };
 };
 
-export type GetCreatedTicketsQueryVariables = Exact<{
+export type CreatedTicketsQueryVariables = Exact<{
   taskId: Scalars["String"];
 }>;
 
-export type GetCreatedTicketsQuery = {
+export type CreatedTicketsQuery = {
   __typename?: "Query";
   bbGetCreatedTickets: Array<{
     __typename?: "JiraTicket";
@@ -5017,12 +5017,12 @@ export type GetCreatedTicketsQuery = {
   }>;
 };
 
-export type GetDisplayTaskQueryVariables = Exact<{
+export type DisplayTaskQueryVariables = Exact<{
   taskId: Scalars["String"];
   execution?: InputMaybe<Scalars["Int"]>;
 }>;
 
-export type GetDisplayTaskQuery = {
+export type DisplayTaskQuery = {
   __typename?: "Query";
   task?: Maybe<{
     __typename?: "Task";
@@ -5049,9 +5049,9 @@ export type DistrosQuery = {
   >;
 };
 
-export type GetGithubOrgsQueryVariables = Exact<{ [key: string]: never }>;
+export type GithubOrgsQueryVariables = Exact<{ [key: string]: never }>;
 
-export type GetGithubOrgsQuery = {
+export type GithubOrgsQuery = {
   __typename?: "Query";
   spruceConfig?: Maybe<{
     __typename?: "SpruceConfig";
@@ -5073,11 +5073,11 @@ export type GithubProjectConflictsQuery = {
   };
 };
 
-export type GetHasVersionQueryVariables = Exact<{
+export type HasVersionQueryVariables = Exact<{
   id: Scalars["String"];
 }>;
 
-export type GetHasVersionQuery = { __typename?: "Query"; hasVersion: boolean };
+export type HasVersionQuery = { __typename?: "Query"; hasVersion: boolean };
 
 export type HostEventsQueryVariables = Exact<{
   id: Scalars["String"];
@@ -5175,12 +5175,12 @@ export type IsPatchConfiguredQuery = {
   };
 };
 
-export type GetCustomCreatedIssuesQueryVariables = Exact<{
+export type CustomCreatedIssuesQueryVariables = Exact<{
   taskId: Scalars["String"];
   execution?: InputMaybe<Scalars["Int"]>;
 }>;
 
-export type GetCustomCreatedIssuesQuery = {
+export type CustomCreatedIssuesQuery = {
   __typename?: "Query";
   task?: Maybe<{
     __typename?: "Task";
@@ -5223,12 +5223,12 @@ export type GetCustomCreatedIssuesQuery = {
   }>;
 };
 
-export type GetIssuesQueryVariables = Exact<{
+export type IssuesQueryVariables = Exact<{
   taskId: Scalars["String"];
   execution?: InputMaybe<Scalars["Int"]>;
 }>;
 
-export type GetIssuesQuery = {
+export type IssuesQuery = {
   __typename?: "Query";
   task?: Maybe<{
     __typename?: "Task";
@@ -5271,12 +5271,12 @@ export type GetIssuesQuery = {
   }>;
 };
 
-export type GetSuspectedIssuesQueryVariables = Exact<{
+export type SuspectedIssuesQueryVariables = Exact<{
   taskId: Scalars["String"];
   execution?: InputMaybe<Scalars["Int"]>;
 }>;
 
-export type GetSuspectedIssuesQuery = {
+export type SuspectedIssuesQuery = {
   __typename?: "Query";
   task?: Maybe<{
     __typename?: "Task";
@@ -5319,13 +5319,13 @@ export type GetSuspectedIssuesQuery = {
   }>;
 };
 
-export type GetLastMainlineCommitQueryVariables = Exact<{
+export type LastMainlineCommitQueryVariables = Exact<{
   projectIdentifier: Scalars["String"];
   skipOrderNumber: Scalars["Int"];
   buildVariantOptions: BuildVariantOptions;
 }>;
 
-export type GetLastMainlineCommitQuery = {
+export type LastMainlineCommitQuery = {
   __typename?: "Query";
   mainlineCommits?: Maybe<{
     __typename?: "MainlineCommits";
@@ -5632,11 +5632,11 @@ export type MyVolumesQuery = {
   }>;
 };
 
-export type GetOtherUserQueryVariables = Exact<{
+export type OtherUserQueryVariables = Exact<{
   userId?: InputMaybe<Scalars["String"]>;
 }>;
 
-export type GetOtherUserQuery = {
+export type OtherUserQuery = {
   __typename?: "Query";
   currentUser: { __typename?: "User"; userId: string };
   otherUser: { __typename?: "User"; displayName: string; userId: string };
@@ -5702,11 +5702,11 @@ export type ConfigurePatchQuery = {
   };
 };
 
-export type GetPatchTaskStatusesQueryVariables = Exact<{
+export type PatchTaskStatusesQueryVariables = Exact<{
   id: Scalars["String"];
 }>;
 
-export type GetPatchTaskStatusesQuery = {
+export type PatchTaskStatusesQuery = {
   __typename?: "Query";
   patch: {
     __typename?: "Patch";
@@ -6475,9 +6475,9 @@ export type ProjectSettingsQuery = {
   };
 };
 
-export type GetProjectsQueryVariables = Exact<{ [key: string]: never }>;
+export type ProjectsQueryVariables = Exact<{ [key: string]: never }>;
 
-export type GetProjectsQuery = {
+export type ProjectsQuery = {
   __typename?: "Query";
   projects: Array<
     Maybe<{
@@ -6496,9 +6496,9 @@ export type GetProjectsQuery = {
   >;
 };
 
-export type GetMyPublicKeysQueryVariables = Exact<{ [key: string]: never }>;
+export type MyPublicKeysQueryVariables = Exact<{ [key: string]: never }>;
 
-export type GetMyPublicKeysQuery = {
+export type MyPublicKeysQuery = {
   __typename?: "Query";
   myPublicKeys: Array<{ __typename?: "PublicKey"; key: string; name: string }>;
 };
@@ -7159,9 +7159,9 @@ export type RepoSettingsQuery = {
   };
 };
 
-export type GetSpruceConfigQueryVariables = Exact<{ [key: string]: never }>;
+export type SpruceConfigQueryVariables = Exact<{ [key: string]: never }>;
 
-export type GetSpruceConfigQuery = {
+export type SpruceConfigQuery = {
   __typename?: "Query";
   spruceConfig?: Maybe<{
     __typename?: "SpruceConfig";
@@ -7221,11 +7221,11 @@ export type SystemLogsQuery = {
   }>;
 };
 
-export type GetTaskAllExecutionsQueryVariables = Exact<{
+export type TaskAllExecutionsQueryVariables = Exact<{
   taskId: Scalars["String"];
 }>;
 
-export type GetTaskAllExecutionsQuery = {
+export type TaskAllExecutionsQuery = {
   __typename?: "Query";
   taskAllExecutions: Array<{
     __typename?: "Task";
@@ -7318,21 +7318,21 @@ export type TaskLogsQuery = {
   }>;
 };
 
-export type GetTaskNamesForBuildVariantQueryVariables = Exact<{
+export type TaskNamesForBuildVariantQueryVariables = Exact<{
   projectIdentifier: Scalars["String"];
   buildVariant: Scalars["String"];
 }>;
 
-export type GetTaskNamesForBuildVariantQuery = {
+export type TaskNamesForBuildVariantQuery = {
   __typename?: "Query";
   taskNamesForBuildVariant?: Maybe<Array<string>>;
 };
 
-export type GetTaskStatusesQueryVariables = Exact<{
+export type TaskStatusesQueryVariables = Exact<{
   id: Scalars["String"];
 }>;
 
-export type GetTaskStatusesQuery = {
+export type TaskStatusesQuery = {
   __typename?: "Query";
   version: {
     __typename?: "Version";
@@ -7342,12 +7342,12 @@ export type GetTaskStatusesQuery = {
   };
 };
 
-export type GetTaskTestSampleQueryVariables = Exact<{
+export type TaskTestSampleQueryVariables = Exact<{
   tasks: Array<Scalars["String"]>;
   filters: Array<TestFilter>;
 }>;
 
-export type GetTaskTestSampleQuery = {
+export type TaskTestSampleQuery = {
   __typename?: "Query";
   taskTestSample?: Maybe<
     Array<{
@@ -7395,12 +7395,12 @@ export type TaskTestsQuery = {
   };
 };
 
-export type GetTaskQueryVariables = Exact<{
+export type TaskQueryVariables = Exact<{
   taskId: Scalars["String"];
   execution?: InputMaybe<Scalars["Int"]>;
 }>;
 
-export type GetTaskQuery = {
+export type TaskQuery = {
   __typename?: "Query";
   task?: Maybe<{
     __typename?: "Task";
@@ -7592,7 +7592,7 @@ export type GetTaskQuery = {
   }>;
 };
 
-export type GetTestsQueryVariables = Exact<{
+export type TestsQueryVariables = Exact<{
   execution?: InputMaybe<Scalars["Int"]>;
   groupId?: InputMaybe<Scalars["String"]>;
   taskId: Scalars["String"];
@@ -7601,7 +7601,7 @@ export type GetTestsQueryVariables = Exact<{
   testName?: InputMaybe<Scalars["String"]>;
 }>;
 
-export type GetTestsQuery = {
+export type TestsQuery = {
   __typename?: "Query";
   taskTests: {
     __typename?: "TaskTestResult";
@@ -7619,11 +7619,11 @@ export type GetTestsQuery = {
   };
 };
 
-export type GetUndispatchedTasksQueryVariables = Exact<{
+export type UndispatchedTasksQueryVariables = Exact<{
   versionId: Scalars["String"];
 }>;
 
-export type GetUndispatchedTasksQuery = {
+export type UndispatchedTasksQuery = {
   __typename?: "Query";
   version: {
     __typename?: "Version";
@@ -7642,9 +7642,9 @@ export type GetUndispatchedTasksQuery = {
   };
 };
 
-export type GetUserConfigQueryVariables = Exact<{ [key: string]: never }>;
+export type UserConfigQueryVariables = Exact<{ [key: string]: never }>;
 
-export type GetUserConfigQuery = {
+export type UserConfigQuery = {
   __typename?: "Query";
   userConfig?: Maybe<{
     __typename?: "UserConfig";
@@ -7655,9 +7655,9 @@ export type GetUserConfigQuery = {
   }>;
 };
 
-export type GetUserPermissionsQueryVariables = Exact<{ [key: string]: never }>;
+export type UserPermissionsQueryVariables = Exact<{ [key: string]: never }>;
 
-export type GetUserPermissionsQuery = {
+export type UserPermissionsQuery = {
   __typename?: "Query";
   user: {
     __typename?: "User";
@@ -7666,9 +7666,9 @@ export type GetUserPermissionsQuery = {
   };
 };
 
-export type GetUserSettingsQueryVariables = Exact<{ [key: string]: never }>;
+export type UserSettingsQueryVariables = Exact<{ [key: string]: never }>;
 
-export type GetUserSettingsQuery = {
+export type UserSettingsQuery = {
   __typename?: "Query";
   userSettings?: Maybe<{
     __typename?: "UserSettings";
@@ -7699,9 +7699,9 @@ export type GetUserSettingsQuery = {
   }>;
 };
 
-export type GetUserQueryVariables = Exact<{ [key: string]: never }>;
+export type UserQueryVariables = Exact<{ [key: string]: never }>;
 
-export type GetUserQuery = {
+export type UserQuery = {
   __typename?: "Query";
   user: {
     __typename?: "User";
@@ -7903,11 +7903,9 @@ export type VersionQuery = {
   };
 };
 
-export type GetViewableProjectRefsQueryVariables = Exact<{
-  [key: string]: never;
-}>;
+export type ViewableProjectRefsQueryVariables = Exact<{ [key: string]: never }>;
 
-export type GetViewableProjectRefsQuery = {
+export type ViewableProjectRefsQuery = {
   __typename?: "Query";
   viewableProjectRefs: Array<
     Maybe<{
@@ -8035,11 +8033,11 @@ export type SpawnExpirationInfoQuery = {
   }>;
 };
 
-export type GetSpawnTaskQueryVariables = Exact<{
+export type SpawnTaskQueryVariables = Exact<{
   taskId: Scalars["String"];
 }>;
 
-export type GetSpawnTaskQuery = {
+export type SpawnTaskQuery = {
   __typename?: "Query";
   task?: Maybe<{
     __typename?: "Task";

--- a/src/gql/mocks/getSpruceConfig.ts
+++ b/src/gql/mocks/getSpruceConfig.ts
@@ -1,13 +1,13 @@
 import {
-  GetSpruceConfigQuery,
-  GetSpruceConfigQueryVariables,
+  SpruceConfigQuery,
+  SpruceConfigQueryVariables,
 } from "gql/generated/types";
 import { GET_SPRUCE_CONFIG } from "gql/queries";
 import { ApolloMock } from "types/gql";
 
 export const getSpruceConfigMock: ApolloMock<
-  GetSpruceConfigQuery,
-  GetSpruceConfigQueryVariables
+  SpruceConfigQuery,
+  SpruceConfigQueryVariables
 > = {
   request: {
     query: GET_SPRUCE_CONFIG,

--- a/src/gql/mocks/getUser.ts
+++ b/src/gql/mocks/getUser.ts
@@ -1,8 +1,8 @@
-import { GetUserQuery, GetUserQueryVariables } from "gql/generated/types";
+import { UserQuery, UserQueryVariables } from "gql/generated/types";
 import { GET_USER } from "gql/queries";
 import { ApolloMock } from "types/gql";
 
-export const getUserMock: ApolloMock<GetUserQuery, GetUserQueryVariables> = {
+export const getUserMock: ApolloMock<UserQuery, UserQueryVariables> = {
   request: {
     query: GET_USER,
     variables: {},

--- a/src/gql/mocks/taskData.ts
+++ b/src/gql/mocks/taskData.ts
@@ -1,6 +1,6 @@
-import { GetTaskQuery } from "gql/generated/types";
+import { TaskQuery } from "gql/generated/types";
 
-export const taskQuery: GetTaskQuery = {
+export const taskQuery: TaskQuery = {
   task: {
     __typename: "Task",
     id: "someTaskId",

--- a/src/gql/mutations/abort-task.graphql
+++ b/src/gql/mutations/abort-task.graphql
@@ -2,7 +2,7 @@
 
 mutation AbortTask($taskId: String!) {
   abortTask(taskId: $taskId) {
-    ...baseTask
+    ...BaseTask
     priority
   }
 }

--- a/src/gql/mutations/edit-annotation-note.graphql
+++ b/src/gql/mutations/edit-annotation-note.graphql
@@ -1,4 +1,4 @@
-mutation editAnnotationNote(
+mutation EditAnnotationNote(
   $taskId: String!
   $execution: Int!
   $originalMessage: String!

--- a/src/gql/mutations/edit-spawn-host.graphql
+++ b/src/gql/mutations/edit-spawn-host.graphql
@@ -28,6 +28,6 @@ mutation EditSpawnHost(
       savePublicKey: $savePublicKey
     }
   ) {
-    ...baseSpawnHost
+    ...BaseSpawnHost
   }
 }

--- a/src/gql/mutations/file-jira-ticket.graphql
+++ b/src/gql/mutations/file-jira-ticket.graphql
@@ -1,3 +1,3 @@
-mutation bbCreateTicket($taskId: String!, $execution: Int) {
+mutation BuildBaronCreateTicket($taskId: String!, $execution: Int) {
   bbCreateTicket(taskId: $taskId, execution: $execution)
 }

--- a/src/gql/mutations/override-task-dependencies.graphql
+++ b/src/gql/mutations/override-task-dependencies.graphql
@@ -1,4 +1,4 @@
-mutation overrideTaskDependencies($taskId: String!) {
+mutation OverrideTaskDependencies($taskId: String!) {
   overrideTaskDependencies(taskId: $taskId) {
     execution
     id

--- a/src/gql/mutations/remove-volume.graphql
+++ b/src/gql/mutations/remove-volume.graphql
@@ -1,3 +1,3 @@
-mutation removeVolume($volumeId: String!) {
+mutation RemoveVolume($volumeId: String!) {
   removeVolume(volumeId: $volumeId)
 }

--- a/src/gql/mutations/restart-task.graphql
+++ b/src/gql/mutations/restart-task.graphql
@@ -1,7 +1,7 @@
 #import "../fragments/baseTask.graphql"
 mutation RestartTask($taskId: String!, $failedOnly: Boolean!) {
   restartTask(taskId: $taskId, failedOnly: $failedOnly) {
-    ...baseTask
+    ...BaseTask
     execution
     latestExecution
   }

--- a/src/gql/mutations/save-subscription.graphql
+++ b/src/gql/mutations/save-subscription.graphql
@@ -1,3 +1,3 @@
-mutation SaveSubscription($subscription: SubscriptionInput!) {
+mutation SaveSubscriptionForUser($subscription: SubscriptionInput!) {
   saveSubscription(subscription: $subscription)
 }

--- a/src/gql/mutations/schedule-patch.graphql
+++ b/src/gql/mutations/schedule-patch.graphql
@@ -2,7 +2,7 @@
 
 mutation SchedulePatch($patchId: String!, $configure: PatchConfigure!) {
   schedulePatch(patchId: $patchId, configure: $configure) {
-    ...basePatch
+    ...BasePatch
     tasks
     variants
     versionFull {

--- a/src/gql/mutations/schedule-tasks.graphql
+++ b/src/gql/mutations/schedule-tasks.graphql
@@ -2,6 +2,6 @@
 
 mutation ScheduleTasks($taskIds: [String!]!) {
   scheduleTasks(taskIds: $taskIds) {
-    ...baseTask
+    ...BaseTask
   }
 }

--- a/src/gql/mutations/spawn-host.graphql
+++ b/src/gql/mutations/spawn-host.graphql
@@ -1,5 +1,5 @@
-mutation SpawnHost($SpawnHostInput: SpawnHostInput) {
-  spawnHost(spawnHostInput: $SpawnHostInput) {
+mutation SpawnHost($spawnHostInput: SpawnHostInput) {
+  spawnHost(spawnHostInput: $spawnHostInput) {
     id
     status
   }

--- a/src/gql/mutations/spawn-volume.graphql
+++ b/src/gql/mutations/spawn-volume.graphql
@@ -1,3 +1,3 @@
-mutation SpawnVolume($SpawnVolumeInput: SpawnVolumeInput!) {
-  spawnVolume(spawnVolumeInput: $SpawnVolumeInput)
+mutation SpawnVolume($spawnVolumeInput: SpawnVolumeInput!) {
+  spawnVolume(spawnVolumeInput: $spawnVolumeInput)
 }

--- a/src/gql/mutations/update-spawn-volume.graphql
+++ b/src/gql/mutations/update-spawn-volume.graphql
@@ -1,3 +1,3 @@
-mutation UpdateVolume($UpdateVolumeInput: UpdateVolumeInput!) {
-  updateVolume(updateVolumeInput: $UpdateVolumeInput)
+mutation UpdateVolume($updateVolumeInput: UpdateVolumeInput!) {
+  updateVolume(updateVolumeInput: $updateVolumeInput)
 }

--- a/src/gql/queries/failed-task-status-icon-tooltip.graphql
+++ b/src/gql/queries/failed-task-status-icon-tooltip.graphql
@@ -1,4 +1,4 @@
-query GetFailedTaskStatusIconTooltip($taskId: String!) {
+query FailedTaskStatusIconTooltip($taskId: String!) {
   taskTests(taskId: $taskId, statuses: ["fail"], limit: 5) {
     filteredTestCount
     testResults {

--- a/src/gql/queries/get-agent-logs.graphql
+++ b/src/gql/queries/get-agent-logs.graphql
@@ -6,7 +6,7 @@ query AgentLogs($id: String!, $execution: Int) {
     id
     taskLogs {
       agentLogs {
-        ...logMessage
+        ...LogMessage
       }
     }
   }

--- a/src/gql/queries/get-all-logs.graphql
+++ b/src/gql/queries/get-all-logs.graphql
@@ -6,7 +6,7 @@ query AllLogs($id: String!, $execution: Int) {
     id
     taskLogs {
       allLogs {
-        ...logMessage
+        ...LogMessage
       }
     }
   }

--- a/src/gql/queries/get-annotation-event-data.graphql
+++ b/src/gql/queries/get-annotation-event-data.graphql
@@ -1,9 +1,9 @@
 #import "../fragments/annotation.graphql"
 
-query GetAnnotationEventData($taskId: String!, $execution: Int) {
+query AnnotationEventData($taskId: String!, $execution: Int) {
   task(taskId: $taskId, execution: $execution) {
     annotation {
-      ...annotation
+      ...Annotation
     }
     execution
     id

--- a/src/gql/queries/get-base-version-and-task.graphql
+++ b/src/gql/queries/get-base-version-and-task.graphql
@@ -1,4 +1,4 @@
-query GetBaseVersionAndTask($taskId: String!) {
+query BaseVersionAndTask($taskId: String!) {
   task(taskId: $taskId) {
     baseTask {
       execution

--- a/src/gql/queries/get-build-baron-configured.graphql
+++ b/src/gql/queries/get-build-baron-configured.graphql
@@ -1,4 +1,4 @@
-query GetBuildBaronConfigured($taskId: String!, $execution: Int!) {
+query BuildBaronConfigured($taskId: String!, $execution: Int!) {
   buildBaron(taskId: $taskId, execution: $execution) {
     buildBaronConfigured
   }

--- a/src/gql/queries/get-build-variant-stats.graphql
+++ b/src/gql/queries/get-build-variant-stats.graphql
@@ -1,4 +1,4 @@
-query GetBuildVariantStats($id: String!) {
+query BuildVariantStats($id: String!) {
   version(id: $id) {
     buildVariantStats(options: {}) {
       displayName

--- a/src/gql/queries/get-build-variants-for-task-name.graphql
+++ b/src/gql/queries/get-build-variants-for-task-name.graphql
@@ -1,4 +1,4 @@
-query GetBuildVariantsForTaskName(
+query BuildVariantsForTaskName(
   $projectIdentifier: String!
   $taskName: String!
 ) {

--- a/src/gql/queries/get-code-changes.graphql
+++ b/src/gql/queries/get-code-changes.graphql
@@ -4,7 +4,7 @@ query CodeChanges($id: String!) {
   patch(id: $id) {
     id
     moduleCodeChanges {
-      ...moduleCodeChange
+      ...ModuleCodeChange
     }
   }
 }

--- a/src/gql/queries/get-commit-queue.graphql
+++ b/src/gql/queries/get-commit-queue.graphql
@@ -14,7 +14,7 @@ query CommitQueue($projectIdentifier: String!) {
         description
         id
         moduleCodeChanges {
-          ...moduleCodeChange
+          ...ModuleCodeChange
         }
         versionFull {
           id

--- a/src/gql/queries/get-created-tickets.graphql
+++ b/src/gql/queries/get-created-tickets.graphql
@@ -1,4 +1,4 @@
-query GetCreatedTickets($taskId: String!) {
+query CreatedTickets($taskId: String!) {
   bbGetCreatedTickets(taskId: $taskId) {
     fields {
       assigneeDisplayName

--- a/src/gql/queries/get-display-task.graphql
+++ b/src/gql/queries/get-display-task.graphql
@@ -1,4 +1,4 @@
-query GetDisplayTask($taskId: String!, $execution: Int) {
+query DisplayTask($taskId: String!, $execution: Int) {
   task(taskId: $taskId, execution: $execution) {
     displayName
     displayTask {

--- a/src/gql/queries/get-distros.graphql
+++ b/src/gql/queries/get-distros.graphql
@@ -1,4 +1,4 @@
-query distros($onlySpawnable: Boolean!) {
+query Distros($onlySpawnable: Boolean!) {
   distros(onlySpawnable: $onlySpawnable) {
     isVirtualWorkStation
     name

--- a/src/gql/queries/get-github-orgs.graphql
+++ b/src/gql/queries/get-github-orgs.graphql
@@ -1,4 +1,4 @@
-query GetGithubOrgs {
+query GithubOrgs {
   spruceConfig {
     githubOrgs
   }

--- a/src/gql/queries/get-has-version.graphql
+++ b/src/gql/queries/get-has-version.graphql
@@ -1,3 +1,3 @@
-query GetHasVersion($id: String!) {
+query HasVersion($id: String!) {
   hasVersion(id: $id)
 }

--- a/src/gql/queries/get-host-events.graphql
+++ b/src/gql/queries/get-host-events.graphql
@@ -1,4 +1,4 @@
-query hostEvents($id: String!, $tag: String!, $limit: Int, $page: Int) {
+query HostEvents($id: String!, $tag: String!, $limit: Int, $page: Int) {
   hostEvents(hostId: $id, hostTag: $tag, limit: $limit, page: $page) {
     count
     eventLogEntries {

--- a/src/gql/queries/get-host.graphql
+++ b/src/gql/queries/get-host.graphql
@@ -3,7 +3,7 @@
 query Host($id: String!) {
   host(hostId: $id) {
     ami
-    ...baseHost
+    ...BaseHost
     distro {
       bootstrapMethod
       id

--- a/src/gql/queries/get-jira-custom-created-issues.graphql
+++ b/src/gql/queries/get-jira-custom-created-issues.graphql
@@ -1,10 +1,10 @@
 #import "../fragments/annotations/issueLink.graphql"
 
-query GetCustomCreatedIssues($taskId: String!, $execution: Int) {
+query CustomCreatedIssues($taskId: String!, $execution: Int) {
   task(taskId: $taskId, execution: $execution) {
     annotation {
       createdIssues {
-        ...issueLink
+        ...IssueLink
       }
       id
     }

--- a/src/gql/queries/get-jira-issues.graphql
+++ b/src/gql/queries/get-jira-issues.graphql
@@ -1,11 +1,11 @@
 #import "../fragments/annotations/issueLink.graphql"
 
-query GetIssues($taskId: String!, $execution: Int) {
+query Issues($taskId: String!, $execution: Int) {
   task(taskId: $taskId, execution: $execution) {
     annotation {
       id
       issues {
-        ...issueLink
+        ...IssueLink
       }
     }
     execution

--- a/src/gql/queries/get-jira-suspected-issues.graphql
+++ b/src/gql/queries/get-jira-suspected-issues.graphql
@@ -1,11 +1,11 @@
 #import "../fragments/annotations/issueLink.graphql"
 
-query GetSuspectedIssues($taskId: String!, $execution: Int) {
+query SuspectedIssues($taskId: String!, $execution: Int) {
   task(taskId: $taskId, execution: $execution) {
     annotation {
       id
       suspectedIssues {
-        ...issueLink
+        ...IssueLink
       }
     }
     execution

--- a/src/gql/queries/get-last-mainline-commit.graphql
+++ b/src/gql/queries/get-last-mainline-commit.graphql
@@ -1,4 +1,4 @@
-query GetLastMainlineCommit(
+query LastMainlineCommit(
   $projectIdentifier: String!
   $skipOrderNumber: Int!
   $buildVariantOptions: BuildVariantOptions!

--- a/src/gql/queries/get-mainline-commits-for-history.graphql
+++ b/src/gql/queries/get-mainline-commits-for-history.graphql
@@ -18,7 +18,7 @@ query MainlineCommitsForHistory(
         message
         order
         revision
-        ...upstreamProject
+        ...UpstreamProject
       }
       version {
         author
@@ -37,7 +37,7 @@ query MainlineCommitsForHistory(
         message
         order
         revision
-        ...upstreamProject
+        ...UpstreamProject
       }
     }
   }

--- a/src/gql/queries/get-mainline-commits.graphql
+++ b/src/gql/queries/get-mainline-commits.graphql
@@ -21,7 +21,7 @@ query MainlineCommits(
         message
         order
         revision
-        ...upstreamProject
+        ...UpstreamProject
       }
       version {
         author
@@ -58,7 +58,7 @@ query MainlineCommits(
           }
           eta
         }
-        ...upstreamProject
+        ...UpstreamProject
       }
     }
   }

--- a/src/gql/queries/get-my-hosts.graphql
+++ b/src/gql/queries/get-my-hosts.graphql
@@ -2,6 +2,6 @@
 
 query MyHosts {
   myHosts {
-    ...baseSpawnHost
+    ...BaseSpawnHost
   }
 }

--- a/src/gql/queries/get-other-user.graphql
+++ b/src/gql/queries/get-other-user.graphql
@@ -1,4 +1,4 @@
-query GetOtherUser($userId: String) {
+query OtherUser($userId: String) {
   currentUser: user {
     userId
   }

--- a/src/gql/queries/get-patch-configure.graphql
+++ b/src/gql/queries/get-patch-configure.graphql
@@ -2,7 +2,7 @@
 
 query ConfigurePatch($id: String!) {
   patch(id: $id) {
-    ...basePatch
+    ...BasePatch
     childPatchAliases {
       alias
       patchId

--- a/src/gql/queries/get-patch-task-statuses.graphql
+++ b/src/gql/queries/get-patch-task-statuses.graphql
@@ -1,4 +1,4 @@
-query GetPatchTaskStatuses($id: String!) {
+query PatchTaskStatuses($id: String!) {
   patch(id: $id) {
     baseTaskStatuses
     id

--- a/src/gql/queries/get-patch.graphql
+++ b/src/gql/queries/get-patch.graphql
@@ -2,7 +2,7 @@
 
 query Patch($id: String!) {
   patch(id: $id) {
-    ...basePatch
+    ...BasePatch
     githash
     patchNumber
     projectID

--- a/src/gql/queries/get-pod-events.graphql
+++ b/src/gql/queries/get-pod-events.graphql
@@ -1,4 +1,4 @@
-query podEvents($id: String!, $limit: Int, $page: Int) {
+query PodEvents($id: String!, $limit: Int, $page: Int) {
   pod(podId: $id) {
     events(page: $page, limit: $limit) {
       count

--- a/src/gql/queries/get-project-event-logs.graphql
+++ b/src/gql/queries/get-project-event-logs.graphql
@@ -5,10 +5,10 @@ query ProjectEventLogs($identifier: String!, $limit: Int, $before: Time) {
     count
     eventLogEntries {
       after {
-        ...projectEventSettings
+        ...ProjectEventSettings
       }
       before {
-        ...projectEventSettings
+        ...ProjectEventSettings
       }
       timestamp
       user

--- a/src/gql/queries/get-project-settings.graphql
+++ b/src/gql/queries/get-project-settings.graphql
@@ -2,6 +2,6 @@
 
 query ProjectSettings($identifier: String!) {
   projectSettings(identifier: $identifier) {
-    ...projectSettings
+    ...ProjectSettings
   }
 }

--- a/src/gql/queries/get-project-settings.graphql
+++ b/src/gql/queries/get-project-settings.graphql
@@ -2,6 +2,6 @@
 
 query ProjectSettings($identifier: String!) {
   projectSettings(identifier: $identifier) {
-    ...ProjectSettings
+    ...ProjectSettingsFields
   }
 }

--- a/src/gql/queries/get-projects.graphql
+++ b/src/gql/queries/get-projects.graphql
@@ -1,4 +1,4 @@
-query GetProjects {
+query Projects {
   projects {
     groupDisplayName
     projects {

--- a/src/gql/queries/get-public-keys.graphql
+++ b/src/gql/queries/get-public-keys.graphql
@@ -1,4 +1,4 @@
-query GetMyPublicKeys {
+query MyPublicKeys {
   myPublicKeys {
     key
     name

--- a/src/gql/queries/get-repo-event-logs.graphql
+++ b/src/gql/queries/get-repo-event-logs.graphql
@@ -5,10 +5,10 @@ query RepoEventLogs($id: String!, $limit: Int, $before: Time) {
     count
     eventLogEntries {
       after {
-        ...projectEventSettings
+        ...ProjectEventSettings
       }
       before {
-        ...projectEventSettings
+        ...ProjectEventSettings
       }
       timestamp
       user

--- a/src/gql/queries/get-repo-settings.graphql
+++ b/src/gql/queries/get-repo-settings.graphql
@@ -2,6 +2,6 @@
 
 query RepoSettings($repoId: String!) {
   repoSettings(id: $repoId) {
-    ...RepoSettings
+    ...RepoSettingsFields
   }
 }

--- a/src/gql/queries/get-repo-settings.graphql
+++ b/src/gql/queries/get-repo-settings.graphql
@@ -2,6 +2,6 @@
 
 query RepoSettings($repoId: String!) {
   repoSettings(id: $repoId) {
-    ...repoSettings
+    ...RepoSettings
   }
 }

--- a/src/gql/queries/get-spruce-config.graphql
+++ b/src/gql/queries/get-spruce-config.graphql
@@ -1,4 +1,4 @@
-query GetSpruceConfig {
+query SpruceConfig {
   spruceConfig {
     banner
     bannerTheme

--- a/src/gql/queries/get-system-logs.graphql
+++ b/src/gql/queries/get-system-logs.graphql
@@ -6,7 +6,7 @@ query SystemLogs($id: String!, $execution: Int) {
     id
     taskLogs {
       systemLogs {
-        ...logMessage
+        ...LogMessage
       }
     }
   }

--- a/src/gql/queries/get-task-all-executions.graphql
+++ b/src/gql/queries/get-task-all-executions.graphql
@@ -1,4 +1,4 @@
-query GetTaskAllExecutions($taskId: String!) {
+query TaskAllExecutions($taskId: String!) {
   taskAllExecutions(taskId: $taskId) {
     activatedTime
     execution

--- a/src/gql/queries/get-task-logs.graphql
+++ b/src/gql/queries/get-task-logs.graphql
@@ -6,7 +6,7 @@ query TaskLogs($id: String!, $execution: Int) {
     id
     taskLogs {
       taskLogs {
-        ...logMessage
+        ...LogMessage
       }
     }
   }

--- a/src/gql/queries/get-task-names-for-build-variant.graphql
+++ b/src/gql/queries/get-task-names-for-build-variant.graphql
@@ -1,4 +1,4 @@
-query GetTaskNamesForBuildVariant(
+query TaskNamesForBuildVariant(
   $projectIdentifier: String!
   $buildVariant: String!
 ) {

--- a/src/gql/queries/get-task-statuses.graphql
+++ b/src/gql/queries/get-task-statuses.graphql
@@ -1,4 +1,4 @@
-query GetTaskStatuses($id: String!) {
+query TaskStatuses($id: String!) {
   version(id: $id) {
     baseTaskStatuses
     id

--- a/src/gql/queries/get-task-test-sample.graphql
+++ b/src/gql/queries/get-task-test-sample.graphql
@@ -1,4 +1,4 @@
-query GetTaskTestSample($tasks: [String!]!, $filters: [TestFilter!]!) {
+query TaskTestSample($tasks: [String!]!, $filters: [TestFilter!]!) {
   taskTestSample(tasks: $tasks, filters: $filters) {
     execution
     matchingFailedTestNames

--- a/src/gql/queries/get-task.graphql
+++ b/src/gql/queries/get-task.graphql
@@ -1,7 +1,7 @@
 #import "../fragments/baseTask.graphql"
 #import "../fragments/annotation.graphql"
 
-query GetTask($taskId: String!, $execution: Int) {
+query Task($taskId: String!, $execution: Int) {
   task(taskId: $taskId, execution: $execution) {
     aborted
     abortInfo {
@@ -16,9 +16,8 @@ query GetTask($taskId: String!, $execution: Int) {
     activatedTime
     ami
     annotation {
-      ...annotation
+      ...Annotation
     }
-    ...baseTask
     baseTask {
       execution
       id
@@ -28,6 +27,7 @@ query GetTask($taskId: String!, $execution: Int) {
         revision
       }
     }
+    ...BaseTask
     blocked
     canAbort
     canDisable

--- a/src/gql/queries/get-tests.graphql
+++ b/src/gql/queries/get-tests.graphql
@@ -1,4 +1,4 @@
-query GetTests(
+query Tests(
   $execution: Int
   $groupId: String
   $taskId: String!

--- a/src/gql/queries/get-undispatched-tasks.graphql
+++ b/src/gql/queries/get-undispatched-tasks.graphql
@@ -1,4 +1,4 @@
-query GetUndispatchedTasks($versionId: String!) {
+query UndispatchedTasks($versionId: String!) {
   version(id: $versionId) {
     id
     tasks(

--- a/src/gql/queries/get-user-config.graphql
+++ b/src/gql/queries/get-user-config.graphql
@@ -1,4 +1,4 @@
-query GetUserConfig {
+query UserConfig {
   userConfig {
     api_key
     api_server_host

--- a/src/gql/queries/get-user-permissions.graphql
+++ b/src/gql/queries/get-user-permissions.graphql
@@ -1,4 +1,4 @@
-query GetUserPermissions {
+query UserPermissions {
   user {
     permissions {
       canCreateProject

--- a/src/gql/queries/get-user-settings.graphql
+++ b/src/gql/queries/get-user-settings.graphql
@@ -1,4 +1,4 @@
-query GetUserSettings {
+query UserSettings {
   userSettings {
     dateFormat
     githubUser {

--- a/src/gql/queries/get-user.graphql
+++ b/src/gql/queries/get-user.graphql
@@ -1,4 +1,4 @@
-query GetUser {
+query User {
   user {
     displayName
     emailAddress

--- a/src/gql/queries/get-version.graphql
+++ b/src/gql/queries/get-version.graphql
@@ -72,7 +72,7 @@ query Version($id: String!) {
     startTime
     status
     taskCount
-    ...upstreamProject
+    ...UpstreamProject
     versionTiming {
       makespan
       timeTaken

--- a/src/gql/queries/get-viewable-projects.graphql
+++ b/src/gql/queries/get-viewable-projects.graphql
@@ -1,4 +1,4 @@
-query GetViewableProjectRefs {
+query ViewableProjectRefs {
   viewableProjectRefs {
     groupDisplayName
     projects {

--- a/src/gql/queries/spawn-task.graphql
+++ b/src/gql/queries/spawn-task.graphql
@@ -1,8 +1,8 @@
 #import "../fragments/baseTask.graphql"
 
-query GetSpawnTask($taskId: String!) {
+query SpawnTask($taskId: String!) {
   task(taskId: $taskId, execution: 0) {
-    ...baseTask
+    ...BaseTask
     canSync
     project {
       id

--- a/src/hooks/tests/useBreadcrumbRoot.test.tsx
+++ b/src/hooks/tests/useBreadcrumbRoot.test.tsx
@@ -1,9 +1,6 @@
 import { MockedProvider } from "@apollo/client/testing";
 import { renderHook } from "@testing-library/react-hooks";
-import {
-  GetOtherUserQuery,
-  GetOtherUserQueryVariables,
-} from "gql/generated/types";
+import { OtherUserQuery, OtherUserQueryVariables } from "gql/generated/types";
 import { getUserMock } from "gql/mocks/getUser";
 import { GET_OTHER_USER } from "gql/queries";
 import { useBreadcrumbRoot } from "hooks";
@@ -56,43 +53,41 @@ describe("useBreadcrumbRoot", () => {
   });
 });
 
-const sameUserMock: ApolloMock<GetOtherUserQuery, GetOtherUserQueryVariables> =
-  {
-    request: {
-      query: GET_OTHER_USER,
-      variables: {
+const sameUserMock: ApolloMock<OtherUserQuery, OtherUserQueryVariables> = {
+  request: {
+    query: GET_OTHER_USER,
+    variables: {
+      userId: "admin",
+    },
+  },
+  result: {
+    data: {
+      otherUser: {
+        userId: "admin",
+        displayName: "Evergreen Admin",
+        __typename: "User",
+      },
+      currentUser: { userId: "admin", __typename: "User" },
+    },
+  },
+};
+
+const otherUserMock: ApolloMock<OtherUserQuery, OtherUserQueryVariables> = {
+  request: {
+    query: GET_OTHER_USER,
+    variables: {
+      userId: "john.doe",
+    },
+  },
+  result: {
+    data: {
+      otherUser: {
+        userId: "john.doe",
+        displayName: "John Doe",
+      },
+      currentUser: {
         userId: "admin",
       },
     },
-    result: {
-      data: {
-        otherUser: {
-          userId: "admin",
-          displayName: "Evergreen Admin",
-          __typename: "User",
-        },
-        currentUser: { userId: "admin", __typename: "User" },
-      },
-    },
-  };
-
-const otherUserMock: ApolloMock<GetOtherUserQuery, GetOtherUserQueryVariables> =
-  {
-    request: {
-      query: GET_OTHER_USER,
-      variables: {
-        userId: "john.doe",
-      },
-    },
-    result: {
-      data: {
-        otherUser: {
-          userId: "john.doe",
-          displayName: "John Doe",
-        },
-        currentUser: {
-          userId: "admin",
-        },
-      },
-    },
-  };
+  },
+};

--- a/src/hooks/tests/useGetUserPatchesPageTitleAndLink.test.tsx
+++ b/src/hooks/tests/useGetUserPatchesPageTitleAndLink.test.tsx
@@ -1,14 +1,11 @@
 import { MockedProvider } from "@apollo/client/testing";
 import { renderHook } from "@testing-library/react-hooks";
-import {
-  GetOtherUserQuery,
-  GetOtherUserQueryVariables,
-} from "gql/generated/types";
+import { OtherUserQuery, OtherUserQueryVariables } from "gql/generated/types";
 import { GET_OTHER_USER } from "gql/queries";
 import { useGetUserPatchesPageTitleAndLink } from "hooks";
 import { ApolloMock } from "types/gql";
 
-const mocks: ApolloMock<GetOtherUserQuery, GetOtherUserQueryVariables>[] = [
+const mocks: ApolloMock<OtherUserQuery, OtherUserQueryVariables>[] = [
   {
     request: {
       query: GET_OTHER_USER,

--- a/src/hooks/useGetUserPatchesPageTitleAndLink.ts
+++ b/src/hooks/useGetUserPatchesPageTitleAndLink.ts
@@ -1,16 +1,13 @@
 import { useQuery } from "@apollo/client";
 import { getUserPatchesRoute } from "constants/routes";
-import {
-  GetOtherUserQuery,
-  GetOtherUserQueryVariables,
-} from "gql/generated/types";
+import { OtherUserQuery, OtherUserQueryVariables } from "gql/generated/types";
 import { GET_OTHER_USER } from "gql/queries";
 
 export const useGetUserPatchesPageTitleAndLink = (
   userId: string,
   skip: boolean = false
 ) => {
-  const { data } = useQuery<GetOtherUserQuery, GetOtherUserQueryVariables>(
+  const { data } = useQuery<OtherUserQuery, OtherUserQueryVariables>(
     GET_OTHER_USER,
     { variables: { userId }, skip }
   );

--- a/src/hooks/useKonamiCode/useKonamiCode.test.tsx
+++ b/src/hooks/useKonamiCode/useKonamiCode.test.tsx
@@ -2,7 +2,7 @@ import { MockedProvider } from "@apollo/client/testing";
 import userEvent from "@testing-library/user-event";
 import { act } from "react-dom/test-utils";
 import { RenderFakeToastContext } from "context/toast/__mocks__";
-import { GetTaskQuery, GetTaskQueryVariables } from "gql/generated/types";
+import { TaskQuery, TaskQueryVariables } from "gql/generated/types";
 import { cache } from "gql/GQLWrapper";
 import { taskQuery } from "gql/mocks/taskData";
 import { GET_TASK } from "gql/queries";
@@ -35,7 +35,7 @@ describe("useKonamiCode", () => {
     );
     window.HTMLMediaElement.prototype.play = audioPlayMock;
 
-    cache.writeQuery<GetTaskQuery, GetTaskQueryVariables>({
+    cache.writeQuery<TaskQuery, TaskQueryVariables>({
       query: GET_TASK,
       data: {
         ...taskQuery,
@@ -83,7 +83,7 @@ describe("useKonamiCode", () => {
     );
     window.HTMLMediaElement.prototype.play = audioPlayMock;
 
-    cache.writeQuery<GetTaskQuery, GetTaskQueryVariables>({
+    cache.writeQuery<TaskQuery, TaskQueryVariables>({
       query: GET_TASK,
       data: {
         ...taskQuery,
@@ -127,7 +127,7 @@ describe("useKonamiCode", () => {
     );
     window.HTMLMediaElement.prototype.play = audioPlayMock;
 
-    cache.writeQuery<GetTaskQuery, GetTaskQueryVariables>({
+    cache.writeQuery<TaskQuery, TaskQueryVariables>({
       query: GET_TASK,
       data: {
         ...taskQuery,

--- a/src/hooks/useSpruceConfig.ts
+++ b/src/hooks/useSpruceConfig.ts
@@ -1,15 +1,14 @@
 import { useQuery } from "@apollo/client";
 import {
-  GetSpruceConfigQuery,
-  GetSpruceConfigQueryVariables,
+  SpruceConfigQuery,
+  SpruceConfigQueryVariables,
 } from "gql/generated/types";
 import { GET_SPRUCE_CONFIG } from "gql/queries";
 
 export const useSpruceConfig = () => {
-  const { data } = useQuery<
-    GetSpruceConfigQuery,
-    GetSpruceConfigQueryVariables
-  >(GET_SPRUCE_CONFIG);
+  const { data } = useQuery<SpruceConfigQuery, SpruceConfigQueryVariables>(
+    GET_SPRUCE_CONFIG
+  );
 
   const { spruceConfig } = data || {};
   return spruceConfig;

--- a/src/hooks/useTaskStatuses.ts
+++ b/src/hooks/useTaskStatuses.ts
@@ -4,8 +4,8 @@ import { TreeDataEntry } from "components/TreeSelect";
 import { DEFAULT_POLL_INTERVAL } from "constants/index";
 import { taskStatusesFilterTreeData } from "constants/task";
 import {
-  GetTaskStatusesQuery,
-  GetTaskStatusesQueryVariables,
+  TaskStatusesQuery,
+  TaskStatusesQueryVariables,
 } from "gql/generated/types";
 import { GET_TASK_STATUSES } from "gql/queries";
 import { usePolling } from "hooks";
@@ -24,8 +24,8 @@ export const useTaskStatuses = ({
   versionId,
 }: UseTaskStatusesProps): UseTaskStatusesResult => {
   const { data, refetch, startPolling, stopPolling } = useQuery<
-    GetTaskStatusesQuery,
-    GetTaskStatusesQueryVariables
+    TaskStatusesQuery,
+    TaskStatusesQueryVariables
   >(GET_TASK_STATUSES, {
     variables: { id: versionId },
     pollInterval: DEFAULT_POLL_INTERVAL,

--- a/src/hooks/useUserSettings.ts
+++ b/src/hooks/useUserSettings.ts
@@ -1,7 +1,7 @@
 import { useQuery } from "@apollo/client";
 import {
-  GetUserSettingsQuery,
-  GetUserSettingsQueryVariables,
+  UserSettingsQuery,
+  UserSettingsQueryVariables,
 } from "gql/generated/types";
 import { GET_USER_SETTINGS } from "gql/queries";
 
@@ -11,8 +11,8 @@ type UseUserSettingsOptions = {
 
 export const useUserSettings = (options?: UseUserSettingsOptions) => {
   const { data, loading } = useQuery<
-    GetUserSettingsQuery,
-    GetUserSettingsQueryVariables
+    UserSettingsQuery,
+    UserSettingsQueryVariables
   >(GET_USER_SETTINGS, {
     onError(err) {
       options?.onError?.(err);

--- a/src/hooks/useUserTimeZone.ts
+++ b/src/hooks/useUserTimeZone.ts
@@ -1,9 +1,9 @@
 import { useQuery } from "@apollo/client";
-import { GetUserSettingsQuery } from "gql/generated/types";
+import { UserSettingsQuery } from "gql/generated/types";
 import { GET_USER_SETTINGS } from "gql/queries";
 
 // get the timezone for the user
 export const useUserTimeZone = () => {
-  const { data } = useQuery<GetUserSettingsQuery>(GET_USER_SETTINGS);
+  const { data } = useQuery<UserSettingsQuery>(GET_USER_SETTINGS);
   return data?.userSettings?.timezone;
 };

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -4,7 +4,7 @@ import styled from "@emotion/styled";
 import { Location } from "history";
 import { Navigate, useLocation } from "react-router-dom";
 import { useAuthDispatchContext, useAuthStateContext } from "context/auth";
-import { GetUserQuery, GetUserQueryVariables } from "gql/generated/types";
+import { UserQuery, UserQueryVariables } from "gql/generated/types";
 import { GET_USER } from "gql/queries";
 
 const getReferrer = (location: Location): string => {
@@ -23,7 +23,7 @@ export const Login: React.VFC = () => {
   // this top-level query is required for authentication to work
   // afterware is used at apollo link level to authenticate or deauthenticate user based on response to query
   // therefore this could be any query as long as it is top-level
-  useQuery<GetUserQuery, GetUserQueryVariables>(GET_USER);
+  useQuery<UserQuery, UserQueryVariables>(GET_USER);
 
   const loginHandler = (): void => {
     devLogin({ username, password });

--- a/src/pages/MyPatches.tsx
+++ b/src/pages/MyPatches.tsx
@@ -1,11 +1,11 @@
 import { useQuery } from "@apollo/client";
 import { Navigate } from "react-router-dom";
 import { getUserPatchesRoute } from "constants/routes";
-import { GetUserQuery } from "gql/generated/types";
+import { UserQuery } from "gql/generated/types";
 import { GET_USER } from "gql/queries";
 
 export const MyPatches: React.VFC = () => {
-  const { data } = useQuery<GetUserQuery>(GET_USER);
+  const { data } = useQuery<UserQuery>(GET_USER);
   if (data) {
     return <Navigate replace to={getUserPatchesRoute(data.user.userId)} />;
   }

--- a/src/pages/Task.tsx
+++ b/src/pages/Task.tsx
@@ -12,7 +12,7 @@ import {
 import TaskStatusBadge from "components/TaskStatusBadge";
 import { DEFAULT_POLL_INTERVAL } from "constants/index";
 import { useToastContext } from "context/toast";
-import { GetTaskQuery, GetTaskQueryVariables } from "gql/generated/types";
+import { TaskQuery, TaskQueryVariables } from "gql/generated/types";
 import { GET_TASK } from "gql/queries";
 import { usePolling } from "hooks";
 import { useUpdateURLQueryParams } from "hooks/useUpdateURLQueryParams";
@@ -38,8 +38,8 @@ export const Task = () => {
 
   // Query task data
   const { data, loading, error, refetch, startPolling, stopPolling } = useQuery<
-    GetTaskQuery,
-    GetTaskQueryVariables
+    TaskQuery,
+    TaskQueryVariables
   >(GET_TASK, {
     variables: { taskId: id, execution: selectedExecution },
     pollInterval: DEFAULT_POLL_INTERVAL,

--- a/src/pages/Version.tsx
+++ b/src/pages/Version.tsx
@@ -18,8 +18,8 @@ import {
   VersionQueryVariables,
   IsPatchConfiguredQuery,
   IsPatchConfiguredQueryVariables,
-  GetHasVersionQuery,
-  GetHasVersionQueryVariables,
+  HasVersionQuery,
+  HasVersionQueryVariables,
 } from "gql/generated/types";
 import {
   GET_VERSION,
@@ -75,8 +75,8 @@ export const VersionPage: React.VFC = () => {
   });
 
   const { error: hasVersionError } = useQuery<
-    GetHasVersionQuery,
-    GetHasVersionQueryVariables
+    HasVersionQuery,
+    HasVersionQueryVariables
   >(GET_HAS_VERSION, {
     variables: { id },
     onCompleted: ({ hasVersion }) => {

--- a/src/pages/commits/ActiveCommits/buildVariantCard/WaterfallTaskStatusIcon.test.tsx
+++ b/src/pages/commits/ActiveCommits/buildVariantCard/WaterfallTaskStatusIcon.test.tsx
@@ -1,7 +1,7 @@
 import { MockedProvider } from "@apollo/client/testing";
 import {
-  GetFailedTaskStatusIconTooltipQuery,
-  GetFailedTaskStatusIconTooltipQueryVariables,
+  FailedTaskStatusIconTooltipQuery,
+  FailedTaskStatusIconTooltipQueryVariables,
 } from "gql/generated/types";
 import { GET_FAILED_TASK_STATUS_ICON_TOOLTIP } from "gql/queries";
 import {
@@ -99,8 +99,8 @@ describe("waterfallTaskStatusIcon", () => {
 });
 
 const getTooltipQueryMock: ApolloMock<
-  GetFailedTaskStatusIconTooltipQuery,
-  GetFailedTaskStatusIconTooltipQueryVariables
+  FailedTaskStatusIconTooltipQuery,
+  FailedTaskStatusIconTooltipQueryVariables
 > = {
   request: {
     query: GET_FAILED_TASK_STATUS_ICON_TOOLTIP,

--- a/src/pages/commits/ActiveCommits/buildVariantCard/WaterfallTaskStatusIcon.tsx
+++ b/src/pages/commits/ActiveCommits/buildVariantCard/WaterfallTaskStatusIcon.tsx
@@ -10,8 +10,8 @@ import { TaskStatusIcon } from "components/TaskStatusIcon";
 import { getTaskRoute } from "constants/routes";
 import { size, zIndex } from "constants/tokens";
 import {
-  GetFailedTaskStatusIconTooltipQuery,
-  GetFailedTaskStatusIconTooltipQueryVariables,
+  FailedTaskStatusIconTooltipQuery,
+  FailedTaskStatusIconTooltipQueryVariables,
 } from "gql/generated/types";
 import { GET_FAILED_TASK_STATUS_ICON_TOOLTIP } from "gql/queries";
 import { isFailedTaskStatus } from "utils/statuses";
@@ -42,8 +42,8 @@ export const WaterfallTaskStatusIcon: React.VFC<
   const { sendEvent } = useProjectHealthAnalytics({ page: "Commit chart" });
   const [enabled, setEnabled] = useState(false);
   const [loadData, { data, loading }] = useLazyQuery<
-    GetFailedTaskStatusIconTooltipQuery,
-    GetFailedTaskStatusIconTooltipQueryVariables
+    FailedTaskStatusIconTooltipQuery,
+    FailedTaskStatusIconTooltipQueryVariables
   >(GET_FAILED_TASK_STATUS_ICON_TOOLTIP, { variables: { taskId } });
   const { testResults, filteredTestCount } = data?.taskTests ?? {};
   const failedTestDifference = filteredTestCount - (testResults ?? []).length;

--- a/src/pages/commits/index.tsx
+++ b/src/pages/commits/index.tsx
@@ -19,8 +19,8 @@ import { size } from "constants/tokens";
 import { newMainlineCommitsUser } from "constants/welcomeModalProps";
 import { useToastContext } from "context/toast";
 import {
-  GetSpruceConfigQuery,
-  GetSpruceConfigQueryVariables,
+  SpruceConfigQuery,
+  SpruceConfigQueryVariables,
   MainlineCommitsQuery,
   MainlineCommitsQueryVariables,
 } from "gql/generated/types";
@@ -64,8 +64,8 @@ const Commits = () => {
   // Push default project to URL if there isn't a project in
   // the URL already and an mci-project-cookie does not exist.
   const { data: spruceData } = useQuery<
-    GetSpruceConfigQuery,
-    GetSpruceConfigQueryVariables
+    SpruceConfigQuery,
+    SpruceConfigQueryVariables
   >(GET_SPRUCE_CONFIG, {
     skip: !!projectIdentifier || !!recentlySelectedProject,
   });

--- a/src/pages/preferences/preferencesTabs/NewUITab.tsx
+++ b/src/pages/preferences/preferencesTabs/NewUITab.tsx
@@ -49,7 +49,7 @@ export const NewUITab: React.VFC = () => {
           },
         },
       },
-      refetchQueries: ["GetUserSettings"],
+      refetchQueries: ["UserSettings"],
     });
   };
 

--- a/src/pages/preferences/preferencesTabs/NotificationsTab.tsx
+++ b/src/pages/preferences/preferencesTabs/NotificationsTab.tsx
@@ -73,7 +73,7 @@ export const NotificationsTab: React.VFC = () => {
     try {
       await updateUserSettings({
         variables,
-        refetchQueries: ["GetUserSettings"],
+        refetchQueries: ["UserSettings"],
       });
     } catch (err) {}
   };

--- a/src/pages/preferences/preferencesTabs/ProfileTab.tsx
+++ b/src/pages/preferences/preferencesTabs/ProfileTab.tsx
@@ -40,7 +40,7 @@ export const ProfileTab: React.VFC = () => {
     onError: (err) => {
       dispatchToast.error(`Error while saving settings: '${err.message}'`);
     },
-    refetchQueries: ["GetUserSettings"],
+    refetchQueries: ["UserSettings"],
   });
 
   const [hasErrors, setHasErrors] = useState(false);

--- a/src/pages/preferences/preferencesTabs/PublicKeysTab.tsx
+++ b/src/pages/preferences/preferencesTabs/PublicKeysTab.tsx
@@ -11,8 +11,8 @@ import { WordBreak } from "components/styles";
 import { size } from "constants/tokens";
 import { useToastContext } from "context/toast";
 import {
-  GetMyPublicKeysQuery,
-  GetMyPublicKeysQueryVariables,
+  MyPublicKeysQuery,
+  MyPublicKeysQueryVariables,
   RemovePublicKeyMutation,
   RemovePublicKeyMutationVariables,
 } from "gql/generated/types";
@@ -33,8 +33,8 @@ export const PublicKeysTab: React.VFC = () => {
     setEditModalProps(defaultEditModalProps);
   };
   const { data: myKeysData, loading: loadingMyPublicKeys } = useQuery<
-    GetMyPublicKeysQuery,
-    GetMyPublicKeysQueryVariables
+    MyPublicKeysQuery,
+    MyPublicKeysQueryVariables
   >(GET_MY_PUBLIC_KEYS, {
     onError(error) {
       dispatchToast.error(
@@ -53,7 +53,7 @@ export const PublicKeysTab: React.VFC = () => {
       );
     },
     update(cache, { data }) {
-      cache.writeQuery<GetMyPublicKeysQuery, GetMyPublicKeysQueryVariables>({
+      cache.writeQuery<MyPublicKeysQuery, MyPublicKeysQueryVariables>({
         query: GET_MY_PUBLIC_KEYS,
         data: { myPublicKeys: [...data.removePublicKey] },
       });

--- a/src/pages/preferences/preferencesTabs/cliTab/AuthenticationCard.tsx
+++ b/src/pages/preferences/preferencesTabs/cliTab/AuthenticationCard.tsx
@@ -7,10 +7,7 @@ import { Skeleton } from "antd";
 import get from "lodash/get";
 import { usePreferencesAnalytics } from "analytics";
 import { size } from "constants/tokens";
-import {
-  GetUserConfigQuery,
-  GetUserConfigQueryVariables,
-} from "gql/generated/types";
+import { UserConfigQuery, UserConfigQueryVariables } from "gql/generated/types";
 import { GET_USER_CONFIG } from "gql/queries";
 import { PreferencesCard } from "pages/preferences/Card";
 import { request } from "utils";
@@ -19,8 +16,8 @@ const { post } = request;
 
 export const AuthenticationCard = () => {
   const { data, loading, refetch } = useQuery<
-    GetUserConfigQuery,
-    GetUserConfigQueryVariables
+    UserConfigQuery,
+    UserConfigQueryVariables
   >(GET_USER_CONFIG);
   const { sendEvent } = usePreferencesAnalytics();
   if (loading) {

--- a/src/pages/preferences/preferencesTabs/publicKeysTab/EditModal.tsx
+++ b/src/pages/preferences/preferencesTabs/publicKeysTab/EditModal.tsx
@@ -9,10 +9,10 @@ import { ErrorMessage } from "components/styles";
 import { size } from "constants/tokens";
 import { useToastContext } from "context/toast";
 import {
-  GetMyPublicKeysQuery,
+  MyPublicKeysQuery,
   UpdatePublicKeyMutation,
   UpdatePublicKeyMutationVariables,
-  GetMyPublicKeysQueryVariables,
+  MyPublicKeysQueryVariables,
   CreatePublicKeyMutation,
   CreatePublicKeyMutationVariables,
 } from "gql/generated/types";
@@ -38,8 +38,8 @@ export const EditModal: React.VFC<EditModalProps> = ({
   onCancel,
 }) => {
   const { data: myKeysData } = useQuery<
-    GetMyPublicKeysQuery,
-    GetMyPublicKeysQueryVariables
+    MyPublicKeysQuery,
+    MyPublicKeysQueryVariables
   >(GET_MY_PUBLIC_KEYS, { fetchPolicy: "cache-only" });
   const { sendEvent } = usePreferencesAnalytics();
   const dispatchToast = useToastContext();
@@ -55,7 +55,7 @@ export const EditModal: React.VFC<EditModalProps> = ({
     },
     onCompleted() {},
     update(cache, { data }) {
-      cache.writeQuery<GetMyPublicKeysQuery, GetMyPublicKeysQueryVariables>({
+      cache.writeQuery<MyPublicKeysQuery, MyPublicKeysQueryVariables>({
         query: GET_MY_PUBLIC_KEYS,
         data: { myPublicKeys: [...data.updatePublicKey] },
       });
@@ -72,7 +72,7 @@ export const EditModal: React.VFC<EditModalProps> = ({
     },
     onCompleted() {},
     update(cache, { data }) {
-      cache.writeQuery<GetMyPublicKeysQuery, GetMyPublicKeysQueryVariables>({
+      cache.writeQuery<MyPublicKeysQuery, MyPublicKeysQueryVariables>({
         query: GET_MY_PUBLIC_KEYS,
         data: { myPublicKeys: [...data.createPublicKey] },
       });

--- a/src/pages/projectSettings/CreateDuplicateProjectButton.test.tsx
+++ b/src/pages/projectSettings/CreateDuplicateProjectButton.test.tsx
@@ -1,8 +1,8 @@
 import { MockedProvider, MockedResponse } from "@apollo/client/testing";
 import { RenderFakeToastContext } from "context/toast/__mocks__";
 import {
-  GetUserPermissionsQuery,
-  GetUserPermissionsQueryVariables,
+  UserPermissionsQuery,
+  UserPermissionsQueryVariables,
 } from "gql/generated/types";
 import { GET_USER_PERMISSIONS } from "gql/queries";
 import {
@@ -39,8 +39,8 @@ const Button = ({
 describe("createDuplicateProjectField", () => {
   it("does not show button when user lacks permissions", async () => {
     const lacksPermissionsMock: ApolloMock<
-      GetUserPermissionsQuery,
-      GetUserPermissionsQueryVariables
+      UserPermissionsQuery,
+      UserPermissionsQueryVariables
     > = {
       request: {
         query: GET_USER_PERMISSIONS,
@@ -128,8 +128,8 @@ describe("createDuplicateProjectField", () => {
 });
 
 const userPermissionsMock: ApolloMock<
-  GetUserPermissionsQuery,
-  GetUserPermissionsQueryVariables
+  UserPermissionsQuery,
+  UserPermissionsQueryVariables
 > = {
   request: {
     query: GET_USER_PERMISSIONS,

--- a/src/pages/projectSettings/CreateDuplicateProjectButton.tsx
+++ b/src/pages/projectSettings/CreateDuplicateProjectButton.tsx
@@ -3,7 +3,7 @@ import { useQuery } from "@apollo/client";
 import { Menu, MenuItem } from "@leafygreen-ui/menu";
 import { PlusButton, Size, Variant } from "components/Buttons";
 import { zIndex } from "constants/tokens";
-import { GetUserPermissionsQuery } from "gql/generated/types";
+import { UserPermissionsQuery } from "gql/generated/types";
 import { GET_USER_PERMISSIONS } from "gql/queries";
 import { CopyProjectModal } from "./CopyProjectModal";
 import { CreateProjectModal } from "./CreateProjectModal";
@@ -34,7 +34,7 @@ export const CreateDuplicateProjectButton: React.VFC<Props> = ({
   projectType,
   repo,
 }) => {
-  const { data } = useQuery<GetUserPermissionsQuery>(GET_USER_PERMISSIONS);
+  const { data } = useQuery<UserPermissionsQuery>(GET_USER_PERMISSIONS);
   const {
     user: {
       permissions: { canCreateProject },

--- a/src/pages/projectSettings/CreateProjectModal.test.tsx
+++ b/src/pages/projectSettings/CreateProjectModal.test.tsx
@@ -4,8 +4,8 @@ import { RenderFakeToastContext } from "context/toast/__mocks__";
 import {
   CreateProjectMutation,
   CreateProjectMutationVariables,
-  GetGithubOrgsQuery,
-  GetGithubOrgsQueryVariables,
+  GithubOrgsQuery,
+  GithubOrgsQueryVariables,
 } from "gql/generated/types";
 import { CREATE_PROJECT } from "gql/mutations";
 import { GET_GITHUB_ORGS } from "gql/queries";
@@ -313,18 +313,16 @@ const createProjectMock: ApolloMock<
   },
 };
 
-const getGithubOrgsMock: ApolloMock<
-  GetGithubOrgsQuery,
-  GetGithubOrgsQueryVariables
-> = {
-  request: {
-    query: GET_GITHUB_ORGS,
-  },
-  result: {
-    data: {
-      spruceConfig: {
-        githubOrgs: ["evergreen-ci", "10gen"],
+const getGithubOrgsMock: ApolloMock<GithubOrgsQuery, GithubOrgsQueryVariables> =
+  {
+    request: {
+      query: GET_GITHUB_ORGS,
+    },
+    result: {
+      data: {
+        spruceConfig: {
+          githubOrgs: ["evergreen-ci", "10gen"],
+        },
       },
     },
-  },
-};
+  };

--- a/src/pages/projectSettings/CreateProjectModal.tsx
+++ b/src/pages/projectSettings/CreateProjectModal.tsx
@@ -10,7 +10,7 @@ import { useToastContext } from "context/toast";
 import {
   CreateProjectMutation,
   CreateProjectMutationVariables,
-  GetGithubOrgsQuery,
+  GithubOrgsQuery,
 } from "gql/generated/types";
 import { CREATE_PROJECT } from "gql/mutations";
 import { GET_GITHUB_ORGS } from "gql/queries";
@@ -42,7 +42,7 @@ export const CreateProjectModal: React.VFC<Props> = ({
   });
   const [hasError, setHasError] = useState(true);
 
-  const { data: gitOrgs } = useQuery<GetGithubOrgsQuery>(GET_GITHUB_ORGS, {
+  const { data: gitOrgs } = useQuery<GithubOrgsQuery>(GET_GITHUB_ORGS, {
     skip: !open,
   });
   const { spruceConfig: { githubOrgs = [] } = {} } = gitOrgs ?? {};

--- a/src/pages/projectSettings/HeaderButtons.tsx
+++ b/src/pages/projectSettings/HeaderButtons.tsx
@@ -83,7 +83,7 @@ export const HeaderButtons: React.VFC<Props> = ({ id, projectType, tab }) => {
       },
     }) =>
       identifier === newIdentifier
-        ? ["ProjectSettings", "GetViewableProjectRefs"]
+        ? ["ProjectSettings", "ViewableProjectRefs"]
         : [],
   });
 
@@ -98,7 +98,7 @@ export const HeaderButtons: React.VFC<Props> = ({ id, projectType, tab }) => {
     onError(err) {
       dispatchToast.error(`There was an error saving the repo: ${err.message}`);
     },
-    refetchQueries: ["RepoSettings", "GetViewableProjectRefs"],
+    refetchQueries: ["RepoSettings", "ViewableProjectRefs"],
   });
 
   const onClick = () => {

--- a/src/pages/projectSettings/tabs/GeneralTab/Fields/AttachDetachModal.tsx
+++ b/src/pages/projectSettings/tabs/GeneralTab/Fields/AttachDetachModal.tsx
@@ -49,7 +49,7 @@ export const AttachDetachModal: React.VFC<ModalProps> = ({
     refetchQueries: [
       "ProjectSettings",
       "RepoSettings",
-      "GetViewableProjectRefs",
+      "ViewableProjectRefs",
       "GithubProjectConflicts",
     ],
   });
@@ -67,11 +67,7 @@ export const AttachDetachModal: React.VFC<ModalProps> = ({
         `There was an error detaching the project: ${err.message}`
       );
     },
-    refetchQueries: [
-      "ProjectSettings",
-      "RepoSettings",
-      "GetViewableProjectRefs",
-    ],
+    refetchQueries: ["ProjectSettings", "RepoSettings", "ViewableProjectRefs"],
   });
 
   return (

--- a/src/pages/projectSettings/tabs/GeneralTab/Fields/MoveRepoModal.tsx
+++ b/src/pages/projectSettings/tabs/GeneralTab/Fields/MoveRepoModal.tsx
@@ -54,7 +54,7 @@ export const MoveRepoModal: React.VFC<ModalProps> = ({
     refetchQueries: [
       "ProjectSettings",
       "RepoSettings",
-      "GetViewableProjectRefs",
+      "ViewableProjectRefs",
       "GithubProjectConflicts",
     ],
   });

--- a/src/pages/projectSettings/tabs/GeneralTab/Fields/RepoConfigField.test.tsx
+++ b/src/pages/projectSettings/tabs/GeneralTab/Fields/RepoConfigField.test.tsx
@@ -8,8 +8,8 @@ import {
   AttachProjectToRepoMutationVariables,
   DetachProjectFromRepoMutation,
   DetachProjectFromRepoMutationVariables,
-  GetGithubOrgsQuery,
-  GetGithubOrgsQueryVariables,
+  GithubOrgsQuery,
+  GithubOrgsQueryVariables,
 } from "gql/generated/types";
 import {
   ATTACH_PROJECT_TO_REPO,
@@ -367,18 +367,16 @@ const detachProjectFromRepoMock: ApolloMock<
   },
 };
 
-const getGithubOrgsMock: ApolloMock<
-  GetGithubOrgsQuery,
-  GetGithubOrgsQueryVariables
-> = {
-  request: {
-    query: GET_GITHUB_ORGS,
-  },
-  result: {
-    data: {
-      spruceConfig: {
-        githubOrgs: ["evergreen-ci", "10gen"],
+const getGithubOrgsMock: ApolloMock<GithubOrgsQuery, GithubOrgsQueryVariables> =
+  {
+    request: {
+      query: GET_GITHUB_ORGS,
+    },
+    result: {
+      data: {
+        spruceConfig: {
+          githubOrgs: ["evergreen-ci", "10gen"],
+        },
       },
     },
-  },
-};
+  };

--- a/src/pages/projectSettings/tabs/GeneralTab/Fields/RepoConfigField.tsx
+++ b/src/pages/projectSettings/tabs/GeneralTab/Fields/RepoConfigField.tsx
@@ -6,7 +6,7 @@ import Tooltip from "@leafygreen-ui/tooltip";
 import { Field } from "@rjsf/core";
 import { SpruceForm } from "components/SpruceForm";
 import { size, zIndex } from "constants/tokens";
-import { GetGithubOrgsQuery } from "gql/generated/types";
+import { GithubOrgsQuery } from "gql/generated/types";
 import { GET_GITHUB_ORGS } from "gql/queries";
 import { ProjectType } from "../../utils";
 import { AttachDetachModal } from "./AttachDetachModal";
@@ -36,7 +36,7 @@ export const RepoConfigField: Field = ({
   const ownerOrRepoHasChanges =
     formData.owner !== initialOwner || formData.repo !== initialRepo;
 
-  const { data } = useQuery<GetGithubOrgsQuery>(GET_GITHUB_ORGS);
+  const { data } = useQuery<GithubOrgsQuery>(GET_GITHUB_ORGS);
   const { spruceConfig: { githubOrgs = [] } = {} } = data ?? {};
 
   return (

--- a/src/pages/spawn/spawnHost/spawnHostButton/SpawnHostModal.tsx
+++ b/src/pages/spawn/spawnHost/spawnHostButton/SpawnHostModal.tsx
@@ -16,8 +16,8 @@ import { useToastContext } from "context/toast";
 import {
   SpawnHostMutation,
   SpawnHostMutationVariables,
-  GetSpawnTaskQuery,
-  GetSpawnTaskQueryVariables,
+  SpawnTaskQuery,
+  SpawnTaskQueryVariables,
 } from "gql/generated/types";
 import { SPAWN_HOST } from "gql/mutations";
 import { GET_SPAWN_TASK } from "gql/queries";
@@ -42,8 +42,8 @@ export const SpawnHostModal: React.VFC<SpawnHostModalProps> = ({
   const taskIdQueryParam = getString(queryParams.taskId);
   const distroIdQueryParam = getString(queryParams.distroId);
   const { data: spawnTaskData } = useQuery<
-    GetSpawnTaskQuery,
-    GetSpawnTaskQueryVariables
+    SpawnTaskQuery,
+    SpawnTaskQueryVariables
   >(GET_SPAWN_TASK, {
     skip: !(taskIdQueryParam && distroIdQueryParam),
     variables: { taskId: taskIdQueryParam },
@@ -65,7 +65,7 @@ export const SpawnHostModal: React.VFC<SpawnHostModalProps> = ({
         `There was an error while spawning your host: ${err.message}`
       );
     },
-    refetchQueries: ["MyHosts", "MyVolumes", "GetMyPublicKeys"],
+    refetchQueries: ["MyHosts", "MyVolumes", "MyPublicKeys"],
   });
 
   const [formState, setFormState] = useState<FormState>({});
@@ -106,7 +106,7 @@ export const SpawnHostModal: React.VFC<SpawnHostModalProps> = ({
       ]),
     });
     spawnHostMutation({
-      variables: { SpawnHostInput: mutationInput },
+      variables: { spawnHostInput: mutationInput },
     });
   };
 

--- a/src/pages/spawn/spawnVolume/SpawnVolumeModal.test.tsx
+++ b/src/pages/spawn/spawnVolume/SpawnVolumeModal.test.tsx
@@ -75,7 +75,7 @@ describe("spawnVolumeModal", () => {
       request: {
         query: SPAWN_VOLUME,
         variables: {
-          SpawnVolumeInput: {
+          spawnVolumeInput: {
             availabilityZone: "us-east-1a",
             size: 500,
             type: "gp2",
@@ -117,7 +117,7 @@ describe("spawnVolumeModal", () => {
       request: {
         query: SPAWN_VOLUME,
         variables: {
-          SpawnVolumeInput: {
+          spawnVolumeInput: {
             availabilityZone: "us-east-1c",
             size: 24,
             type: "st1",

--- a/src/pages/spawn/spawnVolume/SpawnVolumeModal.tsx
+++ b/src/pages/spawn/spawnVolume/SpawnVolumeModal.tsx
@@ -55,7 +55,7 @@ export const SpawnVolumeModal: React.VFC<SpawnVolumeModalProps> = ({
       params: mutationInput,
     });
     spawnVolumeMutation({
-      variables: { SpawnVolumeInput: mutationInput },
+      variables: { spawnVolumeInput: mutationInput },
     });
   };
 

--- a/src/pages/spawn/spawnVolume/spawnVolumeTableActions/EditVolumeModal.tsx
+++ b/src/pages/spawn/spawnVolume/spawnVolumeTableActions/EditVolumeModal.tsx
@@ -69,7 +69,7 @@ export const EditVolumeModal: React.VFC<Props> = ({
       params: mutationInput,
     });
     updateVolumeMutation({
-      variables: { UpdateVolumeInput: mutationInput },
+      variables: { updateVolumeInput: mutationInput },
     });
   };
 

--- a/src/pages/spawn/spawnVolume/spawnVolumeTableActions/MigrateVolumeModal.tsx
+++ b/src/pages/spawn/spawnVolume/spawnVolumeTableActions/MigrateVolumeModal.tsx
@@ -58,7 +58,7 @@ export const MigrateVolumeModal: React.VFC<MigrateVolumeModalProps> = ({
       );
       dispatch({ type: "resetPage" });
     },
-    refetchQueries: ["MyHosts", "MyVolumes", "GetMyPublicKeys"],
+    refetchQueries: ["MyHosts", "MyVolumes", "MyPublicKeys"],
   });
 
   const distros = useMemo(

--- a/src/pages/task/ActionButtons.tsx
+++ b/src/pages/task/ActionButtons.tsx
@@ -24,7 +24,7 @@ import {
   UnscheduleTaskMutationVariables,
   OverrideTaskDependenciesMutation,
   OverrideTaskDependenciesMutationVariables,
-  GetTaskQuery,
+  TaskQuery,
 } from "gql/generated/types";
 import {
   ABORT_TASK,
@@ -45,7 +45,7 @@ interface Props {
   initialPriority?: number;
   isDisplayTask: boolean;
   isExecutionTask: boolean;
-  task: GetTaskQuery["task"];
+  task: TaskQuery["task"];
 }
 
 export const ActionButtons: React.VFC<Props> = ({

--- a/src/pages/task/TaskTabs.tsx
+++ b/src/pages/task/TaskTabs.tsx
@@ -6,7 +6,7 @@ import { TrendChartsPlugin } from "components/PerfPlugin";
 import { StyledTabs } from "components/styles/StyledTabs";
 import { TabLabelWithBadge } from "components/TabLabelWithBadge";
 import { getTaskRoute } from "constants/routes";
-import { GetTaskQuery } from "gql/generated/types";
+import { TaskQuery } from "gql/generated/types";
 import { usePrevious } from "hooks";
 import { TaskTab } from "types/task";
 import { queryString } from "utils";
@@ -20,7 +20,7 @@ import { TestsTable } from "./taskTabs/TestsTable";
 const { parseQueryString } = queryString;
 interface TaskTabProps {
   isDisplayTask: boolean;
-  task: GetTaskQuery["task"];
+  task: TaskQuery["task"];
 }
 export const TaskTabs: React.VFC<TaskTabProps> = ({ isDisplayTask, task }) => {
   const { tab: urlTab } = useParams<{ id: string; tab: TaskTab | null }>();

--- a/src/pages/task/actionButtons/previousCommits/PreviousCommits.test.tsx
+++ b/src/pages/task/actionButtons/previousCommits/PreviousCommits.test.tsx
@@ -1,9 +1,9 @@
 import { MockedProvider } from "@apollo/client/testing";
 import {
-  GetBaseVersionAndTaskQuery,
-  GetBaseVersionAndTaskQueryVariables,
-  GetLastMainlineCommitQuery,
-  GetLastMainlineCommitQueryVariables,
+  BaseVersionAndTaskQuery,
+  BaseVersionAndTaskQueryVariables,
+  LastMainlineCommitQuery,
+  LastMainlineCommitQueryVariables,
 } from "gql/generated/types";
 import {
   GET_BASE_VERSION_AND_TASK,
@@ -224,8 +224,8 @@ const baseTaskId =
 const baseTaskHref = `/task/${baseTaskId}`;
 
 const getPatchTaskWithSuccessfulBaseTask: ApolloMock<
-  GetBaseVersionAndTaskQuery,
-  GetBaseVersionAndTaskQueryVariables
+  BaseVersionAndTaskQuery,
+  BaseVersionAndTaskQueryVariables
 > = {
   request: {
     query: GET_BASE_VERSION_AND_TASK,
@@ -264,8 +264,8 @@ const getPatchTaskWithSuccessfulBaseTask: ApolloMock<
 };
 
 const getPatchTaskWithRunningBaseTask: ApolloMock<
-  GetBaseVersionAndTaskQuery,
-  GetBaseVersionAndTaskQueryVariables
+  BaseVersionAndTaskQuery,
+  BaseVersionAndTaskQueryVariables
 > = {
   request: {
     query: GET_BASE_VERSION_AND_TASK,
@@ -304,8 +304,8 @@ const getPatchTaskWithRunningBaseTask: ApolloMock<
 };
 
 const getPatchTaskWithFailingBaseTask: ApolloMock<
-  GetBaseVersionAndTaskQuery,
-  GetBaseVersionAndTaskQueryVariables
+  BaseVersionAndTaskQuery,
+  BaseVersionAndTaskQueryVariables
 > = {
   request: {
     query: GET_BASE_VERSION_AND_TASK,
@@ -344,8 +344,8 @@ const getPatchTaskWithFailingBaseTask: ApolloMock<
 };
 
 const getPatchTaskWithNoBaseVersion: ApolloMock<
-  GetBaseVersionAndTaskQuery,
-  GetBaseVersionAndTaskQueryVariables
+  BaseVersionAndTaskQuery,
+  BaseVersionAndTaskQueryVariables
 > = {
   request: {
     query: GET_BASE_VERSION_AND_TASK,
@@ -374,8 +374,8 @@ const getPatchTaskWithNoBaseVersion: ApolloMock<
 };
 
 const getLastPassingVersion: ApolloMock<
-  GetLastMainlineCommitQuery,
-  GetLastMainlineCommitQueryVariables
+  LastMainlineCommitQuery,
+  LastMainlineCommitQueryVariables
 > = {
   request: {
     query: GET_LAST_MAINLINE_COMMIT,
@@ -421,8 +421,8 @@ const getLastPassingVersion: ApolloMock<
 };
 
 const getLastExecutedVersion: ApolloMock<
-  GetLastMainlineCommitQuery,
-  GetLastMainlineCommitQueryVariables
+  LastMainlineCommitQuery,
+  LastMainlineCommitQueryVariables
 > = {
   request: {
     query: GET_LAST_MAINLINE_COMMIT,
@@ -479,8 +479,8 @@ const getLastExecutedVersion: ApolloMock<
 
 // patch specific
 const getPatchTaskWithNoBaseTask: ApolloMock<
-  GetBaseVersionAndTaskQuery,
-  GetBaseVersionAndTaskQueryVariables
+  BaseVersionAndTaskQuery,
+  BaseVersionAndTaskQueryVariables
 > = {
   request: {
     query: GET_BASE_VERSION_AND_TASK,
@@ -515,8 +515,8 @@ const getPatchTaskWithNoBaseTask: ApolloMock<
 
 // Mainline commits specific
 const getMainlineTaskWithBaseVersion: ApolloMock<
-  GetBaseVersionAndTaskQuery,
-  GetBaseVersionAndTaskQueryVariables
+  BaseVersionAndTaskQuery,
+  BaseVersionAndTaskQueryVariables
 > = {
   request: {
     query: GET_BASE_VERSION_AND_TASK,
@@ -550,8 +550,8 @@ const getMainlineTaskWithBaseVersion: ApolloMock<
 };
 
 const getNullParentTask: ApolloMock<
-  GetLastMainlineCommitQuery,
-  GetLastMainlineCommitQueryVariables
+  LastMainlineCommitQuery,
+  LastMainlineCommitQueryVariables
 > = {
   request: {
     query: GET_LAST_MAINLINE_COMMIT,
@@ -569,8 +569,8 @@ const getNullParentTask: ApolloMock<
 };
 
 const getParentTaskWithError: ApolloMock<
-  GetLastMainlineCommitQuery,
-  GetLastMainlineCommitQueryVariables
+  LastMainlineCommitQuery,
+  LastMainlineCommitQueryVariables
 > = {
   request: {
     query: GET_LAST_MAINLINE_COMMIT,

--- a/src/pages/task/actionButtons/previousCommits/PreviousCommits.tsx
+++ b/src/pages/task/actionButtons/previousCommits/PreviousCommits.tsx
@@ -9,10 +9,10 @@ import { ConditionalWrapper } from "components/ConditionalWrapper";
 import { finishedTaskStatuses } from "constants/task";
 import { size } from "constants/tokens";
 import {
-  GetBaseVersionAndTaskQuery,
-  GetBaseVersionAndTaskQueryVariables,
-  GetLastMainlineCommitQuery,
-  GetLastMainlineCommitQueryVariables,
+  BaseVersionAndTaskQuery,
+  BaseVersionAndTaskQueryVariables,
+  LastMainlineCommitQuery,
+  LastMainlineCommitQueryVariables,
 } from "gql/generated/types";
 import {
   GET_BASE_VERSION_AND_TASK,
@@ -48,15 +48,15 @@ export const PreviousCommits: React.VFC<PreviousCommitsProps> = ({
   ] = useReducer(reducer, initialState);
 
   const { data: taskData } = useQuery<
-    GetBaseVersionAndTaskQuery,
-    GetBaseVersionAndTaskQueryVariables
+    BaseVersionAndTaskQuery,
+    BaseVersionAndTaskQueryVariables
   >(GET_BASE_VERSION_AND_TASK, {
     variables: { taskId },
   });
 
   const [fetchParentTask, { loading: parentLoading }] = useLazyQuery<
-    GetLastMainlineCommitQuery,
-    GetLastMainlineCommitQueryVariables
+    LastMainlineCommitQuery,
+    LastMainlineCommitQueryVariables
   >(GET_LAST_MAINLINE_COMMIT, {
     onCompleted: (data) => {
       dispatch({
@@ -67,8 +67,8 @@ export const PreviousCommits: React.VFC<PreviousCommitsProps> = ({
   });
 
   const [fetchLastPassing, { loading: passingLoading }] = useLazyQuery<
-    GetLastMainlineCommitQuery,
-    GetLastMainlineCommitQueryVariables
+    LastMainlineCommitQuery,
+    LastMainlineCommitQueryVariables
   >(GET_LAST_MAINLINE_COMMIT, {
     onCompleted: (data) => {
       dispatch({
@@ -79,8 +79,8 @@ export const PreviousCommits: React.VFC<PreviousCommitsProps> = ({
   });
 
   const [fetchLastExecuted, { loading: executedLoading }] = useLazyQuery<
-    GetLastMainlineCommitQuery,
-    GetLastMainlineCommitQueryVariables
+    LastMainlineCommitQuery,
+    LastMainlineCommitQueryVariables
   >(GET_LAST_MAINLINE_COMMIT, {
     onCompleted: (data) => {
       dispatch({
@@ -218,7 +218,7 @@ export const PreviousCommits: React.VFC<PreviousCommitsProps> = ({
 // The return value from GetLastMainlineCommitQuery has a lot of nested fields that may or may
 // not exist. The logic to extract the task from it is written in this function.
 const getTaskFromMainlineCommitsQuery = (
-  data: GetLastMainlineCommitQuery
+  data: LastMainlineCommitQuery
 ): CommitTask => {
   const buildVariants =
     data?.mainlineCommits.versions.find(({ version }) => version)?.version

--- a/src/pages/task/actionButtons/previousCommits/types.ts
+++ b/src/pages/task/actionButtons/previousCommits/types.ts
@@ -1,4 +1,4 @@
-import { GetBaseVersionAndTaskQuery } from "gql/generated/types";
+import { BaseVersionAndTaskQuery } from "gql/generated/types";
 
 export enum CommitType {
   Base = "base",
@@ -6,4 +6,4 @@ export enum CommitType {
   LastExecuted = "lastExecuted",
 }
 
-export type CommitTask = GetBaseVersionAndTaskQuery["task"]["baseTask"];
+export type CommitTask = BaseVersionAndTaskQuery["task"]["baseTask"];

--- a/src/pages/task/executionDropdown/ExecutionSelector.tsx
+++ b/src/pages/task/executionDropdown/ExecutionSelector.tsx
@@ -5,8 +5,8 @@ import { Select } from "antd";
 import { TaskStatusIcon } from "components/TaskStatusIcon";
 import { fontSize, size } from "constants/tokens";
 import {
-  GetTaskAllExecutionsQuery,
-  GetTaskAllExecutionsQueryVariables,
+  TaskAllExecutionsQuery,
+  TaskAllExecutionsQueryVariables,
 } from "gql/generated/types";
 import { GET_TASK_ALL_EXECUTIONS } from "gql/queries";
 import { useDateFormat } from "hooks";
@@ -26,8 +26,8 @@ export const ExecutionSelect: React.VFC<ExecutionSelectProps> = ({
   updateExecution,
 }) => {
   const allExecutionsResult = useQuery<
-    GetTaskAllExecutionsQuery,
-    GetTaskAllExecutionsQueryVariables
+    TaskAllExecutionsQuery,
+    TaskAllExecutionsQueryVariables
   >(GET_TASK_ALL_EXECUTIONS, {
     variables: { taskId: id },
   });

--- a/src/pages/task/metadata/index.tsx
+++ b/src/pages/task/metadata/index.tsx
@@ -20,7 +20,7 @@ import {
   getPodRoute,
 } from "constants/routes";
 import { size } from "constants/tokens";
-import { GetTaskQuery } from "gql/generated/types";
+import { TaskQuery } from "gql/generated/types";
 import { useDateFormat } from "hooks";
 import { TaskStatus } from "types/task";
 import { string } from "utils";
@@ -34,7 +34,7 @@ const { red } = palette;
 interface Props {
   taskId: string;
   loading: boolean;
-  task: GetTaskQuery["task"];
+  task: TaskQuery["task"];
   error: ApolloError;
 }
 

--- a/src/pages/task/taskTabs/ExecutionTasksTable.tsx
+++ b/src/pages/task/taskTabs/ExecutionTasksTable.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import { useLocation } from "react-router-dom";
 import { useTaskAnalytics } from "analytics";
 import { TasksTable } from "components/Table/TasksTable";
-import { GetTaskQuery, Task } from "gql/generated/types";
+import { TaskQuery, Task } from "gql/generated/types";
 import { useUpdateURLQueryParams } from "hooks/useUpdateURLQueryParams";
 import { RequiredQueryParams, TableOnChange } from "types/task";
 import { queryString } from "utils";
@@ -11,7 +11,7 @@ const { parseQueryString, parseSortString, toSortString } = queryString;
 
 interface Props {
   execution: number;
-  executionTasksFull: GetTaskQuery["task"]["executionTasksFull"];
+  executionTasksFull: TaskQuery["task"]["executionTasksFull"];
   isPatch: boolean;
 }
 

--- a/src/pages/task/taskTabs/TestsTable.tsx
+++ b/src/pages/task/taskTabs/TestsTable.tsx
@@ -23,7 +23,7 @@ import {
   TestSortCategory,
   TestResult,
   TaskTestResult,
-  GetTaskQuery,
+  TaskQuery,
 } from "gql/generated/types";
 import { GET_TASK_TESTS } from "gql/queries";
 import {
@@ -45,7 +45,7 @@ export interface UpdateQueryArg {
 }
 
 interface TestsTableProps {
-  task: GetTaskQuery["task"];
+  task: TaskQuery["task"];
 }
 export const TestsTable: React.VFC<TestsTableProps> = ({ task }) => {
   const { pathname, search } = useLocation();

--- a/src/pages/task/taskTabs/buildBaronAndAnnotations/AddIssueModal/index.tsx
+++ b/src/pages/task/taskTabs/buildBaronAndAnnotations/AddIssueModal/index.tsx
@@ -69,7 +69,7 @@ export const AddIssueModal: React.VFC<Props> = ({
         `There was an error adding the issue: ${error.message}`
       );
     },
-    refetchQueries: ["GetAnnotationEventData"],
+    refetchQueries: ["AnnotationEventData"],
   });
 
   const spruceConfig = useSpruceConfig();

--- a/src/pages/task/taskTabs/buildBaronAndAnnotations/AnnotationNote.tsx
+++ b/src/pages/task/taskTabs/buildBaronAndAnnotations/AnnotationNote.tsx
@@ -48,7 +48,7 @@ const AnnotationNote: React.VFC<Props> = ({
         `There was an error updating this note: ${error.message}`
       );
     },
-    refetchQueries: ["GetAnnotationEventData"],
+    refetchQueries: ["AnnotationEventData"],
   });
   const saveAnnotationNote = () => {
     updateAnnotationNote({

--- a/src/pages/task/taskTabs/buildBaronAndAnnotations/AnnotationTicketsTable/AnnotationTicketsTable.tsx
+++ b/src/pages/task/taskTabs/buildBaronAndAnnotations/AnnotationTicketsTable/AnnotationTicketsTable.tsx
@@ -145,7 +145,7 @@ const AnnotationTicketsTable: React.VFC<AnnotationTicketsProps> = ({
         `There was an error removing the ${issueString}: ${error.message}`
       );
     },
-    refetchQueries: ["GetSuspectedIssues", "GetIssues"],
+    refetchQueries: ["SuspectedIssues", "Issues"],
   });
 
   const [moveAnnotation] = useMutation<
@@ -164,7 +164,7 @@ const AnnotationTicketsTable: React.VFC<AnnotationTicketsProps> = ({
         `There was an error moving the ${issueString}: ${error.message}`
       );
     },
-    refetchQueries: ["GetSuspectedIssues", "GetIssues"],
+    refetchQueries: ["SuspectedIssues", "Issues"],
   });
 
   const handleRemove = (url: string, issueKey: string): void => {

--- a/src/pages/task/taskTabs/buildBaronAndAnnotations/AnnotationTicketsTable/types.ts
+++ b/src/pages/task/taskTabs/buildBaronAndAnnotations/AnnotationTicketsTable/types.ts
@@ -1,7 +1,7 @@
-import { GetIssuesQuery } from "gql/generated/types";
+import { IssuesQuery } from "gql/generated/types";
 import { Unpacked } from "types/utils";
 
-type AnnotationTickets = GetIssuesQuery["task"]["annotation"]["issues"];
+type AnnotationTickets = IssuesQuery["task"]["annotation"]["issues"];
 type AnnotationTicket = Unpacked<AnnotationTickets>;
 
 export type { AnnotationTickets, AnnotationTicket };

--- a/src/pages/task/taskTabs/buildBaronAndAnnotations/BuildBaron.test.tsx
+++ b/src/pages/task/taskTabs/buildBaronAndAnnotations/BuildBaron.test.tsx
@@ -2,12 +2,12 @@ import { MockedProvider } from "@apollo/client/testing";
 import MatchMediaMock from "jest-matchmedia-mock";
 import { RenderFakeToastContext } from "context/toast/__mocks__";
 import {
-  BbCreateTicketMutation,
-  BbCreateTicketMutationVariables,
+  BuildBaronCreateTicketMutation,
+  BuildBaronCreateTicketMutationVariables,
   BuildBaronQuery,
   BuildBaronQueryVariables,
-  GetCreatedTicketsQuery,
-  GetCreatedTicketsQueryVariables,
+  CreatedTicketsQuery,
+  CreatedTicketsQueryVariables,
 } from "gql/generated/types";
 import { getSpruceConfigMock } from "gql/mocks/getSpruceConfig";
 import { getUserMock } from "gql/mocks/getUser";
@@ -203,8 +203,8 @@ const getBuildBaronMock: ApolloMock<BuildBaronQuery, BuildBaronQueryVariables> =
   };
 
 const fileJiraTicketMock: ApolloMock<
-  BbCreateTicketMutation,
-  BbCreateTicketMutationVariables
+  BuildBaronCreateTicketMutation,
+  BuildBaronCreateTicketMutationVariables
 > = {
   request: {
     query: FILE_JIRA_TICKET,
@@ -220,8 +220,8 @@ const fileJiraTicketMock: ApolloMock<
   },
 };
 const getJiraTicketsMock: ApolloMock<
-  GetCreatedTicketsQuery,
-  GetCreatedTicketsQueryVariables
+  CreatedTicketsQuery,
+  CreatedTicketsQueryVariables
 > = {
   request: {
     query: GET_CREATED_TICKETS,

--- a/src/pages/task/taskTabs/buildBaronAndAnnotations/BuildBaronContent.tsx
+++ b/src/pages/task/taskTabs/buildBaronAndAnnotations/BuildBaronContent.tsx
@@ -6,10 +6,10 @@ import { useToastContext } from "context/toast";
 import {
   BuildBaron,
   Annotation,
-  GetCustomCreatedIssuesQuery,
-  GetCustomCreatedIssuesQueryVariables,
-  GetCreatedTicketsQuery,
-  GetCreatedTicketsQueryVariables,
+  CustomCreatedIssuesQuery,
+  CustomCreatedIssuesQueryVariables,
+  CreatedTicketsQuery,
+  CreatedTicketsQueryVariables,
 } from "gql/generated/types";
 import {
   GET_CREATED_TICKETS,
@@ -41,8 +41,8 @@ const BuildBaronContent: React.VFC<BuildBaronCoreProps> = ({
   const dispatchToast = useToastContext();
 
   const { data: customCreatedTickets } = useQuery<
-    GetCustomCreatedIssuesQuery,
-    GetCustomCreatedIssuesQueryVariables
+    CustomCreatedIssuesQuery,
+    CustomCreatedIssuesQueryVariables
   >(GET_JIRA_CUSTOM_CREATED_ISSUES, {
     variables: { taskId, execution },
     onError: (err) => {
@@ -53,8 +53,8 @@ const BuildBaronContent: React.VFC<BuildBaronCoreProps> = ({
   });
 
   const { data: bbCreatedTickets } = useQuery<
-    GetCreatedTicketsQuery,
-    GetCreatedTicketsQueryVariables
+    CreatedTicketsQuery,
+    CreatedTicketsQueryVariables
   >(GET_CREATED_TICKETS, {
     variables: { taskId },
     onError(error) {

--- a/src/pages/task/taskTabs/buildBaronAndAnnotations/CreatedTicketsTable/BuildBaronTable.tsx
+++ b/src/pages/task/taskTabs/buildBaronAndAnnotations/CreatedTicketsTable/BuildBaronTable.tsx
@@ -1,8 +1,8 @@
 import { Table } from "antd";
-import { GetCreatedTicketsQuery } from "gql/generated/types";
+import { CreatedTicketsQuery } from "gql/generated/types";
 import { JiraTicketRow } from "../BBComponents";
 
-type CreatedTickets = GetCreatedTicketsQuery["bbGetCreatedTickets"];
+type CreatedTickets = CreatedTicketsQuery["bbGetCreatedTickets"];
 
 const columns = [
   {

--- a/src/pages/task/taskTabs/buildBaronAndAnnotations/FileTicketButton.tsx
+++ b/src/pages/task/taskTabs/buildBaronAndAnnotations/FileTicketButton.tsx
@@ -7,8 +7,8 @@ import Popconfirm from "components/Popconfirm";
 import { size } from "constants/tokens";
 import { useToastContext } from "context/toast";
 import {
-  BbCreateTicketMutation,
-  BbCreateTicketMutationVariables,
+  BuildBaronCreateTicketMutation,
+  BuildBaronCreateTicketMutationVariables,
 } from "gql/generated/types";
 import { FILE_JIRA_TICKET } from "gql/mutations";
 import { ButtonWrapper } from "./BBComponents";
@@ -25,8 +25,8 @@ const FileTicketButton: React.VFC<FileTicketProps> = ({
   const dispatchToast = useToastContext();
 
   const [fileJiraTicket, { loading: loadingFileJiraTicket }] = useMutation<
-    BbCreateTicketMutation,
-    BbCreateTicketMutationVariables
+    BuildBaronCreateTicketMutation,
+    BuildBaronCreateTicketMutationVariables
   >(FILE_JIRA_TICKET, {
     onCompleted: () => {
       setButtonText("File another ticket");

--- a/src/pages/task/taskTabs/buildBaronAndAnnotations/Issues/Issues.tsx
+++ b/src/pages/task/taskTabs/buildBaronAndAnnotations/Issues/Issues.tsx
@@ -1,8 +1,8 @@
 import { useQuery } from "@apollo/client";
 import { useToastContext } from "context/toast";
 import {
-  GetIssuesQuery,
-  GetIssuesQueryVariables,
+  IssuesQuery,
+  IssuesQueryVariables,
   Annotation,
 } from "gql/generated/types";
 import { GET_JIRA_ISSUES } from "gql/queries";
@@ -27,7 +27,7 @@ const Issues: React.VFC<IssuesProps> = ({
 }) => {
   const dispatchToast = useToastContext();
   // Query Jira ticket data
-  const { data, loading } = useQuery<GetIssuesQuery, GetIssuesQueryVariables>(
+  const { data, loading } = useQuery<IssuesQuery, IssuesQueryVariables>(
     GET_JIRA_ISSUES,
     {
       variables: { taskId, execution },

--- a/src/pages/task/taskTabs/buildBaronAndAnnotations/Issues/SuspectedIssues.tsx
+++ b/src/pages/task/taskTabs/buildBaronAndAnnotations/Issues/SuspectedIssues.tsx
@@ -1,8 +1,8 @@
 import { useQuery } from "@apollo/client";
 import { useToastContext } from "context/toast";
 import {
-  GetSuspectedIssuesQuery,
-  GetSuspectedIssuesQueryVariables,
+  SuspectedIssuesQuery,
+  SuspectedIssuesQueryVariables,
   Annotation,
 } from "gql/generated/types";
 import { GET_JIRA_SUSPECTED_ISSUES } from "gql/queries";
@@ -28,8 +28,8 @@ const SuspectedIssues: React.VFC<SuspectedIssuesProps> = ({
   const dispatchToast = useToastContext();
   // Query Jira ticket data
   const { data, loading } = useQuery<
-    GetSuspectedIssuesQuery,
-    GetSuspectedIssuesQueryVariables
+    SuspectedIssuesQuery,
+    SuspectedIssuesQueryVariables
   >(GET_JIRA_SUSPECTED_ISSUES, {
     variables: { taskId, execution },
     onError: (err) => {

--- a/src/pages/task/taskTabs/buildBaronAndAnnotations/useBuildBaronVariables.ts
+++ b/src/pages/task/taskTabs/buildBaronAndAnnotations/useBuildBaronVariables.ts
@@ -1,7 +1,7 @@
 import { useQuery } from "@apollo/client";
 import {
-  GetBuildBaronConfiguredQuery,
-  GetBuildBaronConfiguredQueryVariables,
+  BuildBaronConfiguredQuery,
+  BuildBaronConfiguredQueryVariables,
 } from "gql/generated/types";
 import { GET_BUILD_BARON_CONFIGURED } from "gql/queries";
 import { statuses } from "utils";
@@ -20,8 +20,8 @@ const useBuildBaronVariables = ({ task }: UseBuildBaronVariablesType) => {
   const { id, execution, status, hasAnnotation, canModifyAnnotation } = task;
   const isFailedTask = isFailedTaskStatus(status);
   const { data: buildBaronData } = useQuery<
-    GetBuildBaronConfiguredQuery,
-    GetBuildBaronConfiguredQueryVariables
+    BuildBaronConfiguredQuery,
+    BuildBaronConfiguredQueryVariables
   >(GET_BUILD_BARON_CONFIGURED, {
     variables: {
       taskId: id,

--- a/src/pages/task/taskTabs/testsTable/LogsColumn.tsx
+++ b/src/pages/task/taskTabs/testsTable/LogsColumn.tsx
@@ -3,7 +3,7 @@ import Button from "@leafygreen-ui/button";
 import { useTaskAnalytics } from "analytics";
 import { getTaskHistoryRoute } from "constants/routes";
 import { size } from "constants/tokens";
-import { TestResult, GetTaskQuery } from "gql/generated/types";
+import { TestResult, TaskQuery } from "gql/generated/types";
 import { TestStatus } from "types/test";
 import { string } from "utils";
 import { TaskHistoryTestsButton } from "./logsColumn/TaskHistoryTestsButton";
@@ -11,7 +11,7 @@ import { TaskHistoryTestsButton } from "./logsColumn/TaskHistoryTestsButton";
 const { escapeRegex } = string;
 interface Props {
   testResult: TestResult;
-  task: GetTaskQuery["task"];
+  task: TaskQuery["task"];
 }
 
 export const LogsColumn: React.VFC<Props> = ({ testResult, task }) => {

--- a/src/pages/task/taskTabs/testsTable/getColumnsTemplate.tsx
+++ b/src/pages/task/taskTabs/testsTable/getColumnsTemplate.tsx
@@ -6,11 +6,7 @@ import {
   getColumnTreeSelectFilterProps,
 } from "components/Table/Filters";
 import { TreeSelectProps } from "components/TreeSelect";
-import {
-  TestSortCategory,
-  TestResult,
-  GetTaskQuery,
-} from "gql/generated/types";
+import { TestSortCategory, TestResult, TaskQuery } from "gql/generated/types";
 import { string } from "utils";
 import { LogsColumn } from "./LogsColumn";
 import { TestStatusBadge } from "./TestStatusBadge";
@@ -21,7 +17,7 @@ interface GetColumnsTemplateParams {
   onColumnHeaderClick?: (sortField) => void;
   statusSelectorProps: TreeSelectProps;
   testNameInputProps: InputFilterProps;
-  task: GetTaskQuery["task"];
+  task: TaskQuery["task"];
 }
 
 export const getColumnsTemplate = ({

--- a/src/pages/taskHistory/BuildVariantSelector.tsx
+++ b/src/pages/taskHistory/BuildVariantSelector.tsx
@@ -3,8 +3,8 @@ import styled from "@emotion/styled";
 import { Combobox, ComboboxOption } from "@leafygreen-ui/combobox";
 import { useProjectHealthAnalytics } from "analytics/projectHealth/useProjectHealthAnalytics";
 import {
-  GetBuildVariantsForTaskNameQuery,
-  GetBuildVariantsForTaskNameQueryVariables,
+  BuildVariantsForTaskNameQuery,
+  BuildVariantsForTaskNameQueryVariables,
 } from "gql/generated/types";
 import { GET_BUILD_VARIANTS_FOR_TASK_NAME } from "gql/queries";
 import { useQueryParam } from "hooks/useQueryParam";
@@ -26,8 +26,8 @@ const BuildVariantSelector: React.VFC<BuildVariantSelectorProps> = ({
   );
 
   const { data, loading } = useQuery<
-    GetBuildVariantsForTaskNameQuery,
-    GetBuildVariantsForTaskNameQueryVariables
+    BuildVariantsForTaskNameQuery,
+    BuildVariantsForTaskNameQueryVariables
   >(GET_BUILD_VARIANTS_FOR_TASK_NAME, {
     variables: {
       projectIdentifier,

--- a/src/pages/taskHistory/ColumnHeaders.test.tsx
+++ b/src/pages/taskHistory/ColumnHeaders.test.tsx
@@ -2,8 +2,8 @@ import { ProviderWrapper } from "components/HistoryTable/hooks/test-utils";
 import { taskHistoryMaxLength as maxLength } from "constants/history";
 import { RenderFakeToastContext } from "context/toast/__mocks__";
 import {
-  GetBuildVariantsForTaskNameQuery,
-  GetBuildVariantsForTaskNameQueryVariables,
+  BuildVariantsForTaskNameQuery,
+  BuildVariantsForTaskNameQueryVariables,
 } from "gql/generated/types";
 import { GET_BUILD_VARIANTS_FOR_TASK_NAME } from "gql/queries";
 import {
@@ -191,10 +191,10 @@ describe("columnHeaders (Task History)", () => {
 });
 
 const mock = (
-  buildVariants: GetBuildVariantsForTaskNameQuery["buildVariantsForTaskName"]
+  buildVariants: BuildVariantsForTaskNameQuery["buildVariantsForTaskName"]
 ): ApolloMock<
-  GetBuildVariantsForTaskNameQuery,
-  GetBuildVariantsForTaskNameQueryVariables
+  BuildVariantsForTaskNameQuery,
+  BuildVariantsForTaskNameQueryVariables
 > => ({
   request: {
     query: GET_BUILD_VARIANTS_FOR_TASK_NAME,

--- a/src/pages/taskHistory/ColumnHeaders.tsx
+++ b/src/pages/taskHistory/ColumnHeaders.tsx
@@ -6,8 +6,8 @@ import { taskHistoryMaxLength as maxLength } from "constants/history";
 import { getVariantHistoryRoute } from "constants/routes";
 import { useToastContext } from "context/toast";
 import {
-  GetBuildVariantsForTaskNameQuery,
-  GetBuildVariantsForTaskNameQueryVariables,
+  BuildVariantsForTaskNameQuery,
+  BuildVariantsForTaskNameQueryVariables,
 } from "gql/generated/types";
 import { GET_BUILD_VARIANTS_FOR_TASK_NAME } from "gql/queries";
 import { array, string, errorReporting } from "utils";
@@ -34,8 +34,8 @@ const ColumnHeaders: React.VFC<ColumnHeadersProps> = ({
 
   // Fetch the column headers from the same query used on the dropdown.
   const { data: columnData, loading } = useQuery<
-    GetBuildVariantsForTaskNameQuery,
-    GetBuildVariantsForTaskNameQueryVariables
+    BuildVariantsForTaskNameQuery,
+    BuildVariantsForTaskNameQueryVariables
   >(GET_BUILD_VARIANTS_FOR_TASK_NAME, {
     variables: {
       projectIdentifier,

--- a/src/pages/taskHistory/TaskHistoryRow.test.tsx
+++ b/src/pages/taskHistory/TaskHistoryRow.test.tsx
@@ -4,8 +4,8 @@ import { HistoryTableReducerState } from "components/HistoryTable/historyTableCo
 import { mainlineCommitData } from "components/HistoryTable/testData";
 import { rowType, CommitRowType } from "components/HistoryTable/types";
 import {
-  GetTaskTestSampleQuery,
-  GetTaskTestSampleQueryVariables,
+  TaskTestSampleQuery,
+  TaskTestSampleQueryVariables,
 } from "gql/generated/types";
 import { GET_TASK_TEST_SAMPLE } from "gql/queries";
 import {
@@ -339,8 +339,8 @@ const taskRow: CommitRowType = {
 };
 
 const noFilterData: ApolloMock<
-  GetTaskTestSampleQuery,
-  GetTaskTestSampleQueryVariables
+  TaskTestSampleQuery,
+  TaskTestSampleQueryVariables
 > = {
   request: {
     query: GET_TASK_TEST_SAMPLE,
@@ -372,8 +372,8 @@ const noFilterData: ApolloMock<
 };
 
 const withMatchingFilter: ApolloMock<
-  GetTaskTestSampleQuery,
-  GetTaskTestSampleQueryVariables
+  TaskTestSampleQuery,
+  TaskTestSampleQueryVariables
 > = {
   request: {
     query: GET_TASK_TEST_SAMPLE,
@@ -407,8 +407,8 @@ const withMatchingFilter: ApolloMock<
 };
 
 const withNonMatchingFilter: ApolloMock<
-  GetTaskTestSampleQuery,
-  GetTaskTestSampleQueryVariables
+  TaskTestSampleQuery,
+  TaskTestSampleQueryVariables
 > = {
   request: {
     query: GET_TASK_TEST_SAMPLE,

--- a/src/pages/variantHistory/ColumnHeaders.test.tsx
+++ b/src/pages/variantHistory/ColumnHeaders.test.tsx
@@ -2,8 +2,8 @@ import { ProviderWrapper } from "components/HistoryTable/hooks/test-utils";
 import { variantHistoryMaxLength as maxLength } from "constants/history";
 import { RenderFakeToastContext } from "context/toast/__mocks__";
 import {
-  GetTaskNamesForBuildVariantQuery,
-  GetTaskNamesForBuildVariantQueryVariables,
+  TaskNamesForBuildVariantQuery,
+  TaskNamesForBuildVariantQueryVariables,
 } from "gql/generated/types";
 import { GET_TASK_NAMES_FOR_BUILD_VARIANT } from "gql/queries";
 import {
@@ -143,10 +143,10 @@ describe("columnHeaders (Variant History)", () => {
 });
 
 const mock = (
-  taskNames: GetTaskNamesForBuildVariantQuery["taskNamesForBuildVariant"]
+  taskNames: TaskNamesForBuildVariantQuery["taskNamesForBuildVariant"]
 ): ApolloMock<
-  GetTaskNamesForBuildVariantQuery,
-  GetTaskNamesForBuildVariantQueryVariables
+  TaskNamesForBuildVariantQuery,
+  TaskNamesForBuildVariantQueryVariables
 > => ({
   request: {
     query: GET_TASK_NAMES_FOR_BUILD_VARIANT,

--- a/src/pages/variantHistory/ColumnHeaders.tsx
+++ b/src/pages/variantHistory/ColumnHeaders.tsx
@@ -6,8 +6,8 @@ import { variantHistoryMaxLength as maxLength } from "constants/history";
 import { getTaskHistoryRoute } from "constants/routes";
 import { useToastContext } from "context/toast";
 import {
-  GetTaskNamesForBuildVariantQuery,
-  GetTaskNamesForBuildVariantQueryVariables,
+  TaskNamesForBuildVariantQuery,
+  TaskNamesForBuildVariantQueryVariables,
 } from "gql/generated/types";
 import { GET_TASK_NAMES_FOR_BUILD_VARIANT } from "gql/queries";
 import { array, string, errorReporting } from "utils";
@@ -34,8 +34,8 @@ const ColumnHeaders: React.VFC<ColumnHeadersProps> = ({
 
   // Fetch the column headers from the same query used on the dropdown.
   const { data: columnData, loading } = useQuery<
-    GetTaskNamesForBuildVariantQuery,
-    GetTaskNamesForBuildVariantQueryVariables
+    TaskNamesForBuildVariantQuery,
+    TaskNamesForBuildVariantQueryVariables
   >(GET_TASK_NAMES_FOR_BUILD_VARIANT, {
     variables: {
       projectIdentifier,

--- a/src/pages/variantHistory/TaskSelector.tsx
+++ b/src/pages/variantHistory/TaskSelector.tsx
@@ -3,8 +3,8 @@ import styled from "@emotion/styled";
 import { Combobox, ComboboxOption } from "@leafygreen-ui/combobox";
 import { useProjectHealthAnalytics } from "analytics/projectHealth/useProjectHealthAnalytics";
 import {
-  GetTaskNamesForBuildVariantQuery,
-  GetTaskNamesForBuildVariantQueryVariables,
+  TaskNamesForBuildVariantQuery,
+  TaskNamesForBuildVariantQueryVariables,
 } from "gql/generated/types";
 import { GET_TASK_NAMES_FOR_BUILD_VARIANT } from "gql/queries";
 import { useQueryParam } from "hooks/useQueryParam";
@@ -27,8 +27,8 @@ const TaskSelector: React.VFC<TaskSelectorProps> = ({
   );
 
   const { data, loading } = useQuery<
-    GetTaskNamesForBuildVariantQuery,
-    GetTaskNamesForBuildVariantQueryVariables
+    TaskNamesForBuildVariantQuery,
+    TaskNamesForBuildVariantQueryVariables
   >(GET_TASK_NAMES_FOR_BUILD_VARIANT, {
     variables: {
       projectIdentifier,

--- a/src/pages/variantHistory/VariantHistoryRow.test.tsx
+++ b/src/pages/variantHistory/VariantHistoryRow.test.tsx
@@ -5,8 +5,8 @@ import { HistoryTableReducerState } from "components/HistoryTable/historyTableCo
 import { mainlineCommitData } from "components/HistoryTable/testData";
 import { CommitRowType } from "components/HistoryTable/types";
 import {
-  GetTaskTestSampleQuery,
-  GetTaskTestSampleQueryVariables,
+  TaskTestSampleQuery,
+  TaskTestSampleQueryVariables,
 } from "gql/generated/types";
 import { GET_TASK_TEST_SAMPLE } from "gql/queries";
 import {
@@ -306,8 +306,8 @@ const taskRow: CommitRowType = {
 };
 
 const noFilterData: ApolloMock<
-  GetTaskTestSampleQuery,
-  GetTaskTestSampleQueryVariables
+  TaskTestSampleQuery,
+  TaskTestSampleQueryVariables
 > = {
   request: {
     query: GET_TASK_TEST_SAMPLE,
@@ -340,8 +340,8 @@ const noFilterData: ApolloMock<
 };
 
 const withMatchingFilter: ApolloMock<
-  GetTaskTestSampleQuery,
-  GetTaskTestSampleQueryVariables
+  TaskTestSampleQuery,
+  TaskTestSampleQueryVariables
 > = {
   request: {
     query: GET_TASK_TEST_SAMPLE,
@@ -376,8 +376,8 @@ const withMatchingFilter: ApolloMock<
 };
 
 const withNonMatchingFilter: ApolloMock<
-  GetTaskTestSampleQuery,
-  GetTaskTestSampleQueryVariables
+  TaskTestSampleQuery,
+  TaskTestSampleQueryVariables
 > = {
   request: {
     query: GET_TASK_TEST_SAMPLE,

--- a/src/pages/version/BuildVariants.tsx
+++ b/src/pages/version/BuildVariants.tsx
@@ -9,8 +9,8 @@ import { DEFAULT_POLL_INTERVAL } from "constants/index";
 import { getVersionRoute } from "constants/routes";
 import { size } from "constants/tokens";
 import {
-  GetBuildVariantStatsQuery,
-  GetBuildVariantStatsQueryVariables,
+  BuildVariantStatsQuery,
+  BuildVariantStatsQueryVariables,
   StatusCount,
 } from "gql/generated/types";
 import { GET_BUILD_VARIANTS_STATS } from "gql/queries";
@@ -25,8 +25,8 @@ export const BuildVariants: React.VFC = () => {
   const { id } = useParams<{ id: string }>();
 
   const { data, loading, error, refetch, startPolling, stopPolling } = useQuery<
-    GetBuildVariantStatsQuery,
-    GetBuildVariantStatsQueryVariables
+    BuildVariantStatsQuery,
+    BuildVariantStatsQueryVariables
   >(GET_BUILD_VARIANTS_STATS, {
     variables: { id },
     pollInterval: DEFAULT_POLL_INTERVAL,


### PR DESCRIPTION
EVG-19316

### Description
This PR enables the rule [`@graphql-eslint/naming-convention`](https://the-guild.dev/graphql/eslint/rules/naming-convention).
