### PR TITLE
EVG-20918: Update search input focus shortcut on configure page

### DIFF
--- a/src/pages/configurePatch/configurePatchCore/ConfigureTasks/index.tsx
+++ b/src/pages/configurePatch/configurePatchCore/ConfigureTasks/index.tsx
@@ -7,7 +7,7 @@ import Tooltip from "@leafygreen-ui/tooltip";
 import { Body, Disclaimer } from "@leafygreen-ui/typography";
 import pluralize from "pluralize";
 import Icon from "components/Icon";
-import { CharKey, ModifierKey } from "constants/keys";
+import { CharKey } from "constants/keys";
 import { size } from "constants/tokens";
 import { VariantTask } from "gql/generated/types";
 import useKeyboardShortcut from "hooks/useKeyboardShortcut";
@@ -61,8 +61,7 @@ const ConfigureTasks: React.FC<Props> = ({
   const searchRef = useRef<HTMLInputElement>(null);
   useKeyboardShortcut(
     {
-      charKey: CharKey.F,
-      modifierKeys: [ModifierKey.Control],
+      charKey: CharKey.ForwardSlash,
     },
     () => {
       searchRef.current?.focus();


### PR DESCRIPTION
EVG-20918

### Description
I updated the shortcut to `/ ` which is a common search hotkey in various tools like the GitHub web app and vim.