### PR TITLE
EVG-20078: Expose merge queue section to production

### DIFF
--- a/cypress/integration/projectSettings/project_settings.ts
+++ b/cypress/integration/projectSettings/project_settings.ts
@@ -157,7 +157,7 @@ describe("Repo Settings", { testIsolation: false }, () => {
         .contains(
           "A GitHub Patch Definition must be specified for this feature to run."
         )
-        .should("be.visible");
+        .should("exist");
     });
 
     it("Shows an error banner when Commit Checks are enabled", () => {
@@ -168,7 +168,7 @@ describe("Repo Settings", { testIsolation: false }, () => {
         .contains(
           "A Commit Check Definition must be specified for this feature to run."
         )
-        .should("be.visible");
+        .should("exist");
       cy.dataCy("github-checks-enabled-radio-box").within(($el) => {
         cy.wrap($el).getInputByLabel("Disabled").parent().click();
       });
@@ -211,8 +211,7 @@ describe("Repo Settings", { testIsolation: false }, () => {
         .contains(
           "A Commit Queue Patch Definition must be specified for this feature to run."
         )
-        .scrollIntoView()
-        .should("be.visible");
+        .should("exist");
     });
 
     it("Presents three options for merge method", () => {

--- a/cypress/integration/projectSettings/project_settings.ts
+++ b/cypress/integration/projectSettings/project_settings.ts
@@ -157,7 +157,7 @@ describe("Repo Settings", { testIsolation: false }, () => {
         .contains(
           "A GitHub Patch Definition must be specified for this feature to run."
         )
-        .should("exist");
+        .should("be.visible");
     });
 
     it("Shows an error banner when Commit Checks are enabled", () => {
@@ -168,10 +168,7 @@ describe("Repo Settings", { testIsolation: false }, () => {
         .contains(
           "A Commit Check Definition must be specified for this feature to run."
         )
-        .should("exist");
-    });
-
-    it("Hides error banner when Commit Checks are disabled", () => {
+        .should("be.visible");
       cy.dataCy("github-checks-enabled-radio-box").within(($el) => {
         cy.wrap($el).getInputByLabel("Disabled").parent().click();
       });
@@ -190,10 +187,8 @@ describe("Repo Settings", { testIsolation: false }, () => {
     });
 
     it("Updates a patch definition", () => {
-      cy.dataCy("add-button").contains("Add Patch Definition").parent().click();
-
+      cy.contains("button", "Add Patch Definition").click();
       cy.dataCy("variant-tags-input").first().type("vtag");
-
       cy.dataCy("task-tags-input").first().type("ttag");
     });
 
@@ -214,9 +209,10 @@ describe("Repo Settings", { testIsolation: false }, () => {
 
       cy.dataCy("error-banner")
         .contains(
-          "A Commit Check Definition must be specified for this feature to run."
+          "A Commit Queue Patch Definition must be specified for this feature to run."
         )
-        .should("not.exist");
+        .scrollIntoView()
+        .should("be.visible");
     });
 
     it("Presents three options for merge method", () => {
@@ -239,15 +235,14 @@ describe("Repo Settings", { testIsolation: false }, () => {
     });
 
     it("Adds a commit queue definition", () => {
-      cy.dataCy("add-button")
-        .contains("Add Commit Queue Patch Definition")
-        .parent()
-        .click();
+      cy.contains("button", "Add Commit Queue Patch Definition").click();
       cy.dataCy("variant-tags-input").last().type("cqvtag");
       cy.dataCy("task-tags-input").last().type("cqttag");
     });
 
     it("Successfully saves the page", () => {
+      cy.dataCy("warning-banner").should("not.exist");
+      cy.dataCy("error-banner").should("not.exist");
       clickSave();
       cy.validateToast("success", "Successfully updated repo");
     });

--- a/src/constants/externalResources.ts
+++ b/src/constants/externalResources.ts
@@ -39,7 +39,7 @@ export const konamiSoundTrackUrl =
   "https://www.myinstants.com/media/sounds/mvssf-win.mp3";
 
 export const githubMergeQueueUrl =
-  "https://github.blog/changelog/2023-02-08-pull-request-merge-queue-public-beta";
+  "https://github.blog/2023-07-12-github-merge-queue-is-generally-available";
 
 export const legacyRoutes = {
   distros: "/distros",

--- a/src/constants/externalResources.ts
+++ b/src/constants/externalResources.ts
@@ -38,9 +38,6 @@ export const getJiraImprovementUrl = (jiraHost: string) =>
 export const konamiSoundTrackUrl =
   "https://www.myinstants.com/media/sounds/mvssf-win.mp3";
 
-export const githubMergeQueueUrl =
-  "https://github.blog/2023-07-12-github-merge-queue-is-generally-available";
-
 export const legacyRoutes = {
   distros: "/distros",
   hosts: "/spawn",

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -82,6 +82,20 @@ export type BootstrapSettings = {
   shellPath?: Maybe<Scalars["String"]>;
 };
 
+export type BootstrapSettingsInput = {
+  clientDir?: InputMaybe<Scalars["String"]>;
+  communication?: InputMaybe<Scalars["String"]>;
+  env?: InputMaybe<Array<EnvVarInput>>;
+  jasperBinaryDir?: InputMaybe<Scalars["String"]>;
+  jasperCredentialsPath?: InputMaybe<Scalars["String"]>;
+  method?: InputMaybe<Scalars["String"]>;
+  preconditionScripts?: InputMaybe<Array<PreconditionScriptInput>>;
+  resourceLimits?: InputMaybe<ResourceLimitsInput>;
+  rootDir?: InputMaybe<Scalars["String"]>;
+  serviceUser?: InputMaybe<Scalars["String"]>;
+  shellPath?: InputMaybe<Scalars["String"]>;
+};
+
 export type Build = {
   __typename?: "Build";
   actualMakespan: Scalars["Duration"];
@@ -240,6 +254,11 @@ export type CopyProjectInput = {
   projectIdToCopy: Scalars["String"];
 };
 
+/** CreateDistroInput is the input to the createDistro mutation. */
+export type CreateDistroInput = {
+  newDistroId: Scalars["String"];
+};
+
 /**
  * CreateProjectInput is the input to the createProject mutation.
  * It contains information about a new project to be created.
@@ -275,6 +294,10 @@ export type Dependency = {
 export type DispatcherSettings = {
   __typename?: "DispatcherSettings";
   version?: Maybe<Scalars["String"]>;
+};
+
+export type DispatcherSettingsInput = {
+  version?: InputMaybe<Scalars["String"]>;
 };
 
 export type DisplayTask = {
@@ -326,6 +349,45 @@ export type DistroInfo = {
   workDir?: Maybe<Scalars["String"]>;
 };
 
+export type DistroInput = {
+  aliases?: InputMaybe<Array<Scalars["String"]>>;
+  arch?: InputMaybe<Scalars["String"]>;
+  authorizedKeysFile?: InputMaybe<Scalars["String"]>;
+  bootstrapSettings?: InputMaybe<BootstrapSettingsInput>;
+  cloneMethod?: InputMaybe<Scalars["String"]>;
+  containerPool?: InputMaybe<Scalars["String"]>;
+  disableShallowClone?: InputMaybe<Scalars["Boolean"]>;
+  disabled?: InputMaybe<Scalars["Boolean"]>;
+  dispatcherSettings?: InputMaybe<DispatcherSettingsInput>;
+  expansions?: InputMaybe<Array<ExpansionInput>>;
+  finderSettings?: InputMaybe<FinderSettingsInput>;
+  homeVolumeSettings?: InputMaybe<HomeVolumeSettingsInput>;
+  hostAllocatorSettings?: InputMaybe<HostAllocatorSettingsInput>;
+  iceCreamSettings?: InputMaybe<IceCreamSettingsInput>;
+  isCluster?: InputMaybe<Scalars["Boolean"]>;
+  isVirtualWorkStation?: InputMaybe<Scalars["Boolean"]>;
+  name?: InputMaybe<Scalars["String"]>;
+  note?: InputMaybe<Scalars["String"]>;
+  plannerSettings?: InputMaybe<PlannerSettingsInput>;
+  provider?: InputMaybe<Scalars["String"]>;
+  providerSettingsList?: InputMaybe<Array<Scalars["Map"]>>;
+  setup?: InputMaybe<Scalars["String"]>;
+  setupAsSudo?: InputMaybe<Scalars["Boolean"]>;
+  sshKey?: InputMaybe<Scalars["String"]>;
+  sshOptions?: InputMaybe<Array<Scalars["String"]>>;
+  user?: InputMaybe<Scalars["String"]>;
+  userSpawnAllowed?: InputMaybe<Scalars["Boolean"]>;
+  validProjects?: InputMaybe<Array<Scalars["String"]>>;
+  workDir?: InputMaybe<Scalars["String"]>;
+};
+
+export enum DistroOnSaveOperation {
+  Decommission = "DECOMMISSION",
+  None = "NONE",
+  Reprovision = "REPROVISION",
+  RestartJasper = "RESTART_JASPER",
+}
+
 export type DistroPermissions = {
   __typename?: "DistroPermissions";
   admin: Scalars["Boolean"];
@@ -342,6 +404,14 @@ export enum DistroSettingsAccess {
   Create = "CREATE",
   Edit = "EDIT",
   View = "VIEW",
+}
+
+export enum DistroSettingsSection {
+  General = "GENERAL",
+  Host = "HOST",
+  Project = "PROJECT",
+  Provider = "PROVIDER",
+  Task = "TASK",
 }
 
 export type EcsConfig = {
@@ -374,10 +444,20 @@ export type EnvVar = {
   value?: Maybe<Scalars["String"]>;
 };
 
+export type EnvVarInput = {
+  key?: InputMaybe<Scalars["String"]>;
+  value?: InputMaybe<Scalars["String"]>;
+};
+
 export type Expansion = {
   __typename?: "Expansion";
   key?: Maybe<Scalars["String"]>;
   value?: Maybe<Scalars["String"]>;
+};
+
+export type ExpansionInput = {
+  key?: InputMaybe<Scalars["String"]>;
+  value?: InputMaybe<Scalars["String"]>;
 };
 
 export type ExternalLink = {
@@ -418,6 +498,10 @@ export type FileDiff = {
 export type FinderSettings = {
   __typename?: "FinderSettings";
   version?: Maybe<Scalars["String"]>;
+};
+
+export type FinderSettingsInput = {
+  version?: InputMaybe<Scalars["String"]>;
 };
 
 export type GeneralSubscription = {
@@ -510,6 +594,10 @@ export type HomeVolumeSettings = {
   formatCommand?: Maybe<Scalars["String"]>;
 };
 
+export type HomeVolumeSettingsInput = {
+  formatCommand?: InputMaybe<Scalars["String"]>;
+};
+
 /** Host models a host, which are used for things like running tasks or as virtual workstations. */
 export type Host = {
   __typename?: "Host";
@@ -548,6 +636,16 @@ export type HostAllocatorSettings = {
   minimumHosts: Scalars["Int"];
   roundingRule?: Maybe<Scalars["String"]>;
   version?: Maybe<Scalars["String"]>;
+};
+
+export type HostAllocatorSettingsInput = {
+  acceptableHostIdleTime?: InputMaybe<Scalars["Duration"]>;
+  feedbackRule?: InputMaybe<Scalars["String"]>;
+  hostsOverallocatedRule?: InputMaybe<Scalars["String"]>;
+  maximumHosts?: InputMaybe<Scalars["Int"]>;
+  minimumHosts?: InputMaybe<Scalars["Int"]>;
+  roundingRule?: InputMaybe<Scalars["String"]>;
+  version?: InputMaybe<Scalars["String"]>;
 };
 
 export type HostEventLogData = {
@@ -617,6 +715,11 @@ export type IceCreamSettings = {
   __typename?: "IceCreamSettings";
   configPath?: Maybe<Scalars["String"]>;
   schedulerHost?: Maybe<Scalars["String"]>;
+};
+
+export type IceCreamSettingsInput = {
+  configPath?: InputMaybe<Scalars["String"]>;
+  schedulerHost?: InputMaybe<Scalars["String"]>;
 };
 
 export type InstanceTag = {
@@ -817,6 +920,7 @@ export type Mutation = {
   clearMySubscriptions: Scalars["Int"];
   copyDistro: NewDistroPayload;
   copyProject: Project;
+  createDistro: NewDistroPayload;
   createProject: Project;
   createPublicKey: Array<PublicKey>;
   deactivateStepbackTask: Scalars["Boolean"];
@@ -843,6 +947,7 @@ export type Mutation = {
   restartJasper: Scalars["Int"];
   restartTask: Task;
   restartVersions?: Maybe<Array<Version>>;
+  saveDistroSection: SaveDistroSectionPayload;
   saveProjectSettingsForSection: ProjectSettings;
   saveRepoSettingsForSection: RepoSettings;
   saveSubscription: Scalars["Boolean"];
@@ -905,6 +1010,10 @@ export type MutationCopyDistroArgs = {
 export type MutationCopyProjectArgs = {
   project: CopyProjectInput;
   requestS3Creds?: InputMaybe<Scalars["Boolean"]>;
+};
+
+export type MutationCreateDistroArgs = {
+  opts: CreateDistroInput;
 };
 
 export type MutationCreateProjectArgs = {
@@ -1029,6 +1138,10 @@ export type MutationRestartVersionsArgs = {
   abort: Scalars["Boolean"];
   versionId: Scalars["String"];
   versionsToRestart: Array<VersionToRestart>;
+};
+
+export type MutationSaveDistroSectionArgs = {
+  opts: SaveDistroInput;
 };
 
 export type MutationSaveProjectSettingsForSectionArgs = {
@@ -1345,6 +1458,17 @@ export type PlannerSettings = {
   version?: Maybe<Scalars["String"]>;
 };
 
+export type PlannerSettingsInput = {
+  expectedRuntimeFactor?: InputMaybe<Scalars["Int"]>;
+  generateTaskFactor?: InputMaybe<Scalars["Int"]>;
+  groupVersions?: InputMaybe<Scalars["Boolean"]>;
+  mainlineTimeInQueueFactor?: InputMaybe<Scalars["Int"]>;
+  patchFactor?: InputMaybe<Scalars["Int"]>;
+  patchTimeInQueueFactor?: InputMaybe<Scalars["Int"]>;
+  targetTime?: InputMaybe<Scalars["Duration"]>;
+  version?: InputMaybe<Scalars["String"]>;
+};
+
 export type Pod = {
   __typename?: "Pod";
   events: PodEvents;
@@ -1396,6 +1520,11 @@ export type PreconditionScript = {
   __typename?: "PreconditionScript";
   path?: Maybe<Scalars["String"]>;
   script?: Maybe<Scalars["String"]>;
+};
+
+export type PreconditionScriptInput = {
+  path?: InputMaybe<Scalars["String"]>;
+  script?: InputMaybe<Scalars["String"]>;
 };
 
 /** Project models single repository on GitHub. */
@@ -1964,6 +2093,28 @@ export type ResourceLimits = {
   numProcesses?: Maybe<Scalars["Int"]>;
   numTasks?: Maybe<Scalars["Int"]>;
   virtualMemoryKb?: Maybe<Scalars["Int"]>;
+};
+
+export type ResourceLimitsInput = {
+  lockedMemoryKb?: InputMaybe<Scalars["Int"]>;
+  numFiles?: InputMaybe<Scalars["Int"]>;
+  numProcesses?: InputMaybe<Scalars["Int"]>;
+  numTasks?: InputMaybe<Scalars["Int"]>;
+  virtualMemoryKb?: InputMaybe<Scalars["Int"]>;
+};
+
+export type SaveDistroInput = {
+  changes?: InputMaybe<DistroInput>;
+  distroId: Scalars["String"];
+  onSave: DistroOnSaveOperation;
+  section: DistroSettingsSection;
+};
+
+/** Return type representing the updated distro and the number of hosts that were updated. */
+export type SaveDistroSectionPayload = {
+  __typename?: "SaveDistroSectionPayload";
+  distro: Distro;
+  hostCount: Scalars["Int"];
 };
 
 export type SearchReturnInfo = {

--- a/src/pages/projectSettings/tabs/GithubCommitQueueTab/getFormSchema.tsx
+++ b/src/pages/projectSettings/tabs/GithubCommitQueueTab/getFormSchema.tsx
@@ -7,7 +7,6 @@ import {
   pullRequestAliasesDocumentationUrl,
   gitTagAliasesDocumentationUrl,
   githubChecksAliasesDocumentationUrl,
-  githubMergeQueueUrl,
 } from "constants/externalResources";
 import {
   getProjectSettingsRoute,
@@ -195,7 +194,6 @@ export const getFormSchema = (
             },
           },
           dependencies: {
-            // @ts-expect-error - Allow React element in Radio description
             enabled: {
               oneOf: [
                 {
@@ -232,18 +230,7 @@ export const getFormSchema = (
                           type: "string" as "string",
                           title: "GitHub",
                           enum: [MergeQueue.Github],
-                          description: (
-                            <>
-                              Use the GitHub merge queue. Read the documentation{" "}
-                              <StyledLink
-                                target="_blank"
-                                href={githubMergeQueueUrl}
-                              >
-                                here
-                              </StyledLink>
-                              .
-                            </>
-                          ),
+                          description: "Use the GitHub merge queue.",
                         },
                       ],
                     },

--- a/src/pages/projectSettings/tabs/GithubCommitQueueTab/getFormSchema.tsx
+++ b/src/pages/projectSettings/tabs/GithubCommitQueueTab/getFormSchema.tsx
@@ -1,5 +1,3 @@
-import styled from "@emotion/styled";
-import { palette } from "@leafygreen-ui/palette";
 import { Description } from "@leafygreen-ui/typography";
 import { CardFieldTemplate } from "components/SpruceForm/FieldTemplates";
 import widgets from "components/SpruceForm/Widgets";
@@ -15,19 +13,14 @@ import {
   getProjectSettingsRoute,
   ProjectSettingsTabRoutes,
 } from "constants/routes";
-import { size } from "constants/tokens";
 import { GithubProjectConflicts, MergeQueue } from "gql/generated/types";
 import { getTabTitle } from "pages/projectSettings/getTabTitle";
-import { environmentVariables } from "utils";
 import { GetFormSchema } from "../types";
 import { alias, form, ProjectType } from "../utils";
 import { githubConflictErrorStyling, sectionHasError } from "./getErrors";
 import { GithubTriggerAliasField } from "./GithubTriggerAliasField";
 import { GCQFormState } from "./types";
 
-const { green } = palette;
-
-const { isProduction } = environmentVariables;
 const { aliasArray, aliasRowUiSchema, gitTagArray } = alias;
 const { insertIf, overrideRadioBox, placeholderIf, radioBoxOptions } = form;
 
@@ -47,8 +40,6 @@ export const getFormSchema = (
         : "hidden",
     "ui:showLabel": false,
   };
-
-  const isCQTestProject = identifier === "github-merge-queue-sandbox";
 
   const errorStyling = sectionHasError(versionControlEnabled, projectType);
 
@@ -204,7 +195,7 @@ export const getFormSchema = (
             },
           },
           dependencies: {
-            // @ts-expect-error - Allow the BETA badge in Radio Button widget title.
+            // @ts-expect-error - Allow React element in Radio description
             enabled: {
               oneOf: [
                 {
@@ -223,46 +214,39 @@ export const getFormSchema = (
                     enabled: {
                       enum: [true],
                     },
-                    ...((!isProduction() || isCQTestProject) && {
-                      mergeQueueTitle: {
-                        title: "Merge Queue",
-                        type: "null",
-                      },
-                      mergeQueue: {
-                        type: "string" as "string",
-                        oneOf: [
-                          {
-                            type: "string" as "string",
-                            title: "Evergreen",
-                            enum: [MergeQueue.Evergreen],
-                            description:
-                              "Use the standard commit queue owned and maintained by Evergreen.",
-                          },
-                          {
-                            type: "string" as "string",
-                            title: (
-                              <span>
-                                GitHub <BetaBadge>Beta</BetaBadge>
-                              </span>
-                            ),
-                            enum: [MergeQueue.Github],
-                            description: (
-                              <>
-                                Use the GitHub merge queue. Read the
-                                documentation{" "}
-                                <StyledLink
-                                  target="_blank"
-                                  href={githubMergeQueueUrl}
-                                >
-                                  here
-                                </StyledLink>
-                                .
-                              </>
-                            ),
-                          },
-                        ],
-                      },
-                    }),
+                    mergeQueueTitle: {
+                      title: "Merge Queue",
+                      type: "null",
+                    },
+                    mergeQueue: {
+                      type: "string" as "string",
+                      oneOf: [
+                        {
+                          type: "string" as "string",
+                          title: "Evergreen",
+                          enum: [MergeQueue.Evergreen],
+                          description:
+                            "Use the standard commit queue owned and maintained by Evergreen.",
+                        },
+                        {
+                          type: "string" as "string",
+                          title: "GitHub",
+                          enum: [MergeQueue.Github],
+                          description: (
+                            <>
+                              Use the GitHub merge queue. Read the documentation{" "}
+                              <StyledLink
+                                target="_blank"
+                                href={githubMergeQueueUrl}
+                              >
+                                here
+                              </StyledLink>
+                              .
+                            </>
+                          ),
+                        },
+                      ],
+                    },
                     message: {
                       type: "string" as "string",
                       title: "Commit Queue Message",
@@ -654,13 +638,3 @@ const GitHubChecksAliasesDescription = (
     and no aliases are defined on the project or repo page.
   </>
 );
-
-const BetaBadge = styled.span`
-  color: ${green.dark1};
-  border: 1px solid ${green.dark1};
-  border-radius: ${size.s};
-  padding: 0 ${size.xxs};
-  font-size: 11px;
-  text-transform: uppercase;
-  vertical-align: bottom;
-`;


### PR DESCRIPTION
EVG-20078

### Description
This PR removes the `isProduction()` flag from the merge queue section. Also removes the "beta" badge since the GitHub merge queue is out of beta.

### Testing
For some reason, removing the beta badge caused the e2e tests to fail... the only way I could fix it was removing the invalid objects from the Radio widget. So the GitHub documentation link unfortunately had to be removed.

Also cleaned up some assertions.
