### PR TITLE
EVG-21009: Make distro settings page readonly if user lacks edit permissions

### DIFF
--- a/cypress/integration/distroSettings/permissions.ts
+++ b/cypress/integration/distroSettings/permissions.ts
@@ -1,0 +1,83 @@
+describe("with various permission levels", () => {
+  it("hides the new distro button when a user cannot create distros", () => {
+    const userData = {
+      data: {
+        user: {
+          userId: "admin",
+          permissions: {
+            canCreateDistro: false,
+            distroPermissions: {
+              admin: true,
+              edit: true,
+            },
+          },
+        },
+      },
+    };
+    cy.overwriteGQL("UserDistroSettingsPermissions", userData);
+    cy.visit("/distro/rhel71-power8-large/settings/general");
+    cy.dataCy("new-distro-button").should("not.exist");
+    cy.dataCy("delete-distro-button").should(
+      "not.have.attr",
+      "aria-disabled",
+      "true"
+    );
+    cy.get("textarea").should("not.be.disabled");
+  });
+
+  it("disables the delete button when user lacks admin permissions", () => {
+    const userData = {
+      data: {
+        user: {
+          userId: "admin",
+          permissions: {
+            canCreateDistro: false,
+            distroPermissions: {
+              admin: false,
+              edit: true,
+            },
+          },
+        },
+      },
+    };
+    cy.overwriteGQL("UserDistroSettingsPermissions", userData);
+    cy.visit("/distro/rhel71-power8-large/settings/general");
+    cy.dataCy("new-distro-button").should("not.exist");
+    cy.dataCy("delete-distro-button").should(
+      "have.attr",
+      "aria-disabled",
+      "true"
+    );
+    cy.get("textarea").should("not.be.disabled");
+  });
+
+  it("disables fields when user lacks edit permissions", () => {
+    const userData = {
+      data: {
+        user: {
+          userId: "admin",
+          permissions: {
+            canCreateDistro: false,
+            distroPermissions: {
+              admin: false,
+              edit: false,
+            },
+          },
+        },
+      },
+    };
+    cy.overwriteGQL("UserDistroSettingsPermissions", userData);
+    cy.visit("/distro/rhel71-power8-large/settings/general");
+    cy.dataCy("new-distro-button").should("not.exist");
+    cy.dataCy("delete-distro-button").should(
+      "have.attr",
+      "aria-disabled",
+      "true"
+    );
+    cy.dataCy("distro-settings-page").within(() => {
+      cy.get("input").should("be.disabled");
+      cy.get("textarea").should("be.disabled");
+      cy.get("button").should("have.attr", "aria-disabled", "true");
+    });
+  });
+});

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -8471,7 +8471,11 @@ export type UserDistroSettingsPermissionsQuery = {
     permissions: {
       __typename?: "Permissions";
       canCreateDistro: boolean;
-      distroPermissions: { __typename?: "DistroPermissions"; admin: boolean };
+      distroPermissions: {
+        __typename?: "DistroPermissions";
+        admin: boolean;
+        edit: boolean;
+      };
     };
   };
 };

--- a/src/gql/queries/user-distro-settings-permissions.graphql
+++ b/src/gql/queries/user-distro-settings-permissions.graphql
@@ -4,6 +4,7 @@ query UserDistroSettingsPermissions($distroId: String!) {
       canCreateDistro
       distroPermissions(options: { distroId: $distroId }) {
         admin
+        edit
       }
     }
     userId

--- a/src/pages/distroSettings/DeleteDistro/DeleteDistro.test.tsx
+++ b/src/pages/distroSettings/DeleteDistro/DeleteDistro.test.tsx
@@ -131,6 +131,7 @@ const isAdminMock: ApolloMock<
           distroPermissions: {
             __typename: "DistroPermissions",
             admin: true,
+            edit: true,
           },
         },
       },
@@ -159,6 +160,7 @@ const notAdminMock: ApolloMock<
           distroPermissions: {
             __typename: "DistroPermissions",
             admin: false,
+            edit: false,
           },
         },
       },

--- a/src/pages/distroSettings/NewDistro/NewDistroButton.test.tsx
+++ b/src/pages/distroSettings/NewDistro/NewDistroButton.test.tsx
@@ -41,6 +41,7 @@ describe("new distro button", () => {
               distroPermissions: {
                 __typename: "DistroPermissions",
                 admin: false,
+                edit: false,
               },
             },
           },
@@ -131,6 +132,7 @@ const hasPermissionsMock: ApolloMock<
           distroPermissions: {
             __typename: "DistroPermissions",
             admin: true,
+            edit: true,
           },
         },
       },

--- a/src/pages/distroSettings/tabs/BaseTab.tsx
+++ b/src/pages/distroSettings/tabs/BaseTab.tsx
@@ -1,6 +1,12 @@
+import { useQuery } from "@apollo/client";
 import { useParams } from "react-router-dom";
 import { Form } from "components/Settings/Form";
 import { GetFormSchema, ValidateProps } from "components/SpruceForm";
+import {
+  UserDistroSettingsPermissionsQuery,
+  UserDistroSettingsPermissionsQueryVariables,
+} from "gql/generated/types";
+import { USER_DISTRO_SETTINGS_PERMISSIONS } from "gql/queries";
 import { usePopulateForm, useDistroSettingsContext } from "../Context";
 import { FormStateMap, WritableDistroSettingsType } from "./types";
 
@@ -15,12 +21,22 @@ export const BaseTab = <T extends WritableDistroSettingsType>({
   initialFormState,
   ...rest
 }: BaseTabProps<T>) => {
-  const { tab } = useParams<{ tab: T }>();
+  const { distroId, tab } = useParams<{ distroId: string; tab: T }>();
   const state = useDistroSettingsContext();
   usePopulateForm(initialFormState, tab);
 
+  const { data } = useQuery<
+    UserDistroSettingsPermissionsQuery,
+    UserDistroSettingsPermissionsQueryVariables
+  >(USER_DISTRO_SETTINGS_PERMISSIONS, {
+    variables: { distroId },
+  });
+  const canEditDistro =
+    data?.user?.permissions?.distroPermissions?.edit ?? false;
+
   return (
     <Form<WritableDistroSettingsType, FormStateMap>
+      disabled={!canEditDistro}
       {...rest}
       state={state}
       tab={tab}


### PR DESCRIPTION
EVG-21009

### Description
<!-- add description, context, thought process, etc -->
- Make all forms disabled if user lacks edit permissions for a given distro. The save button would currently fail under these conditions, but making the page clearly view-only is more helpful than only notifying a user once their save fails.
- Limiting users who lack view permissions already works as designed
- Create, copy, and delete functionality is also appropriately gated

### Screenshots
<!-- add screenshots of visible changes -->
Disabled general settings page. You can see that the "New distro" button is omitted, and the delete button is disabled as well.
<img width="1394" alt="Screenshot 2023-10-04 at 1 57 34 PM" src="https://github.com/evergreen-ci/spruce/assets/9298431/0c7efcc3-62d6-4103-af2b-8d254c07f3b3">

Existing functionality for a user who lacks view permissions:
<img width="1394" alt="image" src="https://github.com/evergreen-ci/spruce/assets/9298431/70901411-017f-4744-8efc-fe511d55632c">