### PR TITLE
EVG-20650 Add unscheduleDownstreamVersions to Spruce

### DIFF
--- a/src/gql/fragments/projectSettings/projectTriggers.graphql
+++ b/src/gql/fragments/projectSettings/projectTriggers.graphql
@@ -8,6 +8,7 @@ fragment ProjectTriggersSettings on Project {
     project
     status
     taskRegex
+    unscheduleDownstreamVersions
   }
 }
 
@@ -21,5 +22,6 @@ fragment RepoTriggersSettings on RepoRef {
     project
     status
     taskRegex
+    unscheduleDownstreamVersions
   }
 }

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -60,6 +60,16 @@ export type Annotation = {
   webhookConfigured: Scalars["Boolean"];
 };
 
+export enum Arch {
+  Linux_64Bit = "LINUX_64_BIT",
+  LinuxArm_64Bit = "LINUX_ARM_64_BIT",
+  LinuxPpc_64Bit = "LINUX_PPC_64_BIT",
+  LinuxZseries = "LINUX_ZSERIES",
+  Osx_64Bit = "OSX_64_BIT",
+  OsxArm_64Bit = "OSX_ARM_64_BIT",
+  Windows_64Bit = "WINDOWS_64_BIT",
+}
+
 export enum BannerTheme {
   Announcement = "ANNOUNCEMENT",
   Important = "IMPORTANT",
@@ -67,14 +77,20 @@ export enum BannerTheme {
   Warning = "WARNING",
 }
 
+export enum BootstrapMethod {
+  LegacySsh = "LEGACY_SSH",
+  Ssh = "SSH",
+  UserData = "USER_DATA",
+}
+
 export type BootstrapSettings = {
   __typename?: "BootstrapSettings";
   clientDir: Scalars["String"];
-  communication: Scalars["String"];
+  communication: CommunicationMethod;
   env: Array<EnvVar>;
   jasperBinaryDir: Scalars["String"];
   jasperCredentialsPath: Scalars["String"];
-  method: Scalars["String"];
+  method: BootstrapMethod;
   preconditionScripts: Array<PreconditionScript>;
   resourceLimits: ResourceLimits;
   rootDir: Scalars["String"];
@@ -84,11 +100,11 @@ export type BootstrapSettings = {
 
 export type BootstrapSettingsInput = {
   clientDir: Scalars["String"];
-  communication: Scalars["String"];
+  communication: CommunicationMethod;
   env: Array<EnvVarInput>;
   jasperBinaryDir: Scalars["String"];
   jasperCredentialsPath: Scalars["String"];
-  method: Scalars["String"];
+  method: BootstrapMethod;
   preconditionScripts: Array<PreconditionScriptInput>;
   resourceLimits: ResourceLimitsInput;
   rootDir: Scalars["String"];
@@ -227,6 +243,12 @@ export type CommitQueueParamsInput = {
   message?: InputMaybe<Scalars["String"]>;
 };
 
+export enum CommunicationMethod {
+  LegacySsh = "LEGACY_SSH",
+  Rpc = "RPC",
+  Ssh = "SSH",
+}
+
 export type ContainerResources = {
   __typename?: "ContainerResources";
   cpu: Scalars["Int"];
@@ -319,7 +341,7 @@ export type DisplayTask = {
 export type Distro = {
   __typename?: "Distro";
   aliases: Array<Scalars["String"]>;
-  arch: Scalars["String"];
+  arch: Arch;
   authorizedKeysFile: Scalars["String"];
   bootstrapSettings: BootstrapSettings;
   cloneMethod: CloneMethod;
@@ -383,7 +405,7 @@ export type DistroInfo = {
 
 export type DistroInput = {
   aliases: Array<Scalars["String"]>;
-  arch: Scalars["String"];
+  arch: Arch;
   authorizedKeysFile: Scalars["String"];
   bootstrapSettings: BootstrapSettingsInput;
   cloneMethod: CloneMethod;
@@ -502,6 +524,12 @@ export type ExternalLinkInput = {
   requesters: Array<Scalars["String"]>;
   urlTemplate: Scalars["String"];
 };
+
+export enum FeedbackRule {
+  Default = "DEFAULT",
+  NoFeedback = "NO_FEEDBACK",
+  WaitsOverThresh = "WAITS_OVER_THRESH",
+}
 
 export type File = {
   __typename?: "File";
@@ -661,25 +689,29 @@ export type Host = {
 export type HostAllocatorSettings = {
   __typename?: "HostAllocatorSettings";
   acceptableHostIdleTime: Scalars["Duration"];
-  feedbackRule: Scalars["String"];
+  feedbackRule: FeedbackRule;
   futureHostFraction: Scalars["Float"];
-  hostsOverallocatedRule: Scalars["String"];
+  hostsOverallocatedRule: OverallocatedRule;
   maximumHosts: Scalars["Int"];
   minimumHosts: Scalars["Int"];
-  roundingRule: Scalars["String"];
-  version: Scalars["String"];
+  roundingRule: RoundingRule;
+  version: HostAllocatorVersion;
 };
 
 export type HostAllocatorSettingsInput = {
   acceptableHostIdleTime: Scalars["Int"];
-  feedbackRule: Scalars["String"];
+  feedbackRule: FeedbackRule;
   futureHostFraction: Scalars["Float"];
-  hostsOverallocatedRule: Scalars["String"];
+  hostsOverallocatedRule: OverallocatedRule;
   maximumHosts: Scalars["Int"];
   minimumHosts: Scalars["Int"];
-  roundingRule: Scalars["String"];
-  version: Scalars["String"];
+  roundingRule: RoundingRule;
+  version: HostAllocatorVersion;
 };
+
+export enum HostAllocatorVersion {
+  Utilization = "UTILIZATION",
+}
 
 export type HostEventLogData = {
   __typename?: "HostEventLogData";
@@ -1312,6 +1344,12 @@ export type OomTrackerInfo = {
   detected: Scalars["Boolean"];
   pids?: Maybe<Array<Maybe<Scalars["Int"]>>>;
 };
+
+export enum OverallocatedRule {
+  Default = "DEFAULT",
+  Ignore = "IGNORE",
+  Terminate = "TERMINATE",
+}
 
 export type Parameter = {
   __typename?: "Parameter";
@@ -2157,6 +2195,12 @@ export type ResourceLimitsInput = {
   virtualMemoryKb: Scalars["Int"];
 };
 
+export enum RoundingRule {
+  Default = "DEFAULT",
+  Down = "DOWN",
+  Up = "UP",
+}
+
 /** SaveDistroInput is the input to the saveDistro mutation. */
 export type SaveDistroInput = {
   distro: DistroInput;
@@ -2700,6 +2744,7 @@ export type TriggerAlias = {
   project: Scalars["String"];
   status: Scalars["String"];
   taskRegex: Scalars["String"];
+  unscheduleDownstreamVersions?: Maybe<Scalars["Boolean"]>;
 };
 
 export type TriggerAliasInput = {
@@ -2711,6 +2756,7 @@ export type TriggerAliasInput = {
   project: Scalars["String"];
   status: Scalars["String"];
   taskRegex: Scalars["String"];
+  unscheduleDownstreamVersions?: InputMaybe<Scalars["Boolean"]>;
 };
 
 export type UiConfig = {
@@ -3570,6 +3616,7 @@ export type ProjectSettingsFieldsFragment = {
       project: string;
       status: string;
       taskRegex: string;
+      unscheduleDownstreamVersions?: boolean | null;
     }> | null;
     parsleyFilters?: Array<{
       __typename?: "ParsleyFilter";
@@ -3768,6 +3815,7 @@ export type RepoSettingsFieldsFragment = {
       project: string;
       status: string;
       taskRegex: string;
+      unscheduleDownstreamVersions?: boolean | null;
     }>;
     workstationConfig: {
       __typename?: "RepoWorkstationConfig";
@@ -4158,6 +4206,7 @@ export type ProjectEventSettingsFragment = {
       project: string;
       status: string;
       taskRegex: string;
+      unscheduleDownstreamVersions?: boolean | null;
     }> | null;
     parsleyFilters?: Array<{
       __typename?: "ParsleyFilter";
@@ -4257,6 +4306,7 @@ export type ProjectTriggersSettingsFragment = {
     project: string;
     status: string;
     taskRegex: string;
+    unscheduleDownstreamVersions?: boolean | null;
   }> | null;
 };
 
@@ -4272,6 +4322,7 @@ export type RepoTriggersSettingsFragment = {
     project: string;
     status: string;
     taskRegex: string;
+    unscheduleDownstreamVersions?: boolean | null;
   }>;
 };
 
@@ -5130,7 +5181,7 @@ export type DistroQuery = {
   distro?: {
     __typename?: "Distro";
     aliases: Array<string>;
-    arch: string;
+    arch: Arch;
     authorizedKeysFile: string;
     cloneMethod: CloneMethod;
     containerPool: string;
@@ -5153,10 +5204,10 @@ export type DistroQuery = {
     bootstrapSettings: {
       __typename?: "BootstrapSettings";
       clientDir: string;
-      communication: string;
+      communication: CommunicationMethod;
       jasperBinaryDir: string;
       jasperCredentialsPath: string;
-      method: string;
+      method: BootstrapMethod;
       rootDir: string;
       serviceUser: string;
       shellPath: string;
@@ -5188,13 +5239,13 @@ export type DistroQuery = {
     hostAllocatorSettings: {
       __typename?: "HostAllocatorSettings";
       acceptableHostIdleTime: number;
-      feedbackRule: string;
+      feedbackRule: FeedbackRule;
       futureHostFraction: number;
-      hostsOverallocatedRule: string;
+      hostsOverallocatedRule: OverallocatedRule;
       maximumHosts: number;
       minimumHosts: number;
-      roundingRule: string;
-      version: string;
+      roundingRule: RoundingRule;
+      version: HostAllocatorVersion;
     };
     iceCreamSettings: {
       __typename?: "IceCreamSettings";
@@ -6532,6 +6583,7 @@ export type ProjectEventLogsQuery = {
             project: string;
             status: string;
             taskRegex: string;
+            unscheduleDownstreamVersions?: boolean | null;
           }> | null;
           parsleyFilters?: Array<{
             __typename?: "ParsleyFilter";
@@ -6742,6 +6794,7 @@ export type ProjectEventLogsQuery = {
             project: string;
             status: string;
             taskRegex: string;
+            unscheduleDownstreamVersions?: boolean | null;
           }> | null;
           parsleyFilters?: Array<{
             __typename?: "ParsleyFilter";
@@ -6967,6 +7020,7 @@ export type ProjectSettingsQuery = {
         project: string;
         status: string;
         taskRegex: string;
+        unscheduleDownstreamVersions?: boolean | null;
       }> | null;
       parsleyFilters?: Array<{
         __typename?: "ParsleyFilter";
@@ -7216,6 +7270,7 @@ export type RepoEventLogsQuery = {
             project: string;
             status: string;
             taskRegex: string;
+            unscheduleDownstreamVersions?: boolean | null;
           }> | null;
           parsleyFilters?: Array<{
             __typename?: "ParsleyFilter";
@@ -7426,6 +7481,7 @@ export type RepoEventLogsQuery = {
             project: string;
             status: string;
             taskRegex: string;
+            unscheduleDownstreamVersions?: boolean | null;
           }> | null;
           parsleyFilters?: Array<{
             __typename?: "ParsleyFilter";
@@ -7641,6 +7697,7 @@ export type RepoSettingsQuery = {
         project: string;
         status: string;
         taskRegex: string;
+        unscheduleDownstreamVersions?: boolean | null;
       }>;
       workstationConfig: {
         __typename?: "RepoWorkstationConfig";

--- a/src/pages/distroSettings/tabs/testData.ts
+++ b/src/pages/distroSettings/tabs/testData.ts
@@ -1,20 +1,27 @@
 import {
+  Arch,
+  BootstrapMethod,
   CloneMethod,
+  CommunicationMethod,
   DispatcherVersion,
   DistroQuery,
+  FeedbackRule,
   FinderVersion,
+  HostAllocatorVersion,
+  OverallocatedRule,
   PlannerVersion,
   Provider,
+  RoundingRule,
 } from "gql/generated/types";
 
 const distroData: DistroQuery["distro"] = {
   __typename: "Distro",
   aliases: ["rhel71-power8", "rhel71-power8-build"],
-  arch: "linux_ppc64le",
+  arch: Arch.Linux_64Bit,
   authorizedKeysFile: "",
   bootstrapSettings: {
     clientDir: "/home/evg/client",
-    communication: "legacy-ssh",
+    communication: CommunicationMethod.LegacySsh,
     env: [
       {
         key: "foo",
@@ -23,7 +30,7 @@ const distroData: DistroQuery["distro"] = {
     ],
     jasperBinaryDir: "/home/evg/jasper",
     jasperCredentialsPath: "/home/evg/jasper/creds.json",
-    method: "legacy-ssh",
+    method: BootstrapMethod.LegacySsh,
     preconditionScripts: [],
     resourceLimits: {
       lockedMemoryKb: -1,
@@ -65,13 +72,13 @@ const distroData: DistroQuery["distro"] = {
   },
   hostAllocatorSettings: {
     acceptableHostIdleTime: 0,
-    feedbackRule: "",
+    feedbackRule: FeedbackRule.Default,
     futureHostFraction: 0,
-    hostsOverallocatedRule: "",
+    hostsOverallocatedRule: OverallocatedRule.Default,
     maximumHosts: 0,
     minimumHosts: 0,
-    roundingRule: "",
-    version: "utilization",
+    roundingRule: RoundingRule.Default,
+    version: HostAllocatorVersion.Utilization,
   },
   iceCreamSettings: {
     configPath: "",

--- a/src/pages/projectSettings/tabs/ProjectTriggersTab/getFormSchema.ts
+++ b/src/pages/projectSettings/tabs/ProjectTriggersTab/getFormSchema.ts
@@ -156,6 +156,7 @@ export const getFormSchema = (
           "ui:description":
             "Downstream versions created by this trigger will be deactivated by default",
           "ui:optional": true,
+          "ui:bold": true,
         },
       },
     },

--- a/src/pages/projectSettings/tabs/ProjectTriggersTab/getFormSchema.ts
+++ b/src/pages/projectSettings/tabs/ProjectTriggersTab/getFormSchema.ts
@@ -94,6 +94,10 @@ export const getFormSchema = (
               title: "Alias",
               default: "",
             },
+            unscheduleDownstreamVersions: {
+              type: "boolean" as "boolean",
+              title: "Unschedule Downstream Versions",
+            },
           },
         },
       }
@@ -146,6 +150,11 @@ export const getFormSchema = (
         alias: {
           "ui:description":
             "Patch alias to filter variants/tasks in this project.",
+          "ui:optional": true,
+        },
+        unscheduleDownstreamVersions: {
+          "ui:description":
+            "Downstream versions created by this trigger will be deactivated by default",
           "ui:optional": true,
         },
       },

--- a/src/pages/projectSettings/tabs/ProjectTriggersTab/transformers.test.ts
+++ b/src/pages/projectSettings/tabs/ProjectTriggersTab/transformers.test.ts
@@ -55,6 +55,7 @@ const repoForm: ProjectTriggersFormState = {
       project: "spruce",
       status: "succeeded",
       taskRegex: ".*",
+      unscheduleDownstreamVersions: true,
     },
   ],
 };
@@ -72,6 +73,7 @@ const repoResult: Pick<RepoSettingsInput, "projectRef"> = {
         project: "spruce",
         status: "succeeded",
         taskRegex: ".*",
+        unscheduleDownstreamVersions: true,
       },
     ],
   },

--- a/src/pages/projectSettings/tabs/ProjectTriggersTab/transformers.ts
+++ b/src/pages/projectSettings/tabs/ProjectTriggersTab/transformers.ts
@@ -50,6 +50,7 @@ export const formToGql = (({ triggers, triggersOverride }, projectId) => ({
           dateCutoff: trigger.dateCutoff,
           configFile: trigger.configFile,
           alias: trigger.alias,
+          unscheduleDownstreamVersions: trigger.unscheduleDownstreamVersions,
         }))
       : null,
   },

--- a/src/pages/projectSettings/tabs/ProjectTriggersTab/types.ts
+++ b/src/pages/projectSettings/tabs/ProjectTriggersTab/types.ts
@@ -10,6 +10,7 @@ type FormTrigger = {
   configFile: string;
   alias: string;
   displayTitle?: string;
+  unscheduleDownstreamVersions: boolean;
 };
 
 export type ProjectTriggersFormState = {

--- a/src/pages/projectSettings/tabs/testData.ts
+++ b/src/pages/projectSettings/tabs/testData.ts
@@ -243,6 +243,7 @@ const repoBase: RepoSettingsQuery["repoSettings"] = {
         taskRegex: ".*",
         configFile: ".evergreen.yml",
         alias: "my-alias",
+        unscheduleDownstreamVersions: true,
       },
     ],
     periodicBuilds: [


### PR DESCRIPTION
EVG-20650

### Description
Adding a "Unschedule Downstream Versions" checkbox to the project triggers field in Spruce now that resolvers are supported with this field on the Evergreen side

### Testing
Tested in staging and modified unit tests here.
### Evergreen PR
https://github.com/evergreen-ci/evergreen/pull/6968