### PR TITLE
EVG-20126: Use react-virtuoso in VersionRestartModal

### DIFF
--- a/cypress/integration/myPatches/patchCard/dropdown_menu.ts
+++ b/cypress/integration/myPatches/patchCard/dropdown_menu.ts
@@ -71,11 +71,8 @@ describe("Dropdown Menu of Patch Actions", { testIsolation: false }, () => {
     });
     cy.dataCy("restart-version").click({ force: true });
 
-    cy.dataCy("accordion-toggle").first().click();
-    cy.dataCy("patch-status-selector-container")
-      .children()
-      .first()
-      .click({ force: true });
+    cy.dataCy("variant-accordion").first().click();
+    cy.dataCy("task-status-checkbox").should("exist");
     cy.contains("generate-lint").click();
     cy.dataCy("version-restart-modal").within(() => {
       cy.contains("Restart").click();

--- a/cypress/integration/version/restart_modal.ts
+++ b/cypress/integration/version/restart_modal.ts
@@ -22,7 +22,7 @@ describe("Restarting a patch", { testIsolation: false }, () => {
 
   it("Clicking on a variant should toggle an accordion drop down of tasks", () => {
     cy.dataCy("variant-accordion").first().click();
-    cy.dataCy("patch-status-selector-container").should("exist");
+    cy.dataCy("task-status-checkbox").should("exist");
   });
   it("Clicking on a variant checkbox should toggle its textbox and all the associated tasks", () => {
     cy.dataCy("task-status-badge").should("contain.text", "0 of 1 Selected");
@@ -33,7 +33,6 @@ describe("Restarting a patch", { testIsolation: false }, () => {
   });
   it("Clicking on a task should toggle its check box and select the task", () => {
     cy.dataCy("task-status-checkbox").first().click({ force: true });
-    cy.dataCy("patch-status-selector-container").should("exist");
     cy.dataCy("task-status-badge").should("contain.text", "1 of 1 Selected");
   });
 

--- a/package.json
+++ b/package.json
@@ -125,8 +125,7 @@
     "react-dom": "17.0.1",
     "react-router-dom": "6.11.1",
     "react-string-replace": "1.1.1",
-    "react-virtuoso": "^4.3.11",
-    "react-window": "^1.8.9"
+    "react-virtuoso": "^4.3.11"
   },
   "devDependencies": {
     "@babel/plugin-proposal-private-property-in-object": "^7.17.12",
@@ -163,7 +162,6 @@
     "@types/pluralize": "0.0.29",
     "@types/react": "17.0.0",
     "@types/react-dom": "17.0.0",
-    "@types/react-window": "^1.8.5",
     "@typescript-eslint/eslint-plugin": "5.57.1",
     "@typescript-eslint/parser": "5.57.1",
     "@vitejs/plugin-react": "4.0.0",

--- a/src/components/TaskStatusFilters/index.tsx
+++ b/src/components/TaskStatusFilters/index.tsx
@@ -2,6 +2,7 @@ import styled from "@emotion/styled";
 import Dropdown from "components/Dropdown";
 import { TreeSelect } from "components/TreeSelect";
 import { noFilterMessage } from "constants/strings";
+import { size } from "constants/tokens";
 import { useTaskStatuses } from "hooks";
 
 interface Props {
@@ -10,7 +11,6 @@ interface Props {
   selectedBaseStatuses: string[];
   onChangeStatusFilter: (s: string[]) => void;
   onChangeBaseStatusFilter: (s: string[]) => void;
-  filterWidth?: string;
 }
 
 export const TaskStatusFilters: React.VFC<Props> = ({
@@ -22,7 +22,7 @@ export const TaskStatusFilters: React.VFC<Props> = ({
 }) => {
   const { baseStatuses, currentStatuses } = useTaskStatuses({ versionId });
   return (
-    <>
+    <Container>
       <SelectorWrapper>
         <Dropdown
           data-cy="task-status-filter"
@@ -57,9 +57,15 @@ export const TaskStatusFilters: React.VFC<Props> = ({
           />
         </Dropdown>
       </SelectorWrapper>
-    </>
+    </Container>
   );
 };
+
+const Container = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${size.xxs};
+`;
 
 const SelectorWrapper = styled.div`
   width: 50%;

--- a/src/components/VersionRestartModal/BuildVariantAccordion.tsx
+++ b/src/components/VersionRestartModal/BuildVariantAccordion.tsx
@@ -7,18 +7,18 @@ import { selectedStrings } from "hooks/useVersionTaskStatusSelect";
 import { TaskStatusCheckboxContainer } from "./TaskStatusCheckboxContainer";
 
 interface BuildVariantAccordionProps {
-  versionId: string;
+  displayName: string;
+  selectedTasks: selectedStrings;
   tasks: {
     id: string;
     status: string;
     baseStatus?: string;
     displayName: string;
   }[];
-  displayName: string;
-  selectedTasks: selectedStrings;
   toggleSelectedTask: (
     taskIds: { [versionId: string]: string } | { [versionId: string]: string[] }
   ) => void;
+  versionId: string;
 }
 export const BuildVariantAccordion: React.VFC<BuildVariantAccordionProps> = ({
   displayName,
@@ -76,7 +76,7 @@ const countMatchingTasks = (
 };
 
 const BadgeWrapper = styled.div`
-  padding-left: 10px;
+  padding-left: ${size.xs};
 `;
 
 const Wrapper = styled.div`

--- a/src/components/VersionRestartModal/BuildVariantAccordion.tsx
+++ b/src/components/VersionRestartModal/BuildVariantAccordion.tsx
@@ -77,6 +77,7 @@ const countMatchingTasks = (
 
 const BadgeWrapper = styled.div`
   padding-left: ${size.xs};
+  flex-shrink: 0;
 `;
 
 const Wrapper = styled.div`

--- a/src/components/VersionRestartModal/TaskStatusCheckbox.tsx
+++ b/src/components/VersionRestartModal/TaskStatusCheckbox.tsx
@@ -5,35 +5,30 @@ import { TaskStatusIcon } from "components/TaskStatusIcon";
 import { size } from "constants/tokens";
 
 interface TaskStatusCheckboxProps {
+  baseStatus?: string;
+  checked: boolean;
   displayName: string;
+  onClick: () => void;
   status: string;
   taskId: string;
-  checked: boolean;
-  baseStatus?: string;
-  style: React.CSSProperties; // passed in by react-window to handle list virtualization
 }
 
 const CheckboxComponent: React.VFC<TaskStatusCheckboxProps> = ({
   baseStatus,
   checked,
   displayName,
+  onClick,
   status,
-  style,
   taskId,
 }) => (
   <Checkbox
-    style={style}
+    onClick={onClick}
     data-cy="task-status-checkbox"
-    className="task-checkbox"
     name={taskId}
     label={
       <StateItemWrapper>
-        <StyledTaskStatusIcon status={status} />
-        {baseStatus ? (
-          <StyledTaskStatusIcon status={baseStatus} />
-        ) : (
-          <EmptyCell />
-        )}
+        <TaskStatusIcon status={status} />
+        {baseStatus ? <TaskStatusIcon status={baseStatus} /> : <EmptyCell />}
         <div>{displayName}</div>
       </StateItemWrapper>
     }
@@ -44,19 +39,14 @@ const CheckboxComponent: React.VFC<TaskStatusCheckboxProps> = ({
 
 export const TaskStatusCheckbox = memo(CheckboxComponent);
 
-const StateItemWrapper = styled("div")`
+const StateItemWrapper = styled.div`
   display: flex;
   flex-direction: row;
   align-items: center;
+  gap: ${size.xxs};
   white-space: nowrap;
 `;
 
-const StyledTaskStatusIcon = styled(TaskStatusIcon)`
-  margin-right: ${size.xxs};
-`;
-
-// Wrapping checkboxes with fix width container
-// adjusts alignment.
 const EmptyCell = styled.span`
-  width: 19px;
+  width: ${size.s};
 `;

--- a/src/components/VersionRestartModal/TaskStatusCheckboxContainer.tsx
+++ b/src/components/VersionRestartModal/TaskStatusCheckboxContainer.tsx
@@ -1,17 +1,17 @@
-import { FixedSizeList } from "react-window";
+import { Virtuoso } from "react-virtuoso";
 import { selectedStrings } from "hooks/useVersionTaskStatusSelect";
 import { TaskStatusCheckbox } from "./TaskStatusCheckbox";
 
 interface TaskStatusCheckboxContainerProps {
-  versionId: string;
+  selectedTasks: selectedStrings;
   tasks: {
     id: string;
     status: string;
     baseStatus?: string;
     displayName: string;
   }[];
-  selectedTasks: selectedStrings;
   toggleSelectedTask: (taskIds: { [patchId: string]: string }) => void;
+  versionId: string;
 }
 export const TaskStatusCheckboxContainer: React.VFC<
   TaskStatusCheckboxContainerProps
@@ -19,39 +19,32 @@ export const TaskStatusCheckboxContainer: React.VFC<
   const possibleListHeight = tasks.length * itemSize;
   const listHeight =
     possibleListHeight < maxListHeight ? possibleListHeight : maxListHeight;
-  const toggleHandler = (e) => {
-    const { name } = e.target;
-    if (selectedTasks[name] !== undefined) {
-      toggleSelectedTask({ [versionId]: name });
-    }
-  };
+
   return (
-    // eslint-disable-next-line jsx-a11y/no-static-element-interactions,jsx-a11y/click-events-have-key-events
-    <div data-cy="patch-status-selector-container" onClick={toggleHandler}>
-      <FixedSizeList
-        height={listHeight}
-        itemSize={itemSize}
-        itemCount={tasks.length}
-        itemData={tasks}
-        width="100%"
-      >
-        {({ data, index, style }) => {
-          const { baseStatus, displayName, id: taskId, status } = data[index];
-          const checked = !!selectedTasks[taskId];
-          return (
-            <TaskStatusCheckbox
-              style={style}
-              checked={checked}
-              displayName={displayName}
-              key={taskId}
-              status={status}
-              baseStatus={baseStatus}
-              taskId={taskId}
-            />
-          );
-        }}
-      </FixedSizeList>
-    </div>
+    <Virtuoso
+      style={{ height: listHeight, width: "100%" }}
+      totalCount={tasks.length}
+      data={tasks}
+      itemContent={(_idx, task) => {
+        const { baseStatus, displayName, id: taskId, status } = task;
+        const checked = !!selectedTasks[taskId];
+        return (
+          <TaskStatusCheckbox
+            onClick={() => {
+              if (selectedTasks[taskId] !== undefined) {
+                toggleSelectedTask({ [versionId]: taskId });
+              }
+            }}
+            checked={checked}
+            displayName={displayName}
+            key={taskId}
+            status={status}
+            baseStatus={baseStatus}
+            taskId={taskId}
+          />
+        );
+      }}
+    />
   );
 };
 

--- a/src/components/VersionRestartModal/VersionRestartModal.tsx
+++ b/src/components/VersionRestartModal/VersionRestartModal.tsx
@@ -7,8 +7,6 @@ import { Skeleton } from "antd";
 import { useVersionAnalytics } from "analytics";
 import { Accordion } from "components/Accordion";
 import { ConfirmationModal } from "components/ConfirmationModal";
-import { Divider } from "components/styles/Divider";
-import { TaskStatusFilters } from "components/TaskStatusFilters";
 import { size } from "constants/tokens";
 import { useToastContext } from "context/toast";
 import {
@@ -24,7 +22,7 @@ import {
   versionSelectedTasks,
   selectedStrings,
 } from "hooks/useVersionTaskStatusSelect";
-import { BuildVariantAccordion } from "./BuildVariantAccordion";
+import VersionTasks from "./VersionTasks";
 
 interface VersionRestartModalProps {
   onCancel: () => void;
@@ -173,56 +171,6 @@ const VersionRestartModal: React.VFC<VersionRestartModalProps> = ({
       )}
     </ConfirmationModal>
   );
-};
-
-interface VersionTasksProps {
-  baseStatusFilterTerm: string[];
-  selectedTasks: versionSelectedTasks;
-  setBaseStatusFilterTerm: (statuses: string[]) => void;
-  setVersionStatusFilterTerm: (statuses: string[]) => void;
-  toggleSelectedTask: (
-    taskIds: { [patchId: string]: string } | { [patchId: string]: string[] }
-  ) => void;
-  version: BuildVariantsWithChildrenQuery["version"];
-  versionStatusFilterTerm: string[];
-}
-
-const VersionTasks: React.VFC<VersionTasksProps> = ({
-  baseStatusFilterTerm,
-  selectedTasks,
-  setBaseStatusFilterTerm,
-  setVersionStatusFilterTerm,
-  toggleSelectedTask,
-  version,
-  versionStatusFilterTerm,
-}) => {
-  const { buildVariants } = version || {};
-  const tasks = selectedTasks[version?.id] || {};
-
-  return buildVariants ? (
-    <>
-      <TaskStatusFilters
-        onChangeBaseStatusFilter={setBaseStatusFilterTerm}
-        onChangeStatusFilter={setVersionStatusFilterTerm}
-        versionId={version?.id}
-        selectedBaseStatuses={baseStatusFilterTerm || []}
-        selectedStatuses={versionStatusFilterTerm || []}
-      />
-      {[...buildVariants]
-        .sort((a, b) => a.displayName.localeCompare(b.displayName))
-        .map((patchBuildVariant) => (
-          <BuildVariantAccordion
-            versionId={version?.id}
-            key={`accordion_${patchBuildVariant.variant}`}
-            tasks={patchBuildVariant.tasks}
-            displayName={patchBuildVariant.displayName}
-            selectedTasks={tasks}
-            toggleSelectedTask={toggleSelectedTask}
-          />
-        ))}
-      <Divider />
-    </>
-  ) : null;
 };
 
 const selectedArray = (selected: selectedStrings) => {

--- a/src/components/VersionRestartModal/VersionTasks.tsx
+++ b/src/components/VersionRestartModal/VersionTasks.tsx
@@ -1,0 +1,57 @@
+import { Divider } from "components/styles/Divider";
+import { TaskStatusFilters } from "components/TaskStatusFilters";
+import { BuildVariantsWithChildrenQuery } from "gql/generated/types";
+import { versionSelectedTasks } from "hooks/useVersionTaskStatusSelect";
+import { BuildVariantAccordion } from "./BuildVariantAccordion";
+
+interface VersionTasksProps {
+  baseStatusFilterTerm: string[];
+  selectedTasks: versionSelectedTasks;
+  setBaseStatusFilterTerm: (statuses: string[]) => void;
+  setVersionStatusFilterTerm: (statuses: string[]) => void;
+  toggleSelectedTask: (
+    taskIds: { [patchId: string]: string } | { [patchId: string]: string[] }
+  ) => void;
+  version: BuildVariantsWithChildrenQuery["version"];
+  versionStatusFilterTerm: string[];
+}
+
+const VersionTasks: React.VFC<VersionTasksProps> = ({
+  baseStatusFilterTerm,
+  selectedTasks,
+  setBaseStatusFilterTerm,
+  setVersionStatusFilterTerm,
+  toggleSelectedTask,
+  version,
+  versionStatusFilterTerm,
+}) => {
+  const { buildVariants, id: versionId } = version || {};
+  const tasks = selectedTasks[versionId] || {};
+
+  return versionId && buildVariants ? (
+    <>
+      <TaskStatusFilters
+        onChangeBaseStatusFilter={setBaseStatusFilterTerm}
+        onChangeStatusFilter={setVersionStatusFilterTerm}
+        versionId={versionId}
+        selectedBaseStatuses={baseStatusFilterTerm || []}
+        selectedStatuses={versionStatusFilterTerm || []}
+      />
+      {[...buildVariants]
+        .sort((a, b) => a.displayName.localeCompare(b.displayName))
+        .map((patchBuildVariant) => (
+          <BuildVariantAccordion
+            versionId={versionId}
+            key={`accordion_${patchBuildVariant.variant}`}
+            tasks={patchBuildVariant.tasks}
+            displayName={patchBuildVariant.displayName}
+            selectedTasks={tasks}
+            toggleSelectedTask={toggleSelectedTask}
+          />
+        ))}
+      <Divider />
+    </>
+  ) : null;
+};
+
+export default VersionTasks;

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -2481,6 +2481,7 @@ export type TaskQueueDistro = {
  */
 export type TaskQueueItem = {
   __typename?: "TaskQueueItem";
+  activatedBy: Scalars["String"];
   buildVariant: Scalars["String"];
   displayName: Scalars["String"];
   expectedDuration: Scalars["Duration"];

--- a/yarn.lock
+++ b/yarn.lock
@@ -7014,13 +7014,6 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-window@^1.8.5":
-  version "1.8.5"
-  resolved "https://registry.yarnpkg.com/@types/react-window/-/react-window-1.8.5.tgz#285fcc5cea703eef78d90f499e1457e9b5c02fc1"
-  integrity sha512-V9q3CvhC9Jk9bWBOysPGaWy/Z0lxYcTXLtLipkt2cnRj1JOSFNF7wqGpkScSXMgBwC+fnVRg/7shwgddBG5ICw==
-  dependencies:
-    "@types/react" "*"
-
 "@types/react@*", "@types/react@17.0.0":
   version "17.0.0"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.0.tgz#5af3eb7fad2807092f0046a1302b7823e27919b8"
@@ -13110,11 +13103,6 @@ media-typer@0.3.0:
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==
 
-"memoize-one@>=3.1.1 <6":
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.2.1.tgz#8337aa3c4335581839ec01c3d594090cebe8f00e"
-  integrity sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==
-
 memoize-one@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-6.0.0.tgz#b2591b871ed82948aee4727dc6abceeeac8c1045"
@@ -14919,14 +14907,6 @@ react-virtuoso@^4.3.11:
   version "4.3.11"
   resolved "https://registry.yarnpkg.com/react-virtuoso/-/react-virtuoso-4.3.11.tgz#ab24e707287ef1b4bb5b52f3b14795ba896e9768"
   integrity sha512-0YrCvQ5GsIKRcN34GxrzhSJGuMNI+hGxWci5cTVuPQ8QWTEsrKfCyqm7YNBMmV3pu7onG1YVUBo86CyCXdejXg==
-
-react-window@^1.8.9:
-  version "1.8.9"
-  resolved "https://registry.yarnpkg.com/react-window/-/react-window-1.8.9.tgz#24bc346be73d0468cdf91998aac94e32bc7fa6a8"
-  integrity sha512-+Eqx/fj1Aa5WnhRfj9dJg4VYATGwIUP2ItwItiJ6zboKWA6EX3lYDAXfGF2hyNqplEprhbtjbipiADEcwQ823Q==
-  dependencies:
-    "@babel/runtime" "^7.0.0"
-    memoize-one ">=3.1.1 <6"
 
 react@17.0.1:
   version "17.0.1"


### PR DESCRIPTION
EVG-20126

### Description
This PR:
* Replaces `FixedSizeList` with `Virtuoso`
* Removes `react-window` from dependencies
* Removes styles that were unnecessary + updates styles
* Alphabetizes props

### Screenshots
(Looks the same pretty much)

https://github.com/evergreen-ci/spruce/assets/47064971/9ad508e4-7807-4dbe-a256-d83c9d491851



### Testing
- Updated e2e tests
