### PR TITLE
EVG-19804: Query projectSubscriptions instead of subscriptions

### DIFF
--- a/src/gql/fragments/projectSettings/index.graphql
+++ b/src/gql/fragments/projectSettings/index.graphql
@@ -30,7 +30,7 @@ fragment ProjectSettingsFields on ProjectSettings {
     ...ProjectVirtualWorkstationSettings
     repoRefId
   }
-  subscriptions {
+  projectSubscriptions {
     ...Subscriptions
   }
   vars {
@@ -55,10 +55,10 @@ fragment RepoSettingsFields on RepoSettings {
     ...RepoTriggersSettings
     ...RepoVirtualWorkstationSettings
   }
-  ...RepoGithubCommitQueue
-  subscriptions {
+  projectSubscriptions {
     ...Subscriptions
   }
+  ...RepoGithubCommitQueue
   vars {
     ...Variables
   }

--- a/src/gql/fragments/projectSettings/projectEventSettings.graphql
+++ b/src/gql/fragments/projectSettings/projectEventSettings.graphql
@@ -30,7 +30,7 @@ fragment ProjectEventSettings on ProjectEventSettings {
     tracksPushEvents
     versionControlEnabled
   }
-  subscriptions {
+  projectSubscriptions {
     ...Subscriptions
   }
   vars {

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -3184,7 +3184,7 @@ export type ProjectSettingsFieldsFragment = {
       message: string;
     };
   }>;
-  subscriptions?: Maybe<
+  projectSubscriptions?: Maybe<
     Array<{
       __typename?: "ProjectSubscription";
       id: string;
@@ -3388,7 +3388,7 @@ export type RepoSettingsFieldsFragment = {
       message: string;
     };
   }>;
-  subscriptions?: Maybe<
+  projectSubscriptions?: Maybe<
     Array<{
       __typename?: "ProjectSubscription";
       id: string;
@@ -3794,7 +3794,7 @@ export type ProjectEventSettingsFragment = {
       message: string;
     };
   }>;
-  subscriptions?: Maybe<
+  projectSubscriptions?: Maybe<
     Array<{
       __typename?: "ProjectSubscription";
       id: string;
@@ -6027,7 +6027,7 @@ export type ProjectEventLogsQuery = {
             message: string;
           };
         }>;
-        subscriptions?: Maybe<
+        projectSubscriptions?: Maybe<
           Array<{
             __typename?: "ProjectSubscription";
             id: string;
@@ -6241,7 +6241,7 @@ export type ProjectEventLogsQuery = {
             message: string;
           };
         }>;
-        subscriptions?: Maybe<
+        projectSubscriptions?: Maybe<
           Array<{
             __typename?: "ProjectSubscription";
             id: string;
@@ -6472,7 +6472,7 @@ export type ProjectSettingsQuery = {
         message: string;
       };
     }>;
-    subscriptions?: Maybe<
+    projectSubscriptions?: Maybe<
       Array<{
         __typename?: "ProjectSubscription";
         id: string;
@@ -6731,7 +6731,7 @@ export type RepoEventLogsQuery = {
             message: string;
           };
         }>;
-        subscriptions?: Maybe<
+        projectSubscriptions?: Maybe<
           Array<{
             __typename?: "ProjectSubscription";
             id: string;
@@ -6945,7 +6945,7 @@ export type RepoEventLogsQuery = {
             message: string;
           };
         }>;
-        subscriptions?: Maybe<
+        projectSubscriptions?: Maybe<
           Array<{
             __typename?: "ProjectSubscription";
             id: string;
@@ -7166,7 +7166,7 @@ export type RepoSettingsQuery = {
         message: string;
       };
     }>;
-    subscriptions?: Maybe<
+    projectSubscriptions?: Maybe<
       Array<{
         __typename?: "ProjectSubscription";
         id: string;

--- a/src/pages/projectSettings/CopyProjectModal.test.tsx
+++ b/src/pages/projectSettings/CopyProjectModal.test.tsx
@@ -339,7 +339,7 @@ const projectSettingsMock: ApolloMock<
             __typename: "CommitQueueParams",
           },
         },
-        subscriptions: [],
+        projectSubscriptions: [],
         vars: {
           vars: {},
           privateVars: [],

--- a/src/pages/projectSettings/tabs/EventLogTab/EventLogTab.test.tsx
+++ b/src/pages/projectSettings/tabs/EventLogTab/EventLogTab.test.tsx
@@ -147,7 +147,7 @@ const eventLogEntry: ProjectEventLogsQuery["projectEvents"]["eventLogEntries"][0
           __typename: "CommitQueueParams",
         },
       },
-      subscriptions: [],
+      projectSubscriptions: [],
       vars: {
         vars: {
           node_path: "/opt/axstarst$PATH",
@@ -228,7 +228,7 @@ const eventLogEntry: ProjectEventLogsQuery["projectEvents"]["eventLogEntries"][0
           __typename: "CommitQueueParams",
         },
       },
-      subscriptions: [],
+      projectSubscriptions: [],
       vars: {
         vars: {},
         privateVars: [],

--- a/src/pages/projectSettings/tabs/NotificationsTab/transformers.ts
+++ b/src/pages/projectSettings/tabs/NotificationsTab/transformers.ts
@@ -1,10 +1,10 @@
 import { ProjectSettingsTabRoutes } from "constants/routes";
 import { projectTriggers } from "constants/triggers";
 import {
-  ProjectInput,
-  SubscriptionInput,
   BannerTheme,
-  ProjectSettingsQuery,
+  ProjectInput,
+  Subscriber,
+  SubscriptionInput,
 } from "gql/generated/types";
 import { NotificationMethods } from "types/subscription";
 import { TriggerType } from "types/triggers";
@@ -18,10 +18,7 @@ type Tab = ProjectSettingsTabRoutes.Notifications;
 
 const { toSentenceCase } = string;
 
-const getSubscriberText = (
-  subscriberType: string,
-  subscriber: ProjectSettingsQuery["projectSettings"]["subscriptions"][0]["subscriber"]["subscriber"]
-) => {
+const getSubscriberText = (subscriberType: string, subscriber: Subscriber) => {
   switch (subscriberType) {
     case NotificationMethods.JIRA_COMMENT:
       return subscriber.jiraCommentSubscriber;
@@ -97,7 +94,7 @@ const getHttpHeaders = (headers: { key: string; value: string }[]) =>
 
 export const gqlToForm: GqlToFormFunction<Tab> = (data, { projectType }) => {
   if (!data) return null;
-  const { projectRef, subscriptions } = data;
+  const { projectRef, projectSubscriptions: subscriptions } = data;
   return {
     ...(projectType !== ProjectType.Repo &&
       "banner" in projectRef && {


### PR DESCRIPTION
EVG-19804

### Description
<!-- add description, context, thought process, etc -->
- Part 1 of changing the type of the `subscriptions` field from `ProjectSubscription` to `GeneralSubscription`: start querying `projectSubscriptions` instead so that we can change the type of `subscriptions` without breaking the UI.