### PR TITLE
EVG-19701 Fix event log tab showing an invalid state for no events

### DIFF
--- a/src/pages/projectSettings/tabs/EventLogTab/EventLogTab.tsx
+++ b/src/pages/projectSettings/tabs/EventLogTab/EventLogTab.tsx
@@ -98,7 +98,7 @@ export const EventLogTab: React.VFC<TabProps> = ({
           Load more events
         </Button>
       )}
-      {allEventsFetched && events.length && (
+      {allEventsFetched && events.length === 0 && (
         <Subtitle>No more events to show.</Subtitle>
       )}
     </Container>


### PR DESCRIPTION
EVG-19701

### Description
On certain repo-level logs, the event log page would not display any logs and would not display an error it would display the number 0.  
### Screenshots
<img width="1231" alt="image" src="https://user-images.githubusercontent.com/4605522/236238053-d674b926-23f1-4330-ace6-5b7e9813c951.png">

