### PR TITLE
EVG-21038 Update webhook disabled message to mention the GitHub app

### DIFF
--- a/src/pages/projectSettings/tabs/GithubCommitQueueTab/GithubCommitQueueTab.tsx
+++ b/src/pages/projectSettings/tabs/GithubCommitQueueTab/GithubCommitQueueTab.tsx
@@ -87,8 +87,9 @@ export const GithubCommitQueueTab: React.FC<TabProps> = ({
     <>
       {!githubWebhooksEnabled && (
         <Banner data-cy="disabled-webhook-banner" variant="warning">
-          GitHub features are disabled because webhooks are not enabled.
-          Webhooks are enabled after saving with a valid owner and repository.
+          GitHub features are disabled because the Evergreen GitHub App is not
+          installed on the saved owner/repo. Contact IT to install the App and
+          enable GitHub features.
         </Banner>
       )}
       <BaseTab


### PR DESCRIPTION
EVG-21038

### Description
updates message to tell users that they need a github app to use github features

### Screenshots
<img width="727" alt="image" src="https://github.com/evergreen-ci/spruce/assets/26491602/48f954bf-c6fb-4015-bc73-61813ced4ff0">

### Testing
local message 
