### PR TITLE
EVG-20808 Add analytics events for task file link clicks.

### DIFF
--- a/src/analytics/task/useTaskAnalytics.ts
+++ b/src/analytics/task/useTaskAnalytics.ts
@@ -61,14 +61,14 @@ type Action =
   | { name: "Click Display Task Link" }
   | { name: "Click Project Link" }
   | { name: "Click See History Button" }
-  | { name: "Click Trace Link" }
-  | { name: "Click Trace Metrics Link" }
-  | { name: "Submit Previous Commit Selector"; type: CommitType }
   | {
       name: "Click Task File Link";
       parsleyAvailable: boolean;
       fileName: string;
-    };
+    }
+  | { name: "Click Trace Link" }
+  | { name: "Click Trace Metrics Link" }
+  | { name: "Submit Previous Commit Selector"; type: CommitType };
 
 export const useTaskAnalytics = () => {
   const { id } = useParams<{ id: string }>();

--- a/src/analytics/task/useTaskAnalytics.ts
+++ b/src/analytics/task/useTaskAnalytics.ts
@@ -1,5 +1,5 @@
 import { useQuery } from "@apollo/client";
-import { useParams, useLocation } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import { useAnalyticsRoot } from "analytics/useAnalyticsRoot";
 import {
   SaveSubscriptionForUserMutationVariables,
@@ -9,11 +9,9 @@ import {
   TestSortCategory,
 } from "gql/generated/types";
 import { TASK } from "gql/queries";
+import { useQueryParam } from "hooks/useQueryParam";
 import { CommitType } from "pages/task/actionButtons/previousCommits/types";
 import { RequiredQueryParams, LogTypes } from "types/task";
-import { queryString } from "utils";
-
-const { parseQueryString } = queryString;
 
 type LogViewer = "raw" | "html" | "parsley" | "lobster";
 type Action =
@@ -72,10 +70,8 @@ type Action =
 
 export const useTaskAnalytics = () => {
   const { id } = useParams<{ id: string }>();
-  const location = useLocation();
 
-  const parsed = parseQueryString(location.search);
-  const execution = Number(parsed[RequiredQueryParams.Execution]);
+  const [execution] = useQueryParam(RequiredQueryParams.Execution, 0);
   const { data: eventData } = useQuery<TaskQuery, TaskQueryVariables>(TASK, {
     variables: { taskId: id, execution },
     fetchPolicy: "cache-first",

--- a/src/analytics/task/useTaskAnalytics.ts
+++ b/src/analytics/task/useTaskAnalytics.ts
@@ -63,7 +63,12 @@ type Action =
   | { name: "Click See History Button" }
   | { name: "Click Trace Link" }
   | { name: "Click Trace Metrics Link" }
-  | { name: "Submit Previous Commit Selector"; type: CommitType };
+  | { name: "Submit Previous Commit Selector"; type: CommitType }
+  | {
+      name: "Click Task File Link";
+      parsleyAvailable: boolean;
+      fileName: string;
+    };
 
 export const useTaskAnalytics = () => {
   const { id } = useParams<{ id: string }>();

--- a/src/pages/task/taskTabs/FileTable/GroupedFileTable/index.tsx
+++ b/src/pages/task/taskTabs/FileTable/GroupedFileTable/index.tsx
@@ -29,7 +29,7 @@ const columns = (
           taskAnalytics.sendEvent({
             name: "Click Task File Link",
             parsleyAvailable: false,
-            fileName: value.getValue(),
+            fileName: value.getValue() as GroupedFilesFile["name"],
           });
         }}
       >

--- a/src/pages/task/taskTabs/FileTable/GroupedFileTable/index.tsx
+++ b/src/pages/task/taskTabs/FileTable/GroupedFileTable/index.tsx
@@ -1,7 +1,8 @@
-import { useRef } from "react";
+import { useMemo, useRef } from "react";
 import styled from "@emotion/styled";
 import { useLeafyGreenTable, LGColumnDef } from "@leafygreen-ui/table/new";
 import { Subtitle } from "@leafygreen-ui/typography";
+import { useTaskAnalytics } from "analytics";
 import { StyledLink } from "components/styles";
 import { BaseTable } from "components/Table/BaseTable";
 import { size } from "constants/tokens";
@@ -10,7 +11,10 @@ import { GroupedFiles } from "../types";
 
 type GroupedFilesFile = Unpacked<GroupedFiles["files"]>;
 
-const columns: LGColumnDef<GroupedFilesFile>[] = [
+// taskAnalytics is the return value of useTaskAnalytics
+const columns = (
+  taskAnalytics: ReturnType<typeof useTaskAnalytics>
+): LGColumnDef<GroupedFilesFile>[] => [
   {
     accessorKey: "name",
     header: "Name",
@@ -21,6 +25,13 @@ const columns: LGColumnDef<GroupedFilesFile>[] = [
         href={value.row.original.link}
         data-cy="file-link"
         target="_blank"
+        onClick={() => {
+          taskAnalytics.sendEvent({
+            name: "Click Task File Link",
+            parsleyAvailable: false,
+            fileName: value.getValue(),
+          });
+        }}
       >
         {value.getValue()}
       </StyledLink>
@@ -37,11 +48,16 @@ const GroupedFileTable: React.FC<GroupedFileTableProps> = ({
   taskName,
 }) => {
   const tableContainerRef = useRef<HTMLDivElement>(null);
+  const taskAnalytics = useTaskAnalytics();
 
+  const memoizedColumns = useMemo(
+    () => columns(taskAnalytics),
+    [taskAnalytics]
+  );
   const table = useLeafyGreenTable<GroupedFilesFile>({
     containerRef: tableContainerRef,
     data: files,
-    columns,
+    columns: memoizedColumns,
   });
 
   return (

--- a/src/pages/task/taskTabs/FileTable/GroupedFileTable/index.tsx
+++ b/src/pages/task/taskTabs/FileTable/GroupedFileTable/index.tsx
@@ -11,7 +11,6 @@ import { GroupedFiles } from "../types";
 
 type GroupedFilesFile = Unpacked<GroupedFiles["files"]>;
 
-// taskAnalytics is the return value of useTaskAnalytics
 const columns = (
   taskAnalytics: ReturnType<typeof useTaskAnalytics>
 ): LGColumnDef<GroupedFilesFile>[] => [


### PR DESCRIPTION
EVG-20808

### Description
Added an analytics tracking event for link clicks to open task files.
I've included a field that will be in a future PR be conditionally set if parsley is usable for that file. I'm hoping this can be used to gain insights if people are opting to use Parsley instead of the normal log viewer if it is available. 

Also logging the file name so that we can determine if some types of files are more likely to be used in Parsley than others. I'm hopeful this will allow us to gain some more insights into the use cases people like Parsley for.

### Screenshots
n/a
