### PR TITLE
EVG-19220: Upgrade date-fns-tz to v2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "antd": "4.20.0",
     "axios": "1.3.6",
     "date-fns": "2.28.0",
-    "date-fns-tz": "^1.3.5",
+    "date-fns-tz": "2.0.0",
     "deep-object-diff": "1.1.9",
     "env-cmd": "10.1.0",
     "graphql": "16.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9184,10 +9184,10 @@ dataloader@2.2.2:
   resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-2.2.2.tgz#216dc509b5abe39d43a9b9d97e6e5e473dfbe3e0"
   integrity sha512-8YnDaaf7N3k/q5HnTJVuzSyLETjoZjVmHc4AeKAzOvKHEFQKcn64OKBfzHYtE9zGjctNM7V9I0MfnUVLpi7M5g==
 
-date-fns-tz@^1.3.5:
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/date-fns-tz/-/date-fns-tz-1.3.5.tgz#415086b0095dab80121d66912b93f1dec5729e6e"
-  integrity sha512-SNhl/fWe7i2HoIB9ejLZhEEJ6ZtRRpOBbzizFrq11K2/iceS9Nk7fPN2VTYVOMgFB9u0f3eidSC4n1xaRONW2A==
+date-fns-tz@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/date-fns-tz/-/date-fns-tz-2.0.0.tgz#1b14c386cb8bc16fc56fe333d4fc34ae1d1099d5"
+  integrity sha512-OAtcLdB9vxSXTWHdT8b398ARImVwQMyjfYGkKD2zaGpHseG2UPHbHjXELReErZFxWdSLph3c2zOaaTyHfOhERQ==
 
 date-fns@2.28.0, date-fns@2.x:
   version "2.28.0"


### PR DESCRIPTION
EVG-19220

### Description
Upgrades `date-fns-tz`.
