### PR TITLE
EVG-19804: Fetch subscriptions instead of projectSubscriptions

### DIFF
--- a/src/gql/GQLWrapper.tsx
+++ b/src/gql/GQLWrapper.tsx
@@ -50,6 +50,9 @@ const cache = new InMemoryCache({
         },
       },
     },
+    GeneralSubscription: {
+      keyFields: false,
+    },
     ProjectEvents: {
       fields: {
         count: {
@@ -68,9 +71,6 @@ const cache = new InMemoryCache({
       keyFields: false,
     },
     Project: {
-      keyFields: false,
-    },
-    ProjectSubscription: {
       keyFields: false,
     },
     User: {

--- a/src/gql/fragments/projectSettings/index.graphql
+++ b/src/gql/fragments/projectSettings/index.graphql
@@ -30,7 +30,7 @@ fragment ProjectSettingsFields on ProjectSettings {
     ...ProjectVirtualWorkstationSettings
     repoRefId
   }
-  projectSubscriptions {
+  subscriptions {
     ...Subscriptions
   }
   vars {
@@ -55,10 +55,10 @@ fragment RepoSettingsFields on RepoSettings {
     ...RepoTriggersSettings
     ...RepoVirtualWorkstationSettings
   }
-  projectSubscriptions {
+  ...RepoGithubCommitQueue
+  subscriptions {
     ...Subscriptions
   }
-  ...RepoGithubCommitQueue
   vars {
     ...Variables
   }

--- a/src/gql/fragments/projectSettings/notifications.graphql
+++ b/src/gql/fragments/projectSettings/notifications.graphql
@@ -10,7 +10,7 @@ fragment RepoNotificationSettings on RepoRef {
   notifyOnBuildFailure
 }
 
-fragment Subscriptions on ProjectSubscription {
+fragment Subscriptions on GeneralSubscription {
   id
   ownerType
   regexSelectors {

--- a/src/gql/fragments/projectSettings/projectEventSettings.graphql
+++ b/src/gql/fragments/projectSettings/projectEventSettings.graphql
@@ -30,7 +30,7 @@ fragment ProjectEventSettings on ProjectEventSettings {
     tracksPushEvents
     versionControlEnabled
   }
-  projectSubscriptions {
+  subscriptions {
     ...Subscriptions
   }
   vars {

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -1229,6 +1229,7 @@ export type Project = {
   periodicBuilds?: Maybe<Array<PeriodicBuild>>;
   prTestingEnabled?: Maybe<Scalars["Boolean"]>;
   private?: Maybe<Scalars["Boolean"]>;
+  projectHealthView: ProjectHealthView;
   remotePath: Scalars["String"];
   repo: Scalars["String"];
   repoRefId: Scalars["String"];
@@ -1320,6 +1321,11 @@ export type ProjectEvents = {
   count: Scalars["Int"];
   eventLogEntries: Array<ProjectEventLogEntry>;
 };
+
+export enum ProjectHealthView {
+  ProjectHealthViewAll = "PROJECT_HEALTH_VIEW_ALL",
+  ProjectHealthViewFailed = "PROJECT_HEALTH_VIEW_FAILED",
+}
 
 export type ProjectInput = {
   admins?: InputMaybe<Array<Scalars["String"]>>;

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -715,6 +715,8 @@ export type Mutation = {
   scheduleUndispatchedBaseTasks?: Maybe<Array<Task>>;
   setAnnotationMetadataLinks: Scalars["Boolean"];
   setPatchPriority?: Maybe<Scalars["String"]>;
+  /** setPatchVisibility takes a list of patch ids and a boolean to set the visibility on the my patches queries */
+  setPatchVisibility: Array<Patch>;
   setTaskPriority: Task;
   spawnHost: Host;
   spawnVolume: Scalars["Boolean"];
@@ -918,6 +920,11 @@ export type MutationSetPatchPriorityArgs = {
   priority: Scalars["Int"];
 };
 
+export type MutationSetPatchVisibilityArgs = {
+  hidden: Scalars["Boolean"];
+  patchIds: Array<Scalars["String"]>;
+};
+
 export type MutationSetTaskPriorityArgs = {
   priority: Scalars["Int"];
   taskId: Scalars["String"];
@@ -1023,6 +1030,7 @@ export type Patch = {
   description: Scalars["String"];
   duration?: Maybe<PatchDuration>;
   githash: Scalars["String"];
+  hidden: Scalars["Boolean"];
   id: Scalars["ID"];
   moduleCodeChanges: Array<ModuleCodeChange>;
   parameters: Array<Parameter>;
@@ -1475,7 +1483,6 @@ export type Query = {
   taskNamesForBuildVariant?: Maybe<Array<Scalars["String"]>>;
   taskQueueDistros: Array<TaskQueueDistro>;
   taskTestSample?: Maybe<Array<TaskTestResultSample>>;
-  taskTests: TaskTestResult;
   user: User;
   userConfig?: Maybe<UserConfig>;
   userSettings?: Maybe<UserSettings>;
@@ -1598,18 +1605,6 @@ export type QueryTaskNamesForBuildVariantArgs = {
 export type QueryTaskTestSampleArgs = {
   filters: Array<TestFilter>;
   tasks: Array<Scalars["String"]>;
-};
-
-export type QueryTaskTestsArgs = {
-  execution?: InputMaybe<Scalars["Int"]>;
-  groupId?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  page?: InputMaybe<Scalars["Int"]>;
-  sortCategory?: InputMaybe<TestSortCategory>;
-  sortDirection?: InputMaybe<SortDirection>;
-  statuses?: Array<Scalars["String"]>;
-  taskId: Scalars["String"];
-  testName?: InputMaybe<Scalars["String"]>;
 };
 
 export type QueryUserArgs = {
@@ -2178,7 +2173,7 @@ export type TaskSyncOptionsInput = {
 };
 
 /**
- * TaskTestResult is the return value for the taskTests query.
+ * TaskTestResult is the return value for the task.Tests resolver.
  * It contains the test results for a task. For example, if there is a task to run all unit tests, then the test results
  * could be the result of each individual unit test.
  */
@@ -3184,9 +3179,9 @@ export type ProjectSettingsFieldsFragment = {
       message: string;
     };
   }>;
-  projectSubscriptions?: Maybe<
+  subscriptions?: Maybe<
     Array<{
-      __typename?: "ProjectSubscription";
+      __typename?: "GeneralSubscription";
       id: string;
       ownerType: string;
       resourceType: string;
@@ -3388,9 +3383,9 @@ export type RepoSettingsFieldsFragment = {
       message: string;
     };
   }>;
-  projectSubscriptions?: Maybe<
+  subscriptions?: Maybe<
     Array<{
-      __typename?: "ProjectSubscription";
+      __typename?: "GeneralSubscription";
       id: string;
       ownerType: string;
       resourceType: string;
@@ -3471,7 +3466,7 @@ export type RepoNotificationSettingsFragment = {
 };
 
 export type SubscriptionsFragment = {
-  __typename?: "ProjectSubscription";
+  __typename?: "GeneralSubscription";
   id: string;
   ownerType: string;
   resourceType: string;
@@ -3794,9 +3789,9 @@ export type ProjectEventSettingsFragment = {
       message: string;
     };
   }>;
-  projectSubscriptions?: Maybe<
+  subscriptions?: Maybe<
     Array<{
-      __typename?: "ProjectSubscription";
+      __typename?: "GeneralSubscription";
       id: string;
       ownerType: string;
       resourceType: string;
@@ -6027,9 +6022,9 @@ export type ProjectEventLogsQuery = {
             message: string;
           };
         }>;
-        projectSubscriptions?: Maybe<
+        subscriptions?: Maybe<
           Array<{
-            __typename?: "ProjectSubscription";
+            __typename?: "GeneralSubscription";
             id: string;
             ownerType: string;
             resourceType: string;
@@ -6241,9 +6236,9 @@ export type ProjectEventLogsQuery = {
             message: string;
           };
         }>;
-        projectSubscriptions?: Maybe<
+        subscriptions?: Maybe<
           Array<{
-            __typename?: "ProjectSubscription";
+            __typename?: "GeneralSubscription";
             id: string;
             ownerType: string;
             resourceType: string;
@@ -6472,9 +6467,9 @@ export type ProjectSettingsQuery = {
         message: string;
       };
     }>;
-    projectSubscriptions?: Maybe<
+    subscriptions?: Maybe<
       Array<{
-        __typename?: "ProjectSubscription";
+        __typename?: "GeneralSubscription";
         id: string;
         ownerType: string;
         resourceType: string;
@@ -6731,9 +6726,9 @@ export type RepoEventLogsQuery = {
             message: string;
           };
         }>;
-        projectSubscriptions?: Maybe<
+        subscriptions?: Maybe<
           Array<{
-            __typename?: "ProjectSubscription";
+            __typename?: "GeneralSubscription";
             id: string;
             ownerType: string;
             resourceType: string;
@@ -6945,9 +6940,9 @@ export type RepoEventLogsQuery = {
             message: string;
           };
         }>;
-        projectSubscriptions?: Maybe<
+        subscriptions?: Maybe<
           Array<{
-            __typename?: "ProjectSubscription";
+            __typename?: "GeneralSubscription";
             id: string;
             ownerType: string;
             resourceType: string;
@@ -7166,9 +7161,9 @@ export type RepoSettingsQuery = {
         message: string;
       };
     }>;
-    projectSubscriptions?: Maybe<
+    subscriptions?: Maybe<
       Array<{
-        __typename?: "ProjectSubscription";
+        __typename?: "GeneralSubscription";
         id: string;
         ownerType: string;
         resourceType: string;

--- a/src/pages/projectSettings/CopyProjectModal.test.tsx
+++ b/src/pages/projectSettings/CopyProjectModal.test.tsx
@@ -339,7 +339,7 @@ const projectSettingsMock: ApolloMock<
             __typename: "CommitQueueParams",
           },
         },
-        projectSubscriptions: [],
+        subscriptions: [],
         vars: {
           vars: {},
           privateVars: [],

--- a/src/pages/projectSettings/tabs/EventLogTab/EventLogTab.test.tsx
+++ b/src/pages/projectSettings/tabs/EventLogTab/EventLogTab.test.tsx
@@ -147,7 +147,7 @@ const eventLogEntry: ProjectEventLogsQuery["projectEvents"]["eventLogEntries"][0
           __typename: "CommitQueueParams",
         },
       },
-      projectSubscriptions: [],
+      subscriptions: [],
       vars: {
         vars: {
           node_path: "/opt/axstarst$PATH",
@@ -228,7 +228,7 @@ const eventLogEntry: ProjectEventLogsQuery["projectEvents"]["eventLogEntries"][0
           __typename: "CommitQueueParams",
         },
       },
-      projectSubscriptions: [],
+      subscriptions: [],
       vars: {
         vars: {},
         privateVars: [],

--- a/src/pages/projectSettings/tabs/NotificationsTab/transformers.ts
+++ b/src/pages/projectSettings/tabs/NotificationsTab/transformers.ts
@@ -94,7 +94,7 @@ const getHttpHeaders = (headers: { key: string; value: string }[]) =>
 
 export const gqlToForm: GqlToFormFunction<Tab> = (data, { projectType }) => {
   if (!data) return null;
-  const { projectRef, projectSubscriptions: subscriptions } = data;
+  const { projectRef, subscriptions } = data;
   return {
     ...(projectType !== ProjectType.Repo &&
       "banner" in projectRef && {


### PR DESCRIPTION
EVG-19804

### Description
<!-- add description, context, thought process, etc -->
- Step 3 of deprecating the `ProjectSubscription` type: Stop making calls to `projectSubscriptions` fields, which use the deprecated type.
- Update caching rule to target `GeneralSubscription` instead of `ProjectSubscription`