### PR TITLE
EVG-20039 Rename patch status to task status

### DIFF
--- a/cypress/integration/version/restart_modal.ts
+++ b/cypress/integration/version/restart_modal.ts
@@ -37,7 +37,7 @@ describe("Restarting a patch", { testIsolation: false }, () => {
     cy.dataCy("task-status-badge").should("contain.text", "1 of 1 Selected");
   });
 
-  it("Selecting on the patch status filter should toggle the tasks that have matching statuses to it", () => {
+  it("Selecting on the task status filter should toggle the tasks that have matching statuses to it", () => {
     cy.dataCy("task-status-filter").click();
     cy.getInputByLabel("All").check({ force: true });
     cy.dataCy("task-status-filter").click();

--- a/src/components/TasksTable/__snapshots__/TasksTable.stories.storyshot
+++ b/src/components/TasksTable/__snapshots__/TasksTable.stories.storyshot
@@ -102,7 +102,7 @@ exports[`storybook Storyshots components/TasksTable Base Task Table 1`] = `
                         <span
                           class="ant-table-column-title"
                         >
-                          Patch Status
+                          Task Status
                         </span>
                         <span
                           class="ant-table-column-sorter ant-table-column-sorter-full"
@@ -571,7 +571,7 @@ exports[`storybook Storyshots components/TasksTable Execution Tasks Table 1`] = 
                         <span
                           class="ant-table-column-title"
                         >
-                          Patch Status
+                          Task Status
                         </span>
                         <span
                           class="ant-table-column-sorter ant-table-column-sorter-full"
@@ -1137,7 +1137,7 @@ exports[`storybook Storyshots components/TasksTable Version Tasks Table 1`] = `
                         <span
                           class="ant-table-column-title"
                         >
-                          Version Status
+                          Task Status
                         </span>
                         <span
                           class="ant-table-column-sorter ant-table-column-sorter-full"

--- a/src/components/TasksTable/index.tsx
+++ b/src/components/TasksTable/index.tsx
@@ -159,7 +159,7 @@ const getColumnDefs = ({
       })),
   },
   {
-    title: `${isPatch ? "Patch" : "Version"} Status`,
+    title: "Task Status",
     dataIndex: "status",
     key: TaskSortCategory.Status,
     onHeaderCell: () => ({

--- a/src/pages/task/taskTabs/__snapshots__/ExecutionTasksTable.stories.storyshot
+++ b/src/pages/task/taskTabs/__snapshots__/ExecutionTasksTable.stories.storyshot
@@ -103,7 +103,7 @@ exports[`storybook Storyshots Pages/Task/Table/Execution Tasks Table Multiple Ex
                         <span
                           class="ant-table-column-title"
                         >
-                          Patch Status
+                          Task Status
                         </span>
                         <span
                           class="ant-table-column-sorter ant-table-column-sorter-full"
@@ -510,7 +510,7 @@ exports[`storybook Storyshots Pages/Task/Table/Execution Tasks Table Single Exec
                         <span
                           class="ant-table-column-title"
                         >
-                          Patch Status
+                          Task Status
                         </span>
                         <span
                           class="ant-table-column-sorter ant-table-column-sorter-full"


### PR DESCRIPTION
EVG-20039 

### Description
@julianedwards  pointed out we use the labels `Patch/ Version Status` on the tasks table over a column that represents task statuses. This updates the verbiage to reflect that.
### Screenshots

![image](https://github.com/evergreen-ci/spruce/assets/4605522/d05a4f4a-b451-4d1c-9678-46748c575a8e)

