### PR TITLE
DEVPROD-934: Allow Cypress to test against dev server on Node 17+

### DIFF
--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -936,6 +936,7 @@ export type MainlineCommitsOptions = {
   limit?: InputMaybe<Scalars["Int"]["input"]>;
   projectIdentifier: Scalars["String"]["input"];
   requesters?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  revision?: InputMaybe<Scalars["String"]["input"]>;
   shouldCollapse?: InputMaybe<Scalars["Boolean"]["input"]>;
   skipOrderNumber?: InputMaybe<Scalars["Int"]["input"]>;
 };
@@ -1503,6 +1504,7 @@ export type Patches = {
  */
 export type PatchesInput = {
   includeCommitQueue?: InputMaybe<Scalars["Boolean"]["input"]>;
+  includeHidden?: InputMaybe<Scalars["Boolean"]["input"]>;
   limit?: Scalars["Int"]["input"];
   onlyCommitQueue?: InputMaybe<Scalars["Boolean"]["input"]>;
   page?: Scalars["Int"]["input"];
@@ -2105,6 +2107,7 @@ export type RepoRef = {
   manualPrTestingEnabled: Scalars["Boolean"]["output"];
   notifyOnBuildFailure: Scalars["Boolean"]["output"];
   owner: Scalars["String"]["output"];
+  parsleyFilters?: Maybe<Array<ParsleyFilter>>;
   patchTriggerAliases?: Maybe<Array<PatchTriggerAlias>>;
   patchingDisabled: Scalars["Boolean"]["output"];
   perfEnabled: Scalars["Boolean"]["output"];
@@ -2146,6 +2149,7 @@ export type RepoRefInput = {
   manualPrTestingEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   notifyOnBuildFailure?: InputMaybe<Scalars["Boolean"]["input"]>;
   owner?: InputMaybe<Scalars["String"]["input"]>;
+  parsleyFilters?: InputMaybe<Array<ParsleyFilterInput>>;
   patchTriggerAliases?: InputMaybe<Array<PatchTriggerAliasInput>>;
   patchingDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   perfEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,7 +9,11 @@ import envCompatible from "vite-plugin-env-compatible";
 import checker from "vite-plugin-checker";
 import { visualizer } from "rollup-plugin-visualizer";
 import tsconfigPaths from "vite-tsconfig-paths";
+import dns from "dns";
 import injectVariablesInHTML from "./config/injectVariablesInHTML";
+
+// Remove when https://github.com/cypress-io/cypress/issues/25397 is resolved.
+dns.setDefaultResultOrder("ipv4first");
 
 // Do not apply Antd's global styles
 fs.writeFileSync(require.resolve("antd/es/style/core/global.less"), "");


### PR DESCRIPTION
DEVPROD-934

### Description
#### Background Information
Node 17 had a breaking change where it prefers IPv6 over IPv4. For localhost, IPv6 corresponds to `::1` and IPv4 corresponds to `127.0.0.1`.

#### Problem Description
Ultimately, I think this is a bug in Cypress described by [this issue](https://www.github.com/cypress-io/cypress/issues/25397). If you are using Node 17+, then running `yarn dev` will launch the server on `::1`. The issue describes a bug where if you call `cy.request()` before any `cy.visit()` calls, Cypress will "lock" itself into using `127.0.0.1`. This is bad because we're expecting `::1`. 

We run into this problem because we call [`cy.login()`](https://github.com/evergreen-ci/spruce/blob/8f2f1cdcff36d42d9edc43aa5d33a625cbe754c2/cypress/support/commands.ts#L64-L70) before all of our tests, which uses `cy.request()`. So we fulfill the condition of this bug, which is to call `cy.request()` before any `cy.visit()` calls.

The straightforward fix is to add a dummy `cy.visit()` before `cy.login()`. While this will enable you to run the tests locally, it ends up introducing a lot of failures in CI ([patch](https://spruce.mongodb.com/version/6543f8b657e85a46f6fe9e6a/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)).

An easier fix is to just tell Vite to launch the dev server on `127.0.0.1`. This will enable you to run the tests locally and has no repercussions in CI ([patch](https://spruce.mongodb.com/version/6542a9bfe3c331e8d3784403/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)).

### Testing
- Should be able to run the Cypress tests against dev server on Node 17+
