### PR TITLE
EVG-20570 Increase timeout on spawn volume test

### DIFF
--- a/src/pages/spawn/spawnVolume/SpawnVolumeModal.test.tsx
+++ b/src/pages/spawn/spawnVolume/SpawnVolumeModal.test.tsx
@@ -158,7 +158,7 @@ describe("spawnVolumeModal", () => {
     });
     userEvent.click(spawnButton);
     await waitFor(() => expect(dispatchToast.success).toHaveBeenCalledTimes(1));
-  }, 10000);
+  }, 15000);
 });
 
 const myHostsMock: ApolloMock<MyHostsQuery, MyHostsQueryVariables> = {


### PR DESCRIPTION
EVG-20570

### Description
Increases timeout for this test so it doesn't fail. Ideally, we should figure out why these long timeouts are necessary/ avoidable but for now, this should suppress the noisy tests. 


Feel free to merge if I'm away when this is approved.