### PR TITLE
EVG-20086 Add task blocked event copy

### DIFF
--- a/src/pages/task/taskTabs/logs/logTypes/TaskEventLogLine.tsx
+++ b/src/pages/task/taskTabs/logs/logTypes/TaskEventLogLine.tsx
@@ -18,7 +18,7 @@ export const TaskEventLogLine: React.FC<TaskEventLogEntry> = ({
   let message: JSX.Element;
   switch (eventType) {
     case TaskEventType.TaskBlocked:
-      message = <>This task is blocked.</>;
+      message = <>Task is blocked.</>;
       break;
     case TaskEventType.TaskFinished:
       message = (

--- a/src/pages/task/taskTabs/logs/logTypes/TaskEventLogLine.tsx
+++ b/src/pages/task/taskTabs/logs/logTypes/TaskEventLogLine.tsx
@@ -17,6 +17,9 @@ export const TaskEventLogLine: React.FC<TaskEventLogEntry> = ({
   const containerOrHostCopy = podId ? "container" : "host";
   let message: JSX.Element;
   switch (eventType) {
+    case TaskEventType.TaskBlocked:
+      message = <>This task is blocked.</>;
+      break;
     case TaskEventType.TaskFinished:
       message = (
         <>

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -106,6 +106,7 @@ export enum TaskEventType {
   TaskFinished = "TASK_FINISHED",
   TaskStarted = "TASK_STARTED",
   TaskDispatched = "TASK_DISPATCHED",
+  TaskBlocked = "TASK_BLOCKED",
   TaskUndispatched = "TASK_UNDISPATCHED",
   TaskCreated = "TASK_CREATED",
   TaskRestarted = "TASK_RESTARTED",


### PR DESCRIPTION
EVG-20086
### Description
Added a new event for TASK_BLOCKED. There isn't any additional info in the event that can be used for the copy. 


### Screenshots
<img width="1247" alt="image" src="https://github.com/evergreen-ci/spruce/assets/4605522/8fd55646-98ee-4097-8111-7c173e1e96ac">
