### PR TITLE
EVG-18757 Allow canceling configuration for configured patches

### DIFF
--- a/cypress/integration/version/unscheduled_patch/configure_patch.ts
+++ b/cypress/integration/version/unscheduled_patch/configure_patch.ts
@@ -29,6 +29,19 @@ describe("Configure Patch Page", () => {
         .should("have.attr", "data-selected", "true");
     });
 
+    it("should allow canceling a configured patch", () => {
+      cy.visit(`/patch/5ecedafb562343215a7ff297/configure/tasks`);
+      cy.dataCy("cancel-button").should("exist");
+      cy.dataCy("cancel-button").click();
+      cy.location().should((loc) =>
+        expect(loc.pathname).to.eq(`/version/5ecedafb562343215a7ff297/tasks`)
+      );
+    });
+    it("should not allow canceling an unconfigured patch", () => {
+      cy.visit(`/patch/${unactivatedPatchId}/configure/tasks`);
+      cy.dataCy("cancel-button").should("not.exist");
+    });
+
     describe("Visiting configure page from a redirect", () => {
       it("should default to the tasks tab when there isn't one in the url", () => {
         cy.visit(`/patch/${unactivatedPatchId}/configure`);

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -715,6 +715,8 @@ export type Mutation = {
   scheduleUndispatchedBaseTasks?: Maybe<Array<Task>>;
   setAnnotationMetadataLinks: Scalars["Boolean"];
   setPatchPriority?: Maybe<Scalars["String"]>;
+  /** setPatchVisibility takes a list of patch ids and a boolean to set the visibility on the my patches queries */
+  setPatchVisibility: Array<Patch>;
   setTaskPriority: Task;
   spawnHost: Host;
   spawnVolume: Scalars["Boolean"];
@@ -918,6 +920,11 @@ export type MutationSetPatchPriorityArgs = {
   priority: Scalars["Int"];
 };
 
+export type MutationSetPatchVisibilityArgs = {
+  hidden: Scalars["Boolean"];
+  patchIds: Array<Scalars["String"]>;
+};
+
 export type MutationSetTaskPriorityArgs = {
   priority: Scalars["Int"];
   taskId: Scalars["String"];
@@ -1023,6 +1030,7 @@ export type Patch = {
   description: Scalars["String"];
   duration?: Maybe<PatchDuration>;
   githash: Scalars["String"];
+  hidden: Scalars["Boolean"];
   id: Scalars["ID"];
   moduleCodeChanges: Array<ModuleCodeChange>;
   parameters: Array<Parameter>;
@@ -1221,6 +1229,7 @@ export type Project = {
   periodicBuilds?: Maybe<Array<PeriodicBuild>>;
   prTestingEnabled?: Maybe<Scalars["Boolean"]>;
   private?: Maybe<Scalars["Boolean"]>;
+  projectHealthView: ProjectHealthView;
   remotePath: Scalars["String"];
   repo: Scalars["String"];
   repoRefId: Scalars["String"];
@@ -1312,6 +1321,11 @@ export type ProjectEvents = {
   count: Scalars["Int"];
   eventLogEntries: Array<ProjectEventLogEntry>;
 };
+
+export enum ProjectHealthView {
+  ProjectHealthViewAll = "PROJECT_HEALTH_VIEW_ALL",
+  ProjectHealthViewFailed = "PROJECT_HEALTH_VIEW_FAILED",
+}
 
 export type ProjectInput = {
   admins?: InputMaybe<Array<Scalars["String"]>>;
@@ -1475,7 +1489,6 @@ export type Query = {
   taskNamesForBuildVariant?: Maybe<Array<Scalars["String"]>>;
   taskQueueDistros: Array<TaskQueueDistro>;
   taskTestSample?: Maybe<Array<TaskTestResultSample>>;
-  taskTests: TaskTestResult;
   user: User;
   userConfig?: Maybe<UserConfig>;
   userSettings?: Maybe<UserSettings>;
@@ -1598,18 +1611,6 @@ export type QueryTaskNamesForBuildVariantArgs = {
 export type QueryTaskTestSampleArgs = {
   filters: Array<TestFilter>;
   tasks: Array<Scalars["String"]>;
-};
-
-export type QueryTaskTestsArgs = {
-  execution?: InputMaybe<Scalars["Int"]>;
-  groupId?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  page?: InputMaybe<Scalars["Int"]>;
-  sortCategory?: InputMaybe<TestSortCategory>;
-  sortDirection?: InputMaybe<SortDirection>;
-  statuses?: Array<Scalars["String"]>;
-  taskId: Scalars["String"];
-  testName?: InputMaybe<Scalars["String"]>;
 };
 
 export type QueryUserArgs = {
@@ -2178,7 +2179,7 @@ export type TaskSyncOptionsInput = {
 };
 
 /**
- * TaskTestResult is the return value for the taskTests query.
+ * TaskTestResult is the return value for the task.Tests resolver.
  * It contains the test results for a task. For example, if there is a task to run all unit tests, then the test results
  * could be the result of each individual unit test.
  */

--- a/src/pages/configurePatch/ConfigurePatchCore.tsx
+++ b/src/pages/configurePatch/ConfigurePatchCore.tsx
@@ -141,7 +141,14 @@ export const ConfigurePatchCore: React.VFC<Props> = ({ patch }) => {
           onChange={(e) => setDescription(e.target.value)}
         />
         {activated && (
-          <StyledButton data-cy="cancel-button" onClick={() => navigate(-1)}>
+          <StyledButton
+            data-cy="cancel-button"
+            onClick={() =>
+              window.history.state.idx > 0
+                ? navigate(-1)
+                : navigate(getVersionRoute(id))
+            }
+          >
             Cancel
           </StyledButton>
         )}

--- a/src/pages/configurePatch/ConfigurePatchCore.tsx
+++ b/src/pages/configurePatch/ConfigurePatchCore.tsx
@@ -14,7 +14,7 @@ import {
 import { PageContent, PageLayout, PageSider } from "components/styles";
 import { StyledTabs } from "components/styles/StyledTabs";
 import { getVersionRoute } from "constants/routes";
-import { size } from "constants/tokens";
+import { fontSize, size } from "constants/tokens";
 
 import { useToastContext } from "context/toast";
 import {
@@ -34,7 +34,6 @@ import {
   VariantTasksState,
   useConfigurePatch,
 } from "hooks/useConfigurePatch";
-import { useLGButtonRouterLink } from "hooks/useLGButtonRouterLink";
 import { ParametersContent } from "pages/configurePatch/ParametersContent";
 import { ConfigureBuildVariants } from "./configurePatchCore/ConfigureBuildVariants";
 import { ConfigureTasks } from "./configurePatchCore/ConfigureTasks";
@@ -120,8 +119,6 @@ export const ConfigurePatchCore: React.VFC<Props> = ({ patch }) => {
     });
   };
 
-  const Link = useLGButtonRouterLink(getVersionRoute(id));
-
   if (variants.length === 0) {
     return (
       // TODO: Full page error
@@ -141,11 +138,10 @@ export const ConfigurePatchCore: React.VFC<Props> = ({ patch }) => {
           label="Patch Name"
           data-cy="patch-name-input"
           value={description}
-          style={{ fontWeight: "bold", fontSize: "16px" }}
           onChange={(e) => setDescription(e.target.value)}
         />
         {activated && (
-          <StyledButton data-cy="cancel-button" as={Link}>
+          <StyledButton data-cy="cancel-button" onClick={() => navigate(-1)}>
             Cancel
           </StyledButton>
         )}
@@ -282,6 +278,8 @@ const filterAliases = (
 };
 
 const StyledInput = styled(TextInput)`
+  font-weight: bold;
+  font-size: ${fontSize.m};
   margin-bottom: ${size.s};
   width: 100%;
 `;

--- a/src/pages/configurePatch/ConfigurePatchCore.tsx
+++ b/src/pages/configurePatch/ConfigurePatchCore.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { useMutation } from "@apollo/client";
 import styled from "@emotion/styled";
+import Button from "@leafygreen-ui/button";
 import { Tab } from "@leafygreen-ui/tabs";
 import TextInput from "@leafygreen-ui/text-input";
 import { useNavigate } from "react-router-dom";
@@ -33,6 +34,7 @@ import {
   VariantTasksState,
   useConfigurePatch,
 } from "hooks/useConfigurePatch";
+import { useLGButtonRouterLink } from "hooks/useLGButtonRouterLink";
 import { ParametersContent } from "pages/configurePatch/ParametersContent";
 import { ConfigureBuildVariants } from "./configurePatchCore/ConfigureBuildVariants";
 import { ConfigureTasks } from "./configurePatchCore/ConfigureTasks";
@@ -118,6 +120,8 @@ export const ConfigurePatchCore: React.VFC<Props> = ({ patch }) => {
     });
   };
 
+  const Link = useLGButtonRouterLink(getVersionRoute(id));
+
   if (variants.length === 0) {
     return (
       // TODO: Full page error
@@ -132,13 +136,20 @@ export const ConfigurePatchCore: React.VFC<Props> = ({ patch }) => {
 
   return (
     <>
-      <StyledInput
-        label="Patch Name"
-        data-cy="patch-name-input"
-        value={description}
-        style={{ fontWeight: "bold", fontSize: "16px" }}
-        onChange={(e) => setDescription(e.target.value)}
-      />
+      <FlexRow>
+        <StyledInput
+          label="Patch Name"
+          data-cy="patch-name-input"
+          value={description}
+          style={{ fontWeight: "bold", fontSize: "16px" }}
+          onChange={(e) => setDescription(e.target.value)}
+        />
+        {activated && (
+          <StyledButton data-cy="cancel-button" as={Link}>
+            Cancel
+          </StyledButton>
+        )}
+      </FlexRow>
       <PageLayout>
         <PageSider>
           <MetadataCard error={null}>
@@ -272,4 +283,17 @@ const filterAliases = (
 
 const StyledInput = styled(TextInput)`
   margin-bottom: ${size.s};
+  width: 100%;
+`;
+
+const StyledButton = styled(Button)`
+  margin-top: ${size.m};
+`;
+
+const FlexRow = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: ${size.m};
+  /* Fill the entire container width */
+  width: 100%;
 `;

--- a/src/pages/configurePatch/ConfigurePatchCore.tsx
+++ b/src/pages/configurePatch/ConfigurePatchCore.tsx
@@ -293,7 +293,5 @@ const StyledButton = styled(Button)`
 const FlexRow = styled.div`
   display: flex;
   flex-direction: row;
-  gap: ${size.m};
-  /* Fill the entire container width */
-  width: 100%;
+  gap: ${size.s};
 `;


### PR DESCRIPTION
EVG-18757

### Description
Adds a cancel button for patches that have already been configured 
### Screenshots
<img width="1191" alt="image" src="https://github.com/evergreen-ci/spruce/assets/4605522/8a96c044-fe1a-433f-b0c1-54c311225d0c">
