### PR TITLE
EVG-19037: Upgrade SearchInput

### DIFF
--- a/cypress/integration/myPatches/my_patches.ts
+++ b/cypress/integration/myPatches/my_patches.ts
@@ -34,7 +34,9 @@ describe("My Patches Page", () => {
   it("Typing in patch description input updates the url, requests patches and renders patches", () => {
     cy.visit(MY_PATCHES_ROUTE);
     const inputVal = "testtest";
-    cy.dataCy("patch-description-input").type(inputVal);
+    cy.dataCy("patch-description-input").within(() => {
+      cy.get("input").type(inputVal);
+    });
     urlSearchParamsAreUpdated({
       pathname: MY_PATCHES_ROUTE,
       paramName: "patchName",
@@ -45,19 +47,27 @@ describe("My Patches Page", () => {
       paramName: "page",
       search: 0,
     });
-    cy.dataCy("patch-description-input").clear();
+    cy.dataCy("patch-description-input").within(() => {
+      cy.get("input").clear();
+    });
   });
 
   it("Inputting a number successfully searches patches", () => {
     cy.visit(MY_PATCHES_ROUTE);
-    cy.dataCy("patch-description-input").type("3186");
+    cy.dataCy("patch-description-input").within(() => {
+      cy.get("input").type("3186");
+    });
     cy.dataCy("patch-card").should("have.length", "1");
-    cy.dataCy("patch-description-input").clear();
+    cy.dataCy("patch-description-input").within(() => {
+      cy.get("input").clear();
+    });
   });
 
   it("Searching for a nonexistent patch shows 'No patches found'", () => {
     cy.visit(MY_PATCHES_ROUTE);
-    cy.dataCy("patch-description-input").type("satenarstharienht");
+    cy.dataCy("patch-description-input").within(() => {
+      cy.get("input").type("satenarstharienht");
+    });
     cy.dataCy("no-patches-found").contains("No patches found");
   });
 

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@leafygreen-ui/popover": "11.0.1",
     "@leafygreen-ui/radio-box-group": "12.0.1",
     "@leafygreen-ui/radio-group": "10.1.1",
-    "@leafygreen-ui/search-input": "1.0.2",
+    "@leafygreen-ui/search-input": "2.0.8",
     "@leafygreen-ui/segmented-control": "7.0.2",
     "@leafygreen-ui/select": "10.2.0",
     "@leafygreen-ui/side-nav": "13.0.2",

--- a/src/components/PatchesPage/index.tsx
+++ b/src/components/PatchesPage/index.tsx
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 import Checkbox from "@leafygreen-ui/checkbox";
-import SearchInput from "@leafygreen-ui/search-input";
+import { SearchInput } from "@leafygreen-ui/search-input";
 import Cookies from "js-cookie";
 import { useLocation } from "react-router-dom";
 import { Analytics } from "analytics/addPageAction";

--- a/src/pages/task/taskTabs/FilesTables.tsx
+++ b/src/pages/task/taskTabs/FilesTables.tsx
@@ -1,7 +1,7 @@
 import { Fragment, useState, useEffect } from "react";
 import { useQuery } from "@apollo/client";
 import styled from "@emotion/styled";
-import SearchInput from "@leafygreen-ui/search-input";
+import { SearchInput } from "@leafygreen-ui/search-input";
 import { Body, Subtitle } from "@leafygreen-ui/typography";
 import { Table, Skeleton } from "antd";
 import { SortOrder } from "antd/es/table/interface";

--- a/yarn.lock
+++ b/yarn.lock
@@ -4432,7 +4432,7 @@
     "@leafygreen-ui/hooks" "^7.7.1"
     "@leafygreen-ui/lib" "^10.3.2"
 
-"@leafygreen-ui/a11y@^1.4.4":
+"@leafygreen-ui/a11y@^1.4.3", "@leafygreen-ui/a11y@^1.4.4":
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/@leafygreen-ui/a11y/-/a11y-1.4.4.tgz#99d936f832b1acf97df3108f5a4cdb0c51d37e7e"
   integrity sha512-QjXputn8XPagHPCibjfGcImQSUMgZijm9Da1VfIjZhxc47dSGD9cb7ncu9UIpu1w/Sz+2fjQ6oDbp+5K9MUO2w==
@@ -4624,7 +4624,7 @@
     "@emotion/css" "^11.1.3"
     "@emotion/server" "^11.4.0"
 
-"@leafygreen-ui/emotion@^4.0.1", "@leafygreen-ui/emotion@^4.0.3", "@leafygreen-ui/emotion@^4.0.4":
+"@leafygreen-ui/emotion@^4.0.3", "@leafygreen-ui/emotion@^4.0.4":
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/@leafygreen-ui/emotion/-/emotion-4.0.4.tgz#8ed1a7cda533daf55866ee56a232a7e5b45c9838"
   integrity sha512-ICiAaGqCX73Zmg02afBe4CRqKXwcS/XPOnSZZWk7XAy+qwhHQjp2cO2pVSjQQbTkJcNpqbuzWErsj5Vy98+sxA==
@@ -4681,6 +4681,13 @@
   dependencies:
     lodash "^4.17.21"
 
+"@leafygreen-ui/hooks@^7.7.5":
+  version "7.7.5"
+  resolved "https://registry.yarnpkg.com/@leafygreen-ui/hooks/-/hooks-7.7.5.tgz#3696380327fefc1e73152711bf32967d6974c44b"
+  integrity sha512-Spk36yndhplGfCdLl14RWuoDPGYfEgA6AwqbaI4T45i+A2QtDTvdSFyMUkNmDK5vzk5cWmR/SmkRS/o5T9zgMA==
+  dependencies:
+    lodash "^4.17.21"
+
 "@leafygreen-ui/icon-button@15.0.5":
   version "15.0.5"
   resolved "https://registry.yarnpkg.com/@leafygreen-ui/icon-button/-/icon-button-15.0.5.tgz#4c9e6a8388c471262c98bcb52b2d95c061625eea"
@@ -4720,6 +4727,19 @@
     "@leafygreen-ui/palette" "^4.0.4"
     "@leafygreen-ui/tokens" "^2.0.3"
 
+"@leafygreen-ui/icon-button@^15.0.12":
+  version "15.0.13"
+  resolved "https://registry.yarnpkg.com/@leafygreen-ui/icon-button/-/icon-button-15.0.13.tgz#ec31ed75f3bccb5edade056f66b268a464adcd23"
+  integrity sha512-1P0BoVGnFzxLZ10g8+JhJvJ2ZNKfAk9NvKsXQHOkGpQTcNXI5mPcree8ZizwiOzBZuIDZtRZ5Gc9MdJmTwcdcg==
+  dependencies:
+    "@leafygreen-ui/a11y" "^1.4.2"
+    "@leafygreen-ui/box" "^3.1.4"
+    "@leafygreen-ui/emotion" "^4.0.4"
+    "@leafygreen-ui/icon" "^11.17.0"
+    "@leafygreen-ui/lib" "^10.4.0"
+    "@leafygreen-ui/palette" "^4.0.4"
+    "@leafygreen-ui/tokens" "^2.1.1"
+
 "@leafygreen-ui/icon@11.12.1":
   version "11.12.1"
   resolved "https://registry.yarnpkg.com/@leafygreen-ui/icon/-/icon-11.12.1.tgz#8ec2a8cd209c07e5e9a3b5a8f42b74afa4364573"
@@ -4727,7 +4747,7 @@
   dependencies:
     "@leafygreen-ui/emotion" "^4.0.3"
 
-"@leafygreen-ui/icon@^11.12.0", "@leafygreen-ui/icon@^11.12.1", "@leafygreen-ui/icon@^11.12.2", "@leafygreen-ui/icon@^11.12.4", "@leafygreen-ui/icon@^11.12.5":
+"@leafygreen-ui/icon@^11.12.0", "@leafygreen-ui/icon@^11.12.1", "@leafygreen-ui/icon@^11.12.4", "@leafygreen-ui/icon@^11.12.5":
   version "11.12.6"
   resolved "https://registry.yarnpkg.com/@leafygreen-ui/icon/-/icon-11.12.6.tgz#9dca03e4a48f821a7f757a25dc401d5fc9396440"
   integrity sha512-0eVzQXNTXCspt+3PDgRA0IvUN551ibdsW1GxcyEx5AwnecKhDP5DVgMwuooGO3xRnzGcKP22t4klD0SLBdcRRQ==
@@ -4778,6 +4798,19 @@
     "@leafygreen-ui/palette" "^3.4.7"
     "@leafygreen-ui/tooltip" "^9.1.3"
 
+"@leafygreen-ui/input-option@^1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@leafygreen-ui/input-option/-/input-option-1.0.5.tgz#d6f814b943900f9ede4981f3bd7107b89fd7b74a"
+  integrity sha512-gU051Rr5oB6CelLziN1xpbymexEP28DsbhgN+KTXxzpOM5q4l1dNAv12UDuCSEJS/xPP0kzkBkMWT/WPOEE/uQ==
+  dependencies:
+    "@leafygreen-ui/a11y" "^1.4.2"
+    "@leafygreen-ui/emotion" "^4.0.4"
+    "@leafygreen-ui/lib" "^10.4.0"
+    "@leafygreen-ui/palette" "^4.0.4"
+    "@leafygreen-ui/polymorphic" "^1.3.2"
+    "@leafygreen-ui/tokens" "^2.1.1"
+    "@leafygreen-ui/typography" "^16.5.1"
+
 "@leafygreen-ui/interaction-ring@7.0.2":
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/@leafygreen-ui/interaction-ring/-/interaction-ring-7.0.2.tgz#bc229b90dde0bb6d8e4e886001d6dc4e75c9b47a"
@@ -4804,13 +4837,6 @@
     "@storybook/csf" "^0.1.0"
     lodash "^4.17.21"
     prop-types "^15.7.2"
-
-"@leafygreen-ui/lib@^9.4.2":
-  version "9.5.2"
-  resolved "https://registry.yarnpkg.com/@leafygreen-ui/lib/-/lib-9.5.2.tgz#c80d7920e819c89ee544866b1046667fe99ea8d3"
-  integrity sha512-soC5ZSnhqoqbFv9b2kAe+1s7nUnAcdcBzrI0yIJZymExCJsZnmI3VWjLTUbViuTrsO1GfnmLDdsUeDr3ezTOOg==
-  dependencies:
-    lodash "^4.17.21"
 
 "@leafygreen-ui/loading-indicator@^1.0.1":
   version "1.0.1"
@@ -4974,6 +5000,18 @@
     "@leafygreen-ui/tokens" "^2.0.0"
     react-transition-group "^4.4.1"
 
+"@leafygreen-ui/popover@^11.0.12":
+  version "11.0.12"
+  resolved "https://registry.yarnpkg.com/@leafygreen-ui/popover/-/popover-11.0.12.tgz#76fe562a1e17ee24481894ffa8de137d92ce2a68"
+  integrity sha512-zF8axGB+RhpoG0xgb4K/p8ydS5JAEXpwqdLrcrY9r7cAYzxX0F4mhIpYg+oyK2K5TIbgGR/fsFPbhKYsmreuMA==
+  dependencies:
+    "@leafygreen-ui/emotion" "^4.0.4"
+    "@leafygreen-ui/hooks" "^7.7.5"
+    "@leafygreen-ui/lib" "^10.4.0"
+    "@leafygreen-ui/portal" "^4.1.4"
+    "@leafygreen-ui/tokens" "^2.1.1"
+    react-transition-group "^4.4.1"
+
 "@leafygreen-ui/popover@^11.0.9":
   version "11.0.9"
   resolved "https://registry.yarnpkg.com/@leafygreen-ui/popover/-/popover-11.0.9.tgz#82eb6b50e5fe4290541c030e929dd333f9166d6e"
@@ -5001,6 +5039,14 @@
   dependencies:
     "@leafygreen-ui/hooks" "^7.7.1"
     "@leafygreen-ui/lib" "^10.3.3"
+
+"@leafygreen-ui/portal@^4.1.4":
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/@leafygreen-ui/portal/-/portal-4.1.4.tgz#31513ce87c8619cdfa514900cac5f4bb882d28e5"
+  integrity sha512-gtzQno7yXGmbblHIVBWpJ6+TIFwep/PL4M6vcloCzAaV88+gSMJ9lhrBJbqYQkfd65xeEaycClDsfCpI35p/nA==
+  dependencies:
+    "@leafygreen-ui/hooks" "^7.7.5"
+    "@leafygreen-ui/lib" "^10.4.0"
 
 "@leafygreen-ui/radio-box-group@12.0.1":
   version "12.0.1"
@@ -5031,16 +5077,25 @@
   dependencies:
     "@leafygreen-ui/tokens" "^2.0.2"
 
-"@leafygreen-ui/search-input@1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@leafygreen-ui/search-input/-/search-input-1.0.2.tgz#50db6aaace4e839c2fea5b38159cbc3c6ab94ab1"
-  integrity sha512-4sF076tChPM8iDMvP8GyH0CCN4PMZErH/B5cHSxxFDTtYsi9/FNGykZVBw3F/WChkpZgfJ1G0M4JspVeLWV6NQ==
+"@leafygreen-ui/search-input@2.0.8":
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/@leafygreen-ui/search-input/-/search-input-2.0.8.tgz#353bf12b9fc1a1c6f22afe92e6de2a37760c4dc0"
+  integrity sha512-ijMpZgyUpOQM1fOnUs1XavIYAcD9P5PNRWp2hprgWMJZp8FrcopsslMJJIDaM00Sdj0MjSDAti9+aXeo+2ZgSw==
   dependencies:
-    "@leafygreen-ui/emotion" "^4.0.1"
-    "@leafygreen-ui/icon" "^11.12.2"
-    "@leafygreen-ui/lib" "^9.4.2"
-    "@leafygreen-ui/palette" "^3.4.5"
-    "@leafygreen-ui/tokens" "^1.4.1"
+    "@leafygreen-ui/a11y" "^1.4.3"
+    "@leafygreen-ui/emotion" "^4.0.4"
+    "@leafygreen-ui/hooks" "^7.7.5"
+    "@leafygreen-ui/icon" "^11.17.0"
+    "@leafygreen-ui/icon-button" "^15.0.12"
+    "@leafygreen-ui/input-option" "^1.0.5"
+    "@leafygreen-ui/lib" "^10.4.0"
+    "@leafygreen-ui/palette" "^4.0.4"
+    "@leafygreen-ui/polymorphic" "^1.3.2"
+    "@leafygreen-ui/popover" "^11.0.12"
+    "@leafygreen-ui/tokens" "^2.1.1"
+    "@leafygreen-ui/typography" "^16.5.1"
+    lodash "^4.17.21"
+    polished "^4.2.2"
 
 "@leafygreen-ui/segmented-control@7.0.2":
   version "7.0.2"


### PR DESCRIPTION
EVG-19037

### Description
<!-- add description, context, thought process, etc -->
- Upgrade `SearchInput` to the latest version
- We don't have any uses where it would make sense to use the `SearchResult`/typeahead features of this release. The files table, for example, pretty much already implements this behavior in the table itself.
- The ticket suggested converting some `TextInput` to `SearchInput` to remove unit test warnings. However, all of the existing `type="search"` inputs are not convertible because they either use a prop not offered by `SearchInput`, like `label` or `description`, or use icons in a way that's better suited to an empty input. Too bad because those warnings are annoying!

### Testing
- Update Cypress tests because `SearchInput` now uses an `<input>` nested inside of a `<form>`, which is where the `data-cy` attribute is attached.