### PR TITLE
EVG-18646: Show breadcrumb for display tasks

### DIFF
--- a/cypress/integration/breadcrumbs.ts
+++ b/cypress/integration/breadcrumbs.ts
@@ -1,24 +1,24 @@
 describe("Viewing a patch", () => {
-  describe("Viewing a users own patch", () => {
+  describe("Viewing a user's own patch", () => {
     beforeEach(() => {
       cy.visit(
-        "/task/mci_ubuntu1604_display_asdf_patch_a1d2c8f70bf5c543de8b9641ac1ec08def1ddb26_5f74d99ab2373627c047c5e5_20_09_30_19_16_47"
+        "/task/mci_ubuntu1604_test_command_patch_a1d2c8f70bf5c543de8b9641ac1ec08def1ddb26_5f74d99ab2373627c047c5e5_20_09_30_19_16_47"
       );
     });
-    it("Clicking on the patch message breadcrumb from a task should take you to that version", () => {
-      cy.dataCy("bc-message").should(
-        "include.text",
-        "Patch 234 - mai…message (#4048)"
+    it("Clicking on the display task breadcrumb should take you to that task", () => {
+      cy.dataCy("bc-display-task").should("include.text", "asdf");
+      cy.dataCy("bc-display-task").click();
+      cy.url().should(
+        "include",
+        "/task/mci_ubuntu1604_display_asdf_patch_a1d2c8f70bf5c543de8b9641ac1ec08def1ddb26_5f74d99ab2373627c047c5e5_20_09_30_19_16_47"
       );
-      cy.dataCy("bc-message").click();
-      cy.url().should("include", "/version/5f74d99ab2373627c047c5e5");
     });
     it("Clicking the 'My Patches' breadcrumb goes to the logged in user's Patches Page when the current patch belongs to the logged in user", () => {
       cy.contains("My Patches").click();
       cy.url().should("include", "/user/admin/patches");
     });
   });
-  describe("Viewing another users patch", () => {
+  describe("Viewing another user's patch", () => {
     beforeEach(() => {
       cy.visit(
         "/task/evergreen_ubuntu1604_dist_patch_33016573166a36bd5f46b4111151899d5c4e95b1_5ecedafb562343215a7ff297_20_05_27_21_39_46"

--- a/src/analytics/breadcrumb/useBreadcrumbAnalytics.ts
+++ b/src/analytics/breadcrumb/useBreadcrumbAnalytics.ts
@@ -7,7 +7,7 @@ import { useGetUserQuery } from "analytics/useGetUserQuery";
 
 type Action = {
   name: "Click Link";
-  link: "myPatches" | "patch" | "version" | "waterfall";
+  link: "myPatches" | "patch" | "version" | "waterfall" | "displayTask";
 };
 
 interface P extends Properties {}

--- a/src/components/Breadcrumbs/index.tsx
+++ b/src/components/Breadcrumbs/index.tsx
@@ -21,7 +21,7 @@ interface BreadcrumbsProps {
 const Breadcrumbs: React.VFC<BreadcrumbsProps> = ({ breadcrumbs }) => (
   <Container>
     {breadcrumbs.map((bc, index) => (
-      <Fragment key={`breadCrumb-${bc.text}`}>
+      <Fragment key={`breadcrumb-${bc.text}`}>
         <BreadcrumbFragment breadcrumb={bc} />
         {breadcrumbs.length - 1 !== index && (
           <PaddedIcon

--- a/src/pages/Task.tsx
+++ b/src/pages/Task.tsx
@@ -86,8 +86,9 @@ export const Task = () => {
       <ProjectBanner projectIdentifier={versionMetadata?.projectIdentifier} />
       {task && (
         <TaskPageBreadcrumbs
-          taskName={displayName}
+          displayTask={displayTask}
           patchNumber={patchNumber}
+          taskName={displayName}
           versionMetadata={versionMetadata}
         />
       )}

--- a/src/pages/task/Breadcrumbs/index.tsx
+++ b/src/pages/task/Breadcrumbs/index.tsx
@@ -1,12 +1,17 @@
 import { useBreadcrumbAnalytics } from "analytics";
 import Breadcrumbs, { Breadcrumb } from "components/Breadcrumbs";
-import { getVersionRoute } from "constants/routes";
+import { getTaskRoute, getVersionRoute } from "constants/routes";
 import { useBreadcrumbRoot } from "hooks";
 import { shortenGithash } from "utils/string";
 
 interface TaskPageBreadcrumbsProps {
-  taskName: string;
+  displayTask?: {
+    displayName: string;
+    execution: number;
+    id: string;
+  };
   patchNumber?: number;
+  taskName: string;
   versionMetadata?: {
     id: string;
     revision: string;
@@ -18,9 +23,10 @@ interface TaskPageBreadcrumbsProps {
   };
 }
 const TaskPageBreadcrumbs: React.VFC<TaskPageBreadcrumbsProps> = ({
-  versionMetadata,
+  displayTask,
   patchNumber,
   taskName,
+  versionMetadata,
 }) => {
   const { isPatch, author, projectIdentifier, id, message, revision } =
     versionMetadata ?? {};
@@ -43,6 +49,24 @@ const TaskPageBreadcrumbs: React.VFC<TaskPageBreadcrumbsProps> = ({
     "data-cy": "bc-message",
   };
 
+  const displayTaskBreadcrumb = displayTask
+    ? [
+        {
+          to: getTaskRoute(displayTask.id, {
+            execution: displayTask.execution,
+          }),
+          text: displayTask.displayName,
+          onClick: () => {
+            breadcrumbAnalytics.sendEvent({
+              name: "Click Link",
+              link: "displayTask",
+            });
+          },
+          "data-cy": "bc-display-task",
+        },
+      ]
+    : [];
+
   const taskBreadcrumb = {
     text: taskName,
     "data-cy": "bc-task",
@@ -51,6 +75,7 @@ const TaskPageBreadcrumbs: React.VFC<TaskPageBreadcrumbsProps> = ({
   const breadcrumbs: Breadcrumb[] = [
     breadcrumbRoot,
     messageBreadcrumb,
+    ...displayTaskBreadcrumb,
     taskBreadcrumb,
   ];
 


### PR DESCRIPTION
EVG-18646

### Description
This PR adds a breadcrumb for display tasks. Although a link to the display task exists in the Task Metadata panel, many users try to navigate with the breadcrumb and get frustrated when they get redirected to the entire patch.

### Screenshots
<img width="516" alt="Screenshot 2023-05-10 at 11 41 38 AM" src="https://github.com/evergreen-ci/spruce/assets/47064971/fca1a394-847a-479d-8bf8-cd86306323c6">

### Testing
- Added tests in `breadcrumbs.ts` (Cypress)
