### PR TITLE
EVG-17134: Expose container configurations to production

### DIFF
--- a/src/pages/projectSettings/Tabs.tsx
+++ b/src/pages/projectSettings/Tabs.tsx
@@ -180,21 +180,19 @@ export const ProjectSettingsTabs: React.VFC<Props> = ({
             />
           }
         />
-        {!isProduction() && (
-          <Route
-            path={ProjectSettingsTabRoutes.Containers}
-            element={
-              <ContainersTab
-                identifier={identifier || repoId}
-                projectData={
-                  tabData[ProjectSettingsTabRoutes.Containers].projectData
-                }
-                projectType={projectType}
-                repoData={tabData[ProjectSettingsTabRoutes.Containers].repoData}
-              />
-            }
-          />
-        )}
+        <Route
+          path={ProjectSettingsTabRoutes.Containers}
+          element={
+            <ContainersTab
+              identifier={identifier || repoId}
+              projectData={
+                tabData[ProjectSettingsTabRoutes.Containers].projectData
+              }
+              projectType={projectType}
+              repoData={tabData[ProjectSettingsTabRoutes.Containers].repoData}
+            />
+          }
+        />
         {!isProduction() && (
           <Route
             path={ProjectSettingsTabRoutes.ViewsAndFilters}

--- a/src/pages/projectSettings/index.tsx
+++ b/src/pages/projectSettings/index.tsx
@@ -158,12 +158,10 @@ const ProjectSettings: React.VFC = () => {
             {...sharedProps}
             tab={ProjectSettingsTabRoutes.VirtualWorkstation}
           />
-          {!isProduction() && (
-            <ProjectSettingsNavItem
-              {...sharedProps}
-              tab={ProjectSettingsTabRoutes.Containers}
-            />
-          )}
+          <ProjectSettingsNavItem
+            {...sharedProps}
+            tab={ProjectSettingsTabRoutes.Containers}
+          />
           {/* Views and filters are not available at the repo level at this time. */}
           {!isProduction() && projectType !== ProjectType.Repo && (
             <ProjectSettingsNavItem

--- a/src/pages/projectSettings/tabs/ContainersTab/ContainersTab.tsx
+++ b/src/pages/projectSettings/tabs/ContainersTab/ContainersTab.tsx
@@ -33,7 +33,7 @@ export const ContainersTab: React.VFC<TabProps> = ({
 
   return (
     <>
-      <Banner data-cy="disabled-webhook-banner" variant="warning">
+      <Banner variant="warning">
         Running tasks on containers is currently in beta, and is only available
         to a select group of initial candidates. If you have any questions about
         container tasks or are interested in exploring how this feature could

--- a/src/pages/projectSettings/tabs/ContainersTab/ContainersTab.tsx
+++ b/src/pages/projectSettings/tabs/ContainersTab/ContainersTab.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import Banner from "@leafygreen-ui/banner";
 import { SpruceForm } from "components/SpruceForm";
 import { ProjectSettingsTabRoutes } from "constants/routes";
 import { useSpruceConfig } from "hooks";
@@ -31,12 +32,20 @@ export const ContainersTab: React.VFC<TabProps> = ({
   if (!formData || !ecs) return null;
 
   return (
-    <SpruceForm
-      fields={fields}
-      formData={formData}
-      onChange={onChange}
-      schema={schema}
-      uiSchema={uiSchema}
-    />
+    <>
+      <Banner data-cy="disabled-webhook-banner" variant="warning">
+        Running tasks on containers is currently in beta, and is only available
+        to a select group of initial candidates. If you have any questions about
+        container tasks or are interested in exploring how this feature could
+        benefit your project, please reach out to us in #evergreen-users
+      </Banner>
+      <SpruceForm
+        fields={fields}
+        formData={formData}
+        onChange={onChange}
+        schema={schema}
+        uiSchema={uiSchema}
+      />
+    </>
   );
 };


### PR DESCRIPTION
EVG-17134

### Description
Now that we have multiple teams moving forward to onboard containers to their project,  we should allow for the exposure of the containers tab in Spruce. Given that only a select few beta testers are using this, and they are manually coordinating with us, I added a banner to make that clear.

![image](https://github.com/evergreen-ci/spruce/assets/19805673/0e3ae433-86e7-4dbf-af7b-3ed93eac1986)

