### PR TITLE
DEVPROD-920: Conditionally render base status badge

### DIFF
--- a/src/pages/task/taskTabs/testsTable/getColumnsTemplate.tsx
+++ b/src/pages/task/taskTabs/testsTable/getColumnsTemplate.tsx
@@ -73,9 +73,8 @@ export const getColumnsTemplate = ({
       },
     }),
     sorter: true,
-    render: (status: string): JSX.Element => (
-      <TestStatusBadge status={status} />
-    ),
+    render: (status: string): JSX.Element =>
+      status && <TestStatusBadge status={status} />,
   },
   {
     title: <span data-cy="time-column">Time</span>,


### PR DESCRIPTION
DEVPROD-920

### Description
<!-- add description, context, thought process, etc -->
- In the tests table, omit the base status badge if undefined. We already do this in the tasks table.

### Screenshots
<!-- add screenshots of visible changes -->
Before:

![before](https://github.com/evergreen-ci/spruce/assets/9298431/1d535480-99ce-458a-a9cf-ee28257afdf1)

After:
<img width="1054" alt="image" src="https://github.com/evergreen-ci/spruce/assets/9298431/8b906380-65ab-4790-bde4-4b219dbffdac">