### PR TITLE
DEVPROD-2234: Use correct project for querying task history

### DIFF
--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -5304,6 +5304,7 @@ export type BaseVersionAndTaskQuery = {
     displayName: string;
     execution: number;
     id: string;
+    projectIdentifier?: string | null;
     baseTask?: {
       __typename?: "Task";
       execution: number;
@@ -5318,7 +5319,6 @@ export type BaseVersionAndTaskQuery = {
         __typename?: "Version";
         id: string;
         order: number;
-        projectIdentifier: string;
       } | null;
     };
   } | null;

--- a/src/gql/queries/base-version-and-task.graphql
+++ b/src/gql/queries/base-version-and-task.graphql
@@ -9,11 +9,11 @@ query BaseVersionAndTask($taskId: String!) {
     displayName
     execution
     id
+    projectIdentifier
     versionMetadata {
       baseVersion {
         id
         order
-        projectIdentifier
       }
       id
       isPatch

--- a/src/pages/task/actionButtons/previousCommits/PreviousCommits.test.tsx
+++ b/src/pages/task/actionButtons/previousCommits/PreviousCommits.test.tsx
@@ -205,11 +205,11 @@ const getPatchTaskWithSuccessfulBaseTask: ApolloMock<
         execution: 0,
         displayName: "lint-agent",
         buildVariant: "lint",
+        projectIdentifier: "evergreen",
         versionMetadata: {
           baseVersion: {
             id: "baseVersion",
             order: 3676,
-            projectIdentifier: "evergreen",
             __typename: "Version",
           },
           isPatch: true,
@@ -245,11 +245,11 @@ const getPatchTaskWithRunningBaseTask: ApolloMock<
         execution: 0,
         displayName: "lint-agent",
         buildVariant: "lint",
+        projectIdentifier: "evergreen",
         versionMetadata: {
           baseVersion: {
             id: "baseVersion",
             order: 3676,
-            projectIdentifier: "evergreen",
             __typename: "Version",
           },
           isPatch: true,
@@ -285,11 +285,11 @@ const getPatchTaskWithFailingBaseTask: ApolloMock<
         execution: 0,
         displayName: "lint-agent",
         buildVariant: "lint",
+        projectIdentifier: "evergreen",
         versionMetadata: {
           baseVersion: {
             id: "baseVersion",
             order: 3676,
-            projectIdentifier: "evergreen",
             __typename: "Version",
           },
           isPatch: true,
@@ -325,6 +325,7 @@ const getPatchTaskWithNoBaseVersion: ApolloMock<
         execution: 0,
         displayName: "lint-agent",
         buildVariant: "lint",
+        projectIdentifier: "evergreen",
         versionMetadata: {
           baseVersion: null,
           id: "versionMetadataId",
@@ -460,11 +461,11 @@ const getPatchTaskWithNoBaseTask: ApolloMock<
         execution: 0,
         displayName: "lint-agent",
         buildVariant: "lint",
+        projectIdentifier: "evergreen",
         versionMetadata: {
           baseVersion: {
             id: "baseVersion",
             order: 3676,
-            projectIdentifier: "evergreen",
             __typename: "Version",
           },
           isPatch: true,
@@ -496,11 +497,11 @@ const getMainlineTaskWithBaseVersion: ApolloMock<
         execution: 0,
         displayName: "lint-agent",
         buildVariant: "lint",
+        projectIdentifier: "evergreen",
         versionMetadata: {
           baseVersion: {
             id: "baseVersion",
             order: 3676,
-            projectIdentifier: "evergreen",
             __typename: "Version",
           },
           isPatch: false,

--- a/src/pages/task/actionButtons/previousCommits/index.tsx
+++ b/src/pages/task/actionButtons/previousCommits/index.tsx
@@ -37,10 +37,15 @@ export const PreviousCommits: React.FC<PreviousCommitsProps> = ({ taskId }) => {
     variables: { taskId },
   });
 
-  const { baseTask, buildVariant, displayName, versionMetadata } =
-    taskData?.task ?? {};
-  const { order: skipOrderNumber, projectIdentifier } =
-    versionMetadata?.baseVersion ?? {};
+  const {
+    baseTask,
+    buildVariant,
+    displayName,
+    projectIdentifier,
+    versionMetadata,
+  } = taskData?.task ?? {};
+  const { order: skipOrderNumber } = versionMetadata?.baseVersion ?? {};
+
   const bvOptionsBase = {
     tasks: [applyStrictRegex(displayName)],
     variants: [applyStrictRegex(buildVariant)],


### PR DESCRIPTION
DEVPROD-2234

### Description
<!-- add description, context, thought process, etc -->
We've been querying for task history using the version's project instead of the task's. This is often fine, but downstream tasks will use the wrong value for queries.

The bug was present in the previous version of the history selector, but was encountered a lot less often because a user would have to select "Go to last passing task" in the dropdown before the query ran.

Now, get the project identifier directly from the task.

### Testing
- Update unit tests