### PR TITLE
EVG-17636: Expose more error logs in host events

### DIFF
--- a/cypress/integration/host/host_events.ts
+++ b/cypress/integration/host/host_events.ts
@@ -25,7 +25,7 @@ describe("Host events", () => {
       },
       {
         hostType: "stopped",
-        text: "Host stop attempt",
+        text: "Host stop attempt failed",
       },
       {
         hostType: "started",
@@ -41,7 +41,7 @@ describe("Host events", () => {
       },
       {
         hostType: "created",
-        text: "Host created",
+        text: "Host creation succeeded",
       },
       {
         hostType: "agent-monitor-deploy-failed",
@@ -57,7 +57,7 @@ describe("Host events", () => {
       },
       {
         hostType: "modified",
-        text: "Host modify attempt",
+        text: "Host modify attempt failed",
       },
       {
         hostType: "host-jasper-restarting",
@@ -145,6 +145,16 @@ describe("Host events", () => {
         hostType: "host-status-changed",
         text: "Status changed from running to unreachable by chaya.malik",
         logsTitle: "Additional details",
+      },
+      {
+        hostType: "stopped",
+        text: "Host stop attempt failed",
+        logsTitle: "Attached logs",
+      },
+      {
+        hostType: "modified",
+        text: "Host modify attempt failed",
+        logsTitle: "Attached logs",
       },
     ];
     cy.visit(pathWithEvents);

--- a/cypress/integration/host/host_events.ts
+++ b/cypress/integration/host/host_events.ts
@@ -149,12 +149,12 @@ describe("Host events", () => {
       {
         hostType: "stopped",
         text: "Host stop attempt failed",
-        logsTitle: "Attached logs",
+        logsTitle: "Additional details",
       },
       {
         hostType: "modified",
         text: "Host modify attempt failed",
-        logsTitle: "Attached logs",
+        logsTitle: "Additional details",
       },
     ];
     cy.visit(pathWithEvents);

--- a/src/pages/host/getHostEventString.tsx
+++ b/src/pages/host/getHostEventString.tsx
@@ -124,7 +124,7 @@ export const getHostEventString = (
     case HostEvent.HostJasperRestarted:
       return (
         <div data-cy="host-jasper-restarted">
-          Jasper service restarted with revision<b>{data.jasperRevision}</b>
+          Jasper service restarted with revision <b>{data.jasperRevision}</b>
         </div>
       );
     case HostEvent.HostJasperRestartError:

--- a/src/pages/host/getHostEventString.tsx
+++ b/src/pages/host/getHostEventString.tsx
@@ -32,9 +32,20 @@ export const getHostEventString = (
   data: HostEventLogData
 ) => {
   const succeededString = "succeeded";
+  const failedString = "failed";
+
   switch (eventType) {
     case HostEvent.Created:
-      return <span data-cy="created">Host created</span>;
+      return (
+        <div data-cy="created">
+          Host creation {data.successful ? succeededString : failedString}
+          {data.logs ? (
+            <HostEventLog title="Attached logs" logs={data.logs} isCode />
+          ) : (
+            ""
+          )}
+        </div>
+      );
     case HostEvent.AgentDeployFailed:
       return <span data-cy="agent-deploy-failed">New agent deploy failed</span>;
     case HostEvent.ProvisionError:
@@ -45,21 +56,36 @@ export const getHostEventString = (
       );
     case HostEvent.Started:
       return (
-        <span data-cy="started">
-          Host start attempt {data.successful ? succeededString : ""}
-        </span>
+        <div data-cy="started">
+          Host start attempt {data.successful ? succeededString : failedString}
+          {data.logs ? (
+            <HostEventLog title="Attached logs" logs={data.logs} isCode />
+          ) : (
+            ""
+          )}
+        </div>
       );
     case HostEvent.Stopped:
       return (
-        <span data-cy="stopped">
-          Host stop attempt {data.successful ? succeededString : ""}
-        </span>
+        <div data-cy="stopped">
+          Host stop attempt {data.successful ? succeededString : failedString}
+          {data.logs ? (
+            <HostEventLog title="Attached logs" logs={data.logs} isCode />
+          ) : (
+            ""
+          )}
+        </div>
       );
     case HostEvent.Modified:
       return (
-        <span data-cy="modified">
-          Host modify attempt {data.successful ? succeededString : ""}
-        </span>
+        <div data-cy="modified">
+          Host modify attempt {data.successful ? succeededString : failedString}
+          {data.logs ? (
+            <HostEventLog title="Attached logs" logs={data.logs} isCode />
+          ) : (
+            ""
+          )}
+        </div>
       );
     case HostEvent.Fallback:
       return (
@@ -70,20 +96,16 @@ export const getHostEventString = (
     case HostEvent.AgentDeployed:
       return (
         <div data-cy="agent-deployed">
-          {" "}
           Agent deployed {data.agentRevision ? "with revision" : ""}{" "}
           <b>{data.agentRevision}</b> {data.agentBuild ? " from " : ""}
-          <b>{data.agentBuild}</b>{" "}
+          <b>{data.agentBuild}</b>
         </div>
       );
     case HostEvent.AgentMonitorDeployed:
       return (
         <div data-cy="agent-monitor-deployed">
-          {" "}
-          Agent monitor deployed {data.agentRevision
-            ? "with revision"
-            : ""}{" "}
-          <b>{data.agentRevision}</b>{" "}
+          Agent monitor deployed {data.agentRevision ? "with revision" : ""}{" "}
+          <b>{data.agentRevision}</b>
         </div>
       );
     case HostEvent.AgentMonitorDeployFailed:
@@ -95,24 +117,19 @@ export const getHostEventString = (
     case HostEvent.HostJasperRestarting:
       return (
         <div data-cy="host-jasper-restarting">
-          {" "}
           Jasper service marked as restarting {data.user ? "by" : ""}{" "}
-          <b>{data.user}</b>{" "}
+          <b>{data.user}</b>
         </div>
       );
     case HostEvent.HostJasperRestarted:
       return (
         <div data-cy="host-jasper-restarted">
-          {" "}
-          Jasper service restarted with revision<b>
-            {data.jasperRevision}
-          </b>{" "}
+          Jasper service restarted with revision<b>{data.jasperRevision}</b>
         </div>
       );
     case HostEvent.HostJasperRestartError:
       return (
         <div data-cy="host-jasper-restart-error">
-          {" "}
           Host encountered error when restarting Jasper service
           {data.logs ? (
             <HostEventLog title="Provisioning logs" logs={data.logs} isCode />
@@ -151,7 +168,6 @@ export const getHostEventString = (
     case HostEvent.HostStatusChanged:
       return (
         <div data-cy="host-status-changed">
-          {" "}
           Status changed from <b>{data.oldStatus}</b> to <b>{data.newStatus}</b>{" "}
           {data.user ? "by" : ""} <b>{data.user}</b>{" "}
           {data.logs ? (
@@ -168,14 +184,12 @@ export const getHostEventString = (
     case HostEvent.HostDNSNameSet:
       return (
         <div data-cy="host-dns-name-set">
-          {" "}
-          DNS Name set to <b>{data.hostname}</b>{" "}
+          DNS Name set to <b>{data.hostname}</b>
         </div>
       );
     case HostEvent.HostScriptExecuted:
       return (
         <div data-cy="host-script-executed">
-          {" "}
           Executed script on host
           {data.logs ? (
             <HostEventLog title="Script logs" logs={data.logs} isCode />
@@ -187,7 +201,6 @@ export const getHostEventString = (
     case HostEvent.HostScriptExecuteFailed:
       return (
         <div data-cy="host-script-execute-failed">
-          {" "}
           Failed to execute script on host
           {data.logs ? (
             <HostEventLog title="Script logs" logs={data.logs} isCode />
@@ -205,7 +218,6 @@ export const getHostEventString = (
     case HostEvent.HostRunningTaskSet:
       return (
         <div data-cy="host-running-task-set">
-          {" "}
           Assigned to run task{" "}
           <StyledRouterLink
             data-cy="host-running-task-set-link"
@@ -218,7 +230,6 @@ export const getHostEventString = (
     case HostEvent.HostRunningTaskCleared:
       return (
         <div data-cy="host-running-task-cleared">
-          {" "}
           Current running task cleared (was:
           <StyledRouterLink
             data-cy="host-running-task-cleared-link"
@@ -232,7 +243,6 @@ export const getHostEventString = (
     case HostEvent.HostMonitorFlag:
       return (
         <div data-cy="host-monitor-flag">
-          {" "}
           Flagged for termination because:{" "}
           <b>{getTerminationString(data.monitorOp)}</b>
         </div>
@@ -240,7 +250,6 @@ export const getHostEventString = (
     case HostEvent.HostProvisionFailed:
       return (
         <div data-cy="host-provision-failed">
-          {" "}
           Provisioning failed{" "}
           {data.logs ? (
             <HostEventLog title="Provisioning logs" logs={data.logs} isCode />
@@ -252,12 +261,7 @@ export const getHostEventString = (
     case HostEvent.HostTeardown:
       return (
         <div data-cy="host-teardown">
-          {" "}
-          Teardown script {data.successful ? (
-            "ran successfully"
-          ) : (
-            <b>failed</b>
-          )}{" "}
+          Teardown script {data.successful ? "ran successfully" : <b>failed</b>}{" "}
           in {stringifyNanoseconds(data.duration, true, true)}
           {data.logs ? (
             <HostEventLog title="Teardown logs" logs={data.logs} isCode />
@@ -269,7 +273,6 @@ export const getHostEventString = (
     case HostEvent.HostTaskFinished:
       return (
         <div data-cy="host-task-finished">
-          {" "}
           Task{" "}
           <StyledRouterLink
             data-cy="host-task-finished-link"

--- a/src/pages/host/getHostEventString.tsx
+++ b/src/pages/host/getHostEventString.tsx
@@ -259,7 +259,7 @@ export const getHostEventString = (
             {shortenString(data.taskId, false, 50, "...")}
           </StyledRouterLink>{" "}
           completed with status:
-          <b> {data.taskStatus}</b>{" "}
+          <b> {data.taskStatus}</b>
         </div>
       );
     case HostEvent.HostExpirationWarningSet:

--- a/src/pages/host/getHostEventString.tsx
+++ b/src/pages/host/getHostEventString.tsx
@@ -39,10 +39,8 @@ export const getHostEventString = (
       return (
         <div data-cy="created">
           Host creation {data.successful ? succeededString : failedString}
-          {data.logs ? (
-            <HostEventLog title="Attached logs" logs={data.logs} isCode />
-          ) : (
-            ""
+          {data.logs && (
+            <HostEventLog title="Additional details" logs={data.logs} isCode />
           )}
         </div>
       );
@@ -58,10 +56,8 @@ export const getHostEventString = (
       return (
         <div data-cy="started">
           Host start attempt {data.successful ? succeededString : failedString}
-          {data.logs ? (
-            <HostEventLog title="Attached logs" logs={data.logs} isCode />
-          ) : (
-            ""
+          {data.logs && (
+            <HostEventLog title="Additional details" logs={data.logs} isCode />
           )}
         </div>
       );
@@ -69,10 +65,8 @@ export const getHostEventString = (
       return (
         <div data-cy="stopped">
           Host stop attempt {data.successful ? succeededString : failedString}
-          {data.logs ? (
-            <HostEventLog title="Attached logs" logs={data.logs} isCode />
-          ) : (
-            ""
+          {data.logs && (
+            <HostEventLog title="Additional details" logs={data.logs} isCode />
           )}
         </div>
       );
@@ -80,10 +74,8 @@ export const getHostEventString = (
       return (
         <div data-cy="modified">
           Host modify attempt {data.successful ? succeededString : failedString}
-          {data.logs ? (
-            <HostEventLog title="Attached logs" logs={data.logs} isCode />
-          ) : (
-            ""
+          {data.logs && (
+            <HostEventLog title="Additional details" logs={data.logs} isCode />
           )}
         </div>
       );
@@ -131,10 +123,8 @@ export const getHostEventString = (
       return (
         <div data-cy="host-jasper-restart-error">
           Host encountered error when restarting Jasper service
-          {data.logs ? (
+          {data.logs && (
             <HostEventLog title="Provisioning logs" logs={data.logs} isCode />
-          ) : (
-            ""
           )}
         </div>
       );
@@ -158,10 +148,8 @@ export const getHostEventString = (
       return (
         <div data-cy="host-converting-provisioning-error">
           Host encountered error when converting reprovisioning
-          {data.logs ? (
+          {data.logs && (
             <HostEventLog title="Provisioning logs" logs={data.logs} isCode />
-          ) : (
-            ""
           )}
         </div>
       );
@@ -170,14 +158,12 @@ export const getHostEventString = (
         <div data-cy="host-status-changed">
           Status changed from <b>{data.oldStatus}</b> to <b>{data.newStatus}</b>{" "}
           {data.user ? "by" : ""} <b>{data.user}</b>{" "}
-          {data.logs ? (
+          {data.logs && (
             <HostEventLog
               title="Additional details"
               logs={data.logs}
               isCode={false}
             />
-          ) : (
-            ""
           )}
         </div>
       );
@@ -191,10 +177,8 @@ export const getHostEventString = (
       return (
         <div data-cy="host-script-executed">
           Executed script on host
-          {data.logs ? (
+          {data.logs && (
             <HostEventLog title="Script logs" logs={data.logs} isCode />
-          ) : (
-            ""
           )}
         </div>
       );
@@ -202,10 +186,8 @@ export const getHostEventString = (
       return (
         <div data-cy="host-script-execute-failed">
           Failed to execute script on host
-          {data.logs ? (
+          {data.logs && (
             <HostEventLog title="Script logs" logs={data.logs} isCode />
-          ) : (
-            ""
           )}
         </div>
       );
@@ -251,10 +233,8 @@ export const getHostEventString = (
       return (
         <div data-cy="host-provision-failed">
           Provisioning failed{" "}
-          {data.logs ? (
+          {data.logs && (
             <HostEventLog title="Provisioning logs" logs={data.logs} isCode />
-          ) : (
-            ""
           )}
         </div>
       );
@@ -263,10 +243,8 @@ export const getHostEventString = (
         <div data-cy="host-teardown">
           Teardown script {data.successful ? "ran successfully" : <b>failed</b>}{" "}
           in {stringifyNanoseconds(data.duration, true, true)}
-          {data.logs ? (
+          {data.logs && (
             <HostEventLog title="Teardown logs" logs={data.logs} isCode />
-          ) : (
-            ""
           )}
         </div>
       );


### PR DESCRIPTION
EVG-17636

### Description
This PR adds failure descriptions and logs for the `HOST_CREATED`, `HOST_STARTED`, `HOST_STOPPED`, and `HOST_MODIFIED` events. I also removed some unnecessary leading & trailing whitespace from other events.

### Screenshots
<img width="963" alt="Screenshot 2023-05-25 at 12 38 01 PM" src="https://github.com/evergreen-ci/spruce/assets/47064971/634ae0a4-0025-454a-ab51-f58305f1713f">


### Testing
- Updated e2e tests (won't pass until Evergreen PR is merged). [Link to passing patch](https://spruce.mongodb.com/version/646f87c50ae606e58ab98def/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)

### Evergreen PR
- evergreen-ci/evergreen/pull/6549
