### PR TITLE
DEVPROD-359: Fix task_table sort button flake

### DIFF
--- a/cypress/integration/version/task_table.ts
+++ b/cypress/integration/version/task_table.ts
@@ -18,7 +18,7 @@ describe("Task table", () => {
   it("Updates the url when column headers are clicked", () => {
     cy.visit(pathTasks);
     waitForTaskTable();
-    // TODO: Remove wait in DEVPROD-597
+    // TODO: Remove wait in DEVPROD-597.
     // eslint-disable-next-line cypress/no-unnecessary-waiting
     cy.wait(200);
     cy.location("search").should(
@@ -87,7 +87,7 @@ describe("Task table", () => {
 
   ["NAME", "STATUS", "BASE_STATUS", "VARIANT"].forEach((sortBy) => {
     // TODO: This test doesn't work bc of issues with assertCorrectRequestVariables.
-    // Drop skip in DEVPROD-597.
+    // Remove skip in DEVPROD-597.
     it.skip(`Fetches tasks sorted by ${sortBy} when ${sortBy} header is clicked`, () => {
       // clickSorterAndAssertTasksAreFetched(sortBy);
     });

--- a/cypress/integration/version/task_table.ts
+++ b/cypress/integration/version/task_table.ts
@@ -18,6 +18,8 @@ describe("Task table", () => {
   it("Updates the url when column headers are clicked", () => {
     cy.visit(pathTasks);
     waitForTaskTable();
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(200);
     cy.location("search").should(
       "contain",
       "sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC"

--- a/cypress/integration/version/task_table.ts
+++ b/cypress/integration/version/task_table.ts
@@ -18,6 +18,7 @@ describe("Task table", () => {
   it("Updates the url when column headers are clicked", () => {
     cy.visit(pathTasks);
     waitForTaskTable();
+    // TODO: Remove wait in DEVPROD-597
     // eslint-disable-next-line cypress/no-unnecessary-waiting
     cy.wait(200);
     cy.location("search").should(
@@ -85,7 +86,8 @@ describe("Task table", () => {
   });
 
   ["NAME", "STATUS", "BASE_STATUS", "VARIANT"].forEach((sortBy) => {
-    // TODO: This test doesn't work bc of issues with assertCorrectRequestVariables
+    // TODO: This test doesn't work bc of issues with assertCorrectRequestVariables.
+    // Drop skip in DEVPROD-597.
     it.skip(`Fetches tasks sorted by ${sortBy} when ${sortBy} header is clicked`, () => {
       // clickSorterAndAssertTasksAreFetched(sortBy);
     });

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -2105,6 +2105,7 @@ export type RepoRef = {
   manualPrTestingEnabled: Scalars["Boolean"]["output"];
   notifyOnBuildFailure: Scalars["Boolean"]["output"];
   owner: Scalars["String"]["output"];
+  parsleyFilters?: Maybe<Array<ParsleyFilter>>;
   patchTriggerAliases?: Maybe<Array<PatchTriggerAlias>>;
   patchingDisabled: Scalars["Boolean"]["output"];
   perfEnabled: Scalars["Boolean"]["output"];
@@ -2146,6 +2147,7 @@ export type RepoRefInput = {
   manualPrTestingEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   notifyOnBuildFailure?: InputMaybe<Scalars["Boolean"]["input"]>;
   owner?: InputMaybe<Scalars["String"]["input"]>;
+  parsleyFilters?: InputMaybe<Array<ParsleyFilterInput>>;
   patchTriggerAliases?: InputMaybe<Array<PatchTriggerAliasInput>>;
   patchingDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   perfEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;


### PR DESCRIPTION
DEVPROD-359
### Description
 The flake happens because the AntD table header sort button won't run the onClick handler when it's clicked on right after page load. Subsequent clicks work fine. I suspect this is an issue with how AntD attaches the callback because cypress selector successfully finds and clicks the sort button.
I tried to fix this before in https://github.com/evergreen-ci/spruce/pull/2079 by waiting on table UI state -- this worked well for the test table. An open question is why doesn't the fix for test table flake work and I'm actually not sure. It could be because something on the task page slows down AntD's ability to attach the listener or the loading icon dom update is inconsistent. 
I ran the test [200 times with waiting (0% flake)](https://spruce.mongodb.com/version/6542960d7742ae85f0cff37b/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) and [200 times without waiting (5% flake)](https://spruce.mongodb.com/version/65429a981e2d1751cb1710bc/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC). It's not ideal to wait on a magic number or network request but I think this is okay because it helps ensure the feature works until the AntD table is replaced with LG. 
If this PR is approved, I will update https://jira.mongodb.org/browse/DEVPROD-597 to include `wait` removal.

