### PR TITLE
EVG-19732: Fix flaky useBreadcrumbRoot test

### DIFF
--- a/src/gql/mocks/getUser.ts
+++ b/src/gql/mocks/getUser.ts
@@ -10,9 +10,10 @@ export const getUserMock: ApolloMock<UserQuery, UserQueryVariables> = {
   result: {
     data: {
       user: {
-        userId: "a",
-        displayName: "A",
-        emailAddress: "a@a.com",
+        __typename: "User",
+        userId: "admin",
+        displayName: "Evergreen Admin",
+        emailAddress: "admin@evergreen.com",
       },
     },
   },

--- a/src/hooks/useGetUserPatchesPageTitleAndLink.ts
+++ b/src/hooks/useGetUserPatchesPageTitleAndLink.ts
@@ -11,18 +11,19 @@ export const useGetUserPatchesPageTitleAndLink = (
     GET_OTHER_USER,
     { variables: { userId }, skip }
   );
-  const link = getUserPatchesRoute(userId);
 
   if (!data) {
     return null;
   }
 
-  const { currentUser } = data || {};
+  const { currentUser, otherUser } = data || {};
+  const link = getUserPatchesRoute(userId);
+
   if (userId === currentUser.userId) {
     return { link, title: "My Patches" };
   }
 
-  const otherUserDisplayName = data?.otherUser.displayName ?? "";
+  const otherUserDisplayName = otherUser.displayName ?? "";
   const possessiveModifier =
     otherUserDisplayName.slice(-1) === "s" ? "'" : "'s";
 


### PR DESCRIPTION
EVG-19732

### Description
This PR fixes the flaky `useBreadcrumbRoot` test. The test was having an issue dealing with the cache data, since the UserQuery's key field is `"userId"` rather than the default `"id"`. 

### Testing
- The original test failure can be replicated locally, so I just ran the changes 20 times and made sure it never failed
