### PR TITLE
DEVPROD-1717 update mongo to 7.0

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -493,8 +493,8 @@ buildvariants:
       - ubuntu2204-large
     expansions:
       goroot: /opt/golang/go1.20
-      mongodb_url_2204: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2204-6.0.6.tgz
-      mongosh_url_2204: https://downloads.mongodb.com/compass/mongosh-1.9.0-linux-x64.tgz
+      mongodb_url_2204: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2204-7.0.2.tgz
+      mongosh_url_2204: https://downloads.mongodb.com/compass/mongosh-2.0.2-linux-x64.tgz
       node_version: 16.17.0
     modules:
       - evergreen


### PR DESCRIPTION
[DEVPROD-1717](https://jira.mongodb.org/browse/DEVPROD-1717)

### Description
Upgrade the db to 7.0 in tests in advance of upgrading the db itself. Upgrade mongosh while we're at it.

### Evergreen PR
https://github.com/evergreen-ci/evergreen/pull/7198
