### PR TITLE
DEVPROD-949 Only surface build variant for current task on task history page

### DIFF
--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -257,7 +257,8 @@ const getHistoryRoute = (
     failingTests?: string[];
     passingTests?: string[];
   },
-  selectedCommit?: number
+  selectedCommit?: number,
+  visibleColumns?: string[]
 ) => {
   if (filters || selectedCommit) {
     const failingTests = toArray(filters?.failingTests);
@@ -267,6 +268,7 @@ const getHistoryRoute = (
       [TestStatus.Failed]: failingTests,
       [TestStatus.Passed]: passingTests,
       [HistoryQueryParams.SelectedCommit]: selectedCommit,
+      [HistoryQueryParams.VisibleColumns]: visibleColumns,
     });
     return `${basePath}?${queryParams}`;
   }
@@ -302,14 +304,16 @@ export const getTaskHistoryRoute = (
       passingTests?: string[];
     };
     selectedCommit?: number;
+    visibleColumns?: string[];
   }
 ) => {
-  const { filters, selectedCommit } = options || {};
+  const { filters, selectedCommit, visibleColumns } = options || {};
 
   return getHistoryRoute(
     `${paths.taskHistory}/${encodeURIComponent(projectIdentifier)}/${taskName}`,
     filters,
-    selectedCommit
+    selectedCommit,
+    visibleColumns
   );
 };
 

--- a/src/pages/task/ActionButtons.tsx
+++ b/src/pages/task/ActionButtons.tsx
@@ -55,6 +55,7 @@ export const ActionButtons: React.FC<Props> = ({
   task,
 }) => {
   const {
+    buildVariant,
     canAbort,
     canDisable,
     canOverrideDependencies,
@@ -178,6 +179,7 @@ export const ActionButtons: React.FC<Props> = ({
   const HistoryLink = useLGButtonRouterLink(
     getTaskHistoryRoute(projectIdentifier, displayName, {
       selectedCommit: !isPatch && order,
+      visibleColumns: [buildVariant],
     })
   );
 

--- a/src/pages/task/taskTabs/testsTable/LogsColumn.tsx
+++ b/src/pages/task/taskTabs/testsTable/LogsColumn.tsx
@@ -22,7 +22,7 @@ export const LogsColumn: React.FC<Props> = ({ task, testResult }) => {
     urlParsley,
     urlRaw,
   } = testResult.logs ?? {};
-  const { displayName, displayTask, order, project } = task ?? {};
+  const { buildVariant, displayName, displayTask, order, project } = task ?? {};
   const { sendEvent } = useTaskAnalytics();
   const filters =
     status === TestStatus.Fail
@@ -114,6 +114,7 @@ export const LogsColumn: React.FC<Props> = ({ task, testResult }) => {
           to={getTaskHistoryRoute(project?.identifier, displayName, {
             filters,
             selectedCommit: order,
+            visibleColumns: [buildVariant],
           })}
         />
       )}


### PR DESCRIPTION
DEVPROD-949

### Description
The show history button should only surface the history for the currently selected build variant

