### PR TITLE
EVG-19254: Show details.description regardless of task status

### DIFF
--- a/src/components/ExpandedText/index.tsx
+++ b/src/components/ExpandedText/index.tsx
@@ -1,25 +1,31 @@
 import styled from "@emotion/styled";
 import { palette } from "@leafygreen-ui/palette";
-import Tooltip, { TriggerEvent } from "@leafygreen-ui/tooltip";
+import Tooltip, { TriggerEvent, Align, Justify } from "@leafygreen-ui/tooltip";
 import { Disclaimer } from "@leafygreen-ui/typography";
 import { zIndex } from "constants/tokens";
 
 const { blue } = palette;
 
 interface ExpandedTextProps {
-  message: string;
-  triggerEvent?: (typeof TriggerEvent)[keyof typeof TriggerEvent];
-  popoverZIndex?: number;
+  align?: Align;
   ["data-cy"]?: string;
+  justify?: Justify;
+  message: string;
+  popoverZIndex?: number;
+  triggerEvent?: (typeof TriggerEvent)[keyof typeof TriggerEvent];
 }
 
 const ExpandedText: React.FC<ExpandedTextProps> = ({
+  align,
   "data-cy": dataCy,
+  justify,
   message,
   popoverZIndex = zIndex.popover,
   triggerEvent = TriggerEvent.Hover,
 }) => (
   <Tooltip
+    align={align}
+    justify={justify}
     trigger={<ButtonText>more</ButtonText>}
     triggerEvent={triggerEvent}
     popoverZIndex={popoverZIndex}
@@ -32,6 +38,8 @@ const ButtonText = styled(Disclaimer)`
   color: ${blue.dark2};
   text-decoration: underline;
   cursor: default;
+  width: fit-content;
+  display: inline-block;
 `;
 
 const MessageWrapper = styled.div`

--- a/src/pages/task/metadata/Metadata.test.tsx
+++ b/src/pages/task/metadata/Metadata.test.tsx
@@ -73,7 +73,7 @@ describe("metadata", () => {
     expect(screen.getByDataCy("task-metadata-finished")).toBeInTheDocument();
     expect(screen.getByDataCy("task-trace-link")).toBeInTheDocument();
     expect(screen.getByDataCy("task-metrics-link")).toBeInTheDocument();
-    expect(screen.getByDataCy("task-metadata-details")).toBeInTheDocument();
+    expect(screen.getByDataCy("task-metadata-description")).toBeInTheDocument();
   });
 });
 

--- a/src/pages/task/metadata/Metadata.test.tsx
+++ b/src/pages/task/metadata/Metadata.test.tsx
@@ -73,6 +73,7 @@ describe("metadata", () => {
     expect(screen.getByDataCy("task-metadata-finished")).toBeInTheDocument();
     expect(screen.getByDataCy("task-trace-link")).toBeInTheDocument();
     expect(screen.getByDataCy("task-metrics-link")).toBeInTheDocument();
+    expect(screen.getByDataCy("task-metadata-details")).toBeInTheDocument();
   });
 });
 
@@ -99,6 +100,14 @@ const taskSucceeded = {
     ...taskStarted.task,
     finishTime: addMilliseconds(new Date(), 1228078),
     status: "succeeded",
-    details: { ...taskStarted.task.details, traceID: "trace_abcde" },
+    details: {
+      type: "",
+      status: "success",
+      description: "exiting due to custom reason",
+      traceID: "trace_abcde",
+      oomTracker: {
+        detected: false,
+      },
+    },
   },
 };

--- a/src/pages/task/metadata/Metadata.test.tsx
+++ b/src/pages/task/metadata/Metadata.test.tsx
@@ -2,7 +2,7 @@ import { MockedProvider } from "@apollo/client/testing";
 import { addMilliseconds } from "date-fns";
 import { getUserMock } from "gql/mocks/getUser";
 import { taskQuery } from "gql/mocks/taskData";
-import { renderWithRouterMatch as render, screen } from "test_utils";
+import { renderWithRouterMatch as render, screen, userEvent } from "test_utils";
 import { Metadata } from "./index";
 
 const wrapper = ({ children }) => (
@@ -52,7 +52,8 @@ describe("metadata", () => {
     expect(screen.queryByDataCy("task-metrics-link")).toBeNull();
   });
 
-  it("renders the metadata card with a succeeded status", () => {
+  it("renders the metadata card with a succeeded status", async () => {
+    const user = userEvent.setup();
     render(
       <Metadata
         taskId={taskId}
@@ -73,7 +74,14 @@ describe("metadata", () => {
     expect(screen.getByDataCy("task-metadata-finished")).toBeInTheDocument();
     expect(screen.getByDataCy("task-trace-link")).toBeInTheDocument();
     expect(screen.getByDataCy("task-metrics-link")).toBeInTheDocument();
+
     expect(screen.getByDataCy("task-metadata-description")).toBeInTheDocument();
+    expect(screen.getByText("more")).toBeInTheDocument();
+    await user.hover(screen.getByText("more"));
+    await screen.findByDataCy("task-metadata-description-tooltip");
+    expect(
+      screen.getByDataCy("task-metadata-description-tooltip")
+    ).toHaveTextContent(taskSucceeded.task.details.description);
   });
 });
 
@@ -95,6 +103,7 @@ const taskStarted = {
     status: "started",
   },
 };
+
 const taskSucceeded = {
   task: {
     ...taskStarted.task,
@@ -103,7 +112,8 @@ const taskSucceeded = {
     details: {
       type: "",
       status: "success",
-      description: "exiting due to custom reason",
+      description:
+        "exiting due to custom reason: long long long long long long long long long long long long long message",
       traceID: "trace_abcde",
       oomTracker: {
         detected: false,

--- a/src/pages/task/metadata/index.tsx
+++ b/src/pages/task/metadata/index.tsx
@@ -207,10 +207,14 @@ export const Metadata: React.FC<Props> = ({ error, loading, task, taskId }) => {
           </InlineCode>
         </MetadataItem>
       )}
-      {details?.status === TaskStatus.Failed && (
-        <MetadataItem>
-          Failing command:{" "}
-          {processFailingCommand(details?.description, isContainerTask)}
+      {details?.description && (
+        <MetadataItem data-cy="task-metadata-details">
+          {details?.status === TaskStatus.Failed
+            ? `Failing command: ${processFailingCommand(
+                details.description,
+                isContainerTask
+              )}`
+            : `Command: ${details.description}`}
         </MetadataItem>
       )}
       {details?.timeoutType && details?.timeoutType !== "" && (

--- a/src/pages/task/metadata/index.tsx
+++ b/src/pages/task/metadata/index.tsx
@@ -211,8 +211,8 @@ export const Metadata: React.FC<Props> = ({ error, loading, task, taskId }) => {
       {details?.description && (
         <MetadataItem data-cy="task-metadata-description">
           <DetailsDescription
-            isContainerTask={isContainerTask}
             description={details.description}
+            isContainerTask={isContainerTask}
             status={details?.status}
           />
         </MetadataItem>
@@ -406,8 +406,7 @@ const DetailsDescription = ({
   isContainerTask: boolean;
   status: string;
 }) => {
-  const MAX_CHAR = 80;
-  const shouldTruncate = description.length > MAX_CHAR;
+  const MAX_CHAR = 100;
 
   const fullText =
     status === TaskStatus.Failed
@@ -416,13 +415,14 @@ const DetailsDescription = ({
           isContainerTask
         )}`
       : `Command: ${description}`;
-  const truncatedText = fullText.substring(0, MAX_CHAR).concat("... ");
+  const shouldTruncate = fullText.length > MAX_CHAR;
+  const truncatedText = fullText.substring(0, MAX_CHAR).concat("...");
 
   return (
     <span>
       {shouldTruncate ? (
         <>
-          {truncatedText}
+          {truncatedText}{" "}
           <ExpandedText
             align="right"
             justify="end"

--- a/src/pages/task/metadata/index.tsx
+++ b/src/pages/task/metadata/index.tsx
@@ -7,6 +7,7 @@ import { InlineCode } from "@leafygreen-ui/typography";
 import Cookies from "js-cookie";
 import { Link } from "react-router-dom";
 import { useTaskAnalytics } from "analytics";
+import ExpandedText from "components/ExpandedText";
 import {
   MetadataCard,
   MetadataItem,
@@ -28,7 +29,7 @@ import {
   getProjectPatchesRoute,
   getPodRoute,
 } from "constants/routes";
-import { size } from "constants/tokens";
+import { size, zIndex } from "constants/tokens";
 import { TaskQuery } from "gql/generated/types";
 import { useDateFormat } from "hooks";
 import { TaskStatus } from "types/task";
@@ -209,12 +210,11 @@ export const Metadata: React.FC<Props> = ({ error, loading, task, taskId }) => {
       )}
       {details?.description && (
         <MetadataItem data-cy="task-metadata-description">
-          {details?.status === TaskStatus.Failed
-            ? `Failing command: ${processFailingCommand(
-                details.description,
-                isContainerTask
-              )}`
-            : `Command: ${details.description}`}
+          <DetailsDescription
+            isContainerTask={isContainerTask}
+            description={details.description}
+            status={details?.status}
+          />
         </MetadataItem>
       )}
       {details?.timeoutType && details?.timeoutType !== "" && (
@@ -394,6 +394,47 @@ export const Metadata: React.FC<Props> = ({ error, loading, task, taskId }) => {
         </MetadataItem>
       )}
     </MetadataCard>
+  );
+};
+
+const DetailsDescription = ({
+  description,
+  isContainerTask,
+  status,
+}: {
+  description: string;
+  isContainerTask: boolean;
+  status: string;
+}) => {
+  const MAX_CHAR = 80;
+  const shouldTruncate = description.length > MAX_CHAR;
+
+  const fullText =
+    status === TaskStatus.Failed
+      ? `Failing command: ${processFailingCommand(
+          description,
+          isContainerTask
+        )}`
+      : `Command: ${description}`;
+  const truncatedText = fullText.substring(0, MAX_CHAR).concat("... ");
+
+  return (
+    <span>
+      {shouldTruncate ? (
+        <>
+          {truncatedText}
+          <ExpandedText
+            align="right"
+            justify="end"
+            popoverZIndex={zIndex.tooltip}
+            message={description}
+            data-cy="task-metadata-description-tooltip"
+          />
+        </>
+      ) : (
+        fullText
+      )}
+    </span>
   );
 };
 

--- a/src/pages/task/metadata/index.tsx
+++ b/src/pages/task/metadata/index.tsx
@@ -208,7 +208,7 @@ export const Metadata: React.FC<Props> = ({ error, loading, task, taskId }) => {
         </MetadataItem>
       )}
       {details?.description && (
-        <MetadataItem data-cy="task-metadata-details">
+        <MetadataItem data-cy="task-metadata-description">
           {details?.status === TaskStatus.Failed
             ? `Failing command: ${processFailingCommand(
                 details.description,


### PR DESCRIPTION
EVG-19254

### Description
Users can set the value of `description` even if the task has succeeded ([docs](https://docs.devprod.prod.corp.mongodb.com/evergreen/Project-Configuration/Task-Runtime-Behavior#manually-set-task-status)), but we only show it if the task has failed. We should show the description if it exists.

I wasn't sure what verbiage to use since `description` can be set to anything of the user's choice (or it will default to the last run command), so if you have another suggestion feel free to let me know.

### Testing
- Jest test
- Manually testing using the example link from the ticket
