### PR TITLE
DEVPROD-1759 add end time to the Honeycomb trace link

### DIFF
--- a/src/constants/externalResources.test.ts
+++ b/src/constants/externalResources.test.ts
@@ -54,9 +54,13 @@ describe("getParsleyBuildLogURL", () => {
 describe("getTaskTraceUrl", () => {
   it("generates the correct url", () => {
     expect(
-      getHoneycombTraceUrl("abcdef", new Date("2023-07-07T19:08:41"))
+      getHoneycombTraceUrl(
+        "abcdef",
+        new Date("2023-07-07T19:08:41"),
+        new Date("2023-07-07T19:09:00")
+      )
     ).toBe(
-      "/datasets/evergreen-agent/trace?trace_id=abcdef&trace_start_ts=1688756921"
+      "/datasets/evergreen-agent/trace?trace_id=abcdef&trace_start_ts=1688756921&trace_end_ts=1688756940"
     );
   });
 });

--- a/src/constants/externalResources.ts
+++ b/src/constants/externalResources.ts
@@ -103,10 +103,14 @@ export const getParsleyTestLogURL = (buildId: string, testId: string) =>
 export const getParsleyBuildLogURL = (buildId: string) =>
   `${getParsleyUrl()}/resmoke/${buildId}/all`;
 
-export const getHoneycombTraceUrl = (traceId: string, startTs: Date) =>
+export const getHoneycombTraceUrl = (
+  traceId: string,
+  startTs: Date,
+  endTs: Date
+) =>
   `${getHoneycombBaseURL()}/datasets/evergreen-agent/trace?trace_id=${traceId}&trace_start_ts=${getUnixTime(
     new Date(startTs)
-  )}`;
+  )}&trace_end_ts=${getUnixTime(new Date(endTs))}`;
 
 export const getHoneycombSystemMetricsUrl = (
   taskId: string,

--- a/src/pages/task/metadata/index.tsx
+++ b/src/pages/task/metadata/index.tsx
@@ -371,7 +371,7 @@ export const Metadata: React.FC<Props> = ({ error, loading, task, taskId }) => {
           <StyledLink
             ref={triggerRef}
             data-cy="task-trace-link"
-            href={getHoneycombTraceUrl(taskTrace, startTime)}
+            href={getHoneycombTraceUrl(taskTrace, startTime, finishTime)}
             onClick={() => {
               onHideCue();
               taskAnalytics.sendEvent({ name: "Click Trace Link" });


### PR DESCRIPTION
[DEVPROD-1759](https://jira.mongodb.org/browse/DEVPROD-1759)

### Description
If there's no end time given then Honeycomb will truncate the trace to only show the first 10 minutes. Giving the end time will help Honeycomb find the entire trace.
The Honeycomb docs for linking to a trace are [here](https://docs.honeycomb.io/working-with-your-data/direct-trace-links/).

### Screenshots
No visible changes.

### Testing
The end time was added in local evergreen (when I added a trace id to a task so the links would show).
