### PR TITLE
EVG-20340: Show Views & Filters changes in event log

### DIFF
--- a/src/gql/fragments/projectSettings/projectEventSettings.graphql
+++ b/src/gql/fragments/projectSettings/projectEventSettings.graphql
@@ -9,6 +9,7 @@
 #import "./virtualWorkstation.graphql"
 #import "./projectTriggers.graphql"
 #import "./periodicBuilds.graphql"
+#import "./viewsAndFilters.graphql"
 
 fragment ProjectEventSettings on ProjectEventSettings {
   aliases {
@@ -25,6 +26,7 @@ fragment ProjectEventSettings on ProjectEventSettings {
     ...ProjectPeriodicBuildsSettings
     ...ProjectPluginsSettings
     ...ProjectTriggersSettings
+    ...ProjectViewsAndFiltersSettings
     ...ProjectVirtualWorkstationSettings
     repoRefId
     tracksPushEvents

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -3687,6 +3687,7 @@ export type ProjectEventSettingsFragment = {
     notifyOnBuildFailure?: boolean | null;
     githubTriggerAliases?: Array<string> | null;
     perfEnabled?: boolean | null;
+    projectHealthView: ProjectHealthView;
     githubChecksEnabled?: boolean | null;
     gitTagAuthorizedTeams?: Array<string> | null;
     gitTagAuthorizedUsers?: Array<string> | null;
@@ -3759,6 +3760,12 @@ export type ProjectEventSettingsFragment = {
       project: string;
       status: string;
       taskRegex: string;
+    }> | null;
+    parsleyFilters?: Array<{
+      __typename?: "ParsleyFilter";
+      caseSensitive: boolean;
+      exactMatch: boolean;
+      expression: string;
     }> | null;
     workstationConfig: {
       __typename?: "WorkstationConfig";
@@ -5873,6 +5880,7 @@ export type ProjectEventLogsQuery = {
           notifyOnBuildFailure?: boolean | null;
           githubTriggerAliases?: Array<string> | null;
           perfEnabled?: boolean | null;
+          projectHealthView: ProjectHealthView;
           githubChecksEnabled?: boolean | null;
           gitTagAuthorizedTeams?: Array<string> | null;
           gitTagAuthorizedUsers?: Array<string> | null;
@@ -5945,6 +5953,12 @@ export type ProjectEventLogsQuery = {
             project: string;
             status: string;
             taskRegex: string;
+          }> | null;
+          parsleyFilters?: Array<{
+            __typename?: "ParsleyFilter";
+            caseSensitive: boolean;
+            exactMatch: boolean;
+            expression: string;
           }> | null;
           workstationConfig: {
             __typename?: "WorkstationConfig";
@@ -6069,6 +6083,7 @@ export type ProjectEventLogsQuery = {
           notifyOnBuildFailure?: boolean | null;
           githubTriggerAliases?: Array<string> | null;
           perfEnabled?: boolean | null;
+          projectHealthView: ProjectHealthView;
           githubChecksEnabled?: boolean | null;
           gitTagAuthorizedTeams?: Array<string> | null;
           gitTagAuthorizedUsers?: Array<string> | null;
@@ -6141,6 +6156,12 @@ export type ProjectEventLogsQuery = {
             project: string;
             status: string;
             taskRegex: string;
+          }> | null;
+          parsleyFilters?: Array<{
+            __typename?: "ParsleyFilter";
+            caseSensitive: boolean;
+            exactMatch: boolean;
+            expression: string;
           }> | null;
           workstationConfig: {
             __typename?: "WorkstationConfig";
@@ -6522,6 +6543,7 @@ export type RepoEventLogsQuery = {
           notifyOnBuildFailure?: boolean | null;
           githubTriggerAliases?: Array<string> | null;
           perfEnabled?: boolean | null;
+          projectHealthView: ProjectHealthView;
           githubChecksEnabled?: boolean | null;
           gitTagAuthorizedTeams?: Array<string> | null;
           gitTagAuthorizedUsers?: Array<string> | null;
@@ -6594,6 +6616,12 @@ export type RepoEventLogsQuery = {
             project: string;
             status: string;
             taskRegex: string;
+          }> | null;
+          parsleyFilters?: Array<{
+            __typename?: "ParsleyFilter";
+            caseSensitive: boolean;
+            exactMatch: boolean;
+            expression: string;
           }> | null;
           workstationConfig: {
             __typename?: "WorkstationConfig";
@@ -6718,6 +6746,7 @@ export type RepoEventLogsQuery = {
           notifyOnBuildFailure?: boolean | null;
           githubTriggerAliases?: Array<string> | null;
           perfEnabled?: boolean | null;
+          projectHealthView: ProjectHealthView;
           githubChecksEnabled?: boolean | null;
           gitTagAuthorizedTeams?: Array<string> | null;
           gitTagAuthorizedUsers?: Array<string> | null;
@@ -6790,6 +6819,12 @@ export type RepoEventLogsQuery = {
             project: string;
             status: string;
             taskRegex: string;
+          }> | null;
+          parsleyFilters?: Array<{
+            __typename?: "ParsleyFilter";
+            caseSensitive: boolean;
+            exactMatch: boolean;
+            expression: string;
           }> | null;
           workstationConfig: {
             __typename?: "WorkstationConfig";

--- a/src/pages/projectSettings/tabs/EventLogTab/EventLogTab.test.tsx
+++ b/src/pages/projectSettings/tabs/EventLogTab/EventLogTab.test.tsx
@@ -3,6 +3,7 @@ import { RenderFakeToastContext } from "context/toast/__mocks__";
 import {
   ProjectEventLogsQuery,
   ProjectEventLogsQueryVariables,
+  ProjectHealthView,
 } from "gql/generated/types";
 import { GET_PROJECT_EVENT_LOGS } from "gql/queries";
 import { renderWithRouterMatch as render, screen, waitFor } from "test_utils";
@@ -146,6 +147,8 @@ const eventLogEntry: ProjectEventLogsQuery["projectEvents"]["eventLogEntries"][0
           message: "",
           __typename: "CommitQueueParams",
         },
+        parsleyFilters: [],
+        projectHealthView: ProjectHealthView.All,
       },
       subscriptions: [],
       vars: {
@@ -227,6 +230,8 @@ const eventLogEntry: ProjectEventLogsQuery["projectEvents"]["eventLogEntries"][0
           message: "",
           __typename: "CommitQueueParams",
         },
+        parsleyFilters: [],
+        projectHealthView: ProjectHealthView.Failed,
       },
       subscriptions: [],
       vars: {


### PR DESCRIPTION
EVG-20340

### Description
There was a slight oversight in that I just forgot to add it to the event log query. 🫠

### Screenshots
<!-- add screenshots of visible changes -->
<img width="1154" alt="Screenshot 2023-06-27 at 2 46 50 PM" src="https://github.com/evergreen-ci/spruce/assets/47064971/1579e5b0-4c91-41d8-b789-aacfa367d73d">

### Testing
If you do yarn prod, you should see the changes now.
