### PR TITLE
EVG-19921: Set includeHidden to false in Patches query

### DIFF
--- a/src/components/PatchesPage/index.tsx
+++ b/src/components/PatchesPage/index.tsx
@@ -138,10 +138,11 @@ export const usePatchesInputFromSearch = (search: string): PatchesInput => {
   );
   const statuses = rawStatuses.filter((v) => v && v !== ALL_PATCH_STATUS);
   return {
+    includeHidden: false,
+    limit: getLimitFromSearch(search),
+    page: getPageFromSearch(search),
     patchName: `${patchName}`,
     statuses,
-    page: getPageFromSearch(search),
-    limit: getLimitFromSearch(search),
   };
 };
 

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -1503,6 +1503,7 @@ export type Patches = {
  */
 export type PatchesInput = {
   includeCommitQueue?: InputMaybe<Scalars["Boolean"]["input"]>;
+  includeHidden?: InputMaybe<Scalars["Boolean"]["input"]>;
   limit?: Scalars["Int"]["input"];
   onlyCommitQueue?: InputMaybe<Scalars["Boolean"]["input"]>;
   page?: Scalars["Int"]["input"];


### PR DESCRIPTION
EVG-19921

### Description
This change ensures backwards compatibility after https://github.com/evergreen-ci/evergreen/pull/7116 is merged and before https://github.com/evergreen-ci/spruce/pull/2092 is merged. Once https://github.com/evergreen-ci/evergreen/pull/7116 is merged `includeHidden` is optional and will evaluate to true if not provided in the PatchesInput. That's why it must be set to false. Without this intermediate change, hidden patches will be visible. 