### PR TITLE
DEVPROD-948: Allow setting Parsley filters for repos

### DIFF
--- a/src/gql/fragments/projectSettings/index.graphql
+++ b/src/gql/fragments/projectSettings/index.graphql
@@ -55,6 +55,7 @@ fragment RepoSettingsFields on RepoSettings {
     ...RepoPeriodicBuildsSettings
     ...RepoPluginsSettings
     ...RepoTriggersSettings
+    ...RepoViewsAndFiltersSettings
     ...RepoVirtualWorkstationSettings
   }
   ...RepoGithubCommitQueue

--- a/src/gql/fragments/projectSettings/viewsAndFilters.graphql
+++ b/src/gql/fragments/projectSettings/viewsAndFilters.graphql
@@ -6,3 +6,11 @@ fragment ProjectViewsAndFiltersSettings on Project {
   }
   projectHealthView
 }
+
+fragment RepoViewsAndFiltersSettings on RepoRef {
+  parsleyFilters {
+    caseSensitive
+    exactMatch
+    expression
+  }
+}

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -936,6 +936,7 @@ export type MainlineCommitsOptions = {
   limit?: InputMaybe<Scalars["Int"]["input"]>;
   projectIdentifier: Scalars["String"]["input"];
   requesters?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  revision?: InputMaybe<Scalars["String"]["input"]>;
   shouldCollapse?: InputMaybe<Scalars["Boolean"]["input"]>;
   skipOrderNumber?: InputMaybe<Scalars["Int"]["input"]>;
 };
@@ -1503,6 +1504,7 @@ export type Patches = {
  */
 export type PatchesInput = {
   includeCommitQueue?: InputMaybe<Scalars["Boolean"]["input"]>;
+  includeHidden?: InputMaybe<Scalars["Boolean"]["input"]>;
   limit?: Scalars["Int"]["input"];
   onlyCommitQueue?: InputMaybe<Scalars["Boolean"]["input"]>;
   page?: Scalars["Int"]["input"];

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -2105,6 +2105,7 @@ export type RepoRef = {
   manualPrTestingEnabled: Scalars["Boolean"]["output"];
   notifyOnBuildFailure: Scalars["Boolean"]["output"];
   owner: Scalars["String"]["output"];
+  parsleyFilters?: Maybe<Array<ParsleyFilter>>;
   patchTriggerAliases?: Maybe<Array<PatchTriggerAlias>>;
   patchingDisabled: Scalars["Boolean"]["output"];
   perfEnabled: Scalars["Boolean"]["output"];
@@ -2146,6 +2147,7 @@ export type RepoRefInput = {
   manualPrTestingEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   notifyOnBuildFailure?: InputMaybe<Scalars["Boolean"]["input"]>;
   owner?: InputMaybe<Scalars["String"]["input"]>;
+  parsleyFilters?: InputMaybe<Array<ParsleyFilterInput>>;
   patchTriggerAliases?: InputMaybe<Array<PatchTriggerAliasInput>>;
   patchingDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   perfEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
@@ -3857,6 +3859,12 @@ export type RepoSettingsFieldsFragment = {
       taskRegex: string;
       unscheduleDownstreamVersions?: boolean | null;
     }>;
+    parsleyFilters?: Array<{
+      __typename?: "ParsleyFilter";
+      caseSensitive: boolean;
+      exactMatch: boolean;
+      expression: string;
+    }> | null;
     workstationConfig: {
       __typename?: "RepoWorkstationConfig";
       gitClone: boolean;
@@ -4376,6 +4384,16 @@ export type VariablesFragment = {
 export type ProjectViewsAndFiltersSettingsFragment = {
   __typename?: "Project";
   projectHealthView: ProjectHealthView;
+  parsleyFilters?: Array<{
+    __typename?: "ParsleyFilter";
+    caseSensitive: boolean;
+    exactMatch: boolean;
+    expression: string;
+  }> | null;
+};
+
+export type RepoViewsAndFiltersSettingsFragment = {
+  __typename?: "RepoRef";
   parsleyFilters?: Array<{
     __typename?: "ParsleyFilter";
     caseSensitive: boolean;
@@ -7862,6 +7880,12 @@ export type RepoSettingsQuery = {
         taskRegex: string;
         unscheduleDownstreamVersions?: boolean | null;
       }>;
+      parsleyFilters?: Array<{
+        __typename?: "ParsleyFilter";
+        caseSensitive: boolean;
+        exactMatch: boolean;
+        expression: string;
+      }> | null;
       workstationConfig: {
         __typename?: "RepoWorkstationConfig";
         gitClone: boolean;

--- a/src/pages/projectSettings/Header.tsx
+++ b/src/pages/projectSettings/Header.tsx
@@ -9,7 +9,6 @@ import { size } from "constants/tokens";
 import { getTabTitle } from "./getTabTitle";
 import { HeaderButtons } from "./HeaderButtons";
 import {
-  projectOnlyTabs,
   WritableProjectSettingsTabs,
   WritableProjectSettingsType,
 } from "./tabs/types";
@@ -32,13 +31,12 @@ export const Header: React.FC<Props> = ({
   const saveable = Object.values(WritableProjectSettingsTabs).includes(
     tab as WritableProjectSettingsType
   );
-  const showRepoLink = !projectOnlyTabs.has(tab);
 
   return (
     <Container>
       <TitleContainer>
         <H2 data-cy="project-settings-tab-title">{title}</H2>
-        {projectType === ProjectType.AttachedProject && showRepoLink && (
+        {projectType === ProjectType.AttachedProject && (
           <StyledRouterLink
             to={getProjectSettingsRoute(attachedRepoId, tab)}
             data-cy="attached-repo-link"

--- a/src/pages/projectSettings/Tabs.tsx
+++ b/src/pages/projectSettings/Tabs.tsx
@@ -215,6 +215,9 @@ export const ProjectSettingsTabs: React.FC<Props> = ({
                 tabData[ProjectSettingsTabRoutes.ViewsAndFilters].projectData
               }
               projectType={projectType}
+              repoData={
+                tabData[ProjectSettingsTabRoutes.ViewsAndFilters].repoData
+              }
             />
           }
         />

--- a/src/pages/projectSettings/index.tsx
+++ b/src/pages/projectSettings/index.tsx
@@ -160,13 +160,10 @@ const ProjectSettings: React.FC = () => {
             {...sharedProps}
             tab={ProjectSettingsTabRoutes.Containers}
           />
-          {/* Views and filters are not available at the repo level at this time. */}
-          {projectType !== ProjectType.Repo && (
-            <ProjectSettingsNavItem
-              {...sharedProps}
-              tab={ProjectSettingsTabRoutes.ViewsAndFilters}
-            />
-          )}
+          <ProjectSettingsNavItem
+            {...sharedProps}
+            tab={ProjectSettingsTabRoutes.ViewsAndFilters}
+          />
           <ProjectSettingsNavItem
             {...sharedProps}
             tab={ProjectSettingsTabRoutes.ProjectTriggers}

--- a/src/pages/projectSettings/tabs/ViewsAndFiltersTab/ViewsAndFiltersTab.tsx
+++ b/src/pages/projectSettings/tabs/ViewsAndFiltersTab/ViewsAndFiltersTab.tsx
@@ -8,10 +8,14 @@ import { TabProps, ViewsFormState } from "./types";
 
 const tab = ProjectSettingsTabRoutes.ViewsAndFilters;
 
-export const ViewsAndFiltersTab: React.FC<TabProps> = ({ projectData }) => {
-  const initialFormState = projectData;
+export const ViewsAndFiltersTab: React.FC<TabProps> = ({
+  projectData,
+  projectType,
+  repoData,
+}) => {
+  const initialFormState = projectData || repoData;
 
-  const formSchema = useMemo(() => getFormSchema(), []);
+  const formSchema = useMemo(() => getFormSchema(projectType), [projectType]);
 
   return (
     <BaseTab

--- a/src/pages/projectSettings/tabs/ViewsAndFiltersTab/ViewsAndFiltersTab.tsx
+++ b/src/pages/projectSettings/tabs/ViewsAndFiltersTab/ViewsAndFiltersTab.tsx
@@ -39,12 +39,13 @@ export const ViewsAndFiltersTab: React.FC<TabProps> = ({
   );
 };
 
-/* Display an error and prevent saving if a user enters a Parsley filter expression that already appears in the project. */
+/* Display an error and prevent saving if a user enters a Parsley filter expression that already appears in the project or repo. */
 const validate = ((formData, errors) => {
-  const duplicateIndices = findDuplicateIndices(
-    formData.parsleyFilters,
-    "expression"
-  );
+  const combinedFilters = [
+    ...formData.parsleyFilters,
+    ...(formData?.repoData?.parsleyFilters ?? []),
+  ];
+  const duplicateIndices = findDuplicateIndices(combinedFilters, "expression");
   duplicateIndices.forEach((i) => {
     errors.parsleyFilters?.[i]?.expression?.addError(
       "Filter expression already appears in this project."

--- a/src/pages/projectSettings/tabs/ViewsAndFiltersTab/ViewsAndFiltersTab.tsx
+++ b/src/pages/projectSettings/tabs/ViewsAndFiltersTab/ViewsAndFiltersTab.tsx
@@ -8,12 +8,24 @@ import { TabProps, ViewsFormState } from "./types";
 
 const tab = ProjectSettingsTabRoutes.ViewsAndFilters;
 
+const getInitialFormState = (
+  projectData: TabProps["projectData"],
+  repoData: TabProps["repoData"]
+): ViewsFormState => {
+  if (!projectData) return repoData;
+  if (repoData) return { ...projectData, repoData };
+  return projectData;
+};
+
 export const ViewsAndFiltersTab: React.FC<TabProps> = ({
   projectData,
   projectType,
   repoData,
 }) => {
-  const initialFormState = projectData || repoData;
+  const initialFormState = useMemo(
+    () => getInitialFormState(projectData, repoData),
+    [projectData, repoData]
+  );
 
   const formSchema = useMemo(() => getFormSchema(projectType), [projectType]);
 

--- a/src/pages/projectSettings/tabs/ViewsAndFiltersTab/getFormSchema.ts
+++ b/src/pages/projectSettings/tabs/ViewsAndFiltersTab/getFormSchema.ts
@@ -9,42 +9,8 @@ export const getFormSchema = (
 ): ReturnType<GetFormSchema> => ({
   fields: {},
   schema: {
-    type: "object" as "object",
-    properties: {
-      ...(projectType !== ProjectType.Repo && {
-        view: {
-          title: "Project Health View",
-          type: "object" as "object",
-          description:
-            "This setting will define the default behavior of the Project Health page for all viewers of this project. Users can still toggle between views.",
-          properties: {
-            projectHealthView: {
-              type: "string" as "string",
-              oneOf: [
-                {
-                  type: "string" as "string",
-                  title: "Default view",
-                  enum: [ProjectHealthView.Failed],
-                  description:
-                    "Displays only task failures, making it easier to identify them, and groups tasks by status if they don't match any search criteria. Consider using it for troubleshooting specific issues.",
-                },
-                {
-                  type: "string" as "string",
-                  title: "All tasks view",
-                  enum: [ProjectHealthView.All],
-                  description:
-                    "Displays all tasks without grouping. This view can be helpful for getting a comprehensive overview of all tasks.",
-                },
-              ],
-            },
-          },
-        },
-      }),
-      parsleyFiltersTitle: {
-        type: "null",
-        title: "Parsley Filters",
-      },
-      parsleyFilters: {
+    definitions: {
+      filterArray: {
         title: "",
         type: "array" as "array",
         default: [],
@@ -96,6 +62,52 @@ export const getFormSchema = (
         },
       },
     },
+    type: "object" as "object",
+    properties: {
+      ...(projectType !== ProjectType.Repo && {
+        view: {
+          title: "Project Health View",
+          type: "object" as "object",
+          description:
+            "This setting will define the default behavior of the Project Health page for all viewers of this project. Users can still toggle between views.",
+          properties: {
+            projectHealthView: {
+              type: "string" as "string",
+              oneOf: [
+                {
+                  type: "string" as "string",
+                  title: "Default view",
+                  enum: [ProjectHealthView.Failed],
+                  description:
+                    "Displays only task failures, making it easier to identify them, and groups tasks by status if they don't match any search criteria. Consider using it for troubleshooting specific issues.",
+                },
+                {
+                  type: "string" as "string",
+                  title: "All tasks view",
+                  enum: [ProjectHealthView.All],
+                  description:
+                    "Displays all tasks without grouping. This view can be helpful for getting a comprehensive overview of all tasks.",
+                },
+              ],
+            },
+          },
+        },
+      }),
+      parsleyFiltersTitle: {
+        type: "null",
+        title: "Parsley Filters",
+      },
+      parsleyFilters: { $ref: "#/definitions/filterArray" },
+      ...(projectType === ProjectType.AttachedProject && {
+        repoData: {
+          type: "object" as "object",
+          title: "Repo Filters",
+          properties: {
+            parsleyFilters: { $ref: "#/definitions/filterArray" },
+          },
+        },
+      }),
+    },
   },
   uiSchema: {
     view: {
@@ -131,6 +143,25 @@ export const getFormSchema = (
           "ui:aria-controls": ["exact-match", "inverse-match"],
           "ui:data-cy": "parsley-filter-match-type",
           "ui:sizeVariant": "xsmall",
+        },
+      },
+    },
+    repoData: {
+      parsleyFilters: {
+        "ui:fullWidth": true,
+        "ui:placeholder": "Repo has no filters defined.",
+        "ui:readonly": true,
+        "ui:showLabel": false,
+        "ui:useExpandableCard": true,
+        items: {
+          caseSensitive: {
+            "ui:widget": widgets.SegmentedControlWidget,
+            "ui:sizeVariant": "xsmall",
+          },
+          exactMatch: {
+            "ui:widget": widgets.SegmentedControlWidget,
+            "ui:sizeVariant": "xsmall",
+          },
         },
       },
     },

--- a/src/pages/projectSettings/tabs/ViewsAndFiltersTab/getFormSchema.ts
+++ b/src/pages/projectSettings/tabs/ViewsAndFiltersTab/getFormSchema.ts
@@ -2,39 +2,44 @@ import { GetFormSchema } from "components/SpruceForm";
 import { CardFieldTemplate } from "components/SpruceForm/FieldTemplates";
 import widgets from "components/SpruceForm/Widgets";
 import { ProjectHealthView } from "gql/generated/types";
+import { ProjectType } from "../utils";
 
-export const getFormSchema = (): ReturnType<GetFormSchema> => ({
+export const getFormSchema = (
+  projectType: ProjectType
+): ReturnType<GetFormSchema> => ({
   fields: {},
   schema: {
     type: "object" as "object",
     properties: {
-      view: {
-        title: "Project Health View",
-        type: "object" as "object",
-        description:
-          "This setting will define the default behavior of the Project Health page for all viewers of this project. Users can still toggle between views.",
-        properties: {
-          projectHealthView: {
-            type: "string" as "string",
-            oneOf: [
-              {
-                type: "string" as "string",
-                title: "Default view",
-                enum: [ProjectHealthView.Failed],
-                description:
-                  "Displays only task failures, making it easier to identify them, and groups tasks by status if they don't match any search criteria. Consider using it for troubleshooting specific issues.",
-              },
-              {
-                type: "string" as "string",
-                title: "All tasks view",
-                enum: [ProjectHealthView.All],
-                description:
-                  "Displays all tasks without grouping. This view can be helpful for getting a comprehensive overview of all tasks.",
-              },
-            ],
+      ...(projectType !== ProjectType.Repo && {
+        view: {
+          title: "Project Health View",
+          type: "object" as "object",
+          description:
+            "This setting will define the default behavior of the Project Health page for all viewers of this project. Users can still toggle between views.",
+          properties: {
+            projectHealthView: {
+              type: "string" as "string",
+              oneOf: [
+                {
+                  type: "string" as "string",
+                  title: "Default view",
+                  enum: [ProjectHealthView.Failed],
+                  description:
+                    "Displays only task failures, making it easier to identify them, and groups tasks by status if they don't match any search criteria. Consider using it for troubleshooting specific issues.",
+                },
+                {
+                  type: "string" as "string",
+                  title: "All tasks view",
+                  enum: [ProjectHealthView.All],
+                  description:
+                    "Displays all tasks without grouping. This view can be helpful for getting a comprehensive overview of all tasks.",
+                },
+              ],
+            },
           },
         },
-      },
+      }),
       parsleyFiltersTitle: {
         type: "null",
         title: "Parsley Filters",

--- a/src/pages/projectSettings/tabs/ViewsAndFiltersTab/transformers.test.ts
+++ b/src/pages/projectSettings/tabs/ViewsAndFiltersTab/transformers.test.ts
@@ -1,10 +1,26 @@
-import { ProjectHealthView, ProjectSettingsInput } from "gql/generated/types";
+import {
+  ProjectHealthView,
+  ProjectSettingsInput,
+  RepoSettingsInput,
+} from "gql/generated/types";
 import { data } from "../testData";
 import { ProjectType } from "../utils";
 import { formToGql, gqlToForm } from "./transformers";
 import { ViewsFormState } from "./types";
 
-const { projectBase } = data;
+const { projectBase, repoBase } = data;
+
+describe("repo data", () => {
+  it("correctly converts from GQL to a form", () => {
+    expect(
+      gqlToForm(repoBase, { projectType: ProjectType.Repo })
+    ).toStrictEqual(repoForm);
+  });
+
+  it("correctly converts from a form to GQL", () => {
+    expect(formToGql(repoForm, "repo")).toStrictEqual(repoResult);
+  });
+});
 
 describe("project data", () => {
   it("correctly converts from GQL to a form", () => {
@@ -17,6 +33,30 @@ describe("project data", () => {
     expect(formToGql(projectForm, "project")).toStrictEqual(projectResult);
   });
 });
+
+const repoForm: ViewsFormState = {
+  parsleyFilters: [
+    {
+      displayTitle: "repo-filter",
+      expression: "repo-filter",
+      caseSensitive: false,
+      exactMatch: false,
+    },
+  ],
+};
+
+const repoResult: Pick<RepoSettingsInput, "projectRef"> = {
+  projectRef: {
+    id: "repo",
+    parsleyFilters: [
+      {
+        expression: "repo-filter",
+        caseSensitive: false,
+        exactMatch: false,
+      },
+    ],
+  },
+};
 
 const projectForm: ViewsFormState = {
   parsleyFilters: [

--- a/src/pages/projectSettings/tabs/ViewsAndFiltersTab/transformers.test.ts
+++ b/src/pages/projectSettings/tabs/ViewsAndFiltersTab/transformers.test.ts
@@ -1,5 +1,6 @@
 import { ProjectHealthView, ProjectSettingsInput } from "gql/generated/types";
 import { data } from "../testData";
+import { ProjectType } from "../utils";
 import { formToGql, gqlToForm } from "./transformers";
 import { ViewsFormState } from "./types";
 
@@ -7,7 +8,9 @@ const { projectBase } = data;
 
 describe("project data", () => {
   it("correctly converts from GQL to a form", () => {
-    expect(gqlToForm(projectBase)).toStrictEqual(projectForm);
+    expect(
+      gqlToForm(projectBase, { projectType: ProjectType.Project })
+    ).toStrictEqual(projectForm);
   });
 
   it("correctly converts from a form to GQL", () => {

--- a/src/pages/projectSettings/tabs/ViewsAndFiltersTab/transformers.ts
+++ b/src/pages/projectSettings/tabs/ViewsAndFiltersTab/transformers.ts
@@ -28,18 +28,18 @@ export const gqlToForm = ((data, { projectType }) => {
   };
 }) satisfies GqlToFormFunction<Tab>;
 
-export const formToGql = ((formState, id) => ({
+export const formToGql = (({ parsleyFilters, view }, id) => ({
   projectRef: {
     id,
-    parsleyFilters: formState.parsleyFilters.map(
+    parsleyFilters: parsleyFilters.map(
       ({ caseSensitive, exactMatch, expression }) => ({
         expression,
         caseSensitive,
         exactMatch,
       })
     ),
-    ...("view" in formState && {
-      projectHealthView: formState.view.projectHealthView,
+    ...(view && {
+      projectHealthView: view.projectHealthView,
     }),
   },
 })) satisfies FormToGqlFunction<Tab>;

--- a/src/pages/projectSettings/tabs/ViewsAndFiltersTab/types.ts
+++ b/src/pages/projectSettings/tabs/ViewsAndFiltersTab/types.ts
@@ -1,16 +1,21 @@
 import { ProjectHealthView } from "gql/generated/types";
 import { ProjectType } from "../utils";
 
+type ParsleyFilter = {
+  caseSensitive: boolean;
+  displayTitle?: string;
+  exactMatch: boolean;
+  expression: string;
+};
+
 export interface ViewsFormState {
   view?: {
     projectHealthView: ProjectHealthView;
   };
-  parsleyFilters: {
-    caseSensitive: boolean;
-    displayTitle?: string;
-    exactMatch: boolean;
-    expression: string;
-  }[];
+  parsleyFilters: ParsleyFilter[];
+  repoData?: {
+    parsleyFilters: ParsleyFilter[];
+  };
 }
 
 export type TabProps = {

--- a/src/pages/projectSettings/tabs/ViewsAndFiltersTab/types.ts
+++ b/src/pages/projectSettings/tabs/ViewsAndFiltersTab/types.ts
@@ -2,7 +2,7 @@ import { ProjectHealthView } from "gql/generated/types";
 import { ProjectType } from "../utils";
 
 export interface ViewsFormState {
-  view: {
+  view?: {
     projectHealthView: ProjectHealthView;
   };
   parsleyFilters: {
@@ -17,4 +17,5 @@ export type TabProps = {
   identifier: string;
   projectData?: ViewsFormState;
   projectType: ProjectType;
+  repoData?: ViewsFormState;
 };

--- a/src/pages/projectSettings/tabs/testData.ts
+++ b/src/pages/projectSettings/tabs/testData.ts
@@ -266,6 +266,13 @@ const repoBase: RepoSettingsQuery["repoSettings"] = {
         nextRunTime: new Date("2022-03-30T17:07:10.942Z"),
       },
     ],
+    parsleyFilters: [
+      {
+        expression: "repo-filter",
+        caseSensitive: false,
+        exactMatch: false,
+      },
+    ],
   },
   vars: {
     vars: { repo_name: "repo_value" },

--- a/src/pages/projectSettings/tabs/types.ts
+++ b/src/pages/projectSettings/tabs/types.ts
@@ -59,7 +59,3 @@ export { WritableProjectSettingsTabs };
 
 export type WritableProjectSettingsType =
   (typeof WritableProjectSettingsTabs)[keyof typeof WritableProjectSettingsTabs];
-
-export const projectOnlyTabs: Set<ProjectSettingsTabRoutes> = new Set([
-  ProjectSettingsTabRoutes.ViewsAndFilters,
-]);


### PR DESCRIPTION
DEVPROD-948

### Description
<!-- add description, context, thought process, etc -->
- Allow users to save Parsley filters for repos
- For attached projects, show repo level filters in a disabled view
- I didn't add a "Move filters to repo" button like we have for variables; due to the usage rate of filters, this would be high effort with low impact. It's easy enough to copy the values over manually.
- ~~**Fun update:** because the `Project` resolver [applies the `includeRepo` flag](https://github.com/evergreen-ci/evergreen/blob/26a9c74fb94c21556995b848c5ae9fd6b4a20192/rest/data/project.go#L35), Parsley already handles applying repo-level filters without any further updates 🎉 you can try it out as part of reviewing this PR! I personally don't think there's any need to distinguish a project vs repo-level filter on the Parsley UI.~~ nvm 😢 small backend update required: https://github.com/evergreen-ci/evergreen/pull/7200

### Screenshots
<!-- add screenshots of visible changes -->
Repo view:
<img width="1495" alt="image" src="https://github.com/evergreen-ci/spruce/assets/9298431/ba73c3c3-e5da-4799-bdc7-b150540cd292">

Project view:
<img width="1495" alt="image" src="https://github.com/evergreen-ci/spruce/assets/9298431/c248c8bb-067e-4614-806e-63787e45dbbb">