### PR TITLE
EVG-20817: Don't invalidate General project settings form based on initial project identifier

### DIFF
--- a/src/pages/projectSettings/tabs/GeneralTab/getFormSchema.tsx
+++ b/src/pages/projectSettings/tabs/GeneralTab/getFormSchema.tsx
@@ -82,7 +82,10 @@ export const getFormSchema = (
                   title: "Identifier",
                   default: "",
                   minLength: 1,
-                  format: "noSpecialCharacters",
+                  // Don't invalidate form based on initial data
+                  format: identifierHasChanges
+                    ? "noSpecialCharacters"
+                    : "noSpaces",
                 },
               }),
               batchTime: {


### PR DESCRIPTION
EVG-20817

### Description
This fixes an issue where the General project settings form is disabled when it loads with a project identifier that doesn't pass validation. The form will do normal validation if any changes are made to the project identifier. 