### PR TITLE
EVG-20019: set log message timezone to user timezone and fix format

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -20,6 +20,7 @@ export { useTaskStatuses } from "./useTaskStatuses";
 export { useUpsertQueryParams } from "./useUpsertQueryParams";
 export { useSpruceConfig } from "./useSpruceConfig";
 export { useUserSettings } from "./useUserSettings";
+export { useUserTimeZone } from "./useUserTimeZone";
 export { useDateFormat } from "./useDateFormat";
 export { useBreadcrumbRoot } from "./useBreadcrumbRoot";
 export { useResize } from "./useResize";

--- a/src/pages/task/taskTabs/logs/logTypes/LogMessageLine.tsx
+++ b/src/pages/task/taskTabs/logs/logTypes/LogMessageLine.tsx
@@ -1,12 +1,13 @@
 import { useMemo } from "react";
 import AnsiUp from "ansi_up";
-import { format } from "date-fns";
+import { format, utcToZonedTime } from "date-fns-tz";
 import parse from "html-react-parser";
 import linkifyHtml from "linkify-html";
 import { LogMessageFragment } from "gql/generated/types";
+import { useUserTimeZone } from "hooks";
 import { getLogLineWrapper } from "./logMessageLine/LogLines";
 
-const FORMAT_STR = "yyyy/MM/d, HH:mm:ss.SSS";
+const FORMAT_STR = "yyyy/MM/dd HH:mm:ss.SSS";
 const ansiUp = new AnsiUp();
 
 export const LogMessageLine: React.FC<LogMessageFragment> = ({
@@ -14,7 +15,12 @@ export const LogMessageLine: React.FC<LogMessageFragment> = ({
   severity,
   timestamp,
 }) => {
-  const time = timestamp ? `[${format(new Date(timestamp), FORMAT_STR)}] ` : "";
+  const tz = useUserTimeZone();
+  const time = timestamp
+    ? `[${format(new Date(utcToZonedTime(timestamp, tz)), FORMAT_STR, {
+        timeZone: tz,
+      })}] `
+    : "";
   const LogLineWrapper = getLogLineWrapper(severity);
   const memoizedLogLine = useMemo(() => {
     const render = linkifyHtml(ansiUp.ansi_to_html(message), {


### PR DESCRIPTION
EVG-20019

### Description
This fixes the log message timestamp format and updates the code to use the user timezone on the task page.

### Screenshots
![Screenshot 2023-09-08 at 8 41 54 PM](https://github.com/evergreen-ci/spruce/assets/16562432/dd8673c3-5385-43e2-8646-087fc6dc1b56)

### Testing
Tested in staging that the correct timestamp format and timezone are printed.

### Evergreen PR
https://github.com/evergreen-ci/evergreen/pull/7018