### PR TITLE
EVG-14033 Add button to hide a patch from the my patches pages

### DIFF
--- a/cypress/integration/myPatches/patchCard/dropdown_menu.ts
+++ b/cypress/integration/myPatches/patchCard/dropdown_menu.ts
@@ -103,4 +103,17 @@ describe("Dropdown Menu of Patch Actions", { testIsolation: false }, () => {
     });
     cy.dataCy("enqueue-patch").should("be.disabled");
   });
+  it("hiding a patch should remove it from the page", () => {
+    cy.dataCy("patch-card").should("exist");
+    cy.dataCy("patch-card").contains("testtest").should("exist");
+    cy.dataCy("patch-card").eq(6).should("contain.text", "testtest");
+    getPatchCardByDescription("testtest").within(() => {
+      cy.dataCy("patch-card-dropdown").click();
+    });
+    cy.contains("Hide patch").should("exist");
+    cy.contains("Hide patch").click();
+    cy.contains("button", "Yes").click({ force: true });
+    cy.validateToast("success");
+    cy.dataCy("patch-card").contains("testtest").should("not.exist");
+  });
 });

--- a/src/components/PatchActionButtons/SetPatchVisibility.tsx
+++ b/src/components/PatchActionButtons/SetPatchVisibility.tsx
@@ -27,7 +27,7 @@ export const SetPatchVisibility: React.VFC<Props> = ({
     SetPatchVisibilityMutationVariables
   >(SET_PATCH_VISIBILITY, {
     onCompleted: () => {
-      dispatchToast.success(`This patch was successfully hidden`);
+      dispatchToast.success("This patch was successfully hidden");
     },
     onError: (err) => {
       dispatchToast.error(`Unable to hide this patch: ${err.message}`);
@@ -38,12 +38,8 @@ export const SetPatchVisibility: React.VFC<Props> = ({
   return (
     <>
       <div ref={menuItemRef}>
-        <MenuItem
-          active={open}
-          data-cy="disable"
-          onClick={() => setOpen(!open)}
-        >
-          Hide Patch
+        <MenuItem active={open} onClick={() => setOpen(!open)}>
+          Hide patch
         </MenuItem>
       </div>
       <Popconfirm
@@ -57,10 +53,10 @@ export const SetPatchVisibility: React.VFC<Props> = ({
         refEl={menuItemRef}
         setOpen={setOpen}
       >
-        <Body weight="medium">Hide Patch?</Body>
+        <Body weight="medium">Hide patch?</Body>
         <Body>
-          Hiding this patch will prevent it from being displayed in the my
-          patches page. This can not be undone!
+          Hiding this patch will prevent it from being displayed in the patches
+          pages. This cannot be undone!
         </Body>
       </Popconfirm>
     </>

--- a/src/components/PatchActionButtons/SetPatchVisibility.tsx
+++ b/src/components/PatchActionButtons/SetPatchVisibility.tsx
@@ -1,0 +1,68 @@
+import { useState, useRef } from "react";
+import { useMutation } from "@apollo/client";
+import { MenuItem } from "@leafygreen-ui/menu";
+import { Body } from "@leafygreen-ui/typography";
+import Popconfirm from "components/Popconfirm";
+import { useToastContext } from "context/toast";
+import {
+  SetPatchVisibilityMutation,
+  SetPatchVisibilityMutationVariables,
+} from "gql/generated/types";
+import { SET_PATCH_VISIBILITY } from "gql/mutations";
+
+interface Props {
+  patchId: string;
+  refetchQueries?: string[];
+}
+export const SetPatchVisibility: React.VFC<Props> = ({
+  patchId,
+  refetchQueries = [],
+}) => {
+  const dispatchToast = useToastContext();
+  const [open, setOpen] = useState(false);
+  const menuItemRef = useRef<HTMLDivElement>(null);
+
+  const [setPatchVisibility] = useMutation<
+    SetPatchVisibilityMutation,
+    SetPatchVisibilityMutationVariables
+  >(SET_PATCH_VISIBILITY, {
+    onCompleted: () => {
+      dispatchToast.success(`This patch was successfully hidden`);
+    },
+    onError: (err) => {
+      dispatchToast.error(`Unable to hide this patch: ${err.message}`);
+    },
+    refetchQueries,
+  });
+
+  return (
+    <>
+      <div ref={menuItemRef}>
+        <MenuItem
+          active={open}
+          data-cy="disable"
+          onClick={() => setOpen(!open)}
+        >
+          Hide Patch
+        </MenuItem>
+      </div>
+      <Popconfirm
+        align="left"
+        onConfirm={() => {
+          setPatchVisibility({
+            variables: { patchIds: [patchId], hidden: true },
+          });
+        }}
+        open={open}
+        refEl={menuItemRef}
+        setOpen={setOpen}
+      >
+        <Body weight="medium">Hide Patch?</Body>
+        <Body>
+          Hiding this patch will prevent it from being displayed in the my
+          patches page. This can not be undone!
+        </Body>
+      </Popconfirm>
+    </>
+  );
+};

--- a/src/components/PatchActionButtons/index.tsx
+++ b/src/components/PatchActionButtons/index.tsx
@@ -6,3 +6,4 @@ export { AddNotification } from "./AddNotification";
 export { DisableTasks } from "./DisableTasks";
 export { ScheduleTasks } from "./ScheduleTasks";
 export { ScheduleUndispatchedBaseTasks } from "./ScheduleUndispatchedBaseTasks";
+export { SetPatchVisibility } from "./SetPatchVisibility";

--- a/src/components/PatchesPage/patchCard/DropdownMenu.tsx
+++ b/src/components/PatchesPage/patchCard/DropdownMenu.tsx
@@ -6,6 +6,7 @@ import {
   RestartPatch,
   EnqueuePatch,
   ScheduleTasks,
+  SetPatchVisibility,
 } from "components/PatchActionButtons";
 
 interface Props {
@@ -52,6 +53,11 @@ export const DropdownMenu: React.VFC<Props> = ({
       commitMessage={patchDescription}
       disabled={!canEnqueueToCommitQueue || !hasVersion}
       refetchQueries={refetchQueries}
+    />,
+    <SetPatchVisibility
+      key="hide"
+      patchId={patchId}
+      refetchQueries={["UserPatches", "ProjectPatches"]}
     />,
   ];
 

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -1030,6 +1030,7 @@ export type Patch = {
   description: Scalars["String"];
   duration?: Maybe<PatchDuration>;
   githash: Scalars["String"];
+  hidden: Scalars["Boolean"];
   id: Scalars["ID"];
   moduleCodeChanges: Array<ModuleCodeChange>;
   parameters: Array<Parameter>;
@@ -1304,7 +1305,7 @@ export type ProjectEventSettings = {
   projectRef?: Maybe<Project>;
   /** @deprecated Use subscriptions instead */
   projectSubscriptions?: Maybe<Array<ProjectSubscription>>;
-  subscriptions?: Maybe<Array<ProjectSubscription>>;
+  subscriptions?: Maybe<Array<GeneralSubscription>>;
   vars?: Maybe<ProjectVars>;
 };
 
@@ -1372,7 +1373,7 @@ export type ProjectSettings = {
   projectRef?: Maybe<Project>;
   /** @deprecated Use subscriptions instead */
   projectSubscriptions?: Maybe<Array<ProjectSubscription>>;
-  subscriptions?: Maybe<Array<ProjectSubscription>>;
+  subscriptions?: Maybe<Array<GeneralSubscription>>;
   vars?: Maybe<ProjectVars>;
 };
 
@@ -1732,7 +1733,7 @@ export type RepoSettings = {
   projectRef?: Maybe<RepoRef>;
   /** @deprecated Use subscriptions instead */
   projectSubscriptions?: Maybe<Array<ProjectSubscription>>;
-  subscriptions?: Maybe<Array<ProjectSubscription>>;
+  subscriptions?: Maybe<Array<GeneralSubscription>>;
   vars?: Maybe<ProjectVars>;
 };
 

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -715,6 +715,8 @@ export type Mutation = {
   scheduleUndispatchedBaseTasks?: Maybe<Array<Task>>;
   setAnnotationMetadataLinks: Scalars["Boolean"];
   setPatchPriority?: Maybe<Scalars["String"]>;
+  /** setPatchVisibility takes a list of patch ids and a boolean to set the visibility on the my patches queries */
+  setPatchVisibility: Array<Patch>;
   setTaskPriority: Task;
   spawnHost: Host;
   spawnVolume: Scalars["Boolean"];
@@ -916,6 +918,11 @@ export type MutationSetAnnotationMetadataLinksArgs = {
 export type MutationSetPatchPriorityArgs = {
   patchId: Scalars["String"];
   priority: Scalars["Int"];
+};
+
+export type MutationSetPatchVisibilityArgs = {
+  hidden: Scalars["Boolean"];
+  patchIds: Array<Scalars["String"]>;
 };
 
 export type MutationSetTaskPriorityArgs = {
@@ -4482,6 +4489,16 @@ export type SetPatchPriorityMutationVariables = Exact<{
 export type SetPatchPriorityMutation = {
   __typename?: "Mutation";
   setPatchPriority?: Maybe<string>;
+};
+
+export type SetPatchVisibilityMutationVariables = Exact<{
+  patchIds: Array<Scalars["String"]>;
+  hidden: Scalars["Boolean"];
+}>;
+
+export type SetPatchVisibilityMutation = {
+  __typename?: "Mutation";
+  setPatchVisibility: Array<{ __typename?: "Patch"; id: string }>;
 };
 
 export type SetTaskPriorityMutationVariables = Exact<{

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -1483,7 +1483,6 @@ export type Query = {
   taskNamesForBuildVariant?: Maybe<Array<Scalars["String"]>>;
   taskQueueDistros: Array<TaskQueueDistro>;
   taskTestSample?: Maybe<Array<TaskTestResultSample>>;
-  taskTests: TaskTestResult;
   user: User;
   userConfig?: Maybe<UserConfig>;
   userSettings?: Maybe<UserSettings>;
@@ -1606,18 +1605,6 @@ export type QueryTaskNamesForBuildVariantArgs = {
 export type QueryTaskTestSampleArgs = {
   filters: Array<TestFilter>;
   tasks: Array<Scalars["String"]>;
-};
-
-export type QueryTaskTestsArgs = {
-  execution?: InputMaybe<Scalars["Int"]>;
-  groupId?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  page?: InputMaybe<Scalars["Int"]>;
-  sortCategory?: InputMaybe<TestSortCategory>;
-  sortDirection?: InputMaybe<SortDirection>;
-  statuses?: Array<Scalars["String"]>;
-  taskId: Scalars["String"];
-  testName?: InputMaybe<Scalars["String"]>;
 };
 
 export type QueryUserArgs = {
@@ -2186,7 +2173,7 @@ export type TaskSyncOptionsInput = {
 };
 
 /**
- * TaskTestResult is the return value for the taskTests query.
+ * TaskTestResult is the return value for the task.Tests resolver.
  * It contains the test results for a task. For example, if there is a task to run all unit tests, then the test results
  * could be the result of each individual unit test.
  */

--- a/src/gql/mutations/index.ts
+++ b/src/gql/mutations/index.ts
@@ -37,6 +37,7 @@ import SCHEDULE_PATCH from "./schedule-patch.graphql";
 import SCHEDULE_TASKS from "./schedule-tasks.graphql";
 import SCHEDULE_UNDISPATCHED_BASE_TASKS from "./schedule-undispatched-base-tasks.graphql";
 import SET_PATCH_PRIORITY from "./set-patch-priority.graphql";
+import SET_PATCH_VISIBILITY from "./set-patch-visibility.graphql";
 import SET_TASK_PRIORTY from "./set-task-priority.graphql";
 import SPAWN_HOST from "./spawn-host.graphql";
 import SPAWN_VOLUME from "./spawn-volume.graphql";
@@ -87,6 +88,7 @@ export {
   SCHEDULE_TASKS,
   SCHEDULE_UNDISPATCHED_BASE_TASKS,
   SET_PATCH_PRIORITY,
+  SET_PATCH_VISIBILITY,
   SET_TASK_PRIORTY,
   SPAWN_HOST,
   SPAWN_VOLUME,

--- a/src/gql/mutations/set-patch-visibility.graphql
+++ b/src/gql/mutations/set-patch-visibility.graphql
@@ -1,0 +1,5 @@
+mutation SetPatchVisibility($patchIds: [String!]!, $hidden: Boolean!) {
+  setPatchVisibility(patchIds: $patchIds, hidden: $hidden) {
+    id
+  }
+}


### PR DESCRIPTION
EVG-14033

### Description
Adds a button that will hide patches from appearing on the patches pages.

### Screenshots

https://github.com/evergreen-ci/spruce/assets/4605522/df9a61e3-98e5-4f15-abef-9d99ba6dce17



### Evergreen Patch 
https://github.com/evergreen-ci/evergreen/pull/6485
