### PR TITLE
EVG-20802 Migrate Task.TaskFiles usage to task.files

### DIFF
--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -8102,7 +8102,7 @@ export type TaskFilesQuery = {
     __typename?: "Task";
     execution: number;
     id: string;
-    taskFiles: {
+    files: {
       __typename?: "TaskFiles";
       fileCount: number;
       groupedFiles: Array<{
@@ -8391,6 +8391,7 @@ export type TaskQuery = {
       id: string;
       status: string;
     }> | null;
+    files: { __typename?: "TaskFiles"; fileCount: number };
     logs: {
       __typename?: "TaskLogLinks";
       agentLogLink?: string | null;
@@ -8401,7 +8402,6 @@ export type TaskQuery = {
     };
     pod?: { __typename?: "Pod"; id: string } | null;
     project?: { __typename?: "Project"; id: string; identifier: string } | null;
-    taskFiles: { __typename?: "TaskFiles"; fileCount: number };
     versionMetadata: {
       __typename?: "Version";
       author: string;

--- a/src/gql/mocks/taskData.ts
+++ b/src/gql/mocks/taskData.ts
@@ -79,7 +79,7 @@ export const taskQuery: TaskQuery = {
     spawnHostLink:
       "https://evergreen.mongodb.com/spawn?distro_id=ubuntu1604-small&task_id=spruce_ubuntu1604_e2e_test_patch_e0ece5ad52ad01630bdf29f55b9382a26d6256b3_5f4889313627e0544660c800_20_08_28_04_33_55",
     status: "pending",
-    taskFiles: { __typename: "TaskFiles", fileCount: 38 },
+    files: { __typename: "TaskFiles", fileCount: 38 },
     totalTestCount: 0,
     versionMetadata: {
       __typename: "Version",

--- a/src/gql/queries/task-files.graphql
+++ b/src/gql/queries/task-files.graphql
@@ -1,8 +1,7 @@
 query TaskFiles($taskId: String!, $execution: Int) {
   task(taskId: $taskId, execution: $execution) {
     execution
-    id
-    taskFiles {
+    files {
       fileCount
       groupedFiles {
         files {
@@ -12,5 +11,6 @@ query TaskFiles($taskId: String!, $execution: Int) {
         taskName
       }
     }
+    id
   }
 }

--- a/src/gql/queries/task.graphql
+++ b/src/gql/queries/task.graphql
@@ -74,6 +74,9 @@ query Task($taskId: String!, $execution: Int) {
     }
     expectedDuration
     failedTestCount
+    files {
+      fileCount
+    }
     finishTime
     generatedBy
     generatedByName
@@ -103,9 +106,6 @@ query Task($taskId: String!, $execution: Int) {
     resetWhenFinished
     spawnHostLink
     startTime
-    taskFiles {
-      fileCount
-    }
     timeTaken
     totalTestCount
     versionMetadata {

--- a/src/pages/task/TaskTabs.tsx
+++ b/src/pages/task/TaskTabs.tsx
@@ -35,15 +35,15 @@ export const TaskTabs: React.FC<TaskTabProps> = ({ isDisplayTask, task }) => {
     execution,
     executionTasksFull,
     failedTestCount,
+    files,
     id,
     isPerfPluginEnabled,
     logs: logLinks,
     status,
-    taskFiles,
     totalTestCount,
     versionMetadata,
   } = task ?? {};
-  const { fileCount } = taskFiles ?? {};
+  const { fileCount } = files ?? {};
 
   const { showBuildBaron } = useBuildBaronVariables({
     task: {

--- a/src/pages/task/taskTabs/FileTable/index.tsx
+++ b/src/pages/task/taskTabs/FileTable/index.tsx
@@ -30,9 +30,9 @@ const FileTable: React.FC<FileTableProps> = ({ execution, taskId }) => {
       },
     }
   );
-  const { taskFiles } = data?.task ?? {};
+  const { files } = data?.task ?? {};
 
-  const { groupedFiles = [] } = taskFiles ?? {};
+  const { groupedFiles = [] } = files ?? {};
   const filteredGroupedFiles = filterGroupedFiles(groupedFiles, search);
 
   // We only want to show the file group name if there are multiple file groups.

--- a/src/pages/task/taskTabs/FileTable/types.ts
+++ b/src/pages/task/taskTabs/FileTable/types.ts
@@ -2,5 +2,5 @@ import { TaskFilesQuery } from "gql/generated/types";
 import { Unpacked } from "types/utils";
 
 export type GroupedFiles = Unpacked<
-  TaskFilesQuery["task"]["taskFiles"]["groupedFiles"]
+  TaskFilesQuery["task"]["files"]["groupedFiles"]
 >;


### PR DESCRIPTION
EVG-20802
### Description
Updates all GraphQL queries that rely on `Task.TaskFiles` to now use `Task.Files`

### Testing
N/A