### PR TITLE
EVG-19883: Create outline for Views & Filters tab

### DIFF
--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -37,6 +37,7 @@ export enum ProjectSettingsTabRoutes {
   Plugins = "plugins",
   EventLog = "event-log",
   Containers = "containers",
+  ViewsAndFilters = "views-and-filters",
 }
 
 const paths = {

--- a/src/pages/projectSettings/Header.tsx
+++ b/src/pages/projectSettings/Header.tsx
@@ -11,6 +11,10 @@ import { HeaderButtons } from "./HeaderButtons";
 import { readOnlyTabs, WritableTabRoutes } from "./tabs/types";
 import { ProjectType } from "./tabs/utils";
 
+const notAvailableAtRepoLevel: Set<ProjectSettingsTabRoutes> = new Set([
+  ProjectSettingsTabRoutes.ViewsAndFilters,
+]);
+
 interface Props {
   attachedRepoId?: string;
   id: string;
@@ -26,12 +30,13 @@ export const Header: React.VFC<Props> = ({
 }) => {
   const { title } = getTabTitle(tab);
   const saveable = !(readOnlyTabs as ReadonlyArray<string>).includes(tab);
+  const showRepoLink = !notAvailableAtRepoLevel.has(tab);
 
   return (
     <Container>
       <TitleContainer>
         <H2 data-cy="project-settings-tab-title">{title}</H2>
-        {projectType === ProjectType.AttachedProject && (
+        {projectType === ProjectType.AttachedProject && showRepoLink && (
           <StyledRouterLink
             to={getProjectSettingsRoute(attachedRepoId, tab)}
             data-cy="attached-repo-link"

--- a/src/pages/projectSettings/Header.tsx
+++ b/src/pages/projectSettings/Header.tsx
@@ -8,12 +8,8 @@ import {
 import { size } from "constants/tokens";
 import { getTabTitle } from "./getTabTitle";
 import { HeaderButtons } from "./HeaderButtons";
-import { readOnlyTabs, WritableTabRoutes } from "./tabs/types";
+import { projectOnlyTabs, readOnlyTabs, WritableTabRoutes } from "./tabs/types";
 import { ProjectType } from "./tabs/utils";
-
-const notAvailableAtRepoLevel: Set<ProjectSettingsTabRoutes> = new Set([
-  ProjectSettingsTabRoutes.ViewsAndFilters,
-]);
 
 interface Props {
   attachedRepoId?: string;
@@ -30,7 +26,7 @@ export const Header: React.VFC<Props> = ({
 }) => {
   const { title } = getTabTitle(tab);
   const saveable = !(readOnlyTabs as ReadonlyArray<string>).includes(tab);
-  const showRepoLink = !notAvailableAtRepoLevel.has(tab);
+  const showRepoLink = !projectOnlyTabs.has(tab);
 
   return (
     <Container>

--- a/src/pages/projectSettings/HeaderButtons.tsx
+++ b/src/pages/projectSettings/HeaderButtons.tsx
@@ -30,6 +30,7 @@ const defaultToRepoDisabled: Set<WritableTabRoutes> = new Set([
   ProjectSettingsTabRoutes.Notifications,
   ProjectSettingsTabRoutes.Plugins,
   ProjectSettingsTabRoutes.Containers,
+  ProjectSettingsTabRoutes.ViewsAndFilters,
 ]);
 
 interface Props {
@@ -172,6 +173,8 @@ const mapRouteToSection: Record<WritableTabRoutes, ProjectSettingsSection> = {
     ProjectSettingsSection.PeriodicBuilds,
   [ProjectSettingsTabRoutes.Plugins]: ProjectSettingsSection.Plugins,
   [ProjectSettingsTabRoutes.Containers]: ProjectSettingsSection.Containers,
+  [ProjectSettingsTabRoutes.ViewsAndFilters]:
+    ProjectSettingsSection.ViewsAndFilters,
 };
 
 const ButtonRow = styled.div`

--- a/src/pages/projectSettings/Tabs.tsx
+++ b/src/pages/projectSettings/Tabs.tsx
@@ -6,9 +6,9 @@ import { ProjectSettingsQuery, RepoSettingsQuery } from "gql/generated/types";
 import { isProduction } from "utils/environmentVariables";
 import { useProjectSettingsContext } from "./Context";
 import { Header } from "./Header";
-import { ContainersTab } from "./tabs/ContainersTab/ContainersTab";
 import {
   AccessTab,
+  ContainersTab,
   EventLogTab,
   GeneralTab,
   GithubCommitQueueTab,
@@ -18,6 +18,7 @@ import {
   ProjectTriggersTab,
   VariablesTab,
   PluginsTab,
+  ViewsAndFiltersTab,
   VirtualWorkstationTab,
 } from "./tabs/index";
 import { gqlToFormMap } from "./tabs/transformers";
@@ -188,6 +189,20 @@ export const ProjectSettingsTabs: React.VFC<Props> = ({
                 }
                 projectType={projectType}
                 repoData={tabData[ProjectSettingsTabRoutes.Containers].repoData}
+              />
+            }
+          />
+        )}
+        {!isProduction() && (
+          <Route
+            path={ProjectSettingsTabRoutes.ViewsAndFilters}
+            element={
+              <ViewsAndFiltersTab
+                identifier={identifier}
+                projectData={
+                  tabData[ProjectSettingsTabRoutes.ViewsAndFilters].projectData
+                }
+                projectType={projectType}
               />
             }
           />

--- a/src/pages/projectSettings/getTabTitle.ts
+++ b/src/pages/projectSettings/getTabTitle.ts
@@ -30,6 +30,9 @@ export const getTabTitle = (
       [ProjectSettingsTabRoutes.Containers]: {
         title: "Containers",
       },
+      [ProjectSettingsTabRoutes.ViewsAndFilters]: {
+        title: "Views & Filters",
+      },
       [ProjectSettingsTabRoutes.ProjectTriggers]: {
         title: "Project Triggers",
       },

--- a/src/pages/projectSettings/index.tsx
+++ b/src/pages/projectSettings/index.tsx
@@ -164,6 +164,13 @@ const ProjectSettings: React.VFC = () => {
               tab={ProjectSettingsTabRoutes.Containers}
             />
           )}
+          {/* Views and filters are not available at the repo level at this time. */}
+          {!isProduction() && projectType !== ProjectType.Repo && (
+            <ProjectSettingsNavItem
+              {...sharedProps}
+              tab={ProjectSettingsTabRoutes.ViewsAndFilters}
+            />
+          )}
           <ProjectSettingsNavItem
             {...sharedProps}
             tab={ProjectSettingsTabRoutes.ProjectTriggers}

--- a/src/pages/projectSettings/tabs/ViewsAndFiltersTab/ViewsAndFiltersTab.tsx
+++ b/src/pages/projectSettings/tabs/ViewsAndFiltersTab/ViewsAndFiltersTab.tsx
@@ -1,0 +1,35 @@
+import { useMemo } from "react";
+import { SpruceForm } from "components/SpruceForm";
+import { ProjectSettingsTabRoutes } from "constants/routes";
+import {
+  usePopulateForm,
+  useProjectSettingsContext,
+} from "pages/projectSettings/Context";
+import { getFormSchema } from "./getFormSchema";
+import { TabProps } from "./types";
+
+const tab = ProjectSettingsTabRoutes.ViewsAndFilters;
+
+export const ViewsAndFiltersTab: React.VFC<TabProps> = ({ projectData }) => {
+  const { getTab, updateForm } = useProjectSettingsContext();
+  const { formData } = getTab(tab);
+
+  const initialFormState = projectData;
+  usePopulateForm(initialFormState, tab);
+
+  const onChange = updateForm(tab);
+
+  const { fields, schema, uiSchema } = useMemo(() => getFormSchema(), []);
+
+  if (!formData) return null;
+
+  return (
+    <SpruceForm
+      fields={fields}
+      formData={formData}
+      onChange={onChange}
+      schema={schema}
+      uiSchema={uiSchema}
+    />
+  );
+};

--- a/src/pages/projectSettings/tabs/ViewsAndFiltersTab/getFormSchema.ts
+++ b/src/pages/projectSettings/tabs/ViewsAndFiltersTab/getFormSchema.ts
@@ -1,0 +1,27 @@
+import { CardFieldTemplate } from "components/SpruceForm/FieldTemplates";
+import { GetFormSchema } from "../types";
+
+export const getFormSchema = (): ReturnType<GetFormSchema> => ({
+  fields: {},
+  schema: {
+    type: "object" as "object",
+    properties: {
+      projectHealthView: {
+        title: "Project Health View",
+        type: "object" as "object",
+      },
+      parsleyFilters: {
+        title: "Parsley Filters",
+        type: "object" as "object",
+      },
+    },
+  },
+  uiSchema: {
+    projectHealthView: {
+      "ui:ObjectFieldTemplate": CardFieldTemplate,
+    },
+    parsleyFilters: {
+      "ui:ObjectFieldTemplate": CardFieldTemplate,
+    },
+  },
+});

--- a/src/pages/projectSettings/tabs/ViewsAndFiltersTab/transformers.ts
+++ b/src/pages/projectSettings/tabs/ViewsAndFiltersTab/transformers.ts
@@ -1,16 +1,23 @@
 import { ProjectSettingsTabRoutes } from "constants/routes";
+import { ProjectSettingsQuery } from "gql/generated/types";
 import { FormToGqlFunction, GqlToFormFunction } from "../types";
+import { FormState } from "./types";
 
 type Tab = ProjectSettingsTabRoutes.ViewsAndFilters;
 
-export const gqlToForm = ((data) => {
+export const gqlToForm: GqlToFormFunction<Tab> = (
+  data: ProjectSettingsQuery["projectSettings"]
+) => {
   if (!data) return null;
 
   return {};
-}) satisfies GqlToFormFunction<Tab>;
+};
 
-export const formToGql = ((_formState, id) => ({
+export const formToGql: FormToGqlFunction<Tab> = (
+  _formState: FormState,
+  id: string
+) => ({
   projectRef: {
     id,
   },
-})) satisfies FormToGqlFunction<Tab>;
+});

--- a/src/pages/projectSettings/tabs/ViewsAndFiltersTab/transformers.ts
+++ b/src/pages/projectSettings/tabs/ViewsAndFiltersTab/transformers.ts
@@ -1,0 +1,23 @@
+import { ProjectSettingsTabRoutes } from "constants/routes";
+import { ProjectSettingsQuery } from "gql/generated/types";
+import { FormToGqlFunction, GqlToFormFunction } from "../types";
+import { FormState } from "./types";
+
+type Tab = ProjectSettingsTabRoutes.ViewsAndFilters;
+
+export const gqlToForm: GqlToFormFunction<Tab> = (
+  data: ProjectSettingsQuery["projectSettings"]
+) => {
+  if (!data) return null;
+
+  return {};
+};
+
+export const formToGql: FormToGqlFunction<Tab> = (
+  _formState: FormState,
+  id: string
+) => ({
+  projectRef: {
+    id,
+  },
+});

--- a/src/pages/projectSettings/tabs/ViewsAndFiltersTab/transformers.ts
+++ b/src/pages/projectSettings/tabs/ViewsAndFiltersTab/transformers.ts
@@ -1,23 +1,16 @@
 import { ProjectSettingsTabRoutes } from "constants/routes";
-import { ProjectSettingsQuery } from "gql/generated/types";
 import { FormToGqlFunction, GqlToFormFunction } from "../types";
-import { FormState } from "./types";
 
 type Tab = ProjectSettingsTabRoutes.ViewsAndFilters;
 
-export const gqlToForm: GqlToFormFunction<Tab> = (
-  data: ProjectSettingsQuery["projectSettings"]
-) => {
+export const gqlToForm = ((data) => {
   if (!data) return null;
 
   return {};
-};
+}) satisfies GqlToFormFunction<Tab>;
 
-export const formToGql: FormToGqlFunction<Tab> = (
-  _formState: FormState,
-  id: string
-) => ({
+export const formToGql = ((_formState, id) => ({
   projectRef: {
     id,
   },
-});
+})) satisfies FormToGqlFunction<Tab>;

--- a/src/pages/projectSettings/tabs/ViewsAndFiltersTab/types.ts
+++ b/src/pages/projectSettings/tabs/ViewsAndFiltersTab/types.ts
@@ -1,0 +1,10 @@
+import { ProjectType } from "../utils";
+
+export interface FormState {}
+
+export type TabProps = {
+  identifier: string;
+  projectData?: FormState;
+  projectType: ProjectType;
+  repoData?: FormState;
+};

--- a/src/pages/projectSettings/tabs/ViewsAndFiltersTab/types.ts
+++ b/src/pages/projectSettings/tabs/ViewsAndFiltersTab/types.ts
@@ -6,5 +6,4 @@ export type TabProps = {
   identifier: string;
   projectData?: FormState;
   projectType: ProjectType;
-  repoData?: FormState;
 };

--- a/src/pages/projectSettings/tabs/index.tsx
+++ b/src/pages/projectSettings/tabs/index.tsx
@@ -1,11 +1,13 @@
 export { AccessTab } from "./AccessTab/AccessTab";
+export { ContainersTab } from "./ContainersTab/ContainersTab";
 export { EventLogTab } from "./EventLogTab/EventLogTab";
 export { GeneralTab } from "./GeneralTab/GeneralTab";
 export { GithubCommitQueueTab } from "./GithubCommitQueueTab/GithubCommitQueueTab";
 export { NotificationsTab } from "./NotificationsTab/NotificationsTab";
 export { PatchAliasesTab } from "./PatchAliasesTab/PatchAliasesTab";
 export { PeriodicBuildsTab } from "./PeriodicBuildsTab/PeriodicBuildsTab";
+export { PluginsTab } from "./PluginsTab/PluginsTab";
 export { ProjectTriggersTab } from "./ProjectTriggersTab/ProjectTriggersTab";
 export { VariablesTab } from "./VariablesTab/VariablesTab";
+export { ViewsAndFiltersTab } from "./ViewsAndFiltersTab/ViewsAndFiltersTab";
 export { VirtualWorkstationTab } from "./VirtualWorkstationTab/VirtualWorkstationTab";
-export { PluginsTab } from "./PluginsTab/PluginsTab";

--- a/src/pages/projectSettings/tabs/transformers.ts
+++ b/src/pages/projectSettings/tabs/transformers.ts
@@ -14,6 +14,7 @@ import {
   WritableTabRoutes,
 } from "./types";
 import * as variables from "./VariablesTab/transformers";
+import * as viewsAndFilters from "./ViewsAndFiltersTab/transformers";
 import * as virtualWorkstation from "./VirtualWorkstationTab/transformers";
 
 export const gqlToFormMap: {
@@ -30,6 +31,7 @@ export const gqlToFormMap: {
   [ProjectSettingsTabRoutes.ProjectTriggers]: projectTriggers.gqlToForm,
   [ProjectSettingsTabRoutes.PeriodicBuilds]: periodicBuilds.gqlToForm,
   [ProjectSettingsTabRoutes.Containers]: containers.gqlToForm,
+  [ProjectSettingsTabRoutes.ViewsAndFilters]: viewsAndFilters.gqlToForm,
 };
 
 export const formToGqlMap: {
@@ -46,4 +48,5 @@ export const formToGqlMap: {
   [ProjectSettingsTabRoutes.ProjectTriggers]: projectTriggers.formToGql,
   [ProjectSettingsTabRoutes.PeriodicBuilds]: periodicBuilds.formToGql,
   [ProjectSettingsTabRoutes.Containers]: containers.formToGql,
+  [ProjectSettingsTabRoutes.ViewsAndFilters]: viewsAndFilters.formToGql,
 };

--- a/src/pages/projectSettings/tabs/types.ts
+++ b/src/pages/projectSettings/tabs/types.ts
@@ -17,6 +17,7 @@ import * as plugins from "./PluginsTab/types";
 import * as projectTriggers from "./ProjectTriggersTab/types";
 import { ProjectType } from "./utils";
 import * as variables from "./VariablesTab/types";
+import * as viewsAndFilters from "./ViewsAndFiltersTab/types";
 import * as virtualWorkstation from "./VirtualWorkstationTab/types";
 
 export type FormStateMap = {
@@ -31,6 +32,7 @@ export type FormStateMap = {
   [ProjectSettingsTabRoutes.ProjectTriggers]: projectTriggers.FormState;
   [ProjectSettingsTabRoutes.PeriodicBuilds]: periodicBuilds.FormState;
   [ProjectSettingsTabRoutes.Containers]: containers.FormState;
+  [ProjectSettingsTabRoutes.ViewsAndFilters]: viewsAndFilters.FormState;
 };
 
 export type GetFormSchema = (...any) => {

--- a/src/pages/projectSettings/tabs/types.ts
+++ b/src/pages/projectSettings/tabs/types.ts
@@ -65,3 +65,7 @@ export const readOnlyTabs = [ProjectSettingsTabRoutes.EventLog] as const;
 type ReadOnlyTabs = (typeof readOnlyTabs)[number];
 
 export type WritableTabRoutes = Exclude<ProjectSettingsTabRoutes, ReadOnlyTabs>;
+
+export const projectOnlyTabs: Set<ProjectSettingsTabRoutes> = new Set([
+  ProjectSettingsTabRoutes.ViewsAndFilters,
+]);


### PR DESCRIPTION
EVG-19883

### Description
This PR creates an outline for the new Views & Filters tab. This is just a basic skeleton to unblock [EVG-19891](https://jira.mongodb.org/browse/EVG-19891) and [EVG-19892](https://jira.mongodb.org/browse/EVG-19892).

Since Views & Filters settings are not available at the repo level, I made it so that the tab does not show up on repos and the "Go to repo settings" link does not appear. (Also if you want the tabs in a different order let me know 🙏)

### Screenshots
<img width="1119" alt="Screenshot 2023-05-26 at 9 26 37 AM" src="https://github.com/evergreen-ci/spruce/assets/47064971/cb56c219-936c-4556-b264-b4350bf6ee18">

