### PR TITLE
EVG-20692: Indicate if a version has been ignored

### DIFF
--- a/cypress/integration/version/banners.ts
+++ b/cypress/integration/version/banners.ts
@@ -2,11 +2,11 @@ describe("banners", () => {
   const versionWithBanners =
     "/version/logkeeper_e864cf934194c161aa044e4599c8c81cee7b6237/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC";
 
-  beforeEach(() => {
-    cy.visit(versionWithBanners);
-  });
-
   describe("errors", () => {
+    beforeEach(() => {
+      cy.visit(versionWithBanners);
+    });
+
     it("should display the number of configuration errors", () => {
       cy.dataCy("configuration-errors-banner").should("be.visible");
       cy.contains("4 errors in configuration file").should("be.visible");
@@ -19,6 +19,10 @@ describe("banners", () => {
   });
 
   describe("warnings", () => {
+    beforeEach(() => {
+      cy.visit(versionWithBanners);
+    });
+
     it("should display the number of configuration warnings", () => {
       cy.dataCy("configuration-warnings-banner").should("be.visible");
       cy.contains("3 warnings in configuration file").should("be.visible");
@@ -27,6 +31,21 @@ describe("banners", () => {
       cy.dataCy("configuration-warnings-modal-trigger").click();
       cy.dataCy("configuration-warnings-modal").should("be.visible");
       cy.get("ol").find("li").should("have.length", 3);
+    });
+  });
+
+  describe("ignored", () => {
+    it("should display a banner", () => {
+      cy.visit("/version/spruce_e695f654c8b4b959d3e12e71696c3e318bcd4c33");
+      cy.dataCy("ignored-banner").should("be.visible");
+    });
+
+    it("should indicate if a version is ignored in the inactive commits tooltip", () => {
+      cy.visit("/commits/spruce");
+      cy.dataCy("ignored-version-icon").should("not.exist");
+      cy.dataCy("inactive-commits-button").click();
+      cy.dataCy("inactive-commits-tooltip").should("be.visible");
+      cy.dataCy("ignored-version-icon").should("be.visible");
     });
   });
 });

--- a/cypress/integration/version/banners.ts
+++ b/cypress/integration/version/banners.ts
@@ -42,10 +42,10 @@ describe("banners", () => {
 
     it("should indicate if a version is ignored in the inactive commits tooltip", () => {
       cy.visit("/commits/spruce");
-      cy.dataCy("ignored-version-icon").should("not.exist");
+      cy.dataCy("ignored-icon").should("not.exist");
       cy.dataCy("inactive-commits-button").click();
       cy.dataCy("inactive-commits-tooltip").should("be.visible");
-      cy.dataCy("ignored-version-icon").should("be.visible");
+      cy.dataCy("ignored-icon").should("be.visible");
     });
   });
 });

--- a/src/components/Icon/icons/index.tsx
+++ b/src/components/Icon/icons/index.tsx
@@ -6,6 +6,7 @@ const { green } = palette;
 interface LeafygreenIconProps extends React.SVGProps<SVGSVGElement> {
   size?: number;
   role?: "presentation" | "img";
+  ["data-cy"]?: string;
 }
 
 export const EvergreenLogo: React.ComponentType<LeafygreenIconProps> = ({
@@ -239,5 +240,29 @@ export const Loading: React.ComponentType<LeafygreenIconProps> = ({
         </circle>
       </g>
     </g>
+  </svg>
+);
+
+export const Ignored: React.ComponentType<LeafygreenIconProps> = ({
+  className,
+  "data-cy": dataCy,
+  fill,
+  size = 16,
+}) => (
+  <svg
+    aria-label="Ignored Icon"
+    data-cy={dataCy}
+    className={className}
+    fill="currentColor"
+    height={size}
+    width={size}
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      fill={fill}
+      fillRule="evenodd"
+      d="M8 14A6 6 0 1 0 8 2a6 6 0 0 0 0 12ZM5 7a1 1 0 0 0 0 2h6a1 1 0 1 0 0-2H5Z"
+      clipRule="evenodd"
+    />
   </svg>
 );

--- a/src/constants/externalResources.ts
+++ b/src/constants/externalResources.ts
@@ -26,6 +26,8 @@ export const githubChecksAliasesDocumentationUrl = `${projectDistroSettingsDocum
 
 export const githubMergeQueueDocumentationUrl = `${wikiBaseUrl}/Project-Configuration/Merge-Queue`;
 
+export const ignoredFilesDocumentationUrl = `${wikiBaseUrl}/Project-Configuration/Project-Configuration-Files#ignoring-changes-to-certain-files`;
+
 export const cliDocumentationUrl = `${wikiBaseUrl}/CLI`;
 
 export const windowsPasswordRulesURL =

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -6182,6 +6182,7 @@ export type MainlineCommitsQuery = {
         author: string;
         createTime: Date;
         id: string;
+        ignored: boolean;
         message: string;
         order: number;
         revision: string;
@@ -8739,6 +8740,7 @@ export type VersionQuery = {
     errors: Array<string>;
     finishTime?: Date | null;
     id: string;
+    ignored: boolean;
     isPatch: boolean;
     message: string;
     order: number;

--- a/src/gql/queries/mainline-commits.graphql
+++ b/src/gql/queries/mainline-commits.graphql
@@ -18,6 +18,7 @@ query MainlineCommits(
         author
         createTime
         id
+        ignored
         message
         order
         revision

--- a/src/gql/queries/version.graphql
+++ b/src/gql/queries/version.graphql
@@ -19,6 +19,7 @@ query Version($id: String!) {
       tag
     }
     id
+    ignored
     isPatch
     manifest {
       branch

--- a/src/pages/Version.tsx
+++ b/src/pages/Version.tsx
@@ -28,7 +28,7 @@ import { PageDoesNotExist } from "pages/404";
 import { isPatchUnconfigured } from "utils/patch";
 import { shortenGithash, githubPRLinkify } from "utils/string";
 import { jiraLinkify } from "utils/string/jiraLinkify";
-import { WarningBanner, ErrorBanner } from "./version/Banners";
+import { WarningBanner, ErrorBanner, IgnoredBanner } from "./version/Banners";
 import VersionPageBreadcrumbs from "./version/Breadcrumbs";
 import BuildVariantCard from "./version/BuildVariantCard";
 import { ActionButtons, Metadata, VersionTabs } from "./version/index";
@@ -133,6 +133,7 @@ export const VersionPage: React.FC = () => {
   const { version } = versionData || {};
   const {
     errors,
+    ignored,
     isPatch,
     message,
     order,
@@ -165,6 +166,7 @@ export const VersionPage: React.FC = () => {
       <ProjectBanner projectIdentifier={projectIdentifier} />
       {errors && errors.length > 0 && <ErrorBanner errors={errors} />}
       {warnings && warnings.length > 0 && <WarningBanner warnings={warnings} />}
+      {ignored && <IgnoredBanner />}
       {version && (
         <VersionPageBreadcrumbs
           patchNumber={patchNumber}

--- a/src/pages/commits/InactiveCommits/InactiveCommits.stories.tsx
+++ b/src/pages/commits/InactiveCommits/InactiveCommits.stories.tsx
@@ -1,4 +1,5 @@
 import { CustomStoryObj, CustomMeta } from "test_utils/types";
+import { CommitRolledUpVersions } from "types/commits";
 import { InactiveCommitButton as InactiveCommits } from ".";
 
 export default {
@@ -12,7 +13,7 @@ export const Default: CustomStoryObj<typeof InactiveCommits> = {
   },
 };
 
-const versions = [
+const versions: CommitRolledUpVersions = [
   {
     id: "123",
     createTime: new Date("2021-06-16T23:38:13Z"),
@@ -20,6 +21,7 @@ const versions = [
     order: 39365,
     author: "Mohamed Khelif",
     revision: "4337c33fa4a0d5c747a1115f0853b5f70e46f112",
+    ignored: false,
     upstreamProject: {
       triggerID: "123",
       triggerType: "task",
@@ -38,6 +40,7 @@ const versions = [
     order: 39366,
     author: "Arjun Patel",
     revision: "4337c33fa4a0d5c747a1115f0853b5f70e46f112",
+    ignored: false,
   },
   {
     id: "123",
@@ -46,6 +49,7 @@ const versions = [
     order: 39365,
     author: "Mohamed Khelif",
     revision: "4337c33fa4a0d5c747a1115f0853b5f70e46f112",
+    ignored: false,
   },
   {
     id: "123",
@@ -54,6 +58,7 @@ const versions = [
     order: 39366,
     author: "Arjun Patel",
     revision: "4337c33fa4a0d5c747a1115f0853b5f70e46f112",
+    ignored: false,
   },
   {
     id: "123",
@@ -62,6 +67,7 @@ const versions = [
     order: 39365,
     author: "Elena Chen",
     revision: "4337c33fa4a0d5c747a1115f0853b5f70e46f112",
+    ignored: true,
   },
   {
     id: "123",
@@ -70,5 +76,6 @@ const versions = [
     order: 39366,
     author: "Sophie Stadler",
     revision: "4337c33fa4a0d5c747a1115f0853b5f70e46f112",
+    ignored: false,
   },
 ];

--- a/src/pages/commits/InactiveCommits/InactiveCommits.test.tsx
+++ b/src/pages/commits/InactiveCommits/InactiveCommits.test.tsx
@@ -104,6 +104,17 @@ describe("inactiveCommitButton", () => {
       "6Unmatching"
     );
   });
+
+  it("should show ignored icon for ignored versions", async () => {
+    const user = userEvent.setup();
+    render(<RenderInactiveCommitButton versions={versions.slice(0, 1)} />);
+    expect(screen.queryByDataCy("inactive-commits-tooltip")).toBeNull();
+    await user.click(screen.queryByDataCy("inactive-commits-button"));
+    await waitFor(() => {
+      expect(screen.queryByDataCy("inactive-commits-tooltip")).toBeVisible();
+    });
+    expect(screen.getByDataCy("ignored-icon")).toBeVisible();
+  });
 });
 
 const time = new Date("2021-06-16T23:38:13Z");
@@ -115,7 +126,7 @@ const versions: CommitRolledUpVersions = [
     order: 39365,
     author: "Mohamed Khelif",
     revision: "4137c33fa4a0d5c747a1115f0853b5f70e46f112",
-    ignored: false,
+    ignored: true,
   },
   {
     id: "2",

--- a/src/pages/commits/InactiveCommits/InactiveCommits.test.tsx
+++ b/src/pages/commits/InactiveCommits/InactiveCommits.test.tsx
@@ -107,7 +107,7 @@ describe("inactiveCommitButton", () => {
 });
 
 const time = new Date("2021-06-16T23:38:13Z");
-const versions = [
+const versions: CommitRolledUpVersions = [
   {
     id: "1",
     createTime: time,
@@ -115,6 +115,7 @@ const versions = [
     order: 39365,
     author: "Mohamed Khelif",
     revision: "4137c33fa4a0d5c747a1115f0853b5f70e46f112",
+    ignored: false,
   },
   {
     id: "2",
@@ -123,6 +124,7 @@ const versions = [
     order: 39366,
     author: "Arjun Patel",
     revision: "4237c33fa4a0d5c747a1115f0853b5f70e46f113",
+    ignored: false,
   },
   {
     id: "3",
@@ -131,6 +133,7 @@ const versions = [
     order: 39365,
     author: "Mohamed Khelif",
     revision: "4337c33fa4a0d5c747a1115f0853b5f70e46f114",
+    ignored: false,
   },
   {
     id: "4",
@@ -139,6 +142,7 @@ const versions = [
     order: 39366,
     author: "Arjun Patel",
     revision: "4437c33fa4a0d5c747a1115f0853b5f70e46f115",
+    ignored: false,
   },
   {
     id: "5",
@@ -147,6 +151,7 @@ const versions = [
     order: 39365,
     author: "Elena Chen",
     revision: "4537c33fa4a0d5c747a1115f0853b5f70e46f116",
+    ignored: false,
   },
   {
     id: "6",
@@ -155,5 +160,6 @@ const versions = [
     order: 39366,
     author: "Sophie Stadler",
     revision: "4637c33fa4a0d5c747a1115f0853b5f70e46f117",
+    ignored: false,
   },
 ];

--- a/src/pages/commits/InactiveCommits/index.tsx
+++ b/src/pages/commits/InactiveCommits/index.tsx
@@ -5,6 +5,7 @@ import Tooltip from "@leafygreen-ui/tooltip";
 import { Disclaimer } from "@leafygreen-ui/typography";
 import { useProjectHealthAnalytics } from "analytics/projectHealth/useProjectHealthAnalytics";
 import { DisplayModal } from "components/DisplayModal";
+import Icon from "components/Icon";
 import { StyledRouterLink } from "components/styles";
 import { getVersionRoute, getTaskRoute } from "constants/routes";
 import { size, zIndex, fontSize } from "constants/tokens";
@@ -167,6 +168,13 @@ const CommitCopy: React.FC<CommitCopyProps> = ({ isTooltip, v }) => {
         </>
       )}
       <CommitBodyText>
+        {v.ignored && (
+          <StyledIcon
+            data-cy="ignored-version-icon"
+            glyph="VisibilityOff"
+            size="small"
+          />
+        )}
         {v.author} -{" "}
         {jiraLinkify(message, jiraHost, () => {
           sendEvent({
@@ -180,6 +188,11 @@ const CommitCopy: React.FC<CommitCopyProps> = ({ isTooltip, v }) => {
     </CommitText>
   );
 };
+
+const StyledIcon = styled(Icon)`
+  margin-right: ${size.xxs};
+  vertical-align: text-bottom;
+`;
 
 const InactiveCommitContainer = styled.div`
   display: flex;

--- a/src/pages/commits/InactiveCommits/index.tsx
+++ b/src/pages/commits/InactiveCommits/index.tsx
@@ -168,13 +168,7 @@ const CommitCopy: React.FC<CommitCopyProps> = ({ isTooltip, v }) => {
         </>
       )}
       <CommitBodyText>
-        {v.ignored && (
-          <StyledIcon
-            data-cy="ignored-version-icon"
-            glyph="VisibilityOff"
-            size="small"
-          />
-        )}
+        {v.ignored && <StyledIcon data-cy="ignored-icon" glyph="Ignored" />}
         {v.author} -{" "}
         {jiraLinkify(message, jiraHost, () => {
           sendEvent({

--- a/src/pages/commits/ProjectHealth.stories.tsx
+++ b/src/pages/commits/ProjectHealth.stories.tsx
@@ -235,6 +235,7 @@ const versions: Commits = [
         order: 927,
         message: "v2.11.1",
         revision: "a77bd39ccf515b63327dc2355a8444955043c66a",
+        ignored: false,
       },
     ],
   },

--- a/src/pages/version/Banners/IgnoredBanner/index.tsx
+++ b/src/pages/version/Banners/IgnoredBanner/index.tsx
@@ -1,0 +1,22 @@
+import Banner, { Variant } from "@leafygreen-ui/banner";
+import { StyledLink } from "components/styles";
+import { ignoredFilesDocumentationUrl } from "constants/externalResources";
+import { BannerContainer } from "../styles";
+
+const IgnoredBanner: React.FC = () => (
+  <BannerContainer data-cy="ignored-banner">
+    <Banner variant={Variant.Info}>
+      This revision will not be automatically scheduled, because only{" "}
+      <StyledLink
+        data-cy="fileLink"
+        href={ignoredFilesDocumentationUrl}
+        target="_blank"
+      >
+        ignored files
+      </StyledLink>{" "}
+      are changed. It may still be scheduled manually, or on failure stepback.
+    </Banner>
+  </BannerContainer>
+);
+
+export default IgnoredBanner;

--- a/src/pages/version/Banners/IgnoredBanner/index.tsx
+++ b/src/pages/version/Banners/IgnoredBanner/index.tsx
@@ -7,11 +7,7 @@ const IgnoredBanner: React.FC = () => (
   <BannerContainer data-cy="ignored-banner">
     <Banner variant={Variant.Info}>
       This revision will not be automatically scheduled, because only{" "}
-      <StyledLink
-        data-cy="fileLink"
-        href={ignoredFilesDocumentationUrl}
-        target="_blank"
-      >
+      <StyledLink href={ignoredFilesDocumentationUrl} target="_blank">
         ignored files
       </StyledLink>{" "}
       are changed. It may still be scheduled manually, or on failure stepback.

--- a/src/pages/version/Banners/index.tsx
+++ b/src/pages/version/Banners/index.tsx
@@ -1,4 +1,5 @@
 import ErrorBanner from "./ErrorBanner";
+import IgnoredBanner from "./IgnoredBanner";
 import WarningBanner from "./WarningBanner";
 
-export { WarningBanner, ErrorBanner };
+export { WarningBanner, ErrorBanner, IgnoredBanner };


### PR DESCRIPTION
EVG-20692

### Description
This PR makes it possible to tell if a version has been ignored on Spruce. Previously, there was no information about ignored versions at all.

### Screenshots
`Banner` on Version page (I used a `Banner` because the LeafyGreen design docs say `Callout` should be reserved for [docs only](https://www.mongodb.design/component/callout/guidelines/#basic-usage)):

<img width="1445" alt="Screenshot 2023-10-09 at 3 25 06 PM" src="https://github.com/evergreen-ci/spruce/assets/47064971/9f5c5925-1334-441c-9655-648fd53ba931">

`Icon` in the inactive commits tooltip (this is the same icon on the legacy UI, but if it doesn't seem clear enough, I could also just write out `IGNORED` explicitly):
<img width="307" alt="Screenshot 2023-10-09 at 4 26 55 PM" src="https://github.com/evergreen-ci/spruce/assets/47064971/0863defe-08dc-474c-b900-fc601425c7a0">


### Testing
- Cypress tests