### PR TITLE
EVG-20820: Enable test isolation in commit_queue.ts

### DIFF
--- a/cypress/integration/commit_queue.ts
+++ b/cypress/integration/commit_queue.ts
@@ -9,28 +9,29 @@ const COMMIT_QUEUE_ROUTE_2 = `/commit-queue/${commitQueue.id2}`;
 const INVALID_COMMIT_QUEUE_ROUTE = `/commit-queue/${commitQueue.id3}`;
 const COMMIT_QUEUE_ROUTE_4 = `/commit-queue/${commitQueue.id4}`;
 
-describe("commit queue page", { testIsolation: false }, () => {
+describe("commit queue page", () => {
   describe(COMMIT_QUEUE_ROUTE_1, () => {
-    before(() => {
+    beforeEach(() => {
       cy.visit(COMMIT_QUEUE_ROUTE_1);
     });
+
     it("Should render the commit queue page with one card", () => {
       cy.dataCy("commit-queue-card").should("have.length", 1);
     });
 
-    it("Clicking on Total Code changes should toggle a drop down table", () => {
+    it("Clicking on 'Total code changes' should show the code changes table", () => {
       cy.dataCy("code-changes-table").should("not.be.visible");
       cy.dataCy("accordion-toggle").click();
       cy.dataCy("code-changes-table").should("be.visible");
     });
 
-    it("Clicking on remove a patch from the commit queue should work", () => {
+    it("Should be able to remove a patch from the commit queue", () => {
       cy.dataCy("commit-queue-card").should("exist");
       cy.dataCy("commit-queue-patch-button").should("exist");
       cy.dataCy("commit-queue-patch-button").click();
       cy.dataCy("commit-queue-confirmation-modal").should("be.visible");
       cy.dataCy("commit-queue-confirmation-modal").within(() => {
-        cy.contains("Remove").click();
+        cy.contains("button", "Remove").click();
       });
       cy.dataCy("commit-queue-confirmation-modal").should("not.exist");
       cy.dataCy("commit-queue-card").should("not.exist");
@@ -38,18 +39,17 @@ describe("commit queue page", { testIsolation: false }, () => {
   });
 
   describe(COMMIT_QUEUE_ROUTE_2, () => {
-    before(() => {
-      cy.visit(COMMIT_QUEUE_ROUTE_2);
-    });
     it("visiting a page with multiple sets of code changes should have multiple tables", () => {
+      cy.visit(COMMIT_QUEUE_ROUTE_2);
       cy.dataCy("accordion-toggle").should("have.length", 4);
     });
   });
 
   describe(COMMIT_QUEUE_ROUTE_4, () => {
-    before(() => {
+    beforeEach(() => {
       cy.visit(COMMIT_QUEUE_ROUTE_4);
     });
+
     it("should display the commit queue message if there is one", () => {
       cy.dataCy("commit-queue-message").should("exist");
       cy.dataCy("commit-queue-message").should(
@@ -75,10 +75,8 @@ describe("commit queue page", { testIsolation: false }, () => {
   });
 
   describe(INVALID_COMMIT_QUEUE_ROUTE, () => {
-    before(() => {
+    it("visiting a nonexistent commit queue page should display an error", () => {
       cy.visit(INVALID_COMMIT_QUEUE_ROUTE);
-    });
-    it("visiting a non existent commit queue page should display an error", () => {
       cy.validateToast("error", "There was an error loading the commit queue");
     });
   });


### PR DESCRIPTION
EVG-20820

### Description
Enables test isolation (use `beforeEach` where necessary & tweak some test descriptions).