### PR TITLE
EVG-17662: add mongo tools URL to project config for loading logs on local Evergreen

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -104,7 +104,7 @@ functions:
       env:
         SETTINGS_OVERRIDE: file
         GOROOT: ${goroot}
-        MONGOTOOLS_URL: ${mongotools_url}
+        MONGOTOOLS_URL: ${mongotools_url_2204}
         MONGOTOOLS_DECOMPRESS: ${decompress}
 
   wait-for-evergreen:

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -104,6 +104,8 @@ functions:
       env:
         SETTINGS_OVERRIDE: file
         GOROOT: ${goroot}
+        MONGOTOOLS_URL: ${mongotools_url}
+        MONGOTOOLS_DECOMPRESS: ${decompress}
 
   wait-for-evergreen:
     command: shell.exec
@@ -497,6 +499,7 @@ buildvariants:
       goroot: /opt/golang/go1.20
       mongodb_url_2204: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2204-6.0.6.tgz
       mongosh_url_2204: https://downloads.mongodb.com/compass/mongosh-1.9.0-linux-x64.tgz
+      mongotools_url_2204: https://fastdl.mongodb.org/tools/db/mongodb-database-tools-ubuntu2204-x86_64-100.8.0.tgz
       node_version: 16.17.0
     modules:
       - evergreen


### PR DESCRIPTION
EVG-17662

### Description
Update the project config with the mongo tools URL which is required to load the local Evergreen data.

### Screenshots
N/A

### Testing
[PR patch running E2E test using updated Evergreen module](https://spruce.mongodb.com/version/652d7d902fbabed3205c267d/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)

### Evergreen PR
https://github.com/evergreen-ci/evergreen/pull/7130
