### PR TITLE
EVG-19628: Prohibit JIRA comments when task finishes

### DIFF
--- a/cypress/integration/projectSettings/project_settings.ts
+++ b/cypress/integration/projectSettings/project_settings.ts
@@ -1058,9 +1058,9 @@ describe("Notifications", { testIsolation: false }, () => {
     cy.selectLGOption("Event", "Any Task Finishes");
     cy.selectLGOption("Notification Method", "Comment on a JIRA issue");
     cy.getInputByLabel("JIRA Issue").type("JIRA-123");
-    cy.contains(
-      "JIRA comment subscription not allowed for tasks in a project"
-    ).should("exist");
+    cy.contains("Subscription type not allowed for tasks in a project.").should(
+      "exist"
+    );
     cy.dataCy("save-settings-button").scrollIntoView();
     saveButtonEnabled(false);
   });

--- a/src/constants/triggers.ts
+++ b/src/constants/triggers.ts
@@ -1,3 +1,4 @@
+import { NotificationMethods } from "types/subscription";
 import {
   ExtraField,
   ExtraFieldKey,
@@ -379,7 +380,15 @@ export const waterfallTriggers: Trigger = {
 };
 
 export const invalidProjectTriggerSubscriptionCombinations = {
-  "jira-comment": [
+  [NotificationMethods.JIRA_COMMENT]: [
+    ProjectTriggers.FIRST_FAILURE_TASK,
+    ProjectTriggers.ANY_TASK_FAILS,
+    ProjectTriggers.ANY_TASK_FINISHES,
+    ProjectTriggers.PREVIOUS_PASSING_TASK_FAILS,
+    ProjectTriggers.PREVIOUS_PASSING_TEST_FAILS,
+    ProjectTriggers.SUCCESSFUL_TASK_RUNTIME_CHANGES,
+  ],
+  [NotificationMethods.JIRA_ISSUE]: [
     ProjectTriggers.FIRST_FAILURE_TASK,
     ProjectTriggers.ANY_TASK_FAILS,
     ProjectTriggers.ANY_TASK_FINISHES,

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -1353,8 +1353,8 @@ export type ProjectEvents = {
 };
 
 export enum ProjectHealthView {
-  ProjectHealthViewAll = "PROJECT_HEALTH_VIEW_ALL",
-  ProjectHealthViewFailed = "PROJECT_HEALTH_VIEW_FAILED",
+  All = "ALL",
+  Failed = "FAILED",
 }
 
 export type ProjectInput = {

--- a/src/pages/projectSettings/tabs/NotificationsTab/NotificationsTab.tsx
+++ b/src/pages/projectSettings/tabs/NotificationsTab/NotificationsTab.tsx
@@ -50,8 +50,7 @@ export const NotificationsTab: React.VFC<TabProps> = ({
 const validate = ((formData, errors) => {
   const { subscriptions } = formData;
 
-  for (let i = 0; i < subscriptions.length; i++) {
-    const subscription = subscriptions[i];
+  subscriptions.forEach((subscription, i) => {
     const { subscriptionData } = subscription;
     const { event, notification } = subscriptionData;
     const { notificationSelect } = notification;
@@ -65,12 +64,12 @@ const validate = ((formData, errors) => {
             errors.subscriptions[
               i
             ].subscriptionData?.notification?.notificationSelect?.addError(
-              "JIRA comment subscription not allowed for tasks in a project"
+              "Subscription type not allowed for tasks in a project"
             );
           }
         }
       }
     );
-  }
+  });
   return errors;
 }) satisfies ValidateProps<FormState>;

--- a/src/pages/projectSettings/tabs/NotificationsTab/NotificationsTab.tsx
+++ b/src/pages/projectSettings/tabs/NotificationsTab/NotificationsTab.tsx
@@ -64,7 +64,7 @@ const validate = ((formData, errors) => {
             errors.subscriptions[
               i
             ].subscriptionData?.notification?.notificationSelect?.addError(
-              "Subscription type not allowed for tasks in a project"
+              "Subscription type not allowed for tasks in a project."
             );
           }
         }


### PR DESCRIPTION
EVG-19628

### Description
<!-- add description, context, thought process, etc -->
- We were already prohibiting JIRA comments when tasks finish/fail, just needed to add JIRA issue creation to our validator.

### Screenshots
<!-- add screenshots of visible changes -->
<img width="458" alt="image" src="https://github.com/evergreen-ci/spruce/assets/9298431/93bcde59-18b3-4a89-813d-e45ea3266d89">