### PR TITLE
EVG-20049 Add eslint-jsdoc plugin and fix errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,8 +25,8 @@ module.exports = {
     "airbnb",
     // Airbnb includes some helpful rules for ESLint and React that aren't covered by recommended.
     // See https://github.com/airbnb/javascript/tree/master/packages for specific rules.
-    "plugin:prettier/recommended", // Note: prettier must ALWAYS be the last extension.
     "plugin:jsdoc/recommended-typescript-error",
+    "plugin:prettier/recommended", // Note: prettier must ALWAYS be the last extension.
   ],
   ignorePatterns: ["!.storybook"],
   plugins: ["@typescript-eslint"],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,6 +26,7 @@ module.exports = {
     // Airbnb includes some helpful rules for ESLint and React that aren't covered by recommended.
     // See https://github.com/airbnb/javascript/tree/master/packages for specific rules.
     "plugin:prettier/recommended", // Note: prettier must ALWAYS be the last extension.
+    "plugin:jsdoc/recommended-typescript-error",
   ],
   ignorePatterns: ["!.storybook"],
   plugins: ["@typescript-eslint"],

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -33,7 +33,9 @@ Cypress.Commands.add(
   }
 );
 
-/* enterLoginCredentials */
+/**
+ * `enterLoginCredentials` is a custom command to enter login credentials
+ */
 function enterLoginCredentials() {
   cy.get("input[name=username]").type(user.username);
   cy.get("input[name=password]").type(user.password);

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -88,9 +88,7 @@ declare global {
       /**
        * Custom command to open an antd table filter associated with the
        * the supplied column number
-       *
-       * @param columnNumber The order in which the target
-       * column exists in the table starting at 1
+       * @param columnNumber - The order in which the target column exists in the table starting at 1
        * @example cy.toggleTableFilter(1)
        */
       toggleTableFilter(columnNumber: number): void;

--- a/package.json
+++ b/package.json
@@ -178,6 +178,7 @@
     "eslint-plugin-cypress": "^2.12.1",
     "eslint-plugin-import": "2.26.0",
     "eslint-plugin-jest": "27.2.1",
+    "eslint-plugin-jsdoc": "^46.2.6",
     "eslint-plugin-jsx-a11y": "6.6.0",
     "eslint-plugin-prettier": "4.2.1",
     "eslint-plugin-react": "7.30.1",

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -82,8 +82,9 @@ interface DropdownWithRefProps
 interface DropdownWithRefState {
   isOpen: boolean;
 }
-/** DropdownWithRef is a class component that allows the implementer
- *  to control its internal state methods with a ref in order to trigger state updates */
+/**
+ * DropdownWithRef is a class component that allows the implementer to control its internal state methods with a ref in order to trigger state updates
+ */
 class DropdownWithRef extends Component<
   DropdownWithRefProps,
   DropdownWithRefState

--- a/src/components/EditableTagField/tagRowReducer.ts
+++ b/src/components/EditableTagField/tagRowReducer.ts
@@ -26,7 +26,8 @@ export const getInitialState = (tag: Tag, isNewTag: boolean) => ({
   isInputValid: true,
   shouldShowNewTag: !isNewTag,
 });
-export function reducer(state: State, action: Action) {
+
+export const reducer = (state: State, action: Action) => {
   switch (action.type) {
     case "newTag":
       return {
@@ -55,4 +56,4 @@ export function reducer(state: State, action: Action) {
     default:
       throw new Error("Unknown action type");
   }
-}
+};

--- a/src/components/FilterBadges/useFilterBadgeQueryParams.ts
+++ b/src/components/FilterBadges/useFilterBadgeQueryParams.ts
@@ -8,6 +8,11 @@ const { parseQueryString } = queryString;
 
 /**
  * useFilterBadgeQueryParams is used alongside the FilterBadges component to tie its state to query params
+ * @param validQueryParams - a set of valid query params that the FilterBadges component can use
+ * @returns - an object with the following properties:
+ * `queryParamsList` - a list of badges that are currently in the query params
+ * `handleClearAll` - a function that clears all badges from the query params
+ * `handleOnRemove` - a function that removes a badge from the query params
  */
 const useFilterBadgeQueryParams = (validQueryParams: Set<string>) => {
   const updateQueryParams = useUpdateURLQueryParams();

--- a/src/components/HistoryTable/hooks/useTestResults.test.tsx
+++ b/src/components/HistoryTable/hooks/useTestResults.test.tsx
@@ -187,7 +187,7 @@ type UseMergedTestHookType = (args: Parameters<typeof useTestResults>[0]) => {
   historyTable: ReturnType<typeof useHistoryTable>;
 };
 /**
- * useMergedTestHook combines the useTestResults and useHistoryTable hooks together
+ * `useMergedTestHook` combines the useTestResults and useHistoryTable hooks together
  * and combines them into a shared hook which can be rendered under the same wrapper context
  * and can be used together
  * @param rowIndex - the row index to use for the useTestResults hook

--- a/src/components/HistoryTable/hooks/useTestResults.test.tsx
+++ b/src/components/HistoryTable/hooks/useTestResults.test.tsx
@@ -186,11 +186,17 @@ type UseMergedTestHookType = (args: Parameters<typeof useTestResults>[0]) => {
   hookResponse: ReturnType<typeof useTestResults>;
   historyTable: ReturnType<typeof useHistoryTable>;
 };
-/** useMergedTestHook combines the useTestResults and useHistoryTable hooks together
+/**
+ * useMergedTestHook combines the useTestResults and useHistoryTable hooks together
  * and combines them into a shared hook which can be rendered under the same wrapper context
- * and can be used together */
-const useMergedTestHook: UseMergedTestHookType = (args) => {
-  const hookResponse = useTestResults(args);
+ * and can be used together
+ * @param rowIndex - the row index to use for the useTestResults hook
+ * @returns - the merged hooks
+ * - hookResponse - the useTestResults hook
+ * - historyTable - the useHistoryTable hook
+ */
+const useMergedTestHook: UseMergedTestHookType = (rowIndex) => {
+  const hookResponse = useTestResults(rowIndex);
   const historyTable = useHistoryTable();
 
   return {

--- a/src/components/HistoryTable/hooks/useTestResults.ts
+++ b/src/components/HistoryTable/hooks/useTestResults.ts
@@ -12,8 +12,12 @@ import { rowType } from "../types";
 
 const { convertArrayToObject } = array;
 
-/** useTestResults is a hook that given an index checks if a commit has been loaded and has test filters applied and then fetches the test results for the given tasks  */
-const useTestResults = (index: number) => {
+/**
+ * useTestResults is a hook that given an index checks if a commit has been loaded and has test filters applied and then fetches the test results for the given tasks
+ * @param rowIndex - the index of the row in the history table
+ * @returns getTaskMetadata - a function that given a task id returns the test results for that task
+ */
+const useTestResults = (rowIndex: number) => {
   const { getItem, historyTableFilters } = useHistoryTable();
   let taskIds: string[] = [];
   const hasTestFilters = historyTableFilters.length > 0;
@@ -21,7 +25,7 @@ const useTestResults = (index: number) => {
     [taskId: string]: TaskTestResultSample;
   }>({});
 
-  const commit = getItem(index);
+  const commit = getItem(rowIndex);
   if (commit && commit.type === rowType.COMMIT && commit.commit) {
     taskIds = commit.commit.buildVariants.flatMap((buildVariant) =>
       buildVariant.tasks.map((task) => task.id)

--- a/src/components/Notifications/form/event.ts
+++ b/src/components/Notifications/form/event.ts
@@ -115,11 +115,11 @@ const regexSelector = (
 
 /**
  * getEventSchema returns the schema and uiSchema for the event section of subscriptions.
- *
  * @param regexEnumsToDisable - enums that should not be selectable in the regex selector. Only allow one of each
  * (build-variant, display-name) to be selected
  * @param triggers - an object containing information about available triggers. The available triggers differ between task,
  * version, and project subscriptions
+ * @returns schema and uiSchema for the event section of subscriptions
  */
 export const getEventSchema = (
   regexEnumsToDisable: string[],

--- a/src/components/Notifications/form/notification.ts
+++ b/src/components/Notifications/form/notification.ts
@@ -7,9 +7,9 @@ import {
 
 /**
  * getNotificationSchema returns the schema and uiSchema for the notification section of subscriptions.
- *
  * @param subscriptionMethods - an object containing information about available subscription methods. The available
  * subscription methods differ between task/version and project subscriptions.
+ * @returns - an object containing the schema and uiSchema for the notification section of subscriptions.
  */
 export const getNotificationSchema = (
   subscriptionMethods: SubscriptionMethodOption[]

--- a/src/components/PageSizeSelector/index.tsx
+++ b/src/components/PageSizeSelector/index.tsx
@@ -12,6 +12,10 @@ interface Props {
 /**
  * `data-*` props are not currently supported by @leafygreen-ui/select
  *  https://jira.mongodb.org/browse/EVG-16932
+ * @param props - React props passed to the component
+ * @param props.value - The current page size
+ * @param props.onChange - Callback to be called when the page size is changed
+ * @returns The PageSizeSelector component
  */
 const PageSizeSelector: React.VFC<Props> = ({ value, onChange, ...rest }) => (
   <StyledSelect

--- a/src/components/PageSizeSelector/usePageSizeSelector.ts
+++ b/src/components/PageSizeSelector/usePageSizeSelector.ts
@@ -1,7 +1,10 @@
 import { RECENT_PAGE_SIZE_KEY } from "constants/index";
 import { useQueryParams } from "hooks/useQueryParam";
 
-/** usePageSizeSelector updates the page size query param and saves the page size to local storage */
+/**
+ * `usePageSizeSelector` updates the page size query param and saves the page size to local storage
+ * @returns - a function that updates the page size query param
+ */
 const usePageSizeSelector = () => {
   const [, setQueryParams] = useQueryParams();
   const setPageSize = (pageSize: number) => {

--- a/src/components/Pagination/index.tsx
+++ b/src/components/Pagination/index.tsx
@@ -15,11 +15,12 @@ interface Props {
 /**
  * Pagination component for navigating between pages of data
  * By default it will update the page query param in the URL
- *
- * @param currentPage - 0 indexed current page
- * @param onChange - optional callback for when the page changes (Will override the default behavior of updating the URL query param)
- * @param totalResults - total number of results
- * @param pageSize - maximum number of results per page
+ * @param props - React props passed to the component
+ * @param props.currentPage - the current page
+ * @param props.onChange - optional callback for when the page changes (Will override the default behavior of updating the URL query param)
+ * @param props.totalResults - total number of results
+ * @param props.pageSize - maximum number of results per page
+ * @returns The Pagination component
  */
 const Pagination: React.VFC<Props> = ({
   currentPage,

--- a/src/components/SpruceForm/FieldTemplates/ArrayFieldTemplates/index.tsx
+++ b/src/components/SpruceForm/FieldTemplates/ArrayFieldTemplates/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsdoc/valid-types */
 import styled from "@emotion/styled";
 import Button from "@leafygreen-ui/button";
 import ExpandableCard from "@leafygreen-ui/expandable-card";
@@ -111,6 +112,21 @@ const ArrayItemRow = styled.div<{ border: boolean; index: number }>`
 
 /**
  * `ArrayFieldTemplate` is a custom field template for arrays that renders an array of fields.
+ * @param props ArrayFieldTemplateProps
+ * @param props.canAdd - Whether or not the user can add new items to the array.
+ * @param props.DescriptionField - A custom field for rendering the array's description.
+ * @param props.disabled - Whether or not the field is disabled.
+ * @param props.formData - The form's data.
+ * @param props.idSchema - The field's ID schema.
+ * @param props.items - An array of items to render.
+ * @param props.onAddClick - A callback function for when the user clicks the add button.
+ * @param props.readonly - Whether or not the field is readonly. // jsdoc/valid-types is disabled for this file due to // https://github.com/jsdoc-type-pratt-parser/jsdoc-type-pratt-parser/issues/104
+ * @param props.required - Whether or not the field is required.
+ * @param props.schema - The field's schema.
+ * @param props.title - The field's title.
+ * @param props.TitleField - A custom field for rendering the array's title.
+ * @param props.uiSchema - The field's UI schema.
+ * @returns JSX.Element
  */
 export const ArrayFieldTemplate: React.VFC<ArrayFieldTemplateProps> = ({
   canAdd,

--- a/src/components/SpruceForm/FieldTemplates/ObjectFieldTemplates/index.tsx
+++ b/src/components/SpruceForm/FieldTemplates/ObjectFieldTemplates/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsdoc/valid-types */
 import styled from "@emotion/styled";
 import Banner from "@leafygreen-ui/banner";
 import { Subtitle } from "@leafygreen-ui/typography";
@@ -51,6 +52,17 @@ export const ObjectFieldTemplate = ({
 
 /**
  * `CardFieldTemplate` is a custom ObjectFieldTemplate that renders a card with a title and a list of properties.
+ * @param props - ObjectFieldTemplateProps
+ * @param props.DescriptionField - DescriptionField
+ * @param props.idSchema - idSchema
+ * @param props.properties - properties
+ * @param props.schema - schema
+ * @param props.title - title
+ * @param props.uiSchema - uiSchema
+ * @param props.uiSchema."ui:data-cy" - data-cy
+ * @param props.uiSchema."ui:description" - description
+ * @param props.uiSchema."ui:title" - title
+ * @returns JSX.Element
  */
 export const CardFieldTemplate: React.VFC<ObjectFieldTemplateProps> = ({
   DescriptionField,
@@ -86,6 +98,14 @@ export const CardFieldTemplate: React.VFC<ObjectFieldTemplateProps> = ({
 
 /**
  * `AccordionFieldTemplate` is a custom ObjectFieldTemplate that renders an accordion with a title and a list of properties.
+ * @param props - ObjectFieldTemplateProps
+ * @param props.disabled - disabled
+ * @param props.idSchema - idSchema
+ * @param props.properties - properties
+ * @param props.title - title
+ * @param props.uiSchema - uiSchema
+ * @param props.readonly - readonly property // jsdoc/valid-types is disabled for this file due to // https://github.com/jsdoc-type-pratt-parser/jsdoc-type-pratt-parser/issues/104
+ * @returns JSX.Element
  */
 export const AccordionFieldTemplate: React.VFC<ObjectFieldTemplateProps> = ({
   disabled,
@@ -116,6 +136,11 @@ export const AccordionFieldTemplate: React.VFC<ObjectFieldTemplateProps> = ({
 
 /**
  * `FieldRow` is a custom ObjectFieldTemplate that renders the fields in a row.
+ * @param props - ObjectFieldTemplateProps
+ * @param props.formData - formData
+ * @param props.properties - properties
+ * @param props.uiSchema - uiSchema
+ * @returns JSX.Element
  */
 export const FieldRow: React.VFC<
   Pick<ObjectFieldTemplateProps, "formData" | "properties" | "uiSchema">

--- a/src/components/SpruceForm/Widgets/utils.ts
+++ b/src/components/SpruceForm/Widgets/utils.ts
@@ -2,12 +2,13 @@ import { Errors } from "../errors";
 
 /**
  * Returns true if a given value is null or undefined.
+ * @param val - value to check
+ * @returns true if the value is null or undefined
  */
 export const isNullish = (val: any) => val === null || val === undefined;
 
 /**
  * Processes errors by removing "invisible" and duplicate errors.
- *
  * @param rawErrors - array of error messages
  * @returns an object containing:
  * - processed error messages array
@@ -22,14 +23,11 @@ export const processErrors = (
 };
 
 /**
- * "Invisible" errors are errors that we want to affect formState (e.g. preventing submission) but
- * not show visibly on the UI. This function filters out invisible errors so that they do not affect
- * the visual appearance of the form elements.
+ * "Invisible" errors are errors that we want to affect formState (e.g. preventing submission) but not show visibly on the UI. This function filters out invisible errors so that they do not affect the visual appearance of the form elements.
  *
  * Note that the reason we make use of "invisible" errors rather than overriding the error to be empty
  * is that empty errors do not work with the RJSF validate function. When JSON schema validation and
  * custom validation errors are merged internally in RJSF, empty error messages get ignored.
- *
  * @param errors - array of error messages
  * @returns error messages array with "invisible" errors removed
  */
@@ -38,9 +36,9 @@ const filterInvisibleErrors = (errors: string[]) =>
 
 /**
  * RJSF has a bug where errors can become duplicated when using oneOf dependencies.
+ *
  * (https://github.com/rjsf-team/react-jsonschema-form/issues/1590)
  * This function removes duplicate error messages so that they don't appear on the UI.
- *
  * @param errors - an array of error messages
  * @returns error messages array with duplicate errors removed
  */

--- a/src/components/TupleSelectWithRegexConditional/index.tsx
+++ b/src/components/TupleSelectWithRegexConditional/index.tsx
@@ -12,6 +12,10 @@ interface TupleSelectWithRegexConditionalProps
 
 /**
  * TupleSelectWithRegexConditional is a wrapper around TupleSelect that allows the user to toggle between regex and exact match
+ * @param props - TupleSelectWithRegexConditionalProps
+ * @param props.onSubmit - callback function that is called when the user submits a new input
+ * @param props.validator - function that is called to validate the value of the input
+ * @returns The TupleSelectWithRegexConditional component
  */
 const TupleSelectWithRegexConditional: React.VFC<
   TupleSelectWithRegexConditionalProps

--- a/src/components/VisibilityContainer/index.tsx
+++ b/src/components/VisibilityContainer/index.tsx
@@ -6,6 +6,9 @@ interface VisibilityContainerProps {
 }
 /**
  * `VisibilityContainer` is a component that will only render its children when it is visible in the viewport.
+ * @param props - VisibilityContainerProps
+ * @param props.children - The children to render when the component is visible
+ * @returns The VisibilityContainer component
  */
 const VisibilityContainer: React.VFC<VisibilityContainerProps> = ({
   children,

--- a/src/context/toast/__mocks__/index.tsx
+++ b/src/context/toast/__mocks__/index.tsx
@@ -4,23 +4,12 @@ const { useToastContext } = toast;
 type DispatchToast = ReturnType<typeof useToastContext>;
 
 /**
- * RenderFakeToastContext is a utility that takes a React Component which uses useToastContext and returns the
- * React Component with the context mocked out.
- *
+ * RenderFakeToastContext is a utility that takes a React Component which uses useToastContext and returns a
+ * React Component which renders the component with the context mocked out.
  * It is meant to be used for testing components that rely on the useToastContext hook. It also exposes some
  * methods to assert that the toast context was called with the correct parameters.
- *
- * @param {React.VFC} Component - A React Component which implements useToastContext
- * @returns {Object} response - An object with the following properties:
- * @returns {React.VFC} response.Component - A React Component which renders the component with the context mocked out
- * @returns {Object} response.dispatchToast - A series of jest.fn() methods which can be used to assert that the toast context was called with the correct parameters
- * @returns {Function} response.dispatchToast.success - A jest.fn() method which can be used to assert that the success toast context was called
- * @returns {Function} response.dispatchToast.error - A jest.fn() method which can be used to assert that the error toast context was called
- * @returns {Function} response.dispatchToast.info - A jest.fn() method which can be used to assert that the info toast context was called
- * @returns {Function} response.dispatchToast.warning - A jest.fn() method which can be used to assert that the warning toast context was called
- * @returns {Function} response.dispatchToast.hide - A jest.fn() method which can be used to assert that the hide toast context was called
- * @returns {React.VFC} response.HookWrapper - A React Component which wraps a hook and has the useToastContext mocked out but utilizes the same methods
- * @returns {Function} response.useToastContext - A jest.fn() method which can be used to assert that the useToastContext hook was called
+ * @param Component - A React Component which uses useToastContext
+ * @returns an object with the Component, the mocked useToastContext, and the dispatchToast methods
  */
 const RenderFakeToastContext = (Component?: React.ReactElement) => {
   const dispatchToast: DispatchToast = {

--- a/src/hooks/useFilterInputChangeHandler.ts
+++ b/src/hooks/useFilterInputChangeHandler.ts
@@ -9,8 +9,11 @@ const { parseQueryString } = queryString;
 
 /**
  * Filter input state management hook.
- * @param {FilterHookParams}
- * @return {FilterHookResult<string>}
+ * @param params - filter hook params
+ * @param params.urlParam - the url param to update
+ * @param params.resetPage - whether or not to reset the page to 0 when the input value changes
+ * @param params.sendAnalyticsEvent - callback to send analytics event when input value changes
+ * @returns - the filter input state and its state management functions
  */
 export const useFilterInputChangeHandler = ({
   urlParam,

--- a/src/hooks/useNetworkStatus.ts
+++ b/src/hooks/useNetworkStatus.ts
@@ -7,6 +7,7 @@ type useNetworkStatusType = {
 
 /**
  * This hook sets an eventListener to monitor if the browser is online or offline.
+ * @param sendAnalytics - whether or not to send an analytics event when the browser goes online
  * @returns boolean - true if online, false if offline
  */
 export const useNetworkStatus: useNetworkStatusType = (

--- a/src/hooks/useOnClickOutside.ts
+++ b/src/hooks/useOnClickOutside.ts
@@ -1,10 +1,18 @@
 import { useEffect } from "react";
-
+/**
+ * `useOnClickOutside` is a hook that executes a callback when a click is detected outside of the provided refs.
+ * @param refs - array of refs to check if the click is outside of
+ * @param cb - callback to execute when the click is outside of the refs
+ */
 export const useOnClickOutside = (
   refs: Array<React.RefObject<HTMLElement>>,
   cb: () => void
 ): void => {
   useEffect(() => {
+    /**
+     * This function checks if the click is outside of the provided refs.
+     * @param event - click event
+     */
     function handleClickOutside(event): void {
       const isNotFocused = refs.every(
         (ref) => ref.current && !ref.current.contains(event.target as Node)

--- a/src/hooks/usePageVisibility.ts
+++ b/src/hooks/usePageVisibility.ts
@@ -7,6 +7,7 @@ type usePageVisibilityType = {
 
 /**
  * This hook sets an eventListener to monitor if the tab is visible or hidden.
+ * @param sendAnalytics - whether or not to send an analytics event when the tab goes visible
  * @returns boolean - true if visible, false if hidden
  */
 export const usePageVisibility: usePageVisibilityType = (

--- a/src/hooks/usePolling.ts
+++ b/src/hooks/usePolling.ts
@@ -23,7 +23,7 @@ type usePollingType = {
  * This hook uses determines polling status based on browser status and page visibility.
  * Depending on these values, it calls start and stop polling functions supplied from an
  * Apollo useQuery hook.
- * @param props - Object containing the following:
+ * @param props  - Object containing the following:
  * @param props.stopPolling - Function from useQuery that is called when offline or not visible
  * @param props.refetch - Optional function from useQuery that can be used to refetch data.
  * @param props.shouldPollFaster - Optional boolean to enable increased poll rate.

--- a/src/hooks/usePolling.ts
+++ b/src/hooks/usePolling.ts
@@ -23,11 +23,12 @@ type usePollingType = {
  * This hook uses determines polling status based on browser status and page visibility.
  * Depending on these values, it calls start and stop polling functions supplied from an
  * Apollo useQuery hook.
- * @param startPolling - Function from useQuery that is called when online & visible
- * @param stopPolling - Function from useQuery that is called when offline or not visible
- * @param refetch - Optional function from useQuery that can be used to refetch data
- * @param shouldPollFaster - Optional boolean to enable increased poll rat.
- * @param initialPollingState - Optional boolean to indicate the initial polling state
+ * @param props - Object containing the following:
+ * @param props.stopPolling - Function from useQuery that is called when offline or not visible
+ * @param props.refetch - Optional function from useQuery that can be used to refetch data.
+ * @param props.shouldPollFaster - Optional boolean to enable increased poll rate.
+ * @param props.initialPollingState - Optional boolean to indicate the initial polling state.
+ * @param props.startPolling - Function from useQuery that is called when online and visible
  * @returns boolean - true if polling, false if not polling
  */
 export const usePolling: usePollingType = ({

--- a/src/hooks/useQueryParam/index.ts
+++ b/src/hooks/useQueryParam/index.ts
@@ -44,13 +44,13 @@ const useQueryParams = () => {
  * `queryParam` - the value of the query param
  * `setQueryParam` - a function that updates the query param
  * @example const [page, setPage] = useQueryParam("page", 0);
- * page === 0;
+ * console.log(page); // 0
  * setPage(1);
- * page === 1;
+ * console.log(page); // 1
  * @example const [search, setSearch] = useQueryParam("search", "word");
- * search === "word";
+ * console.log(search); // "word
  * setSearch("something else");
- * search === "something else";
+ * console.log(search); // "something else"
  */
 const useQueryParam = <T>(
   param: string,

--- a/src/hooks/useQueryParam/index.ts
+++ b/src/hooks/useQueryParam/index.ts
@@ -6,7 +6,15 @@ import {
   stringifyQueryAsValue as stringifyQuery,
 } from "utils/queryString";
 
-/** `useQueryParams` returns all of the query params passed into the url */
+/**
+ * `useQueryParams` returns all of the query params passed into the url and a function to update them.
+ * @example const [queryParams, setQueryParams] = useQueryParams();
+ *  const { page, limit } = queryParams;
+ *  setQueryParams({ page: "0", limit: "10" });
+ * @returns - an array with the following properties:
+ * `parsedQueryString` - an object with all of the query params passed into the url
+ * `setQueryString` - a function that updates the query params in the url
+ */
 const useQueryParams = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const setQueryString = useCallback(
@@ -30,6 +38,19 @@ const useQueryParams = () => {
  * `useQueryParam` allows you to interact with a query param in the same way you would use a useState hook.
  *  The first argument is the name of the query param. The second argument is the fallback value of the query param.
  *  `useQueryParam` will default to the second argument if the query param is not present in the url.
+ * @param param - the name of the query param
+ * @param defaultParam - the fallback value of the query param
+ * @returns - an array with the following properties:
+ * `queryParam` - the value of the query param
+ * `setQueryParam` - a function that updates the query param
+ * @example const [page, setPage] = useQueryParam("page", 0);
+ * page === 0;
+ * setPage(1);
+ * page === 1;
+ * @example const [search, setSearch] = useQueryParam("search", "word");
+ * search === "word";
+ * setSearch("something else");
+ * search === "something else";
  */
 const useQueryParam = <T>(
   param: string,

--- a/src/hooks/useResize/index.ts
+++ b/src/hooks/useResize/index.ts
@@ -6,6 +6,7 @@ type UseResizeOptions = {
 
 /**
  * `useResize` determines if the window is currently being resized or not.
+ * @param options - An optional object containing options for the hook.
  * @param options.onResize - An optional callback function that will be called during a resize event.
  * @returns a boolean indicating whether the window is being resized or not
  */

--- a/src/hooks/useStatusesFilter.ts
+++ b/src/hooks/useStatusesFilter.ts
@@ -7,8 +7,11 @@ import { queryString } from "utils";
 const { parseQueryString } = queryString;
 /**
  * Status filter state management hook.
- * @param {FilterHookParams}
- * @return {FilterHookResult<string[]>}
+ * @param props - filter hook params
+ * @param props.urlParam - the url param to update
+ * @param props.resetPage - whether or not to reset the page to 0 when the input value changes
+ * @param props.sendAnalyticsEvent - callback to send analytics event when input value changes
+ * @returns - the status filter state and its state management functions
  */
 export const useStatusesFilter = ({
   urlParam,
@@ -60,13 +63,12 @@ export const useStatusesFilter = ({
 };
 
 /**
- * @typedef   {Object} FilterHookResult - Provides filter input state and state management util functions
- * @template  {T}
- * @property  {T} inputValue - Represents input value
- * @property  {(newValue: T) => void} setAndSubmitInputValue - Sets input value and updates URL query param
- * @property  {(newValue: T) => void} setInputValue - Sets input value
- * @property  {() => void} submitInputValue - Updates URL query param with current input value
- * @property  {() => void} reset - Clears input value and URL query param
+ * FilterHookResult - Provides filter input state and state management util functions
+ * inputValue - Represents input value
+ * setAndSubmitInputValue - Sets input value and updates URL query param
+ * setInputValue - Sets input value
+ * submitInputValue - Updates URL query param with current input value
+ * reset - Clears input value and URL query param
  */
 export interface FilterHookResult<T> {
   inputValue: T;
@@ -77,10 +79,9 @@ export interface FilterHookResult<T> {
 }
 
 /**
- * @typedef {Object} FilterHookParams
- * @property {string} urlParam Represents URL query param name
- * @property {boolean} [resetPage] When true, page URL query paramter is set to 0 upon value submission
- * @property {(filterBy: string, filterValue?: string[]) => void} [sendAnalyticsEvent] A side effect executed upon value submission
+ * urlParam Represents URL query param name
+ * [resetPage] When true, page URL query paramter is set to 0 upon value submission
+ * [sendAnalyticsEvent] A side effect executed upon value submission
  */
 export interface FilterHookParams {
   urlParam: string;

--- a/src/hooks/useStatusesFilter.ts
+++ b/src/hooks/useStatusesFilter.ts
@@ -79,9 +79,9 @@ export interface FilterHookResult<T> {
 }
 
 /**
- * urlParam Represents URL query param name
- * [resetPage] When true, page URL query paramter is set to 0 upon value submission
- * [sendAnalyticsEvent] A side effect executed upon value submission
+ * urlParam - Represents URL query param name
+ * resetPage - When true, page URL query paramter is set to 0 upon value submission
+ * sendAnalyticsEvent - A side effect executed upon value submission
  */
 export interface FilterHookParams {
   urlParam: string;

--- a/src/pages/commits/ActiveCommits/ProjectHealth.stories.tsx
+++ b/src/pages/commits/ActiveCommits/ProjectHealth.stories.tsx
@@ -76,8 +76,9 @@ const RenderCommitsWrapper = ({
 
 /**
  * `generateBuildVariants` generates an array of build variants
- * @param count number of build variants to generate
- * @returns
+ * @param buildVariantCount - number of build variants to generate
+ * @param taskCount - number of tasks to generate per build variant
+ * @returns an array of build variants
  */
 const generateBuildVariants = (buildVariantCount: number, taskCount: number) =>
   new Array(buildVariantCount).fill(undefined).map((_, index) => ({
@@ -89,7 +90,7 @@ const generateBuildVariants = (buildVariantCount: number, taskCount: number) =>
 /**
  * `generateTasks` generates an array of tasks with random statuses
  * @param count number of tasks to generate
- * @returns
+ * @returns an array of tasks
  */
 const generateTasks = (count: number) =>
   Array(count)
@@ -104,8 +105,8 @@ const generateTasks = (count: number) =>
 
 /**
  * randomStatus returns a random status from the TaskStatus enum in a round robin fashion
- * @param index
- * @returns
+ * @param index - the index of the task
+ * @returns a random TaskStatus
  */
 const randomStatus = (index: number) => {
   const TaskStatusWithoutUmbrella = Object.values(TaskStatus).filter(
@@ -174,9 +175,8 @@ const populateVersion = (
 
 /**
  * `groupTasksByStatus` groups tasks by status and returns an array of objects with the status and count
- * @param tasks
- * @returns
- *
+ * @param tasks - an array of tasks
+ * @returns an array of objects with the status and count
  */
 const groupTasksByStatus = (tasks: { status: string }[]) => {
   const taskStatusCounts = tasks.reduce((acc, task) => {

--- a/src/pages/commits/ActiveCommits/utils.ts
+++ b/src/pages/commits/ActiveCommits/utils.ts
@@ -111,7 +111,7 @@ export const constructBuildVariantDict = (
 };
 
 /**
- * Calculates the height of a bar in a bar chart
+ * `calculateBarHeight` calculates the height of a single bar in a bar chart.
  * @param value - the value of the bar to calculate the height of
  * @param max - the largest value in the bar chart
  * @param total - the total amount of values in the bar chart

--- a/src/pages/commits/ActiveCommits/utils.ts
+++ b/src/pages/commits/ActiveCommits/utils.ts
@@ -110,7 +110,14 @@ export const constructBuildVariantDict = (
   return buildVariantDict;
 };
 
-// Used in Commit Chart Component to calculate bar heights
+/**
+ * Calculates the height of a bar in a bar chart
+ * @param value - the value of the bar to calculate the height of
+ * @param max - the largest value in the bar chart
+ * @param total - the total amount of values in the bar chart
+ * @param chartType - the type of chart (percentage or absolute)
+ * @returns the percentage height of the bar
+ */
 export function calculateBarHeight(
   value: number,
   max: number,

--- a/src/pages/commits/InactiveCommits/index.tsx
+++ b/src/pages/commits/InactiveCommits/index.tsx
@@ -115,19 +115,19 @@ export const InactiveCommitButton: React.VFC<InactiveCommitsProps> = ({
   );
 };
 
+interface CommitCopyProps {
+  v: Unpacked<CommitRolledUpVersions>;
+  isTooltip: boolean;
+}
 /**
  * Function that returns formatted information about commits.
  * If isTooltip is true, the commit message is truncated.
- * @param {CommitRolledUpVersions[0]} v: rolled up version
- * @param {boolean} isTooltip: boolean to indicate if used in tooltip
+ * @param props - CommitCopyProps
+ * @param props.v - rolled up version
+ * @param props.isTooltip -boolean to indicate if used in tooltip
+ * @returns CommitCopy component
  */
-const CommitCopy = ({
-  v,
-  isTooltip,
-}: {
-  v: Unpacked<CommitRolledUpVersions>;
-  isTooltip: boolean;
-}) => {
+const CommitCopy: React.VFC<CommitCopyProps> = ({ v, isTooltip }) => {
   const { sendEvent } = useProjectHealthAnalytics({ page: "Commit chart" });
   const getDateCopy = useDateFormat();
   const spruceConfig = useSpruceConfig();

--- a/src/pages/commits/InactiveCommits/index.tsx
+++ b/src/pages/commits/InactiveCommits/index.tsx
@@ -124,7 +124,7 @@ interface CommitCopyProps {
  * If isTooltip is true, the commit message is truncated.
  * @param props - CommitCopyProps
  * @param props.v - rolled up version
- * @param props.isTooltip -boolean to indicate if used in tooltip
+ * @param props.isTooltip - boolean to indicate if used in tooltip
  * @returns CommitCopy component
  */
 const CommitCopy: React.VFC<CommitCopyProps> = ({ v, isTooltip }) => {

--- a/src/pages/commits/hooks/useCommitLimit.ts
+++ b/src/pages/commits/hooks/useCommitLimit.ts
@@ -5,7 +5,8 @@ import { useQueryParam } from "hooks/useQueryParam";
 import { MainlineCommitQueryParams } from "types/commits";
 /**
  * `useCommitLimit` is a hook that calculates the number of commits to fetch based on the width of the commits container.
- * */
+ * @returns - a tuple containing a ref to the commits container, the number of commits to fetch, and a boolean indicating whether the window is being resized or not
+ */
 export const useCommitLimit = <T extends HTMLElement>(): [
   MutableRefObject<T>,
   number,

--- a/src/pages/commits/utils.ts
+++ b/src/pages/commits/utils.ts
@@ -37,7 +37,7 @@ const getMainlineCommitsQueryVariables = (
 };
 
 /**
- * getFilterStatus returns an object containing booleans that describe what filters have been applied.
+ * `getFilterStatus` returns an object containing booleans that describe what filters have been applied.
  * @param state - the state of the commits page filters
  * @returns an object containing booleans that describe what filters have been applied
  */

--- a/src/pages/commits/utils.ts
+++ b/src/pages/commits/utils.ts
@@ -36,7 +36,11 @@ const getMainlineCommitsQueryVariables = (
   return variables;
 };
 
-/** getFilterStatus returns an object containing booleans that describe what filters have been applied. */
+/**
+ * getFilterStatus returns an object containing booleans that describe what filters have been applied.
+ * @param state - the state of the commits page filters
+ * @returns an object containing booleans that describe what filters have been applied
+ */
 const getFilterStatus = (state: FilterState) => ({
   hasFilters:
     state.requesters.length > 0 ||

--- a/src/pages/projectSettings/tabs/utils/form.ts
+++ b/src/pages/projectSettings/tabs/utils/form.ts
@@ -10,10 +10,10 @@ const radioBoxOption = (title: string, value: boolean) => ({
 
 /**
  * Generate the options for a radio box group that conditionally includes a third option to "Default to repo".
- *
- * @param {options} string array representing the primary two radio box labels.
- * @param {field} value upon which the default box should be conditionally shown.
- * @param {invert} specify whether or not the field represents an "inverted" value; i.e. the field indicates a feature is disabled rather than enabled. invert ensures that the form represents values consistently regardless of whether a boolean field represents enabled or disabled.
+ * @param options - array of strings representing the primary two radio box labels.
+ * @param field - The field value for which the option should be shown.
+ * @param invert - Whether or not the field represents an "inverted" value; i.e. the field indicates a feature is disabled rather than enabled. invert ensures that the form represents values consistently regardless of whether a boolean field represents enabled or disabled.
+ * @returns - An array of schema objects representing the radio box options.
  */
 export const radioBoxOptions = (
   options: [string, string],

--- a/src/pages/spawn/spawnVolume/spawnVolumeTableActions/migrateVolumeReducer.ts
+++ b/src/pages/spawn/spawnVolume/spawnVolumeTableActions/migrateVolumeReducer.ts
@@ -12,7 +12,7 @@ interface State {
 
 export const initialState = { page: Page.First, form: {} };
 
-export function reducer(state: State, action: Action): State {
+export const reducer = (state: State, action: Action): State => {
   switch (action.type) {
     case "goToNextPage":
       return {
@@ -28,7 +28,7 @@ export function reducer(state: State, action: Action): State {
     default:
       throw new Error(`Unknown reducer action ${action}`);
   }
-}
+};
 
 type Action =
   | { type: "goToNextPage" }

--- a/src/pages/spawn/utils.ts
+++ b/src/pages/spawn/utils.ts
@@ -1,8 +1,10 @@
 /**
- * AZToRegion takes an availability zone and returns its region name.
+ * `AZToRegion` takes an availability zone and returns its region name.
  * An AWS region is just the availability zone minus the final letter.
  * This rule is defined in evergreen:
  * https://github.com/evergreen-ci/evergreen/blob/299bf20c8da9e353b1097183672cd5169ff3447d/cloud/ec2_util.go#L76-L80
+ * @param availabilityZone - the availability zone to convert
+ * @returns the region name
  */
 export const AZToRegion = (availabilityZone: string): string =>
   availabilityZone.slice(0, -1);

--- a/src/test_utils/hooks.ts
+++ b/src/test_utils/hooks.ts
@@ -2,9 +2,9 @@ import { DependencyList, EffectCallback, useEffect, useRef } from "react";
 
 /**
  * `usePrevious` is a custom hook that returns the previous value of a given value
- * @param value
- * @param initialValue
- * @returns - the previous value
+ * @param value - the value to track
+ * @param initialValue - the initial value
+ * @returns the previous value
  */
 const usePrevious = <T>(value: T, initialValue: T) => {
   const ref = useRef(initialValue);
@@ -16,7 +16,6 @@ const usePrevious = <T>(value: T, initialValue: T) => {
 
 /**
  * `useEffectDebugger` is a custom hook that logs the changed dependencies of a useEffect hook
- *
  * @param effectHook - the effect hook
  * @param dependencies - an array of dependencies
  * @param dependencyNames - an array of strings that correspond to the dependencies

--- a/src/test_utils/index.tsx
+++ b/src/test_utils/index.tsx
@@ -13,8 +13,13 @@ type CustomQueriesType = typeof customQueries;
 
 type CustomRenderType = CustomQueriesType & QueriesType;
 type customRenderOptions = RenderOptions<CustomRenderType>;
-/** `customRender` or `render` takes an instance of react-testing-library's render method
- *  and adds additional selectors for querying your components in tests  */
+/**
+ * `customRender` or `render` takes an instance of react-testing-library's render method
+ *  and adds additional selectors for querying components in tests.
+ * @param ui - React Component to render
+ * @param options - Options to pass to render
+ * @returns RenderResult with custom queries bound to screen
+ */
 const customRender = (ui: React.ReactElement, options?: customRenderOptions) =>
   render(ui, {
     queries: { ...queries, ...customQueries },
@@ -30,8 +35,12 @@ interface renderWithRouterMatchOptions extends customRenderOptions {
   path?: string;
 }
 
-/** `renderWithRouterMatch` implements the `customRender` method and wraps a passed in component
- *  with an instance of `react-router`'s `<Router />` component.
+/**
+ * `renderWithRouterMatch` implements the `customRender` method and wraps a component
+ * with an instance of `react-router`'s `<Router />` component.
+ * @param ui - React Component to render
+ * @param options - Options to pass to render
+ * @returns RenderResult with custom queries bound to screen
  */
 const renderWithRouterMatch = (
   ui: React.ReactElement,

--- a/src/utils/array/index.ts
+++ b/src/utils/array/index.ts
@@ -3,8 +3,8 @@ import { Unpacked } from "types/utils";
 /**
  * `toggleArray` takes in an array of values regardless of type and a new value and safely inserts the value if it doesn't exist in the array.
  * It removes the value from the array if it already exists
- * @param value The value to insert or remove into the array.
- * @param array The array to insert the value into.
+ * @param value - The value to insert or remove into the array.
+ * @param array - The array to insert the value into.
  * @returns The new array with the value inserted.
  * @example
  * const array = [1, 2, 3];
@@ -31,8 +31,8 @@ export const toggleArray = <T>(value: T, array: T[]) => {
 /**
  * `deduplicatedAppend` takes in an array of values regardless of type and a new value and safely inserts the value if it doesn't exist in the array.
  * if it does exist it will do nothing
- * @param value The value to insert into the array.
- * @param array The array to insert the value into.
+ * @param value - The value to insert into the array.
+ * @param array - The array to insert the value into.
  * @returns The new array with the value inserted.
  * @example
  * const array = [1, 2, 3];
@@ -50,8 +50,8 @@ export const deduplicatedAppend = <T>(value: T, array: T[]) => {
 /**
  * `convertArrayToObject` takes an array of objects and a key
  * and returns an object using the provided value of the key as a key and the rest of the object as the value
- * @param array The array of objects to convert to an object
- * @param key The key to use as the key of the object
+ * @param array - The array of objects to convert to an object
+ * @param key - The key to use as the key of the object
  * @returns The object created from the array
  */
 export const convertArrayToObject = <T = { [key: string]: any }>(
@@ -78,7 +78,7 @@ export const convertArrayToObject = <T = { [key: string]: any }>(
 /**
  * `convertObjectToArray` takes an object and returns an array with each of the entries in the object as a value in the array
  * If the entry is an array it will also split up the indices of the array into the array
- * @param obj The object to convert to an array
+ * @param obj - The object to convert to an array
  * @returns The array created from the object
  * @example
  * const obj = {
@@ -109,8 +109,8 @@ type KeyValue<T> = {
 
 /**
  * `mapStringArrayToObject` takes an array of strings and a value and returns an object with a string as the key and the value as the value
- * @param array The string array to convert to an object
- * @param v The value to use as the value of the object or a function that generates a value from the key
+ * @param array - The string array to convert to an object
+ * @param v - The value to use as the value of the object or a function that generates a value from the key
  * @returns The object created from the array
  * @example
  * const array = ['a', 'b', 'c']
@@ -139,7 +139,7 @@ export const mapStringArrayToObject = <T>(
 
 /**
  * `toArray` takes a value and converts it into an array if it is not already
- * @param value The value to convert to an array
+ * @param value - The value to convert to an array
  * @returns The array created from the value
  */
 export const toArray = <T>(value: T | T[]): T[] => {
@@ -150,9 +150,9 @@ export const toArray = <T>(value: T | T[]): T[] => {
 };
 
 /**
- * arrayIntersection takes in two arrays and returns the intersecting elements of the two arrays
- * @param a The first array
- * @param b The second array
+ * `arrayIntersection` takes in two arrays and returns the intersecting elements of the two arrays
+ * @param a - The first array
+ * @param b - The second array
  * @returns The intersecting elements of the two arrays
  * @example arrayIntersection([1, 2, 3], [2, 3, 4]) // [2, 3]
  */
@@ -167,9 +167,9 @@ export const arrayIntersection = <T>(a: T[], b: T[]) => {
 };
 
 /**
- * arraySymmetricDifference takes in two arrays and returns only the elements not in common between the two arrays
- * @param a The first array
- * @param b The second array
+ * `arraySymmetricDifference` takes in two arrays and returns only the elements not in common between the two arrays
+ * @param a - The first array
+ * @param b - The second array
  * @returns The elements not in common between the two arrays
  * @example arraySymmetricDifference([1, 2, 3], [2, 3, 4]) // [1, 4]
  */
@@ -187,9 +187,9 @@ export const arraySymmetricDifference = <T>(a: T[], b: T[]) => {
 };
 
 /**
- * arraySetDifference returns the elements in a that are not in b
- * @param a The first array
- * @param b The second array
+ * `arraySetDifference` returns the elements in a that are not in b
+ * @param a - The first array
+ * @param b - The second array
  * @returns The elements in a that are not in b
  * @example arraySetDifference([1, 2, 3], [2, 3, 4]) // [1]
  */
@@ -206,10 +206,10 @@ export const arraySetDifference = <T>(a: T[], b: T[]) => {
 type SortFunction<T> = (a: T, b: T) => number;
 
 /**
- * arrayUnion takes in two arrays and returns the union of the two arrays it also takes in an optional sort function
- * @param a The first array
- * @param b The second array
- * @param sort An optional sort function to sort the union
+ * `arrayUnion` takes in two arrays and returns the union of the two arrays it also takes in an optional sort function
+ * @param a - The first array
+ * @param b - The second array
+ * @param sort - An optional sort function to sort the union
  * @returns The union of the two arrays
  * @example arrayUnion([1, 2, 3], [2, 3, 4]) // [1, 2, 3, 4]
  * @example arrayUnion([1, 2, 3], [2, 3, 4], (a, b) => b - a) // [4, 3, 2, 1]
@@ -227,12 +227,12 @@ export const arrayUnion = <T>(a: T[], b: T[], sort?: SortFunction<T>) => {
 };
 
 /**
- * Function that works like Python range function. Returns an array that starts at the START value,
+ * `range` works like the Python range function. Returns an array that starts at the START value,
  * incrementing by the STEP value, and stopping once the STOP value has been reached or surpassed.
  * START & STOP are inclusive.
- * @param start The starting value
- * @param stop The stopping value
- * @param step The incrementing value
+ * @param start - The starting value
+ * @param stop - The stopping value
+ * @param step - The incrementing value
  * @returns The array of numbers
  * @example range(0, 10, 2) = [0, 2, 4, 6, 8, 10]
  * Taken from official docs:
@@ -247,8 +247,8 @@ export const range = (start: number, stop: number, step?: number): number[] => {
 /**
  * `conditionalToArray` takes in a generic value and transforms it into an array if shouldBeArray is true.
  * The value remains unchanged if it is already an array, or if shouldBeArray is false.
- * @param value The value to transform into an array
- * @param shouldBeArray Whether or not the value should be transformed into an array
+ * @param value - The value to transform into an array
+ * @param shouldBeArray - Whether or not the value should be transformed into an array
  * @returns The value as an array if shouldBeArray is true, otherwise the value is returned unchanged
  * @example conditionalToArray(1, true) // [1]
  * @example conditionalToArray([1], true) // [1]

--- a/src/utils/array/index.ts
+++ b/src/utils/array/index.ts
@@ -1,11 +1,19 @@
 import { Unpacked } from "types/utils";
 
 /**
- * This takes in an array of values regardless of type and a new value and safely inserts the value if it doesn't exist in the array.
+ * `toggleArray` takes in an array of values regardless of type and a new value and safely inserts the value if it doesn't exist in the array.
  * It removes the value from the array if it already exists
+ * @param value The value to insert or remove into the array.
  * @param array The array to insert the value into.
- * @param value The value to insert into the array.
  * @returns The new array with the value inserted.
+ * @example
+ * const array = [1, 2, 3];
+ * const newArray = toggleArray(2, array);
+ * // newArray = [1, 3]
+ * @example
+ * const array = [1, 2, 3];
+ * const newArray = toggleArray(4, array);
+ * // newArray = [1, 2, 3, 4]
  */
 export const toggleArray = <T>(value: T, array: T[]) => {
   const tempArray = [...array];
@@ -21,10 +29,17 @@ export const toggleArray = <T>(value: T, array: T[]) => {
 };
 
 /**
- * deduplicatedAppend takes in an array of values regardless of type and a new value and safely inserts the value if it doesn't exist in the array.
+ * `deduplicatedAppend` takes in an array of values regardless of type and a new value and safely inserts the value if it doesn't exist in the array.
  * if it does exist it will do nothing
  * @param value The value to insert into the array.
  * @param array The array to insert the value into.
+ * @returns The new array with the value inserted.
+ * @example
+ * const array = [1, 2, 3];
+ * const newArray = deduplicatedAppend(2, array);
+ * // newArray = [1, 2, 3]
+ * const newArray2 = deduplicatedAppend(4, array);
+ * // newArray2 = [1, 2, 3, 4]
  */
 export const deduplicatedAppend = <T>(value: T, array: T[]) => {
   let tempArray = new Set(array);
@@ -33,12 +48,12 @@ export const deduplicatedAppend = <T>(value: T, array: T[]) => {
 };
 
 /**
- * Takes an array of objects and a key
+ * `convertArrayToObject` takes an array of objects and a key
  * and returns an object using the provided value of the key as a key and the rest of the object as the value
  * @param array The array of objects to convert to an object
  * @param key The key to use as the key of the object
  * @returns The object created from the array
- * */
+ */
 export const convertArrayToObject = <T = { [key: string]: any }>(
   array: T[],
   key: keyof T
@@ -61,10 +76,18 @@ export const convertArrayToObject = <T = { [key: string]: any }>(
 };
 
 /**
- * Takes an object and returns an array with each of the entries in the object as a value in the array
+ * `convertObjectToArray` takes an object and returns an array with each of the entries in the object as a value in the array
  * If the entry is an array it will also split up the indices of the array into the array
- * @param object The object to convert to an array
+ * @param obj The object to convert to an array
  * @returns The array created from the object
+ * @example
+ * const obj = {
+ * a: 1,
+ * b: [2, 3],
+ * c: 4
+ * }
+ * const array = convertObjectToArray(obj)
+ * // array = [{key: 'a', value: 1}, {key: 'b', value: 2}, {key: 'b', value: 3}, {key: 'c', value: 4}]
  */
 export const convertObjectToArray = <T extends object>(
   obj: T
@@ -85,10 +108,18 @@ type KeyValue<T> = {
 };
 
 /**
- * Takes an array of strings and a value and returns an object with a string as the key and the value as the value
+ * `mapStringArrayToObject` takes an array of strings and a value and returns an object with a string as the key and the value as the value
  * @param array The string array to convert to an object
  * @param v The value to use as the value of the object or a function that generates a value from the key
  * @returns The object created from the array
+ * @example
+ * const array = ['a', 'b', 'c']
+ * const obj = mapStringArrayToObject(array, 1)
+ * // obj = {a: 1, b: 1, c: 1}
+ * @example
+ * const array = ['a', 'b', 'c']
+ * const obj = mapStringArrayToObject(array, (key) => key.toUpperCase())
+ * // obj = {a: 'A', b: 'B', c: 'C'}
  */
 export const mapStringArrayToObject = <T>(
   array: string[],
@@ -106,7 +137,11 @@ export const mapStringArrayToObject = <T>(
   }, {});
 };
 
-/** toArray takes a value and converts it into an array if it is not already */
+/**
+ * `toArray` takes a value and converts it into an array if it is not already
+ * @param value The value to convert to an array
+ * @returns The array created from the value
+ */
 export const toArray = <T>(value: T | T[]): T[] => {
   if (Array.isArray(value)) {
     return value;
@@ -114,7 +149,11 @@ export const toArray = <T>(value: T | T[]): T[] => {
   return value === undefined || value === null ? [] : [value];
 };
 
-/** arrayIntersection takes in two arrays and returns the intersecting elements of the two arrays
+/**
+ * arrayIntersection takes in two arrays and returns the intersecting elements of the two arrays
+ * @param a The first array
+ * @param b The second array
+ * @returns The intersecting elements of the two arrays
  * @example arrayIntersection([1, 2, 3], [2, 3, 4]) // [2, 3]
  */
 export const arrayIntersection = <T>(a: T[], b: T[]) => {
@@ -127,7 +166,11 @@ export const arrayIntersection = <T>(a: T[], b: T[]) => {
   return intersection;
 };
 
-/** arraySymmetricDifference takes in two arrays and returns only the elements not in common between the two arrays
+/**
+ * arraySymmetricDifference takes in two arrays and returns only the elements not in common between the two arrays
+ * @param a The first array
+ * @param b The second array
+ * @returns The elements not in common between the two arrays
  * @example arraySymmetricDifference([1, 2, 3], [2, 3, 4]) // [1, 4]
  */
 export const arraySymmetricDifference = <T>(a: T[], b: T[]) => {
@@ -143,7 +186,11 @@ export const arraySymmetricDifference = <T>(a: T[], b: T[]) => {
   return difference;
 };
 
-/** arraySetDifference returns the elements in a that are not in b
+/**
+ * arraySetDifference returns the elements in a that are not in b
+ * @param a The first array
+ * @param b The second array
+ * @returns The elements in a that are not in b
  * @example arraySetDifference([1, 2, 3], [2, 3, 4]) // [1]
  */
 export const arraySetDifference = <T>(a: T[], b: T[]) => {
@@ -158,7 +205,12 @@ export const arraySetDifference = <T>(a: T[], b: T[]) => {
 
 type SortFunction<T> = (a: T, b: T) => number;
 
-/** arrayUnion takes in two arrays and returns the union of the two arrays it also takes in an optional sort function
+/**
+ * arrayUnion takes in two arrays and returns the union of the two arrays it also takes in an optional sort function
+ * @param a The first array
+ * @param b The second array
+ * @param sort An optional sort function to sort the union
+ * @returns The union of the two arrays
  * @example arrayUnion([1, 2, 3], [2, 3, 4]) // [1, 2, 3, 4]
  * @example arrayUnion([1, 2, 3], [2, 3, 4], (a, b) => b - a) // [4, 3, 2, 1]
  */
@@ -178,6 +230,10 @@ export const arrayUnion = <T>(a: T[], b: T[], sort?: SortFunction<T>) => {
  * Function that works like Python range function. Returns an array that starts at the START value,
  * incrementing by the STEP value, and stopping once the STOP value has been reached or surpassed.
  * START & STOP are inclusive.
+ * @param start The starting value
+ * @param stop The stopping value
+ * @param step The incrementing value
+ * @returns The array of numbers
  * @example range(0, 10, 2) = [0, 2, 4, 6, 8, 10]
  * Taken from official docs:
  * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/from#sequence_generator_range
@@ -191,7 +247,14 @@ export const range = (start: number, stop: number, step?: number): number[] => {
 /**
  * `conditionalToArray` takes in a generic value and transforms it into an array if shouldBeArray is true.
  * The value remains unchanged if it is already an array, or if shouldBeArray is false.
- * */
+ * @param value The value to transform into an array
+ * @param shouldBeArray Whether or not the value should be transformed into an array
+ * @returns The value as an array if shouldBeArray is true, otherwise the value is returned unchanged
+ * @example conditionalToArray(1, true) // [1]
+ * @example conditionalToArray([1], true) // [1]
+ * @example conditionalToArray(1, false) // 1
+ * @example conditionalToArray([1], false) // [1]
+ */
 export const conditionalToArray = <T>(value: T, shouldBeArray: boolean) => {
   if (shouldBeArray) {
     return Array.isArray(value) ? value : [value];

--- a/src/utils/commits/bucketByCommit.ts
+++ b/src/utils/commits/bucketByCommit.ts
@@ -4,6 +4,8 @@ import { FileDiffsFragment } from "gql/generated/types";
  * Takes a list of fileDiffs and returns a 2-dim array of fileDiffs
  * where 1st-dim represents commit groupings ordered chronologically.
  * FileDiffsFragment.description represents a commit
+ * @param fileDiffs - list of fileDiffs
+ * @returns 2-dim array of fileDiffs
  */
 export const bucketByCommit = (
   fileDiffs: FileDiffsFragment[]

--- a/src/utils/commits/index.ts
+++ b/src/utils/commits/index.ts
@@ -6,8 +6,8 @@ export { bucketByCommit } from "./bucketByCommit";
  * Indicates if a user created a patch with the --preserve-commits flag.
  * We can tell that the user opted to preserve commits if the description of a fileDiff is non-empty,
  * as it will contain the associated commit message.
- * @param {FileDiffsFragment[]} fileDiffs - array containing the fileDiffs for a particular commit
- * @return {boolean} true if commits are preserved, false if otherwise
+ * @param fileDiffs - array containing the fileDiffs for a particular commit
+ * @returns true if commits are preserved, false if otherwise
  */
 export const shouldPreserveCommits = (
   fileDiffs: FileDiffsFragment[]

--- a/src/utils/environmentVariables.ts
+++ b/src/utils/environmentVariables.ts
@@ -1,111 +1,111 @@
 /**
  * `getApiUrl()` - Get the API URL from the environment variables
- * @returns {string} - The Evergreen API URL
+ * @returns - The Evergreen API URL
  */
 export const getApiUrl: () => string = () =>
   process.env.REACT_APP_API_URL || "";
 
 /**
  * `getBugsnagApiKey()` - Get the BUGSNAG API KEY from the environment variables
- * @returns {string} - The API KEY
+ * @returns - The API KEY
  */
 export const getBugsnagApiKey: () => string = () =>
   process.env.REACT_APP_BUGSNAG_API_KEY || "i-am-a-fake-key";
 
 /**
  * `getUiUrl()` - Get the backing evergreen URL from the environment variables
- * @returns {string} - Returns the backing evergreen url
+ * @returns - Returns the backing evergreen url
  */
 export const getUiUrl: () => string = () => process.env.REACT_APP_UI_URL || "";
 
 /**
  * `getSignalProcessingUrl()` - Get the TIPS Signal Processing URL from the environment variables
- * @returns {string} - Returns the TIPS Signal Processing Iframe URL
+ * @returns - Returns the TIPS Signal Processing Iframe URL
  */
 export const getSignalProcessingUrl: () => string = () =>
   process.env.REACT_APP_SIGNAL_PROCESSING_URL || "";
 
 /**
  * `getSpruceURL()` - Get the SPRUCE URL from the environment variables
- * @returns {string} - Returns the Spruce URL
+ * @returns - Returns the Spruce URL
  */
 export const getSpruceURL: () => string = () =>
   process.env.REACT_APP_SPRUCE_URL;
 
 /**
  * `isDevelopmentBuild()` indicates if the current environment is a local development environment.
- * @returns {boolean} `true` if the current environment is a local development environment.
+ * @returns `true` if the current environment is a local development environment.
  */
 export const isDevelopmentBuild: () => boolean = () =>
   process.env.NODE_ENV === "development";
 
 /**
  * `isProductionBuild()` indicates if the current environment is a production bundle.
- * @returns {boolean} `true` if the current environment is a production build.
+ * @returns `true` if the current environment is a production build.
  */
 export const isProductionBuild = (): boolean =>
   process.env.NODE_ENV === "production";
 
 /**
  * `isBeta()` indicates if the current build is a build meant for a beta deployment.
- * @returns {boolean} `true` if the current build is a beta build.
+ * @returns `true` if the current build is a beta build.
  */
 export const isBeta = (): boolean => getReleaseStage() === "beta";
 
 /**
  * `isStaging()` indicates if the current build is a build meant for a staging deployment.
- * @returns {boolean} `true` if the current build is a staging build.
+ * @returns `true` if the current build is a staging build.
  */
 export const isStaging = (): boolean => getReleaseStage() === "staging";
 
 /**
  * `isProduction()` indicates if the current build is a build meant for a production deployment.
- * @returns {boolean} `true` if the current build is a production build.
+ * @returns `true` if the current build is a production build.
  */
 export const isProduction = (): boolean => getReleaseStage() === "production";
 
 /**
  * `isTest()` indicates if the current environment is a test environment.
- * @returns {boolean} `true` if the current environment is a test environment.
+ * @returns `true` if the current environment is a test environment.
  */
 export const isTest = () => process.env.NODE_ENV === "test";
 
 /**
  * `getGQLUrl()` - Get the GQL URL from the environment variables
- * @returns {string} - Returns the graphql endpoint for the current environment.
+ * @returns - Returns the graphql endpoint for the current environment.
  */
 export const getGQLUrl: () => string = () =>
   process.env.REACT_APP_GQL_URL || "";
 
 /**
  * `getLobsterUrl()` - Get the Lobster URL from the environment variables
- * @returns {string} - Returns the lobster URL.
+ * @returns - Returns the lobster URL.
  */
 export const getLobsterURL = (): string =>
   process.env.REACT_APP_LOBSTER_URL || "";
 
 /**
  * `getParsleyUrl()` - Get the Parsley URL from the environment variables
- * @returns {string} - Returns the Parsley URL.
+ * @returns - Returns the Parsley URL.
  */
 export const getParsleyUrl = (): string =>
   process.env.REACT_APP_PARSLEY_URL || "";
 
 /**
  * `getAppVersion()` - Get the app release version from the environment variables
- * @returns {string} - Returns the lobster URL.
+ * @returns - Returns the lobster URL.
  */
 export const getAppVersion = () => process.env.REACT_APP_VERSION || "";
 
 /**
  * `getReleaseStage()` - Get the release stage from the environment variables
- * @returns {string} - Returns the production release environment
+ * @returns - Returns the production release environment
  */
 export const getReleaseStage = () => process.env.REACT_APP_RELEASE_STAGE || "";
 
 /**
  * `getLoginDomain()` - Get the login domain depending on the release stage
- *
+ * @returns - Returns the login domain
  * in development, the dev server on port 3000 proxies the local evergreen server on port 9090
  * therefore in dev we want the login domain to be localhost:3000
  * however in prod and staging and we want the login domain to be evergreen.com

--- a/src/utils/numbers/index.ts
+++ b/src/utils/numbers/index.ts
@@ -1,7 +1,7 @@
 /**
- * toDecimal takes a string or number that represents a percentage value and returns a float
+ * `toDecimal` takes a string or number that represents a percentage value and returns a float
  * @param value - A string or number that represents a percentage value.
- * @return {number} A float representing the percentage value.
+ * @returns A float representing the percentage value.
  * @example
  * toDecimal("50") // => 0.5
  * toDecimal("100") // => 1.0
@@ -15,9 +15,9 @@ const toDecimal = (value: string | null): number => {
 };
 
 /**
- *
+ * `toPercent` takes a string or number that represents a percentage value and returns a float
  * @param value - A string or number that represents a percentage value between 0 and 1.
- * @return {number} A float representing the percentage value.
+ * @returns A float representing the percentage value.
  * @example
  * toPercentage("0.5") // => 50
  * toPercentage("1") // => 100
@@ -30,15 +30,20 @@ const toPercent = (value: string | number): number => {
 };
 
 /**
- * formatZeroIndexForDisplay formats a zero-indexed number for display in the UI.
+ * `formatZeroIndexForDisplay` formats a zero-indexed number for display in the UI.
+ * @param value - the zero-indexed number to format
+ * @returns the number plus one
+ * @example formatZeroIndexForDisplay(0) // => 1
+ * @example formatZeroIndexForDisplay(1) // => 2
  */
 const formatZeroIndexForDisplay = (value: number): number => value + 1;
 
 /**
- * roundDecimal rounds a decimal number to include a certain number of decimal places. It does not add trailing
+ * `roundDecimal` rounds a decimal number to include a certain number of sig figs. It does not add trailing
  * zeroes.
  * @param value - the number to round
  * @param decimalPlaces - the number of decimal places to preserve
+ * @returns the rounded number
  * @example roundDecimal(0.54672, 3) // => 0.547
  * @example roundDecimal(11) // => 11
  */
@@ -46,8 +51,9 @@ const roundDecimal = (value: number, decimalPlaces: number = 0): number =>
   parseFloat(value.toFixed(decimalPlaces));
 
 /**
- * cryptoRandom is a replacement for Math.random() using the web crypto API.
+ * `cryptoRandom` is a replacement for Math.random() using the web crypto API.
  * cryptoRandom generates a number between 0 (inclusive) and 1 (exclusive).
+ * @returns a random number between 0 and 1
  */
 const cryptoRandom = () => {
   const arr = new Uint32Array(1);

--- a/src/utils/numbers/index.ts
+++ b/src/utils/numbers/index.ts
@@ -39,7 +39,7 @@ const toPercent = (value: string | number): number => {
 const formatZeroIndexForDisplay = (value: number): number => value + 1;
 
 /**
- * `roundDecimal` rounds a decimal number to include a certain number of sig figs. It does not add trailing
+ * `roundDecimal` rounds a decimal number to include a certain number of decimal points. It does not add trailing
  * zeroes.
  * @param value - the number to round
  * @param decimalPlaces - the number of decimal places to preserve

--- a/src/utils/statuses/getCurrentStatuses.ts
+++ b/src/utils/statuses/getCurrentStatuses.ts
@@ -2,6 +2,12 @@ import { TreeDataEntry } from "components/TreeSelect";
 
 const allKey = "all";
 
+/**
+ * `getCurrentStatuses` returns a list of statuses that are currently selected in a TreeSelect tree.
+ * @param statuses - list of statuses to filter
+ * @param treeData - treeData to filter by
+ * @returns - a list of statuses that are currently selected in the TreeSelect.
+ */
 export const getCurrentStatuses = (
   statuses: string[],
   treeData: TreeDataEntry[]

--- a/src/utils/string/index.ts
+++ b/src/utils/string/index.ts
@@ -3,36 +3,6 @@ import get from "lodash/get";
 
 export { githubPRLinkify } from "./githubPRLinkify";
 
-// shortenString takes a string and shortens it
-// Useful for displaying part of a long string, such as a long taskId
-export const shortenString = (
-  value: string,
-  wordwise: boolean,
-  max: number,
-  tail: string
-): string => {
-  if (!value) {
-    return "";
-  }
-
-  if (!max) {
-    return value;
-  }
-  if (value.length <= max) {
-    return value;
-  }
-
-  let valueSubstring = value.substr(0, max);
-  if (wordwise) {
-    const lastspace = valueSubstring.lastIndexOf(" ");
-    if (lastspace !== -1) {
-      valueSubstring = valueSubstring.substr(0, lastspace);
-    }
-  }
-
-  return valueSubstring + (tail || " …");
-};
-
 /**
  * `msToDuration` converts a number of milliseconds to a string representing the duration
  * @param ms - milliseconds

--- a/src/utils/string/index.ts
+++ b/src/utils/string/index.ts
@@ -33,6 +33,11 @@ export const shortenString = (
   return valueSubstring + (tail || " …");
 };
 
+/**
+ * `msToDuration` converts a number of milliseconds to a string representing the duration
+ * @param ms - milliseconds
+ * @returns - a string representing the duration in the format of "1d 2h 3m 4s"
+ */
 export const msToDuration = (ms: number): string => {
   const days = Math.floor(ms / (24 * 60 * 60 * 1000));
   const daysMilli = ms % (24 * 60 * 60 * 1000);
@@ -55,6 +60,16 @@ export const msToDuration = (ms: number): string => {
   }
 };
 
+/**
+ * `stringifyNanoseconds` converts a number of nanoseconds to a string representing the duration
+ * @param input - nanoseconds
+ * @param skipDayMax - if true, will not display days if the duration is greater than 24 hours
+ * @param skipSecMax - if true, will not display seconds if the duration is greater than 60 seconds
+ * @returns - a string representing the duration in the format of "1d 2h 3m 4s"
+ * @example
+ * stringifyNanoseconds(1000000000000) // "11 days"
+ * stringifyNanoseconds(1000000000000, true) // "11 days"
+ */
 export const stringifyNanoseconds = (
   input: number,
   skipDayMax: boolean,
@@ -93,6 +108,13 @@ export const stringifyNanoseconds = (
   return ">= 1 day";
 };
 
+/**
+ * `omitTypename` removes the __typename property from an object
+ * @param object - the object to remove the __typename property from
+ * @returns - the object without the __typename property
+ * @example
+ * omitTypename({ __typename: "Task", id: "123" }) // { id: "123" }
+ */
 export const omitTypename = (object) =>
   JSON.parse(JSON.stringify(object), (key, value) =>
     key === "__typename" ? undefined : value
@@ -106,7 +128,17 @@ export type DateCopyOptions = {
   dateFormat?: string;
 };
 
-// Will return a time in the users local timezone when one is not provided
+/**
+ * `getDateCopy` converts a date to a string in the format of "MMM d, yyyy h:mm:ss a z"
+ * @param time - a string, number, or Date object
+ * @param options - an object with options for formatting the date
+ * @param options.tz - a timezone string, such as "America/Los_Angeles"
+ * @param options.dateOnly - if true, will only return the date, not the time
+ * @param options.omitSeconds - if true, will not return the seconds
+ * @param options.omitTimezone - if true, will not return the timezone
+ * @param options.dateFormat - a date format string, such as "MMM d, yyyy"
+ * @returns - a string representing the date in the format of "MMM d, yyyy h:mm:ss a z"
+ */
 export const getDateCopy = (
   time: string | number | Date,
   options?: DateCopyOptions
@@ -133,11 +165,26 @@ export const getDateCopy = (
   return format(new Date(time), finalDateFormat);
 };
 
+/**
+ * `copyToClipboard` copies a string to the clipboard
+ * @param textToCopy - the string to copy to the clipboard
+ */
 export const copyToClipboard = (textToCopy: string) => {
   navigator.clipboard.writeText(textToCopy);
 };
 
-export const sortFunctionString = (a, b, key) => {
+/**
+ * `sortFunctionString` is a helper function for sorting an array of objects by a string key
+ * @param a - the first object to compare
+ * @param b - the second object to compare
+ * @param key - the key to sort by
+ * @returns - a number representing the sort order
+ * @example
+ * const arr = [{ name: "b" }, { name: "a" }];
+ * arr.sort((a, b) => sortFunctionString(a, b, "name"));
+ * // [{ name: "a" }, { name: "b" }]
+ */
+export const sortFunctionString = <T>(a: T, b: T, key: string) => {
   const nameA = get(a, key).toUpperCase();
   const nameB = get(b, key).toUpperCase();
   if (nameA < nameB) {
@@ -149,44 +196,55 @@ export const sortFunctionString = (a, b, key) => {
   return 0;
 };
 
-export const sortFunctionDate = (a, b, key) => {
-  let dateA;
-  let dateB;
+/**
+ * `sortFunctionDate` is a helper function for sorting an array of objects by a date key
+ * @param a - the first object to compare
+ * @param b - the second object to compare
+ * @param key - the key to sort by
+ * @returns - a number representing the sort order
+ * @example
+ * const arr = [{ date: "2021-01-01" }, { date: "2021-01-02" }];
+ * arr.sort((a, b) => sortFunctionDate(a, b, "date"));
+ * // [{ date: "2021-01-01" }, { date: "2021-01-02" }]
+ */
+export const sortFunctionDate = <T>(a: T, b: T, key: string) => {
+  let dateA: Date;
+  let dateB: Date;
   try {
     dateA = new Date(get(a, key));
     dateB = new Date(get(b, key));
   } catch (e) {
     throw Error(`Could not convert ${key} to date`);
   }
-  return dateA - dateB;
+  return dateA.getTime() - dateB.getTime();
 };
 
 /**
- * @param {string}  str - A string that does not contain regex operators.
- * @return {string} A regex that strictly matches on the input.
+ * @param  str - A string that does not contain regex operators.
+ * @returns A regex that strictly matches on the input.
  */
 export const applyStrictRegex = (str: string) => `^${str}$`;
 
 /**
  *
  * @param str - A string that may contain regex operators.
- * @return {string} A regex that matches on the input.
+ * @returns A regex that matches on the input.
  */
 export const escapeRegex = (str: string) =>
   str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
 /**
  * @param str - A string that represents a githash
- * @return {string} A shortenend version of the input string.
+ * @returns A shortenend version of the input string.
  */
 export const shortenGithash = (str: string) => str?.substring(0, 7);
 
 /**
  * Function that trims the middle portion of a string. ex: "EvergreenUI" -> "Ev...UI"
  * The resulting length, if trimmed, is maxLength + 1 (due to ellipsis length).
- * @param {string} str - Text to trim
- * @param {number} maxLength - Max length before trimming text
- * @return {string} The original or trimmed text.
+ * @param str - Text to trim
+ * @param maxLength - Max length before trimming text
+ * @returns The original or trimmed text.
  */
 export const trimStringFromMiddle = (str: string, maxLength: number) => {
   const ellipsis = "…";
@@ -210,9 +268,9 @@ export const trimStringFromMiddle = (str: string, maxLength: number) => {
 /**
  * Convert an array of strings into a string that lists them, separated by commas and with a coordinating conjunction (i.e. "and" or "or") preceding the last word.
  * E.g. joinWithConjunction(["spruce", "app", "plt"], "and") => "spruce, app, and plt"
- * @param {string[]} array - List of words.
- * @param {string} conjunction - Word such as "and" or "or" that should precede the last list item.
- * @return {string} List items joined by a comma with the coordinating conjunction
+ * @param array - List of words.
+ * @param conjunction - Word such as "and" or "or" that should precede the last list item.
+ * @returns List items joined by a comma with the coordinating conjunction
  */
 export const joinWithConjunction = (array: string[], conjunction: string) => {
   if (array.length === 0) {
@@ -229,11 +287,19 @@ export const joinWithConjunction = (array: string[], conjunction: string) => {
 
 /**
  * Given a string, strips new line characters.
- * @param {string} str - string to remove new lines from
- * @return {string} string with new lines removed
+ * @param str - string to remove new lines from
+ * @returns string with new lines removed
  */
 export const stripNewLines = (str: string) => str.replace(/\n/g, "");
 
+/**
+ * Given a string, converts it to sentence case.
+ * @param string - string to convert to sentence case
+ * @returns string in sentence case
+ * @example
+ * toSentenceCase("hello world") => "Hello world"
+ * toSentenceCase("HELLO WORLD") => "Hello world"
+ */
 export const toSentenceCase = (string: string) => {
   if (string === undefined || string.length === 0) {
     return "";

--- a/src/utils/string/string.test.ts
+++ b/src/utils/string/string.test.ts
@@ -357,6 +357,7 @@ describe("stripNewLines", () => {
 describe("toSentenceCase", () => {
   it("capitalizes the first letter in a word", () => {
     expect(toSentenceCase("mystring")).toBe("Mystring");
+    expect(toSentenceCase("myString")).toBe("Mystring");
   });
 });
 

--- a/src/utils/validators/index.ts
+++ b/src/utils/validators/index.ts
@@ -1,3 +1,8 @@
+/**
+ * `validateDuration` tests if a provided string is a valid duration
+ * @param duration - the duration to validate
+ * @returns - true if the provided string is a valid duration, false otherwise
+ */
 const validateDuration = (duration: string) => {
   const durationAsInt = parseInt(duration, 10);
   if (
@@ -12,15 +17,39 @@ const validateDuration = (duration: string) => {
   return true;
 };
 
+/**
+ * `validateEmail` tests if a provided string is a valid email address
+ * @param v - the string to test
+ * @returns - true if the provided string is a valid email address, false otherwise
+ */
 const validateEmail = (v: string): boolean => /\S+@\S+\.\S+/.test(v);
 
 const jiraTicketNumberRegex = ".+-[0-9]+";
 
+/**
+ * `validateJira` tests if a provided string is a valid jira ticket number
+ * @param v - the string to test
+ * @returns - true if the provided string is a valid jira ticket number, false otherwise
+ * @example
+ * validateJira("ABC-123") // true
+ * validateJira("ABC-123-456") // false
+ */
 const validateJira = (v: string) => new RegExp(jiraTicketNumberRegex).test(v);
 
+/**
+ * `validateJiraURL` tests if a provided url is a valid jira url
+ * @param jiraURL - the jira url to test
+ * @param url - the url to test
+ * @returns - true if the provided url is a valid jira url, false otherwise
+ */
 const validateJiraURL = (jiraURL: string, url: string): boolean =>
   new RegExp(`^https://${jiraURL}/browse/${jiraTicketNumberRegex}$`).test(url);
 
+/**
+ * `validateURL` tests if a provided url is a valid url
+ * @param url - the url to test
+ * @returns - true if the provided url is a valid url, false otherwise
+ */
 const validateURL = (url: string): boolean => {
   const validateUrlRegex =
     /^(https?:\/\/(www\.)?|ftp:\/\/(www\.)?|www\.){1}([0-9A-Za-z-.@:%_+~#=]+)+((\.[a-zA-Z]{2,3})+)(\/(.)*)?(\?(.)*)?/;
@@ -30,6 +59,11 @@ const validateURL = (url: string): boolean => {
   return validateUrlRegex.test(url);
 };
 
+/**
+ * `validateURLTemplate` tests if a provided url is a valid url template with a version_id placeholder
+ * @param url - the url to test
+ * @returns - true if the provided url is a valid url template with a version_id placeholder, false otherwise
+ */
 const validateURLTemplate = (url: string): boolean => {
   if (!url) {
     return true;
@@ -48,6 +82,11 @@ const validateSSHPublicKey = (v: string): boolean => {
   return validSSHKey.test(v);
 };
 
+/**
+ * `validatePercentage` tests if a provided string is a valid percentage over 0
+ * @param percent - the percentage to validate
+ * @returns - true if the provided string is a valid percentage, false otherwise
+ */
 const validatePercentage = (percent: string) => {
   const posNumRegex = /^[0-9]+([,.][0-9]+)?$/g;
   if (!posNumRegex.test(percent)) {

--- a/src/utils/validators/index.ts
+++ b/src/utils/validators/index.ts
@@ -38,7 +38,7 @@ const validateJira = (v: string) => new RegExp(jiraTicketNumberRegex).test(v);
 
 /**
  * `validateJiraURL` tests if a provided url is a valid jira url
- * @param jiraURL - the jira url to test
+ * @param jiraURL - the jira host url
  * @param url - the url to test
  * @returns - true if the provided url is a valid jira url, false otherwise
  */
@@ -106,7 +106,7 @@ const validateSlack = (v: string): boolean => {
 };
 
 /**
- *  validateObjectId tests if a provided id is a mongo objectId indicating that it likely belongs to a patch and not a version
+ *  `validateObjectId` tests if a provided id is a mongo objectId indicating that it likely belongs to a patch and not a version
  *  @param id - the id to test
  *  @returns - true if it is a mongo objectId, false otherwise
  */

--- a/src/utils/validators/index.ts
+++ b/src/utils/validators/index.ts
@@ -38,6 +38,11 @@ const validateURLTemplate = (url: string): boolean => {
   return validateURL(formattedURL);
 };
 
+/**
+ * `validateSSHPublicKey` tests if a provided string is a valid ssh public key
+ * @param v - the ssh public key to test
+ * @returns - true if the provided string is a valid ssh public key, false otherwise
+ */
 const validateSSHPublicKey = (v: string): boolean => {
   const validSSHKey = /^(ssh-rsa|ssh-dss|ssh-ed25519|ecdsa-sha2-nistp256) /;
   return validSSHKey.test(v);
@@ -51,6 +56,11 @@ const validatePercentage = (percent: string) => {
   return true;
 };
 
+/**
+ *
+ * @param v - the slack channel, user, or id to validate
+ * @returns - true if the provided string is a valid slack channel, user, or id, false otherwise
+ */
 const validateSlack = (v: string): boolean => {
   const validTarget = /(^\S+$)/;
   return validTarget.test(v);
@@ -58,8 +68,8 @@ const validateSlack = (v: string): boolean => {
 
 /**
  *  validateObjectId tests if a provided id is a mongo objectId indicating that it likely belongs to a patch and not a version
- *  @param  {string} id - the id to test
- *  @return {boolean} - true if it is a mongo objectId, false otherwise
+ *  @param id - the id to test
+ *  @returns - true if it is a mongo objectId, false otherwise
  */
 //
 const validateObjectId = (id: string): boolean => {
@@ -69,8 +79,9 @@ const validateObjectId = (id: string): boolean => {
 };
 
 /**
- * validateRegexp tests if a provided string is a valid regular expression
+ * `validateRegexp` tests if a provided string is a valid regular expression
  * @param regexp - the regexp to test
+ * @returns - true if it is a valid regexp, false otherwise
  */
 const validateRegexp = (regexp: string): boolean => {
   try {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2884,6 +2884,15 @@
   dependencies:
     tiny-lru "7.0.6"
 
+"@es-joy/jsdoccomment@~0.39.4":
+  version "0.39.4"
+  resolved "https://registry.yarnpkg.com/@es-joy/jsdoccomment/-/jsdoccomment-0.39.4.tgz#6b8a62e9b3077027837728818d3c4389a898b392"
+  integrity sha512-Jvw915fjqQct445+yron7Dufix9A+m9j1fCJYlCo1FWlRvTxa3pjJelxdSTdaLWcTwRU6vbL+NYjO4YuNIS5Qg==
+  dependencies:
+    comment-parser "1.3.1"
+    esquery "^1.5.0"
+    jsdoc-type-pratt-parser "~4.0.0"
+
 "@esbuild/android-arm64@0.16.17":
   version "0.16.17"
   resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.16.17.tgz#cf91e86df127aa3d141744edafcba0abdc577d23"
@@ -7087,6 +7096,11 @@ arch@^2.2.0:
   resolved "https://registry.yarnpkg.com/arch/-/arch-2.2.0.tgz#1bc47818f305764f23ab3306b0bfc086c5a29d11"
   integrity sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==
 
+are-docs-informative@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/are-docs-informative/-/are-docs-informative-0.0.2.tgz#387f0e93f5d45280373d387a59d34c96db321963"
+  integrity sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==
+
 are-we-there-yet@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz#372e0e7bd279d8e94c653aaa1f67200884bf3e1c"
@@ -7742,6 +7756,11 @@ buffer@^5.5.0, buffer@^5.6.0, buffer@^5.7.0:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
 
+builtin-modules@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.3.0.tgz#cae62812b89801e9656336e46223e030386be7b6"
+  integrity sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==
+
 busboy@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/busboy/-/busboy-1.6.0.tgz#966ea36a9502e43cdb9146962523b92f531f6893"
@@ -8169,6 +8188,11 @@ commander@^9.3.0:
   version "9.3.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-9.3.0.tgz#f619114a5a2d2054e0d9ff1b31d5ccf89255e26b"
   integrity sha512-hv95iU5uXPbK83mjrJKuZyFM/LBAoCV/XhVGkS5Je6tl7sxr6A0ITMw5WoRV46/UaJ46Nllm3Xt7IaJhXTIkzw==
+
+comment-parser@1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/comment-parser/-/comment-parser-1.3.1.tgz#3d7ea3adaf9345594aedee6563f422348f165c1b"
+  integrity sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==
 
 common-tags@1.8.2, common-tags@^1.8.0:
   version "1.8.2"
@@ -9418,6 +9442,21 @@ eslint-plugin-jest@27.2.1:
   dependencies:
     "@typescript-eslint/utils" "^5.10.0"
 
+eslint-plugin-jsdoc@^46.2.6:
+  version "46.2.6"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-46.2.6.tgz#f25590d371859f20691d65b5dcd4cbe370d65564"
+  integrity sha512-zIaK3zbSrKuH12bP+SPybPgcHSM6MFzh3HFeaODzmsF1N8C1l8dzJ22cW1aq4g0+nayU1VMjmNf7hg0dpShLrA==
+  dependencies:
+    "@es-joy/jsdoccomment" "~0.39.4"
+    are-docs-informative "^0.0.2"
+    comment-parser "1.3.1"
+    debug "^4.3.4"
+    escape-string-regexp "^4.0.0"
+    esquery "^1.5.0"
+    is-builtin-module "^3.2.1"
+    semver "^7.5.1"
+    spdx-expression-parse "^3.0.1"
+
 eslint-plugin-jsx-a11y@6.6.0:
   version "6.6.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.6.0.tgz#2c5ac12e013eb98337b9aa261c3b355275cc6415"
@@ -9578,6 +9617,13 @@ esquery@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.4.0.tgz#2148ffc38b82e8c7057dfed48425b3e61f0f24a5"
   integrity sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==
+  dependencies:
+    estraverse "^5.1.0"
+
+esquery@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.5.0.tgz#6ce17738de8577694edd7361c57182ac8cb0db0b"
+  integrity sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==
   dependencies:
     estraverse "^5.1.0"
 
@@ -10991,6 +11037,13 @@ is-boolean-object@^1.1.0:
     call-bind "^1.0.2"
     has-tostringtag "^1.0.0"
 
+is-builtin-module@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/is-builtin-module/-/is-builtin-module-3.2.1.tgz#f03271717d8654cfcaf07ab0463faa3571581169"
+  integrity sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==
+  dependencies:
+    builtin-modules "^3.3.0"
+
 is-callable@^1.1.3:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.7.tgz#3bc2a85ea742d9e36205dcacdd72ca1fdc51b055"
@@ -11898,6 +11951,11 @@ jscodeshift@^0.14.0:
     recast "^0.21.0"
     temp "^0.8.4"
     write-file-atomic "^2.3.0"
+
+jsdoc-type-pratt-parser@~4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.0.0.tgz#136f0571a99c184d84ec84662c45c29ceff71114"
+  integrity sha512-YtOli5Cmzy3q4dP26GraSOeAhqecewG04hoO8DY56CH4KJ9Fvv5qKWUCCo3HZob7esJQHCv6/+bnTy72xZZaVQ==
 
 jsdom@^20.0.0:
   version "20.0.3"
@@ -14817,7 +14875,7 @@ semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8:
   dependencies:
     lru-cache "^6.0.0"
 
-semver@^7.5.0:
+semver@^7.5.0, semver@^7.5.1:
   version "7.5.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.1.tgz#c90c4d631cf74720e46b21c1d37ea07edfab91ec"
   integrity sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==
@@ -15082,7 +15140,7 @@ spdx-exceptions@^2.1.0:
   resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz#3f28ce1a77a00372683eade4a433183527a2163d"
   integrity sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==
 
-spdx-expression-parse@^3.0.0:
+spdx-expression-parse@^3.0.0, spdx-expression-parse@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz#cf70f50482eefdc98e3ce0a6833e4a53ceeba679"
   integrity sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==


### PR DESCRIPTION
EVG-20049

### Description
Adds the eslint-jsdoc plugin to the spruce repo.
Ran into the following issue because some of our props were named `readonly` for now I disabled the `jsdoc/valid-types` rule on files that are affected.
https://github.com/jsdoc-type-pratt-parser/jsdoc-type-pratt-parser/issues/104

