### PR TITLE
EVG-19940: Add distro settings boilerplate

### DIFF
--- a/src/components/Content/index.tsx
+++ b/src/components/Content/index.tsx
@@ -10,6 +10,7 @@ import { CommitQueue } from "pages/CommitQueue";
 import { Commits } from "pages/Commits";
 import { ConfigurePatch } from "pages/ConfigurePatch";
 import { Container } from "pages/Container";
+import { Distro } from "pages/Distro";
 import { Host } from "pages/Host";
 import { Hosts } from "pages/Hosts";
 import { JobLogs } from "pages/JobLogs";
@@ -39,6 +40,9 @@ export const Content: React.VFC = () => (
         element={<WaterfallCommitsRedirect />}
       />
       <Route path={routes.configurePatch} element={<ConfigurePatch />}>
+        <Route path={tab} element={null} />
+      </Route>
+      <Route path={`${routes.distro}/*`} element={<Distro />}>
         <Route path={tab} element={null} />
       </Route>
       <Route path={routes.host} element={<Host />} />

--- a/src/components/Settings/NavigationWarningModal.test.tsx
+++ b/src/components/Settings/NavigationWarningModal.test.tsx
@@ -1,0 +1,134 @@
+import {
+  createMemoryRouter,
+  Link,
+  Outlet,
+  RouterProvider,
+} from "react-router-dom";
+import { act, render, screen, userEvent } from "test_utils";
+import {
+  NavigationModalProps,
+  NavigationWarningModal,
+} from "./NavigationWarningModal";
+
+const getRouter = ({ shouldBlock, unsavedTabs }: NavigationModalProps) =>
+  createMemoryRouter(
+    [
+      {
+        Component() {
+          return (
+            <div>
+              <Link to="/about">About</Link>
+              <NavigationWarningModal
+                shouldBlock={shouldBlock}
+                unsavedTabs={unsavedTabs}
+              />
+              <Outlet />
+            </div>
+          );
+        },
+        children: [
+          {
+            path: "/",
+            element: <h1>Home Page</h1>,
+          },
+          {
+            path: "/about",
+            element: <h1>About Page</h1>,
+          },
+        ],
+      },
+    ],
+    {
+      initialEntries: ["/"],
+    }
+  );
+
+describe("navigation warning", () => {
+  it("does not warn when navigating and shouldBlock is false", () => {
+    const router = getRouter({ shouldBlock: false, unsavedTabs: [] });
+
+    render(<RouterProvider router={router} />);
+    expect(router.state.location.pathname).toBe("/");
+
+    userEvent.click(screen.getByRole("link"));
+    expect(router.state.location.pathname).toBe("/about");
+    expect(
+      screen.queryByDataCy("navigation-warning-modal")
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole("heading")).toHaveTextContent("About Page");
+  });
+
+  it("warns and shows the modal with unsaved pages", () => {
+    const router = getRouter({
+      shouldBlock: true,
+      unsavedTabs: [{ title: "An Unsaved Page", value: "foo" }],
+    });
+
+    render(<RouterProvider router={router} />);
+    expect(router.state.location.pathname).toBe("/");
+
+    userEvent.click(screen.getByRole("link"));
+    expect(router.state.location.pathname).toBe("/");
+    expect(screen.getByDataCy("navigation-warning-modal")).toBeInTheDocument();
+    expect(screen.getByText("An Unsaved Page")).toBeInTheDocument();
+  });
+
+  it("warns and shows the modal with unsaved pages when a function is provided to shouldBlock", () => {
+    const router = getRouter({
+      shouldBlock: () => true,
+      unsavedTabs: [{ title: "An Unsaved Page", value: "foo" }],
+    });
+
+    render(<RouterProvider router={router} />);
+    expect(router.state.location.pathname).toBe("/");
+
+    userEvent.click(screen.getByRole("link"));
+    expect(router.state.location.pathname).toBe("/");
+    expect(screen.getByDataCy("navigation-warning-modal")).toBeInTheDocument();
+    expect(screen.getByText("An Unsaved Page")).toBeInTheDocument();
+  });
+
+  it("navigates to the next page when 'Leave' button is clicked", () => {
+    const router = getRouter({
+      shouldBlock: true,
+      unsavedTabs: [{ title: "An Unsaved Page", value: "foo" }],
+    });
+
+    render(<RouterProvider router={router} />);
+    expect(router.state.location.pathname).toBe("/");
+
+    userEvent.click(screen.getByRole("link"));
+    expect(router.state.location.pathname).toBe("/");
+    expect(screen.getByDataCy("navigation-warning-modal")).toBeInTheDocument();
+    expect(screen.getByText("An Unsaved Page")).toBeInTheDocument();
+
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    act(() => {
+      userEvent.click(screen.getByRole("button", { name: "Leave" }));
+    });
+    expect(router.state.location.pathname).toBe("/about");
+    expect(screen.queryByRole("heading")).toHaveTextContent("About Page");
+  });
+
+  it("remains on the initial page when 'Cancel' button is clicked", () => {
+    const router = getRouter({
+      shouldBlock: true,
+      unsavedTabs: [{ title: "An Unsaved Page", value: "foo" }],
+    });
+
+    render(<RouterProvider router={router} />);
+    expect(router.state.location.pathname).toBe("/");
+
+    userEvent.click(screen.getByRole("link"));
+    expect(router.state.location.pathname).toBe("/");
+    expect(screen.getByDataCy("navigation-warning-modal")).toBeInTheDocument();
+    expect(screen.getByText("An Unsaved Page")).toBeInTheDocument();
+
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    act(() => {
+      userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    });
+    expect(router.state.location.pathname).toBe("/");
+    expect(screen.queryByRole("heading")).toHaveTextContent("Home Page");
+  });
+});

--- a/src/components/Settings/NavigationWarningModal.tsx
+++ b/src/components/Settings/NavigationWarningModal.tsx
@@ -5,19 +5,19 @@ import {
 } from "react-router-dom";
 import { ConfirmationModal } from "components/ConfirmationModal";
 
-type Props = {
-  shouldConfirmNavigation: BlockerFunction;
+export type NavigationModalProps = {
+  shouldBlock: boolean | BlockerFunction;
   unsavedTabs: Array<{
     title: string;
     value: string;
   }>;
 };
 
-export const NavigationWarningModal: React.VFC<Props> = ({
-  shouldConfirmNavigation,
+export const NavigationWarningModal: React.VFC<NavigationModalProps> = ({
+  shouldBlock,
   unsavedTabs,
 }) => {
-  const blocker = useBlocker(shouldConfirmNavigation);
+  const blocker = useBlocker(shouldBlock);
 
   return (
     blocker.state === "blocked" && (

--- a/src/components/Settings/NavigationWarningModal.tsx
+++ b/src/components/Settings/NavigationWarningModal.tsx
@@ -1,0 +1,42 @@
+import { Body } from "@leafygreen-ui/typography";
+import {
+  unstable_BlockerFunction as BlockerFunction,
+  unstable_useBlocker as useBlocker,
+} from "react-router-dom";
+import { ConfirmationModal } from "components/ConfirmationModal";
+
+type Props = {
+  shouldConfirmNavigation: BlockerFunction;
+  unsavedTabs: Array<{
+    title: string;
+    value: string;
+  }>;
+};
+
+export const NavigationWarningModal: React.VFC<Props> = ({
+  shouldConfirmNavigation,
+  unsavedTabs,
+}) => {
+  const blocker = useBlocker(shouldConfirmNavigation);
+
+  return (
+    blocker.state === "blocked" && (
+      <ConfirmationModal
+        buttonText="Leave"
+        data-cy="navigation-warning-modal"
+        open
+        onCancel={() => blocker.reset?.()}
+        onConfirm={() => blocker.proceed?.()}
+        title="You have unsaved changes that will be discarded. Are you sure you want to leave?"
+        variant="danger"
+      >
+        <Body>Unsaved changes are present on the following pages:</Body>
+        <ol data-cy="unsaved-pages">
+          {unsavedTabs.map(({ title, value }) => (
+            <li key={value}>{title}</li>
+          ))}
+        </ol>
+      </ConfirmationModal>
+    )
+  );
+};

--- a/src/components/Settings/index.ts
+++ b/src/components/Settings/index.ts
@@ -1,0 +1,1 @@
+export { NavigationWarningModal } from "./NavigationWarningModal";

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -40,10 +40,20 @@ export enum ProjectSettingsTabRoutes {
   ViewsAndFilters = "views-and-filters",
 }
 
+export enum DistroSettingsTabRoutes {
+  General = "general",
+  Provider = "provider",
+  Task = "task",
+  Host = "host",
+  Project = "project",
+  EventLog = "event-log",
+}
+
 const paths = {
   commitQueue: "/commit-queue",
   commits: "/commits",
   container: "/container",
+  distro: "/distro",
   host: "/host",
   hosts: "/hosts",
   jobLogs: "/job-logs",
@@ -72,6 +82,7 @@ export const routes = {
   commits: paths.commits,
   configurePatch: `${paths.patch}/:id/configure`,
   container: `${paths.container}/:id`,
+  distro: `${paths.distro}/:distroId/${PageNames.Settings}`,
   host: `${paths.host}/:id`,
   hosts: paths.hosts,
   jobLogs: `${paths.jobLogs}/:buildId`,
@@ -220,6 +231,14 @@ export const getProjectSettingsRoute = (
 
   return `${paths.project}/${projectId}/${PageNames.Settings}/${tab}`;
 };
+
+export const getDistroSettingsRoute = (
+  distroId: string,
+  tab?: DistroSettingsTabRoutes
+) =>
+  tab
+    ? `${paths.distro}/${distroId}/${PageNames.Settings}/${tab}`
+    : `${paths.distro}/${distroId}/${PageNames.Settings}`;
 
 export const getCommitQueueRoute = (projectIdentifier: string) =>
   `${paths.commitQueue}/${projectIdentifier}`;

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -4998,6 +4998,15 @@ export type DistroTaskQueueQuery = {
   }>;
 };
 
+export type DistroQueryVariables = Exact<{
+  distroId: Scalars["String"];
+}>;
+
+export type DistroQuery = {
+  __typename?: "Query";
+  distro?: { __typename?: "Distro"; name?: string | null } | null;
+};
+
 export type FailedTaskStatusIconTooltipQueryVariables = Exact<{
   taskId: Scalars["String"];
 }>;

--- a/src/gql/queries/distro.graphql
+++ b/src/gql/queries/distro.graphql
@@ -1,0 +1,5 @@
+query Distro($distroId: String!) {
+  distro(distroId: $distroId) {
+    name
+  }
+}

--- a/src/gql/queries/index.ts
+++ b/src/gql/queries/index.ts
@@ -1,5 +1,6 @@
 import GET_AWS_REGIONS from "./aws-regions.graphql";
 import DISTRO_TASK_QUEUE from "./distro-task-queue.graphql";
+import DISTRO from "./distro.graphql";
 import GET_FAILED_TASK_STATUS_ICON_TOOLTIP from "./failed-task-status-icon-tooltip.graphql";
 import GET_AGENT_LOGS from "./get-agent-logs.graphql";
 import GET_ALL_LOGS from "./get-all-logs.graphql";
@@ -76,6 +77,7 @@ import GET_USER_PATCHES from "./user-patches.graphql";
 import USER_SUBSCRIPTIONS from "./user-subscriptions.graphql";
 
 export {
+  DISTRO,
   DISTRO_TASK_QUEUE,
   GET_AGENT_LOGS,
   GET_ALL_LOGS,

--- a/src/pages/Distro.tsx
+++ b/src/pages/Distro.tsx
@@ -1,0 +1,3 @@
+import { loadable } from "components/SpruceLoader";
+
+export const Distro = loadable(() => import("./distroSettings/index"));

--- a/src/pages/distroSettings/Context.tsx
+++ b/src/pages/distroSettings/Context.tsx
@@ -1,4 +1,4 @@
-import { useContext } from "react";
+import { useContext, useMemo } from "react";
 import {
   createSettingsContext,
   getUseHasUnsavedTab,
@@ -25,16 +25,21 @@ const DistroSettingsProvider: React.VFC<{ children: React.ReactNode }> = ({
   const { getTab, saveTab, setInitialData, tabs, updateForm } =
     useSettingsState(routes, formToGqlMap);
 
+  const contextValue = useMemo(
+    () => ({
+      getTab,
+      saveTab,
+      setInitialData,
+      tabs,
+      updateForm,
+    }),
+    [getTab, saveTab, setInitialData, tabs, updateForm]
+  );
+
   return (
     <DistroSettingsContext.Provider
       // eslint-disable-next-line react/jsx-no-constructed-context-values
-      value={{
-        getTab,
-        saveTab,
-        setInitialData,
-        tabs,
-        updateForm,
-      }}
+      value={contextValue}
     >
       {children}
     </DistroSettingsContext.Provider>

--- a/src/pages/distroSettings/Context.tsx
+++ b/src/pages/distroSettings/Context.tsx
@@ -1,0 +1,65 @@
+import { useContext } from "react";
+import {
+  createSettingsContext,
+  getUseHasUnsavedTab,
+  getUsePopulateForm,
+  SettingsState,
+  useSettingsState,
+} from "components/Settings/Context";
+import { formToGqlMap } from "./tabs/transformers";
+import {
+  FormStateMap,
+  WritableDistroSettingsTabs,
+  WritableDistroSettingsType,
+} from "./tabs/types";
+
+const routes = Object.values(WritableDistroSettingsTabs);
+const DistroSettingsContext = createSettingsContext<
+  WritableDistroSettingsType,
+  FormStateMap
+>();
+
+const DistroSettingsProvider: React.VFC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const { getTab, saveTab, setInitialData, tabs, updateForm } =
+    useSettingsState(routes, formToGqlMap);
+
+  return (
+    <DistroSettingsContext.Provider
+      // eslint-disable-next-line react/jsx-no-constructed-context-values
+      value={{
+        getTab,
+        saveTab,
+        setInitialData,
+        tabs,
+        updateForm,
+      }}
+    >
+      {children}
+    </DistroSettingsContext.Provider>
+  );
+};
+
+const useDistroSettingsContext = (): SettingsState<
+  WritableDistroSettingsType,
+  FormStateMap
+> => {
+  const context = useContext(DistroSettingsContext);
+  if (context === undefined) {
+    throw new Error(
+      "useDistroSettingsContext must be used within a DistroSettingsProvider"
+    );
+  }
+  return context;
+};
+
+const useHasUnsavedTab = getUseHasUnsavedTab(DistroSettingsContext);
+const usePopulateForm = getUsePopulateForm(DistroSettingsContext);
+
+export {
+  DistroSettingsProvider,
+  useHasUnsavedTab,
+  usePopulateForm,
+  useDistroSettingsContext,
+};

--- a/src/pages/distroSettings/Header.tsx
+++ b/src/pages/distroSettings/Header.tsx
@@ -1,0 +1,41 @@
+import styled from "@emotion/styled";
+import { H2 } from "@leafygreen-ui/typography";
+import { DistroSettingsTabRoutes } from "constants/routes";
+import { size } from "constants/tokens";
+import { getTabTitle } from "./getTabTitle";
+import { HeaderButtons } from "./HeaderButtons";
+import {
+  WritableDistroSettingsTabs,
+  WritableDistroSettingsType,
+} from "./tabs/types";
+
+interface Props {
+  tab: DistroSettingsTabRoutes;
+}
+
+export const Header: React.VFC<Props> = ({ tab }) => {
+  const { title } = getTabTitle(tab);
+  const saveable = Object.values(WritableDistroSettingsTabs).includes(
+    tab as WritableDistroSettingsType
+  );
+
+  return (
+    <Container>
+      <TitleContainer>
+        <H2 data-cy="project-settings-tab-title">{title}</H2>
+      </TitleContainer>
+      {saveable && <HeaderButtons tab={tab as WritableDistroSettingsType} />}
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  align-items: start;
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: ${size.l};
+`;
+
+const TitleContainer = styled.div`
+  margin-right: ${size.s};
+`;

--- a/src/pages/distroSettings/HeaderButtons.tsx
+++ b/src/pages/distroSettings/HeaderButtons.tsx
@@ -1,0 +1,49 @@
+import styled from "@emotion/styled";
+import Button from "@leafygreen-ui/button";
+import { DistroSettingsTabRoutes } from "constants/routes";
+import { DistroSettingsSection } from "gql/generated/types";
+import { useDistroSettingsContext } from "./Context";
+import { WritableDistroSettingsType } from "./tabs/types";
+
+interface Props {
+  tab: WritableDistroSettingsType;
+}
+
+export const HeaderButtons: React.VFC<Props> = ({ tab }) => {
+  const { getTab } = useDistroSettingsContext();
+  const { hasChanges, hasError } = getTab(tab);
+
+  return (
+    <ButtonRow>
+      <Button
+        data-cy="save-settings-button"
+        variant="primary"
+        onClick={() => {}}
+        disabled={hasError || !hasChanges}
+      >
+        Save changes on page
+      </Button>
+    </ButtonRow>
+  );
+};
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const mapRouteToSection: Record<
+  WritableDistroSettingsType,
+  DistroSettingsSection
+> = {
+  [DistroSettingsTabRoutes.General]: DistroSettingsSection.General,
+  [DistroSettingsTabRoutes.Host]: DistroSettingsSection.Host,
+  [DistroSettingsTabRoutes.Project]: DistroSettingsSection.Project,
+  [DistroSettingsTabRoutes.Provider]: DistroSettingsSection.Provider,
+  [DistroSettingsTabRoutes.Task]: DistroSettingsSection.Task,
+};
+
+const ButtonRow = styled.div`
+  display: flex;
+  justify-content: flex-end;
+
+  > :not(:last-child) {
+    margin-right: 12px;
+  }
+`;

--- a/src/pages/distroSettings/NavigationModal.tsx
+++ b/src/pages/distroSettings/NavigationModal.tsx
@@ -1,28 +1,27 @@
 import { matchPath, useParams } from "react-router-dom";
 import { NavigationWarningModal } from "components/Settings";
-import { getProjectSettingsRoute, routes } from "constants/routes";
+import { getDistroSettingsRoute, routes } from "constants/routes";
 import { useHasUnsavedTab } from "./Context";
 import { getTabTitle } from "./getTabTitle";
 
 export const NavigationModal: React.VFC = () => {
   const { hasUnsaved, unsavedTabs } = useHasUnsavedTab();
-  const { projectIdentifier } = useParams();
+  const { distroId } = useParams();
 
   const shouldConfirmNavigation = ({ nextLocation }): boolean => {
-    const isProjectSettingsRoute =
-      nextLocation &&
-      !!matchPath(`${routes.projectSettings}/*`, nextLocation.pathname);
-    if (!isProjectSettingsRoute) {
+    const isDistroSettingsRoute =
+      nextLocation && !!matchPath(`${routes.distro}/*`, nextLocation.pathname);
+    if (!isDistroSettingsRoute) {
       return hasUnsaved;
     }
 
-    /* Identify if the user is navigating to a new project's settings via project select dropdown */
-    const currentProjectRoute = getProjectSettingsRoute(projectIdentifier);
-    const isNewProjectSettingsRoute = !matchPath(
-      `${currentProjectRoute}/*`,
+    /* Identify if the user is navigating to a new distro's settings via distro select dropdown */
+    const currentDistroRoute = getDistroSettingsRoute(distroId);
+    const isNewDistroSettingsRoute = !matchPath(
+      `${currentDistroRoute}/*`,
       nextLocation.pathname
     );
-    if (isNewProjectSettingsRoute) {
+    if (isNewDistroSettingsRoute) {
       return hasUnsaved;
     }
 

--- a/src/pages/distroSettings/NavigationModal.tsx
+++ b/src/pages/distroSettings/NavigationModal.tsx
@@ -30,7 +30,7 @@ export const NavigationModal: React.VFC = () => {
 
   return (
     <NavigationWarningModal
-      shouldConfirmNavigation={shouldConfirmNavigation}
+      shouldBlock={shouldConfirmNavigation}
       unsavedTabs={unsavedTabs.map((tab) => ({
         title: getTabTitle(tab).title,
         value: tab,

--- a/src/pages/distroSettings/Tabs.tsx
+++ b/src/pages/distroSettings/Tabs.tsx
@@ -19,7 +19,7 @@ export const DistroSettingsTabs: React.VFC<Props> = ({ distro }) => {
   const tabData = useMemo(() => getTabData(distro), [distro]);
 
   useEffect(() => {
-    // @ts-expect-error TODO: Remove and type when all tabs have been implemented
+    // @ts-expect-error TODO: Type when all tabs have been implemented
     setInitialData(tabData);
   }, [setInitialData, tabData]);
 

--- a/src/pages/distroSettings/Tabs.tsx
+++ b/src/pages/distroSettings/Tabs.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useMemo } from "react";
+import styled from "@emotion/styled";
+import { useParams } from "react-router-dom";
+import { DistroSettingsTabRoutes } from "constants/routes";
+import { DistroQuery } from "gql/generated/types";
+import { useDistroSettingsContext } from "./Context";
+import { Header } from "./Header";
+import { NavigationModal } from "./NavigationModal";
+import { gqlToFormMap } from "./tabs/transformers";
+
+interface Props {
+  distro: DistroQuery["distro"];
+}
+
+export const DistroSettingsTabs: React.VFC<Props> = ({ distro }) => {
+  const { tab } = useParams<{ tab: DistroSettingsTabRoutes }>();
+  const { setInitialData } = useDistroSettingsContext();
+
+  const tabData = useMemo(() => getTabData(distro), [distro]);
+
+  useEffect(() => {
+    // @ts-expect-error TODO: Remove and type when all tabs have been implemented
+    setInitialData(tabData);
+  }, [setInitialData, tabData]);
+
+  return (
+    <Container>
+      <NavigationModal />
+      <Header tab={tab} />
+      {/* <Routes>
+        <Route
+          path="*"
+          element={<Navigate to={DistroSettingsTabRoutes.General} replace />}
+        />
+      </Routes> */}
+    </Container>
+  );
+};
+
+/* Map data from query to the tab to which it will be passed */
+// TODO: Type when all tabs have been implemented
+const getTabData = (data: Props["distro"]) =>
+  Object.keys(gqlToFormMap).reduce(
+    (obj, tab) => ({
+      ...obj,
+      [tab]: gqlToFormMap[tab](data),
+    }),
+    {}
+  );
+
+const Container = styled.div`
+  min-width: 600px;
+  width: 60%;
+`;

--- a/src/pages/distroSettings/getTabTitle.ts
+++ b/src/pages/distroSettings/getTabTitle.ts
@@ -1,0 +1,11 @@
+import { DistroSettingsTabRoutes } from "constants/routes";
+
+export const getTabTitle = (tab: DistroSettingsTabRoutes): { title: string } =>
+  ({
+    [DistroSettingsTabRoutes.General]: { title: "General Settings" },
+    [DistroSettingsTabRoutes.Provider]: { title: "Provider Settings" },
+    [DistroSettingsTabRoutes.Task]: { title: "Task Settings" },
+    [DistroSettingsTabRoutes.Host]: { title: "Host Settings" },
+    [DistroSettingsTabRoutes.Project]: { title: "Project Settings" },
+    [DistroSettingsTabRoutes.EventLog]: { title: "Event Log" },
+  }[tab]);

--- a/src/pages/distroSettings/index.tsx
+++ b/src/pages/distroSettings/index.tsx
@@ -1,5 +1,4 @@
 import { useQuery } from "@apollo/client";
-import { Skeleton } from "antd";
 import { useParams, Link, Navigate } from "react-router-dom";
 import {
   SideNav,
@@ -65,11 +64,7 @@ const ProjectSettings: React.VFC = () => {
         </SideNavGroup>
       </SideNav>
       <PageWrapper data-cy="project-settings-page">
-        {loading || !data.distro ? (
-          <Skeleton />
-        ) : (
-          <DistroSettingsTabs distro={data.distro} />
-        )}
+        {!loading && data.distro && <DistroSettingsTabs distro={data.distro} />}
       </PageWrapper>
     </DistroSettingsProvider>
   );

--- a/src/pages/distroSettings/index.tsx
+++ b/src/pages/distroSettings/index.tsx
@@ -1,0 +1,78 @@
+import { useQuery } from "@apollo/client";
+import { Skeleton } from "antd";
+import { useParams, Link, Navigate } from "react-router-dom";
+import {
+  SideNav,
+  SideNavGroup,
+  SideNavItem,
+  PageWrapper,
+} from "components/styles";
+import {
+  DistroSettingsTabRoutes,
+  getDistroSettingsRoute,
+} from "constants/routes";
+import { useToastContext } from "context/toast";
+import { DistroQuery, DistroQueryVariables } from "gql/generated/types";
+import { DISTRO } from "gql/queries";
+import { usePageTitle } from "hooks";
+import { DistroSettingsProvider } from "./Context";
+import { getTabTitle } from "./getTabTitle";
+import { DistroSettingsTabs } from "./Tabs";
+
+const ProjectSettings: React.VFC = () => {
+  usePageTitle("Distro Settings");
+  const dispatchToast = useToastContext();
+  const { distroId, tab: currentTab } = useParams<{
+    distroId: string;
+    tab: DistroSettingsTabRoutes;
+  }>();
+
+  const { data, loading } = useQuery<DistroQuery, DistroQueryVariables>(
+    DISTRO,
+    {
+      variables: { distroId },
+      onError: (e) => {
+        dispatchToast.error(
+          `There was an error loading the distro ${distroId}: ${e.message}`
+        );
+      },
+    }
+  );
+
+  if (!Object.values(DistroSettingsTabRoutes).includes(currentTab)) {
+    return (
+      <Navigate
+        to={getDistroSettingsRoute(distroId, DistroSettingsTabRoutes.General)}
+      />
+    );
+  }
+
+  return (
+    <DistroSettingsProvider>
+      <SideNav aria-label="Project Settings" widthOverride={250}>
+        <SideNavGroup>
+          {Object.values(DistroSettingsTabRoutes).map((tab) => (
+            <SideNavItem
+              active={tab === currentTab}
+              as={Link}
+              key={tab}
+              to={getDistroSettingsRoute(distroId, tab)}
+              data-cy={`navitem-${tab}`}
+            >
+              {getTabTitle(tab).title}
+            </SideNavItem>
+          ))}
+        </SideNavGroup>
+      </SideNav>
+      <PageWrapper data-cy="project-settings-page">
+        {loading || !data.distro ? (
+          <Skeleton />
+        ) : (
+          <DistroSettingsTabs distro={data.distro} />
+        )}
+      </PageWrapper>
+    </DistroSettingsProvider>
+  );
+};
+
+export default ProjectSettings;

--- a/src/pages/distroSettings/tabs/transformers.ts
+++ b/src/pages/distroSettings/tabs/transformers.ts
@@ -1,0 +1,24 @@
+import { DistroSettingsTabRoutes } from "constants/routes";
+import { SaveDistroInput } from "gql/generated/types";
+import {
+  FormToGqlFunction,
+  GqlToFormFunction,
+  WritableDistroSettingsType,
+} from "./types";
+
+// TODO: Update maps as transformation functions are added and remove dummy return value.
+const fakeReturn = {} as SaveDistroInput;
+
+export const formToGqlMap: {
+  [T in WritableDistroSettingsType]: FormToGqlFunction<T>;
+} = {
+  [DistroSettingsTabRoutes.General]: () => fakeReturn,
+  [DistroSettingsTabRoutes.Host]: () => fakeReturn,
+  [DistroSettingsTabRoutes.Project]: () => fakeReturn,
+  [DistroSettingsTabRoutes.Provider]: () => fakeReturn,
+  [DistroSettingsTabRoutes.Task]: () => fakeReturn,
+};
+
+export const gqlToFormMap: {
+  [T in WritableDistroSettingsType]?: GqlToFormFunction<T>;
+} = {};

--- a/src/pages/distroSettings/tabs/types.ts
+++ b/src/pages/distroSettings/tabs/types.ts
@@ -7,6 +7,7 @@ export { WritableDistroSettingsTabs };
 export type WritableDistroSettingsType =
   (typeof WritableDistroSettingsTabs)[keyof typeof WritableDistroSettingsTabs];
 
+// TODO: Specify type as tabs are added.
 export type FormStateMap = {
   [T in WritableDistroSettingsType]: {
     [DistroSettingsTabRoutes.General]: any;
@@ -20,7 +21,7 @@ export type FormStateMap = {
 export type FormToGqlFunction<T extends WritableDistroSettingsType> = (
   form: FormStateMap[T],
   id?: string
-) => SaveDistroInput; // TODO: Remove | null
+) => SaveDistroInput;
 
 export type GqlToFormFunction<T extends WritableDistroSettingsType> = (
   data: DistroQuery["distro"]

--- a/src/pages/distroSettings/tabs/types.ts
+++ b/src/pages/distroSettings/tabs/types.ts
@@ -1,0 +1,27 @@
+import { DistroSettingsTabRoutes } from "constants/routes";
+import { DistroQuery, SaveDistroInput } from "gql/generated/types";
+
+const { EventLog, ...WritableDistroSettingsTabs } = DistroSettingsTabRoutes;
+export { WritableDistroSettingsTabs };
+
+export type WritableDistroSettingsType =
+  (typeof WritableDistroSettingsTabs)[keyof typeof WritableDistroSettingsTabs];
+
+export type FormStateMap = {
+  [T in WritableDistroSettingsType]: {
+    [DistroSettingsTabRoutes.General]: any;
+    [DistroSettingsTabRoutes.Provider]: any;
+    [DistroSettingsTabRoutes.Task]: any;
+    [DistroSettingsTabRoutes.Host]: any;
+    [DistroSettingsTabRoutes.Project]: any;
+  }[T];
+};
+
+export type FormToGqlFunction<T extends WritableDistroSettingsType> = (
+  form: FormStateMap[T],
+  id?: string
+) => SaveDistroInput; // TODO: Remove | null
+
+export type GqlToFormFunction<T extends WritableDistroSettingsType> = (
+  data: DistroQuery["distro"]
+) => FormStateMap[T];

--- a/src/pages/projectSettings/NavigationModal.tsx
+++ b/src/pages/projectSettings/NavigationModal.tsx
@@ -31,7 +31,7 @@ export const NavigationModal: React.VFC = () => {
 
   return (
     <NavigationWarningModal
-      shouldConfirmNavigation={shouldConfirmNavigation}
+      shouldBlock={shouldConfirmNavigation}
       unsavedTabs={unsavedTabs.map((tab) => ({
         title: getTabTitle(tab).title,
         value: tab,


### PR DESCRIPTION
EVG-19940

### Description
<!-- add description, context, thought process, etc -->
- Add routing and settings infrastructure for distro settings
- Genericize unsaved page modal to be used in project and distro settings

### Screenshots
<!-- add screenshots of visible changes -->
<img width="1485" alt="image" src="https://github.com/evergreen-ci/spruce/assets/9298431/0e098484-394e-4650-9fc3-82a8caf70cf2">

### Testing
<!-- add a description of how you tested it -->
- Add unit tests for navigation warning modal.
- The distro context doesn't expand in any way on the settings context boilerplate. I think tests would cover the same ground covered in `pages/projectSettings/Context.test.tsx` and `components/Settings/Context.tsx`.
- We'll start adding unit and e2e tests once we're fetching distro data.