### PR TITLE
EVG-20304: Show merge queue section for 'github-merge-queue-sandbox' project

### DIFF
--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -222,6 +222,15 @@ export type ContainerResourcesInput = {
 };
 
 /**
+ * CopyDistroInput is the input to the copyDistro mutation.
+ * It contains information about a distro to be duplicated.
+ */
+export type CopyDistroInput = {
+  distroIdToCopy: Scalars["String"];
+  newDistroId: Scalars["String"];
+};
+
+/**
  * CopyProjectInput is the input to the copyProject mutation.
  * It contains information about a project to be duplicated.
  */
@@ -306,6 +315,17 @@ export type DistroInfo = {
   workDir?: Maybe<Scalars["String"]>;
 };
 
+export type DistroPermissions = {
+  __typename?: "DistroPermissions";
+  admin: Scalars["Boolean"];
+  edit: Scalars["Boolean"];
+  view: Scalars["Boolean"];
+};
+
+export type DistroPermissionsOptions = {
+  distroId: Scalars["String"];
+};
+
 export enum DistroSettingsAccess {
   Admin = "ADMIN",
   Create = "CREATE",
@@ -364,7 +384,7 @@ export type ExternalLinkForMetadata = {
 
 export type ExternalLinkInput = {
   displayName: Scalars["String"];
-  requesters?: InputMaybe<Array<Scalars["String"]>>;
+  requesters: Array<Scalars["String"]>;
   urlTemplate: Scalars["String"];
 };
 
@@ -784,6 +804,7 @@ export type Mutation = {
   attachVolumeToHost: Scalars["Boolean"];
   bbCreateTicket: Scalars["Boolean"];
   clearMySubscriptions: Scalars["Int"];
+  copyDistro: NewDistroPayload;
   copyProject: Project;
   createProject: Project;
   createPublicKey: Array<PublicKey>;
@@ -863,6 +884,10 @@ export type MutationAttachVolumeToHostArgs = {
 export type MutationBbCreateTicketArgs = {
   execution?: InputMaybe<Scalars["Int"]>;
   taskId: Scalars["String"];
+};
+
+export type MutationCopyDistroArgs = {
+  opts: CopyDistroInput;
 };
 
 export type MutationCopyProjectArgs = {
@@ -1083,6 +1108,12 @@ export type MutationUpdateVolumeArgs = {
   updateVolumeInput: UpdateVolumeInput;
 };
 
+/** Return type representing whether a distro was created and any validation errors */
+export type NewDistroPayload = {
+  __typename?: "NewDistroPayload";
+  newDistroId: Scalars["String"];
+};
+
 export type Note = {
   __typename?: "Note";
   message: Scalars["String"];
@@ -1276,8 +1307,14 @@ export type PeriodicBuildInput = {
 
 export type Permissions = {
   __typename?: "Permissions";
+  canCreateDistro: Scalars["Boolean"];
   canCreateProject: Scalars["Boolean"];
+  distroPermissions: DistroPermissions;
   userId: Scalars["String"];
+};
+
+export type PermissionsDistroPermissionsArgs = {
+  options: DistroPermissionsOptions;
 };
 
 export type PlannerSettings = {

--- a/src/pages/projectSettings/tabs/GithubCommitQueueTab/getFormSchema.tsx
+++ b/src/pages/projectSettings/tabs/GithubCommitQueueTab/getFormSchema.tsx
@@ -48,6 +48,8 @@ export const getFormSchema = (
     "ui:showLabel": false,
   };
 
+  const isCQTestProject = identifier === "github-merge-queue-sandbox";
+
   const errorStyling = sectionHasError(versionControlEnabled, projectType);
 
   return {
@@ -221,7 +223,7 @@ export const getFormSchema = (
                     enabled: {
                       enum: [true],
                     },
-                    ...(!isProduction() && {
+                    ...((!isProduction() || isCQTestProject) && {
                       mergeQueueTitle: {
                         title: "Merge Queue",
                         type: "null",


### PR DESCRIPTION
EVG-20304

### Description
Brian is unable to test on staging due to the current state of the GitHub app project. To get around this, he wants to use the `'github-merge-queue-sandbox'` project on production so that he can manually test the merge queue behavior.

I made a special check for that project so that Brian can test on production.
