### PR TITLE
EVG-19588 Make build variant container sticky

### DIFF
--- a/src/components/MetadataCard.tsx
+++ b/src/components/MetadataCard.tsx
@@ -16,8 +16,9 @@ export const MetadataCard: React.VFC<Props> = ({
   children,
   error,
   loading,
+  ...rest
 }) => (
-  <SiderCard>
+  <SiderCard {...rest}>
     {loading && !error && (
       <Skeleton active title={false} paragraph={{ rows: 4 }} />
     )}

--- a/src/pages/version/BuildVariants.tsx
+++ b/src/pages/version/BuildVariants.tsx
@@ -35,9 +35,9 @@ export const BuildVariants: React.VFC = () => {
   const { version } = data || {};
 
   return (
-    <MetadataCard error={error} loading={loading}>
+    <StickyMetadataCard error={error} loading={loading}>
       <MetadataTitle>Build Variants</MetadataTitle>
-      <div data-cy="build-variants">
+      <ScrollableBuildVariantStatsContainer data-cy="build-variants">
         {version?.buildVariantStats?.map(
           ({ displayName, statusCounts, variant }) => (
             <VariantTaskGroup
@@ -49,11 +49,20 @@ export const BuildVariants: React.VFC = () => {
             />
           )
         )}
-      </div>
-    </MetadataCard>
+      </ScrollableBuildVariantStatsContainer>
+    </StickyMetadataCard>
   );
 };
 
+const StickyMetadataCard = styled(MetadataCard)`
+  position: sticky;
+  top: 0;
+`;
+
+const ScrollableBuildVariantStatsContainer = styled.div`
+  max-height: 55vh;
+  overflow-y: auto;
+`;
 interface VariantTaskGroupProps {
   displayName: string;
   statusCounts: StatusCount[];


### PR DESCRIPTION
EVG-19588

### Description
Makes the build variant card sticky so it is always viewable when scrolling through a large tasks table.

### Screenshots

https://github.com/evergreen-ci/spruce/assets/4605522/8e9172b4-2daa-4f2a-879b-b63dce9b92e8



