### PR TITLE
EVG-20704: Save patch trigger aliases with new success status

### DIFF
--- a/src/pages/projectSettings/tabs/PatchAliasesTab/getFormSchema.tsx
+++ b/src/pages/projectSettings/tabs/PatchAliasesTab/getFormSchema.tsx
@@ -74,9 +74,8 @@ export const getFormSchema = (
                     },
                     {
                       type: "string" as "string",
-                      title:
-                        PatchTriggerAliasStatus[PatchStatus.LegacySucceeded],
-                      enum: [PatchStatus.LegacySucceeded],
+                      title: PatchTriggerAliasStatus[PatchStatus.Success],
+                      enum: [PatchStatus.Success],
                     },
                     {
                       type: "string" as "string",

--- a/src/pages/projectSettings/tabs/PatchAliasesTab/transformers.test.ts
+++ b/src/pages/projectSettings/tabs/PatchAliasesTab/transformers.test.ts
@@ -82,7 +82,7 @@ const repoForm: PatchAliasesFormState = {
       {
         alias: "alias1",
         childProjectIdentifier: "spruce",
-        status: "succeeded",
+        status: "success",
         displayTitle: "alias1",
         parentAsModule: "",
         isGithubTriggerAlias: true,
@@ -124,7 +124,7 @@ const repoResult: Pick<RepoSettingsInput, "projectRef" | "aliases"> = {
             variantRegex: ".*",
           },
         ],
-        status: "succeeded",
+        status: "success",
         parentAsModule: "",
       },
     ],

--- a/src/pages/projectSettings/tabs/PatchAliasesTab/transformers.ts
+++ b/src/pages/projectSettings/tabs/PatchAliasesTab/transformers.ts
@@ -1,4 +1,6 @@
 import { ProjectSettingsTabRoutes } from "constants/routes";
+
+import { PatchStatus } from "types/patch";
 import { FormToGqlFunction, GqlToFormFunction } from "../types";
 import { alias as aliasUtils, ProjectType } from "../utils";
 import { TaskSpecifier } from "./types";
@@ -7,12 +9,11 @@ const { sortAliases, transformAliases } = aliasUtils;
 
 type Tab = ProjectSettingsTabRoutes.PatchAliases;
 
-// Ensure that the front end can ingest patch trigger alias status filters that use either "success" or "succeeded".
-// For now, use "succeeded" for either.
-// TODO EVG-20704: Save patch trigger aliases with "success" instead of "succeeded".
+// Ensure that the front end can ingest patch trigger alias status filters that use either "success" or "succeeded" and convert them to "success".
+// TODO EVG-20032: Remove conversion.
 const migrateSuccessStatus = (status: string) => {
-  if (status === "success") {
-    return "succeeded";
+  if (status === PatchStatus.LegacySucceeded) {
+    return PatchStatus.Success;
   }
   return status ?? "";
 };

--- a/src/pages/projectSettings/tabs/PatchAliasesTab/transformers.ts
+++ b/src/pages/projectSettings/tabs/PatchAliasesTab/transformers.ts
@@ -1,5 +1,4 @@
 import { ProjectSettingsTabRoutes } from "constants/routes";
-
 import { PatchStatus } from "types/patch";
 import { FormToGqlFunction, GqlToFormFunction } from "../types";
 import { alias as aliasUtils, ProjectType } from "../utils";

--- a/src/types/patch.ts
+++ b/src/types/patch.ts
@@ -11,6 +11,7 @@ export enum PatchStatus {
   Created = "created",
   Failed = "failed",
   Started = "started",
+  // TODO EVG-20032: Remove legacy status
   LegacySucceeded = "succeeded",
   Success = "success",
   Aborted = "aborted",


### PR DESCRIPTION
EVG-20704

### Description
<!-- add description, context, thought process, etc -->
Save patch trigger aliases with "success" status.

After deploying this change, the following operation will be run, first on staging, to convert all patch trigger aliases from "succeeded" to "success" status:
```
db.project_ref.updateMany(
  { "patch_trigger_aliases": { $exists: true } },
  { $set: { "patch_trigger_aliases.$[elem].status": "success" } },
  { arrayFilters: [ { "elem.status": "succeeded" } ] }
)
```

### Testing
<!-- add a description of how you tested it -->
Validated DB command on local database, ensured that patch trigger aliases with either string function as expected.