### PR TITLE
EVG-20661: Fix useless Sentry error

### DIFF
--- a/src/gql/GQLWrapper.tsx
+++ b/src/gql/GQLWrapper.tsx
@@ -136,17 +136,11 @@ const authLink = (logout: () => void): ApolloLink =>
 const logErrorsLink = onError(({ graphQLErrors, operation }) => {
   if (Array.isArray(graphQLErrors)) {
     graphQLErrors.forEach((gqlErr) => {
-      reportError(
-        {
-          message: "GraphQL Error",
-          name: gqlErr.message,
-        },
-        {
-          gqlErr,
-          operationName: operation.operationName,
-          variables: operation.variables,
-        }
-      ).warning();
+      reportError(new Error(gqlErr.message), {
+        gqlErr,
+        operationName: operation.operationName,
+        variables: operation.variables,
+      }).warning();
     });
   }
   // dont track network errors here because they are


### PR DESCRIPTION
EVG-20661

### Description
<!-- add description, context, thought process, etc -->
We were reporting GraphQL errors using a POJO instead of an `Error`. BugSnag will try to coerce the object into an error ([source](https://docs.bugsnag.com/platforms/javascript/reporting-handled-errors/#basic-usage)):

> If you provide something that is not an Error, such as a string or an object with name and message fields, notify will attempt to generate a stacktrace.

but Sentry does not, instead logging many events like this:

<img width="444" alt="image" src="https://github.com/evergreen-ci/spruce/assets/9298431/13d788c8-004f-4fec-a80f-93842b95bb8f">

Using a proper `Error` fixes the issue. [Here](https://mongodb-org.sentry.io/issues/4480655275/?query=is%3Aunresolved+stack.function%3AlogErrorsLink&referrer=issue-stream&statsPeriod=14d&stream_index=1) is an example.