### PR TITLE
EVG-16363: Specify requesters for metadata links

### DIFF
--- a/src/components/Dropdown/__snapshots__/Dropdown.stories.storyshot
+++ b/src/components/Dropdown/__snapshots__/Dropdown.stories.storyshot
@@ -7,7 +7,7 @@ exports[`storybook Storyshots components/Dropdown Custom Button Render 1`] = `
   >
     <button
       aria-disabled="false"
-      class="lg-ui-button-0000 leafygreen-ui-18d58v3 css-129de3f-StyledButton-menuButtonStyleOverrides e1yw4j302"
+      class="lg-ui-button-0000 leafygreen-ui-18d58v3 css-1dntq6k-StyledButton-menuButtonStyleOverrides e1yw4j302"
       data-cy="dropdown-button"
       type="button"
     >
@@ -59,7 +59,7 @@ exports[`storybook Storyshots components/Dropdown Default 1`] = `
   >
     <button
       aria-disabled="false"
-      class="lg-ui-button-0000 leafygreen-ui-18d58v3 css-129de3f-StyledButton-menuButtonStyleOverrides e1yw4j302"
+      class="lg-ui-button-0000 leafygreen-ui-18d58v3 css-1dntq6k-StyledButton-menuButtonStyleOverrides e1yw4j302"
       data-cy="dropdown-button"
       type="button"
     >

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -152,6 +152,7 @@ const menuButtonStyleOverrides = css`
 
 const StyledButton = styled<ButtonType>(Button)`
   ${menuButtonStyleOverrides}
+  background: white;
   width: 100%;
 `;
 

--- a/src/components/ProjectSelect/__snapshots__/ProjectSelect.stories.storyshot
+++ b/src/components/ProjectSelect/__snapshots__/ProjectSelect.stories.storyshot
@@ -20,7 +20,7 @@ exports[`storybook Storyshots components/ProjectSelect Default 1`] = `
       >
         <button
           aria-disabled="false"
-          class="lg-ui-button-0000 leafygreen-ui-18d58v3 css-129de3f-StyledButton-menuButtonStyleOverrides e1yw4j302"
+          class="lg-ui-button-0000 leafygreen-ui-18d58v3 css-1dntq6k-StyledButton-menuButtonStyleOverrides e1yw4j302"
           data-cy="project-select"
           type="button"
         >
@@ -90,7 +90,7 @@ exports[`storybook Storyshots components/ProjectSelect With Clickable Header 1`]
       >
         <button
           aria-disabled="false"
-          class="lg-ui-button-0000 leafygreen-ui-18d58v3 css-129de3f-StyledButton-menuButtonStyleOverrides e1yw4j302"
+          class="lg-ui-button-0000 leafygreen-ui-18d58v3 css-1dntq6k-StyledButton-menuButtonStyleOverrides e1yw4j302"
           data-cy="project-select"
           type="button"
         >

--- a/src/components/SearchableDropdown/__snapshots__/SearchableDropdown.stories.storyshot
+++ b/src/components/SearchableDropdown/__snapshots__/SearchableDropdown.stories.storyshot
@@ -20,7 +20,7 @@ exports[`storybook Storyshots components/SearchableDropdown Custom Option 1`] = 
       >
         <button
           aria-disabled="false"
-          class="lg-ui-button-0000 leafygreen-ui-18d58v3 css-129de3f-StyledButton-menuButtonStyleOverrides e1yw4j302"
+          class="lg-ui-button-0000 leafygreen-ui-18d58v3 css-1dntq6k-StyledButton-menuButtonStyleOverrides e1yw4j302"
           data-cy="searchable-dropdown"
           type="button"
         >
@@ -90,7 +90,7 @@ exports[`storybook Storyshots components/SearchableDropdown Default 1`] = `
       >
         <button
           aria-disabled="false"
-          class="lg-ui-button-0000 leafygreen-ui-18d58v3 css-129de3f-StyledButton-menuButtonStyleOverrides e1yw4j302"
+          class="lg-ui-button-0000 leafygreen-ui-18d58v3 css-1dntq6k-StyledButton-menuButtonStyleOverrides e1yw4j302"
           data-cy="searchable-dropdown"
           type="button"
         >

--- a/src/components/SpruceForm/Widgets/LeafyGreenWidgets.tsx
+++ b/src/components/SpruceForm/Widgets/LeafyGreenWidgets.tsx
@@ -429,6 +429,6 @@ const StyledSegmentedControl = styled(SegmentedControl)`
   margin-bottom: ${size.s};
 `;
 
-const MaxWidthContainer = styled.div`
+export const MaxWidthContainer = styled.div`
   max-width: 400px;
 `;

--- a/src/components/SpruceForm/Widgets/MultiSelect.tsx
+++ b/src/components/SpruceForm/Widgets/MultiSelect.tsx
@@ -1,0 +1,74 @@
+import styled from "@emotion/styled";
+import { Error, Label } from "@leafygreen-ui/typography";
+import Dropdown from "components/Dropdown";
+import { TreeSelect, ALL_VALUE } from "components/TreeSelect";
+import { size } from "constants/tokens";
+import ElementWrapper from "../ElementWrapper";
+import { MaxWidthContainer } from "./LeafyGreenWidgets";
+import { EnumSpruceWidgetProps } from "./types";
+
+export const MultiSelect: React.VFC<EnumSpruceWidgetProps> = ({
+  disabled,
+  label,
+  onChange,
+  options,
+  value,
+  rawErrors,
+}) => {
+  const { "data-cy": dataCy, elementWrapperCSS, enumOptions } = options;
+
+  const processedOptions = [
+    {
+      title: "All",
+      key: ALL_VALUE,
+      value: ALL_VALUE,
+    },
+    ...enumOptions.map((o) => ({
+      title: o.label,
+      key: o.value,
+      value: o.value,
+    })),
+  ];
+
+  const handleChange = (selected: string[]) => {
+    // Filter out the "all" value since it isn't a valid enum.
+    onChange(selected.filter((s) => s !== ALL_VALUE));
+  };
+
+  const isAllSelected = value.length === enumOptions.length;
+  const selectedOptions = [...value, ...(isAllSelected ? [ALL_VALUE] : [])];
+
+  return (
+    <ElementWrapper css={elementWrapperCSS}>
+      <MaxWidthContainer>
+        <Container>
+          <Label htmlFor={`${label}-multiselect`}>{label}</Label>
+          <Dropdown
+            disabled={disabled}
+            id={`${label}-multiselect`}
+            data-cy={dataCy}
+            buttonText={`${label}: ${
+              value.length ? value.join(", ") : "No options selected."
+            }`}
+          >
+            <TreeSelect
+              onChange={handleChange}
+              tData={processedOptions}
+              state={selectedOptions}
+              hasStyling={false}
+            />
+          </Dropdown>
+          {rawErrors.length > 0 && <Error>{rawErrors.join(", ")}</Error>}
+        </Container>
+      </MaxWidthContainer>
+    </ElementWrapper>
+  );
+};
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${size.xxs};
+`;
+
+export default MultiSelect;

--- a/src/components/TreeSelect/__snapshots__/TreeSelect.stories.storyshot
+++ b/src/components/TreeSelect/__snapshots__/TreeSelect.stories.storyshot
@@ -494,7 +494,7 @@ exports[`storybook Storyshots components/TreeSelect With Dropdown 1`] = `
   >
     <button
       aria-disabled="false"
-      class="lg-ui-button-0000 leafygreen-ui-18d58v3 css-129de3f-StyledButton-menuButtonStyleOverrides e1yw4j302"
+      class="lg-ui-button-0000 leafygreen-ui-18d58v3 css-1dntq6k-StyledButton-menuButtonStyleOverrides e1yw4j302"
       data-cy="dropdown-button"
       type="button"
     >

--- a/src/gql/fragments/projectSettings/plugins.graphql
+++ b/src/gql/fragments/projectSettings/plugins.graphql
@@ -5,6 +5,7 @@ fragment ProjectPluginsSettings on Project {
   }
   externalLinks {
     displayName
+    requesters
     urlTemplate
   }
   perfEnabled
@@ -27,6 +28,7 @@ fragment RepoPluginsSettings on RepoRef {
   }
   externalLinks {
     displayName
+    requesters
     urlTemplate
   }
   perfEnabled

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -350,6 +350,7 @@ export type Expansion = {
 export type ExternalLink = {
   __typename?: "ExternalLink";
   displayName: Scalars["String"];
+  requesters: Array<Scalars["String"]>;
   urlTemplate: Scalars["String"];
 };
 
@@ -361,6 +362,7 @@ export type ExternalLinkForMetadata = {
 
 export type ExternalLinkInput = {
   displayName: Scalars["String"];
+  requesters?: InputMaybe<Array<Scalars["String"]>>;
   urlTemplate: Scalars["String"];
 };
 
@@ -3268,6 +3270,7 @@ export type ProjectSettingsFieldsFragment = {
     externalLinks?: Array<{
       __typename?: "ExternalLink";
       displayName: string;
+      requesters: Array<string>;
       urlTemplate: string;
     }> | null;
     taskAnnotationSettings: {
@@ -3463,6 +3466,7 @@ export type RepoSettingsFieldsFragment = {
     externalLinks?: Array<{
       __typename?: "ExternalLink";
       displayName: string;
+      requesters: Array<string>;
       urlTemplate: string;
     }> | null;
     taskAnnotationSettings: {
@@ -3714,6 +3718,7 @@ export type ProjectPluginsSettingsFragment = {
   externalLinks?: Array<{
     __typename?: "ExternalLink";
     displayName: string;
+    requesters: Array<string>;
     urlTemplate: string;
   }> | null;
   taskAnnotationSettings: {
@@ -3742,6 +3747,7 @@ export type RepoPluginsSettingsFragment = {
   externalLinks?: Array<{
     __typename?: "ExternalLink";
     displayName: string;
+    requesters: Array<string>;
     urlTemplate: string;
   }> | null;
   taskAnnotationSettings: {
@@ -3848,6 +3854,7 @@ export type ProjectEventSettingsFragment = {
     externalLinks?: Array<{
       __typename?: "ExternalLink";
       displayName: string;
+      requesters: Array<string>;
       urlTemplate: string;
     }> | null;
     taskAnnotationSettings: {
@@ -6056,6 +6063,7 @@ export type ProjectEventLogsQuery = {
           externalLinks?: Array<{
             __typename?: "ExternalLink";
             displayName: string;
+            requesters: Array<string>;
             urlTemplate: string;
           }> | null;
           taskAnnotationSettings: {
@@ -6259,6 +6267,7 @@ export type ProjectEventLogsQuery = {
           externalLinks?: Array<{
             __typename?: "ExternalLink";
             displayName: string;
+            requesters: Array<string>;
             urlTemplate: string;
           }> | null;
           taskAnnotationSettings: {
@@ -6477,6 +6486,7 @@ export type ProjectSettingsQuery = {
       externalLinks?: Array<{
         __typename?: "ExternalLink";
         displayName: string;
+        requesters: Array<string>;
         urlTemplate: string;
       }> | null;
       taskAnnotationSettings: {
@@ -6719,6 +6729,7 @@ export type RepoEventLogsQuery = {
           externalLinks?: Array<{
             __typename?: "ExternalLink";
             displayName: string;
+            requesters: Array<string>;
             urlTemplate: string;
           }> | null;
           taskAnnotationSettings: {
@@ -6922,6 +6933,7 @@ export type RepoEventLogsQuery = {
           externalLinks?: Array<{
             __typename?: "ExternalLink";
             displayName: string;
+            requesters: Array<string>;
             urlTemplate: string;
           }> | null;
           taskAnnotationSettings: {
@@ -7130,6 +7142,7 @@ export type RepoSettingsQuery = {
       externalLinks?: Array<{
         __typename?: "ExternalLink";
         displayName: string;
+        requesters: Array<string>;
         urlTemplate: string;
       }> | null;
       taskAnnotationSettings: {

--- a/src/pages/projectSettings/tabs/PluginsTab/PluginsTab.tsx
+++ b/src/pages/projectSettings/tabs/PluginsTab/PluginsTab.tsx
@@ -74,14 +74,24 @@ const validate = ((formData, errors) => {
 
   const displayNameDefined = patchMetadataPanelLink.displayName.trim() !== "";
   const urlTemplateDefined = patchMetadataPanelLink.urlTemplate.trim() !== "";
-  if (displayNameDefined && !urlTemplateDefined) {
-    errors.externalLinks.patchMetadataPanelLink.urlTemplate.addError(
-      "You must specify a URL template or exclude display name."
-    );
-  } else if (!displayNameDefined && urlTemplateDefined) {
-    errors.externalLinks.patchMetadataPanelLink.displayName.addError(
-      "You must specify a display name or exclude URL template."
-    );
+  const requestersDefined = patchMetadataPanelLink.requesters.length > 0;
+
+  if (displayNameDefined || urlTemplateDefined || requestersDefined) {
+    if (!displayNameDefined) {
+      errors.externalLinks.patchMetadataPanelLink.displayName.addError(
+        "You must specify a display name."
+      );
+    }
+    if (!urlTemplateDefined) {
+      errors.externalLinks.patchMetadataPanelLink.urlTemplate.addError(
+        "You must specify a URL template."
+      );
+    }
+    if (!requestersDefined) {
+      errors.externalLinks.patchMetadataPanelLink.requesters.addError(
+        "You must specify requesters."
+      );
+    }
   }
 
   return errors;

--- a/src/pages/projectSettings/tabs/PluginsTab/getFormSchema.ts
+++ b/src/pages/projectSettings/tabs/PluginsTab/getFormSchema.ts
@@ -1,10 +1,34 @@
 import { CardFieldTemplate } from "components/SpruceForm/FieldTemplates";
 import widgets from "components/SpruceForm/Widgets";
+import MultiSelect from "components/SpruceForm/Widgets/MultiSelect";
 import { GetFormSchema } from "../types";
 import { form } from "../utils";
 import { FormState } from "./types";
 
 const { placeholderIf, radioBoxOptions } = form;
+
+const requesters = [
+  {
+    label: "Commits",
+    value: "gitter_request",
+  },
+  {
+    label: "Patches",
+    value: "patch_request",
+  },
+  {
+    label: "GitHub Pull Requests",
+    value: "github_pull_request",
+  },
+  {
+    label: "Commit Queue Merge",
+    value: "merge_test",
+  },
+  {
+    label: "Periodic Builds",
+    value: "ad_hoc",
+  },
+];
 
 export const getFormSchema = (
   repoData?: FormState
@@ -136,14 +160,27 @@ export const getFormSchema = (
       },
       externalLinks: {
         type: "object" as "object",
-        title: "Patch Metadata Link",
+        title: "Metadata Link",
         properties: {
           patchMetadataPanelLink: {
             type: "object" as "object",
             title: "",
             description:
-              "Add a URL to the patch metadata panel to share a custom link with anyone viewing a patch from this project. Include {version_id} in the URL template and it will be replaced by an actual version ID.",
+              "Add a URL to the metadata panel for versions with the specified requester in this project. Include {version_id} in the URL template and it will be replaced by an actual version ID.",
             properties: {
+              requesters: {
+                type: "array" as "array",
+                title: "Requesters",
+                uniqueItems: true,
+                items: {
+                  type: "string" as "string",
+                  anyOf: requesters.map((r) => ({
+                    type: "string" as "string",
+                    title: r.label,
+                    enum: [r.value],
+                  })),
+                },
+              },
               displayName: {
                 type: "string" as "string",
                 title: "Display name",
@@ -212,6 +249,9 @@ export const getFormSchema = (
       "ui:rootFieldId": "externalLinks",
       "ui:ObjectFieldTemplate": CardFieldTemplate,
       patchMetadataPanelLink: {
+        requesters: {
+          "ui:widget": MultiSelect,
+        },
         urlTemplate: {
           "ui:placeholder": "https://example.com/{version_id}",
           "ui:data-cy": "url-template-input",

--- a/src/pages/projectSettings/tabs/PluginsTab/transformers.test.ts
+++ b/src/pages/projectSettings/tabs/PluginsTab/transformers.test.ts
@@ -46,6 +46,7 @@ const projectForm: FormState = {
   },
   externalLinks: {
     patchMetadataPanelLink: {
+      requesters: ["gitter_request", "patch_request"],
       displayName: "a link display name",
       urlTemplate: "https:/a-link-template-{version_id}.com",
     },
@@ -65,6 +66,7 @@ const projectResult: Pick<ProjectSettingsInput, "projectRef"> = {
     },
     externalLinks: [
       {
+        requesters: ["gitter_request", "patch_request"],
         displayName: "a link display name",
         urlTemplate: "https:/a-link-template-{version_id}.com",
       },
@@ -101,6 +103,7 @@ const repoForm: FormState = {
   },
   externalLinks: {
     patchMetadataPanelLink: {
+      requesters: ["gitter_request", "patch_request"],
       displayName: "a link display name",
       urlTemplate: "https:/a-link-template-{version_id}.com",
     },
@@ -125,6 +128,7 @@ const repoResult: Pick<RepoSettingsInput, "projectRef"> = {
     },
     externalLinks: [
       {
+        requesters: ["gitter_request", "patch_request"],
         displayName: "a link display name",
         urlTemplate: "https:/a-link-template-{version_id}.com",
       },

--- a/src/pages/projectSettings/tabs/PluginsTab/transformers.ts
+++ b/src/pages/projectSettings/tabs/PluginsTab/transformers.ts
@@ -40,6 +40,7 @@ export const gqlToForm = ((data) => {
     },
     externalLinks: {
       patchMetadataPanelLink: {
+        requesters: projectRef?.externalLinks?.[0].requesters ?? [],
         displayName: projectRef?.externalLinks?.[0].displayName ?? "",
         urlTemplate: projectRef?.externalLinks?.[0].urlTemplate ?? "",
       },

--- a/src/pages/projectSettings/tabs/PluginsTab/types.ts
+++ b/src/pages/projectSettings/tabs/PluginsTab/types.ts
@@ -23,6 +23,7 @@ export interface FormState {
   };
   externalLinks: {
     patchMetadataPanelLink: {
+      requesters: string[];
       displayName: string;
       urlTemplate: string;
     };

--- a/src/pages/projectSettings/tabs/testData.ts
+++ b/src/pages/projectSettings/tabs/testData.ts
@@ -10,6 +10,7 @@ const projectBase: ProjectSettingsQuery["projectSettings"] = {
   projectRef: {
     externalLinks: [
       {
+        requesters: ["gitter_request", "patch_request"],
         displayName: "a link display name",
         urlTemplate: "https:/a-link-template-{version_id}.com",
       },
@@ -147,6 +148,7 @@ const repoBase: RepoSettingsQuery["repoSettings"] = {
   projectRef: {
     externalLinks: [
       {
+        requesters: ["gitter_request", "patch_request"],
         displayName: "a link display name",
         urlTemplate: "https:/a-link-template-{version_id}.com",
       },

--- a/src/pages/version/Metadata.tsx
+++ b/src/pages/version/Metadata.tsx
@@ -180,7 +180,7 @@ export const Metadata: React.VFC<Props> = ({ loading, version }) => {
         </MetadataItem>
       )}
       <ParametersModal parameters={parameters} />
-      {url && displayName && isPatch && (
+      {url && displayName && (
         <MetadataItem>
           <StyledLink data-cy="external-link" href={url}>
             {displayName}


### PR DESCRIPTION
EVG-16363

### Description
This PR adds the requesters field in the Metadata Links section.

### Screenshots
<img width="530" alt="Screenshot 2023-07-07 at 2 38 34 PM" src="https://github.com/evergreen-ci/spruce/assets/47064971/4e302eae-4116-46e3-b6bc-058247e29250">

### Testing
- Manual testing, updated transformers and e2e tests

### Evergreen PR
- evergreen-ci/evergreen/pull/6744 (must be merged and deployed first)
