### PR TITLE
EVG-19743 RATE_AVG for network stats

### DIFF
--- a/src/constants/externalResources.test.ts
+++ b/src/constants/externalResources.test.ts
@@ -70,7 +70,7 @@ describe("getTaskSystemMetricsUrl", () => {
         new Date("2023-07-07T20:00:00")
       )
     ).toBe(
-      `/datasets/evergreen?query={"calculations":[{"op":"AVG","column":"system.memory.usage.used"},{"op":"AVG","column":"system.cpu.utilization"},{"op":"AVG","column":"system.network.io.transmit"},{"op":"AVG","column":"system.network.io.receive"}],"filters":[{"op":"=","column":"evergreen.task.id","value":"task_12345"}],"start_time":1688756921,"end_time":1688760000,"granularity":15}&omitMissingValues`
+      `/datasets/evergreen?query={"calculations":[{"op":"AVG","column":"system.memory.usage.used"},{"op":"AVG","column":"system.cpu.utilization"},{"op":"RATE_AVG","column":"system.network.io.transmit"},{"op":"RATE_AVG","column":"system.network.io.receive"}],"filters":[{"op":"=","column":"evergreen.task.id","value":"task_12345"}],"start_time":1688756921,"end_time":1688760000,"granularity":15}&omitMissingValues`
     );
   });
 });

--- a/src/constants/externalResources.ts
+++ b/src/constants/externalResources.ts
@@ -122,8 +122,8 @@ export const getHoneycombSystemMetricsUrl = (
     calculations: [
       { op: "AVG", column: "system.memory.usage.used" },
       { op: "AVG", column: "system.cpu.utilization" },
-      { op: "AVG", column: "system.network.io.transmit" },
-      { op: "AVG", column: "system.network.io.receive" },
+      { op: "RATE_AVG", column: "system.network.io.transmit" },
+      { op: "RATE_AVG", column: "system.network.io.receive" },
     ],
     filters: [{ op: "=", column: "evergreen.task.id", value: taskId }],
     start_time: getUnixTime(new Date(startTs)),


### PR DESCRIPTION
[EVG-19743](https://jira.mongodb.org/browse/EVG-19743)

### Description
RATE_AVG is more what users would want to see for the network metrics (per @opsnlops)