### PR TITLE
EVG-20308: Add Sentry Replay

### DIFF
--- a/src/components/ErrorHandling/initialize.test.ts
+++ b/src/components/ErrorHandling/initialize.test.ts
@@ -11,6 +11,9 @@ describe("should initialize error handlers according to release stage", () => {
     jest.spyOn(Bugsnag, "start").mockImplementation(jest.fn());
     jest.spyOn(Bugsnag, "isStarted").mockImplementation(jest.fn(() => false));
     jest.spyOn(Sentry, "init").mockImplementation(jest.fn());
+    jest
+      .spyOn(Sentry, "Replay")
+      .mockImplementation(() => ({} as Sentry.Replay));
   });
 
   afterEach(() => {
@@ -48,6 +51,9 @@ describe("should initialize error handlers according to release stage", () => {
       debug: false,
       normalizeDepth: 5,
       environment: "production",
+      integrations: [{}],
+      replaysOnErrorSampleRate: 0.6,
+      replaysSessionSampleRate: 0,
     });
   });
 
@@ -71,6 +77,9 @@ describe("should initialize error handlers according to release stage", () => {
       debug: true,
       normalizeDepth: 5,
       environment: "beta",
+      integrations: [{}],
+      replaysOnErrorSampleRate: 1,
+      replaysSessionSampleRate: 0,
     });
   });
 
@@ -94,6 +103,9 @@ describe("should initialize error handlers according to release stage", () => {
       debug: true,
       normalizeDepth: 5,
       environment: "staging",
+      integrations: [{}],
+      replaysOnErrorSampleRate: 1,
+      replaysSessionSampleRate: 0,
     });
   });
 });


### PR DESCRIPTION
EVG-20308

### Description
<!-- add description, context, thought process, etc -->
- Add Sentry replay logging
- Note that replays can't currently be logged to the UI because the MongoDB's replay quota has been used up:
  <img width="919" alt="image" src="https://github.com/evergreen-ci/spruce/assets/9298431/4ea74d32-3701-4126-ad76-447742d8462c">
  However, baas-ui was the main user of Replay and they introduced some changes 3 weeks ago that will hopefully alleviate this problem when the quota is refreshed https://github.com/10gen/baas-ui/pull/3455

### Testing
<!-- add a description of how you tested it -->
- Viewed that Sentry attempted to send replays on staging (the requests were denied for the reason above)