### PR TITLE
DEVPROD-945: Fix toast text for clearing subscriptions

### DIFF
--- a/src/pages/preferences/preferencesTabs/notificationTab/ClearSubscriptions.tsx
+++ b/src/pages/preferences/preferencesTabs/notificationTab/ClearSubscriptions.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useMutation } from "@apollo/client";
 import Button, { Variant } from "@leafygreen-ui/button";
+import pluralize from "pluralize";
 import { usePreferencesAnalytics } from "analytics";
 import { ConfirmationModal } from "components/ConfirmationModal";
 import { useToastContext } from "context/toast";
@@ -23,9 +24,10 @@ export const ClearSubscriptions: React.FC = () => {
     onCompleted: (result) => {
       setShowModal(false);
       dispatchToast.success(
-        `Successfully cleared ${result.clearMySubscriptions} subscription${
-          result.clearMySubscriptions !== 1 && "s"
-        }!`
+        `Successfully cleared ${result.clearMySubscriptions} ${pluralize(
+          "subscription",
+          result.clearMySubscriptions
+        )}!`
       );
     },
     onError: (err) => {

--- a/src/pages/preferences/preferencesTabs/notificationTab/ClearSubscriptions.tsx
+++ b/src/pages/preferences/preferencesTabs/notificationTab/ClearSubscriptions.tsx
@@ -27,7 +27,7 @@ export const ClearSubscriptions: React.FC = () => {
         `Successfully cleared ${result.clearMySubscriptions} ${pluralize(
           "subscription",
           result.clearMySubscriptions
-        )}!`
+        )}.`
       );
     },
     onError: (err) => {

--- a/src/pages/taskHistory/ColumnHeaders/index.tsx
+++ b/src/pages/taskHistory/ColumnHeaders/index.tsx
@@ -44,7 +44,7 @@ const ColumnHeaders: React.FC<ColumnHeadersProps> = ({
       if (!buildVariantsForTaskName) {
         reportError(
           new Error("No build variants found for task name")
-        ).severe();
+        ).warning();
         dispatchToast.error(`No build variants found for task: ${taskName}`);
       }
     },

--- a/src/pages/variantHistory/ColumnHeaders.tsx
+++ b/src/pages/variantHistory/ColumnHeaders.tsx
@@ -45,7 +45,9 @@ const ColumnHeaders: React.FC<ColumnHeadersProps> = ({
         reportError(
           new Error("No task names found for build variant")
         ).warning();
-        dispatchToast.error(`No tasks found for buildVariant: ${variantName}}`);
+        dispatchToast.error(
+          `No tasks found for build variant: ${variantName}}`
+        );
       }
     },
   });

--- a/src/pages/variantHistory/ColumnHeaders.tsx
+++ b/src/pages/variantHistory/ColumnHeaders.tsx
@@ -44,7 +44,7 @@ const ColumnHeaders: React.FC<ColumnHeadersProps> = ({
       if (!taskNamesForBuildVariant) {
         reportError(
           new Error("No task names found for build variant")
-        ).severe();
+        ).warning();
         dispatchToast.error(`No tasks found for buildVariant: ${variantName}}`);
       }
     },


### PR DESCRIPTION
DEVPROD-945

### Description
Fixes the toast text for clearing subscriptions.

Also downgrades the build variant / task history page errors to warnings. Added a rule to exclude `"warning"` level errors on Sentry so that they won't report to Slack and tested this on staging (the errors will still report on the Sentry dashboard, just not on Slack).

### Screenshots
<!-- add screenshots of visible changes -->
<img width="417" alt="Screenshot 2023-10-31 at 12 04 17 PM" src="https://github.com/evergreen-ci/spruce/assets/47064971/f3f12ba1-4909-454d-b177-371bfdb803da">

<img width="422" alt="Screenshot 2023-10-31 at 12 05 27 PM" src="https://github.com/evergreen-ci/spruce/assets/47064971/6e4e44fa-52be-4554-845d-e0b3041b5aa6">



