### PR TITLE
EVG-20416 Fix task filter base task assertion

### DIFF
--- a/cypress/integration/version/task_filters.ts
+++ b/cypress/integration/version/task_filters.ts
@@ -130,9 +130,7 @@ describe("Tasks filters", () => {
             search: "failed",
           });
           waitForTable();
-          cy.dataCy("filtered-count")
-            .invoke("text")
-            .should("have.length.greaterThan", 0);
+          cy.dataCy("filtered-count").contains(2);
 
           cy.dataCy("filtered-count")
             .invoke("text")
@@ -210,7 +208,7 @@ describe("Tasks filters", () => {
           });
           waitForTable();
 
-          cy.dataCy("filtered-count").should("have.text", 0);
+          cy.dataCy("filtered-count").should("have.text", 44);
           selectCheckboxOption("Succeeded", false);
           urlSearchParamsAreUpdated({
             pathname: pathTasks,

--- a/cypress/integration/version/task_filters.ts
+++ b/cypress/integration/version/task_filters.ts
@@ -130,7 +130,7 @@ describe("Tasks filters", () => {
             search: "failed",
           });
           waitForTable();
-          cy.dataCy("filtered-count").contains(2);
+          cy.dataCy("filtered-count").should("have.text", 2);
 
           cy.dataCy("filtered-count")
             .invoke("text")


### PR DESCRIPTION
EVG-20416

### Description
While working on https://github.com/evergreen-ci/evergreen/pull/6760 I noticed that one of the assertions we we were doing for task status was just looking at the length of the count instead of the actual count it self this fixes that assertion.

set-module-patch
https://spruce.mongodb.com/version/64bab2590ae606bb26511947/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

### Evergreen PR
https://github.com/evergreen-ci/evergreen/pull/6760
