### PR TITLE
EVG-20065 migrate patch status to success

### DIFF
--- a/src/components/PatchStatusBadge.tsx
+++ b/src/components/PatchStatusBadge.tsx
@@ -17,6 +17,7 @@ const statusToBadgeVariant = {
   [PatchStatus.Failed]: Variant.Red,
   [PatchStatus.Started]: Variant.Yellow,
   [PatchStatus.Success]: Variant.Green,
+  [PatchStatus.LegacySuccess]: Variant.Green,
   [PatchStatus.Aborted]: Variant.LightGray,
 };
 
@@ -26,5 +27,6 @@ const patchStatusToCopy = {
   [PatchStatus.Failed]: "Failed",
   [PatchStatus.Started]: "Running",
   [PatchStatus.Success]: "Succeeded",
+  [PatchStatus.LegacySuccess]: "Succeeded",
   [PatchStatus.Aborted]: "Aborted",
 };

--- a/src/components/PatchesPage/StatusSelector.tsx
+++ b/src/components/PatchesPage/StatusSelector.tsx
@@ -36,6 +36,7 @@ const statusValToCopy = {
   [PatchStatus.Created]: "Created/Unconfigured",
   [PatchStatus.Failed]: "Failed",
   [PatchStatus.Started]: "Running",
+  [PatchStatus.LegacySuccess]: "Succeeded",
   [PatchStatus.Success]: "Succeeded",
 };
 

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -1285,6 +1285,7 @@ export type ProjectPatchesArgs = {
 export type ProjectAlias = {
   __typename?: "ProjectAlias";
   alias: Scalars["String"];
+  description?: Maybe<Scalars["String"]>;
   gitTag: Scalars["String"];
   id: Scalars["String"];
   remotePath: Scalars["String"];
@@ -1296,6 +1297,7 @@ export type ProjectAlias = {
 
 export type ProjectAliasInput = {
   alias: Scalars["String"];
+  description?: InputMaybe<Scalars["String"]>;
   gitTag: Scalars["String"];
   id: Scalars["String"];
   remotePath: Scalars["String"];

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -1353,8 +1353,8 @@ export type ProjectEvents = {
 };
 
 export enum ProjectHealthView {
-  ProjectHealthViewAll = "PROJECT_HEALTH_VIEW_ALL",
-  ProjectHealthViewFailed = "PROJECT_HEALTH_VIEW_FAILED",
+  All = "ALL",
+  Failed = "FAILED",
 }
 
 export type ProjectInput = {

--- a/src/pages/projectSettings/tabs/GithubCommitQueueTab/getFormSchema.tsx
+++ b/src/pages/projectSettings/tabs/GithubCommitQueueTab/getFormSchema.tsx
@@ -39,7 +39,6 @@ export const getFormSchema = (
         : "hidden",
     "ui:showLabel": false,
   };
-
   const errorStyling = sectionHasError(versionControlEnabled, projectType);
 
   return {

--- a/src/pages/projectSettings/tabs/PatchAliasesTab/PatchAliasesTab.tsx
+++ b/src/pages/projectSettings/tabs/PatchAliasesTab/PatchAliasesTab.tsx
@@ -5,12 +5,36 @@ import {
   usePopulateForm,
   useProjectSettingsContext,
 } from "pages/projectSettings/Context";
+import { PatchStatus } from "../../../../types/patch";
 import { getFormSchema } from "./getFormSchema";
 import { TabProps } from "./types";
 
 const tab = ProjectSettingsTabRoutes.PatchAliases;
 
 const getInitialFormState = (projectData, repoData) => {
+  // Resolve legacy status value -- will remove after successful deploy
+  if (projectData) {
+    for (let i = 0; i < projectData.patchTriggerAliases.aliases.length; i++) {
+      if (
+        projectData.patchTriggerAliases.aliases[i].status ===
+        PatchStatus.LegacySuccess
+      ) {
+        // eslint-disable-next-line no-param-reassign
+        projectData.patchTriggerAliases.aliases[i].status = PatchStatus.Success;
+      }
+    }
+  }
+  if (repoData) {
+    for (let i = 0; i < repoData.patchTriggerAliases.aliases.length; i++) {
+      if (
+        repoData.patchTriggerAliases.aliases[i].status ===
+        PatchStatus.LegacySuccess
+      ) {
+        // eslint-disable-next-line no-param-reassign
+        repoData.patchTriggerAliases.aliases[i].status = PatchStatus.Success;
+      }
+    }
+  }
   if (!projectData) return repoData;
   if (repoData) {
     return {

--- a/src/pages/projectSettings/tabs/PatchAliasesTab/transformers.test.ts
+++ b/src/pages/projectSettings/tabs/PatchAliasesTab/transformers.test.ts
@@ -80,7 +80,7 @@ const repoForm: FormState = {
       {
         alias: "alias1",
         childProjectIdentifier: "spruce",
-        status: "succeeded",
+        status: "success",
         displayTitle: "alias1",
         parentAsModule: "",
         isGithubTriggerAlias: true,

--- a/src/pages/projectSettings/tabs/utils/types.ts
+++ b/src/pages/projectSettings/tabs/utils/types.ts
@@ -9,6 +9,6 @@ export enum ProjectType {
 
 export const PatchTriggerAliasStatus = {
   "*": "Any completed status",
-  succeeded: "Success",
+  success: "Success",
   failed: "Failure",
 } as const;

--- a/src/types/patch.ts
+++ b/src/types/patch.ts
@@ -11,7 +11,8 @@ export enum PatchStatus {
   Created = "created",
   Failed = "failed",
   Started = "started",
-  Success = "succeeded",
+  LegacySuccess = "succeeded",
+  Success = "success",
   Aborted = "aborted",
 }
 


### PR DESCRIPTION
EVG-20065
### Description
Attempting to migrate "succeeded" to "success" (re https://github.com/evergreen-ci/evergreen/pull/6567/files).

This needs to be handled for patch statuses, and for patch trigger alias statuses. For the latter I'm converting "succeeded" to "success" in BuildFromService so theoretically if these were deployed together we wouldn't need to support the legacy status, but ideally we could write this so we know how to support both. I'm also certainly not sure if I have found all cases of this.

Lowkey would love to take on this work even though I don't know what I'm doing to get some ⭐ exposure ⭐ so if it seems like conversation here would benefit from a pair program I would definitely be down. 

Will test with staging but eyes before that would probably be helpful to verify how off I am.