### PR TITLE
EVG-20650 Add unscheduleDownstreamVersions to Spruce

### DIFF
--- a/src/components/SpruceForm/Widgets/LeafyGreenWidgets.tsx
+++ b/src/components/SpruceForm/Widgets/LeafyGreenWidgets.tsx
@@ -109,6 +109,7 @@ export const LeafyGreenCheckBox: React.FC<SpruceWidgetProps> = ({
   value,
 }) => {
   const {
+    bold,
     customLabel,
     "data-cy": dataCy,
     description,
@@ -118,7 +119,7 @@ export const LeafyGreenCheckBox: React.FC<SpruceWidgetProps> = ({
   return (
     <ElementWrapper css={elementWrapperCSS}>
       <Checkbox
-        bold={false}
+        bold={bold || false}
         checked={value}
         data-cy={dataCy}
         description={description}

--- a/src/components/SpruceForm/Widgets/types.ts
+++ b/src/components/SpruceForm/Widgets/types.ts
@@ -8,6 +8,7 @@ export interface SpruceWidgetProps extends WidgetProps {
     "aria-controls": string[];
     "data-cy": string;
     ariaLabelledBy: string;
+    bold: boolean;
     customLabel: string;
     description: string;
     elementWrapperCSS: SerializedStyles;

--- a/src/gql/fragments/projectSettings/projectTriggers.graphql
+++ b/src/gql/fragments/projectSettings/projectTriggers.graphql
@@ -8,6 +8,7 @@ fragment ProjectTriggersSettings on Project {
     project
     status
     taskRegex
+    unscheduleDownstreamVersions
   }
 }
 
@@ -21,5 +22,6 @@ fragment RepoTriggersSettings on RepoRef {
     project
     status
     taskRegex
+    unscheduleDownstreamVersions
   }
 }

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -2419,6 +2419,7 @@ export type Task = {
   executionTasksFull?: Maybe<Array<Task>>;
   expectedDuration?: Maybe<Scalars["Duration"]["output"]>;
   failedTestCount: Scalars["Int"]["output"];
+  files: TaskFiles;
   finishTime?: Maybe<Scalars["Time"]["output"]>;
   generateTask?: Maybe<Scalars["Boolean"]["output"]>;
   generatedBy?: Maybe<Scalars["String"]["output"]>;
@@ -2445,6 +2446,7 @@ export type Task = {
   spawnHostLink?: Maybe<Scalars["String"]["output"]>;
   startTime?: Maybe<Scalars["Time"]["output"]>;
   status: Scalars["String"]["output"];
+  /** @deprecated Use files instead */
   taskFiles: TaskFiles;
   taskGroup?: Maybe<Scalars["String"]["output"]>;
   taskGroupMaxHosts?: Maybe<Scalars["Int"]["output"]>;

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -3627,6 +3627,7 @@ export type ProjectSettingsFieldsFragment = {
       project: string;
       status: string;
       taskRegex: string;
+      unscheduleDownstreamVersions?: boolean | null;
     }> | null;
     parsleyFilters?: Array<{
       __typename?: "ParsleyFilter";
@@ -3825,6 +3826,7 @@ export type RepoSettingsFieldsFragment = {
       project: string;
       status: string;
       taskRegex: string;
+      unscheduleDownstreamVersions?: boolean | null;
     }>;
     workstationConfig: {
       __typename?: "RepoWorkstationConfig";
@@ -4215,6 +4217,7 @@ export type ProjectEventSettingsFragment = {
       project: string;
       status: string;
       taskRegex: string;
+      unscheduleDownstreamVersions?: boolean | null;
     }> | null;
     parsleyFilters?: Array<{
       __typename?: "ParsleyFilter";
@@ -4314,6 +4317,7 @@ export type ProjectTriggersSettingsFragment = {
     project: string;
     status: string;
     taskRegex: string;
+    unscheduleDownstreamVersions?: boolean | null;
   }> | null;
 };
 
@@ -4329,6 +4333,7 @@ export type RepoTriggersSettingsFragment = {
     project: string;
     status: string;
     taskRegex: string;
+    unscheduleDownstreamVersions?: boolean | null;
   }>;
 };
 
@@ -6589,6 +6594,7 @@ export type ProjectEventLogsQuery = {
             project: string;
             status: string;
             taskRegex: string;
+            unscheduleDownstreamVersions?: boolean | null;
           }> | null;
           parsleyFilters?: Array<{
             __typename?: "ParsleyFilter";
@@ -6799,6 +6805,7 @@ export type ProjectEventLogsQuery = {
             project: string;
             status: string;
             taskRegex: string;
+            unscheduleDownstreamVersions?: boolean | null;
           }> | null;
           parsleyFilters?: Array<{
             __typename?: "ParsleyFilter";
@@ -7024,6 +7031,7 @@ export type ProjectSettingsQuery = {
         project: string;
         status: string;
         taskRegex: string;
+        unscheduleDownstreamVersions?: boolean | null;
       }> | null;
       parsleyFilters?: Array<{
         __typename?: "ParsleyFilter";
@@ -7273,6 +7281,7 @@ export type RepoEventLogsQuery = {
             project: string;
             status: string;
             taskRegex: string;
+            unscheduleDownstreamVersions?: boolean | null;
           }> | null;
           parsleyFilters?: Array<{
             __typename?: "ParsleyFilter";
@@ -7483,6 +7492,7 @@ export type RepoEventLogsQuery = {
             project: string;
             status: string;
             taskRegex: string;
+            unscheduleDownstreamVersions?: boolean | null;
           }> | null;
           parsleyFilters?: Array<{
             __typename?: "ParsleyFilter";
@@ -7698,6 +7708,7 @@ export type RepoSettingsQuery = {
         project: string;
         status: string;
         taskRegex: string;
+        unscheduleDownstreamVersions?: boolean | null;
       }>;
       workstationConfig: {
         __typename?: "RepoWorkstationConfig";

--- a/src/pages/distroSettings/tabs/testData.ts
+++ b/src/pages/distroSettings/tabs/testData.ts
@@ -17,7 +17,7 @@ import {
 const distroData: DistroQuery["distro"] = {
   __typename: "Distro",
   aliases: ["rhel71-power8", "rhel71-power8-build"],
-  arch: Arch.LinuxPpc_64Bit,
+  arch: Arch.Linux_64Bit,
   authorizedKeysFile: "",
   bootstrapSettings: {
     clientDir: "/home/evg/client",

--- a/src/pages/projectSettings/tabs/ProjectTriggersTab/getFormSchema.ts
+++ b/src/pages/projectSettings/tabs/ProjectTriggersTab/getFormSchema.ts
@@ -94,6 +94,10 @@ export const getFormSchema = (
               title: "Alias",
               default: "",
             },
+            unscheduleDownstreamVersions: {
+              type: "boolean" as "boolean",
+              title: "Unschedule Downstream Versions",
+            },
           },
         },
       }
@@ -147,6 +151,12 @@ export const getFormSchema = (
           "ui:description":
             "Patch alias to filter variants/tasks in this project.",
           "ui:optional": true,
+        },
+        unscheduleDownstreamVersions: {
+          "ui:description":
+            "Downstream versions created by this trigger will be deactivated by default",
+          "ui:optional": true,
+          "ui:bold": true,
         },
       },
     },

--- a/src/pages/projectSettings/tabs/ProjectTriggersTab/transformers.test.ts
+++ b/src/pages/projectSettings/tabs/ProjectTriggersTab/transformers.test.ts
@@ -55,6 +55,7 @@ const repoForm: ProjectTriggersFormState = {
       project: "spruce",
       status: "succeeded",
       taskRegex: ".*",
+      unscheduleDownstreamVersions: true,
     },
   ],
 };
@@ -72,6 +73,7 @@ const repoResult: Pick<RepoSettingsInput, "projectRef"> = {
         project: "spruce",
         status: "succeeded",
         taskRegex: ".*",
+        unscheduleDownstreamVersions: true,
       },
     ],
   },

--- a/src/pages/projectSettings/tabs/ProjectTriggersTab/transformers.ts
+++ b/src/pages/projectSettings/tabs/ProjectTriggersTab/transformers.ts
@@ -50,6 +50,7 @@ export const formToGql = (({ triggers, triggersOverride }, projectId) => ({
           dateCutoff: trigger.dateCutoff,
           configFile: trigger.configFile,
           alias: trigger.alias,
+          unscheduleDownstreamVersions: trigger.unscheduleDownstreamVersions,
         }))
       : null,
   },

--- a/src/pages/projectSettings/tabs/ProjectTriggersTab/types.ts
+++ b/src/pages/projectSettings/tabs/ProjectTriggersTab/types.ts
@@ -10,6 +10,7 @@ type FormTrigger = {
   configFile: string;
   alias: string;
   displayTitle?: string;
+  unscheduleDownstreamVersions: boolean;
 };
 
 export type ProjectTriggersFormState = {

--- a/src/pages/projectSettings/tabs/testData.ts
+++ b/src/pages/projectSettings/tabs/testData.ts
@@ -243,6 +243,7 @@ const repoBase: RepoSettingsQuery["repoSettings"] = {
         taskRegex: ".*",
         configFile: ".evergreen.yml",
         alias: "my-alias",
+        unscheduleDownstreamVersions: true,
       },
     ],
     periodicBuilds: [


### PR DESCRIPTION
EVG-20650

### Description
Adding a "Unschedule Downstream Versions" checkbox to the project triggers field in Spruce now that resolvers are supported with this field on the Evergreen side

### Testing
Tested in staging and modified unit tests here.
### Evergreen PR
https://github.com/evergreen-ci/evergreen/pull/6968