### PR TITLE
EVG-20117: Unlink GitHub PR user

### DIFF
--- a/src/components/PatchesPage/PatchCard.tsx
+++ b/src/components/PatchesPage/PatchCard.tsx
@@ -4,6 +4,7 @@ import { Analytics } from "analytics/addPageAction";
 import { GroupedTaskStatusBadge } from "components/GroupedTaskStatusBadge";
 import { PatchStatusBadge } from "components/PatchStatusBadge";
 import { StyledRouterLink } from "components/styles";
+import { unlinkedPRUsers } from "constants/patch";
 import {
   getProjectPatchesRoute,
   getVersionRoute,
@@ -23,8 +24,6 @@ type P = Unpacked<PatchesPagePatchesFragment["patches"]>;
 type PatchProps = Omit<P, "commitQueuePosition">;
 
 const { gray } = palette;
-
-const unlinkedPRUsers = new Set(["github_pull_request", "parent_patch"]);
 
 interface Props extends PatchProps {
   pageType: "project" | "user";

--- a/src/components/PatchesPage/PatchCard.tsx
+++ b/src/components/PatchesPage/PatchCard.tsx
@@ -24,7 +24,7 @@ type PatchProps = Omit<P, "commitQueuePosition">;
 
 const { gray } = palette;
 
-const githubPrUser = "github_pull_request";
+const unlinkedPRUsers = new Set(["github_pull_request", "parent_patch"]);
 
 interface Props extends PatchProps {
   pageType: "project" | "user";
@@ -64,17 +64,16 @@ export const PatchCard: React.VFC<Props> = ({
   const isUnconfigured = isPatchUnconfigured({ alias, activated });
   let patchProject = null;
   if (pageType === "project") {
-    patchProject =
-      author === githubPrUser ? (
-        authorDisplayName
-      ) : (
-        <StyledRouterLink
-          to={getUserPatchesRoute(author)}
-          data-cy="user-patches-link"
-        >
-          <strong>{authorDisplayName}</strong>
-        </StyledRouterLink>
-      );
+    patchProject = unlinkedPRUsers.has(author) ? (
+      authorDisplayName
+    ) : (
+      <StyledRouterLink
+        to={getUserPatchesRoute(author)}
+        data-cy="user-patches-link"
+      >
+        <strong>{authorDisplayName}</strong>
+      </StyledRouterLink>
+    );
   } else {
     patchProject = projectIdentifier ? (
       <StyledRouterLink

--- a/src/components/PatchesPage/PatchCard.tsx
+++ b/src/components/PatchesPage/PatchCard.tsx
@@ -21,7 +21,10 @@ import { DropdownMenu } from "./patchCard/DropdownMenu";
 
 type P = Unpacked<PatchesPagePatchesFragment["patches"]>;
 type PatchProps = Omit<P, "commitQueuePosition">;
+
 const { gray } = palette;
+
+const githubPrUser = "github_pull_request";
 
 interface Props extends PatchProps {
   pageType: "project" | "user";
@@ -61,14 +64,17 @@ export const PatchCard: React.VFC<Props> = ({
   const isUnconfigured = isPatchUnconfigured({ alias, activated });
   let patchProject = null;
   if (pageType === "project") {
-    patchProject = (
-      <StyledRouterLink
-        to={getUserPatchesRoute(author)}
-        data-cy="user-patches-link"
-      >
-        <strong>{authorDisplayName}</strong>
-      </StyledRouterLink>
-    );
+    patchProject =
+      author === githubPrUser ? (
+        authorDisplayName
+      ) : (
+        <StyledRouterLink
+          to={getUserPatchesRoute(author)}
+          data-cy="user-patches-link"
+        >
+          <strong>{authorDisplayName}</strong>
+        </StyledRouterLink>
+      );
   } else {
     patchProject = projectIdentifier ? (
       <StyledRouterLink

--- a/src/constants/patch.ts
+++ b/src/constants/patch.ts
@@ -1,2 +1,3 @@
 export const commitQueueAlias = "__commit_queue";
 export const commitQueueRequester = "merge_test";
+export const unlinkedPRUsers = new Set(["github_pull_request", "parent_patch"]);


### PR DESCRIPTION
EVG-20117

### Description
<!-- add description, context, thought process, etc -->
- Unlink github_pull_request as a user in the project patches page. Querying its patches takes a long time and they are not very useful. I also threw in parent_patch since it is similarly useless. The pages can still be accessed directly if so desired.

### Screenshots
<!-- add screenshots of visible changes -->
<img width="642" alt="image" src="https://github.com/evergreen-ci/spruce/assets/9298431/8346cd45-4ea1-4e33-8694-d22876e25ef4">