### PR TITLE
DEVPROD-941: linkify user name on version metadata panel

### DIFF
--- a/src/pages/version/Metadata.tsx
+++ b/src/pages/version/Metadata.tsx
@@ -12,6 +12,7 @@ import {
   getCommitQueueRoute,
   getProjectPatchesRoute,
   getTriggerRoute,
+  getUserPatchesRoute,
   getVersionRoute,
 } from "constants/routes";
 import { VersionQuery } from "gql/generated/types";
@@ -117,7 +118,15 @@ export const Metadata: React.FC<Props> = ({ loading, version }) => {
           </span>
         </MetadataItem>
       )}
-      <MetadataItem>{`Submitted by: ${author}`}</MetadataItem>
+      <MetadataItem>
+        Submitted by:{" "}
+        <StyledRouterLink
+          to={getUserPatchesRoute(author)}
+          data-cy="user-patches-link"
+        >
+          {author}
+        </StyledRouterLink>
+      </MetadataItem>
       {isPatch ? (
         <MetadataItem>
           Base commit:{" "}


### PR DESCRIPTION
DEVPROD-941

### Description
The user's name is current static, not linkified. It would be a minor but nice usability improvement to redirect this to a user's patch page. 

### Screenshots
https://github.com/evergreen-ci/spruce/assets/1911841/015749b0-0cbb-4b0e-b3d1-09482393bae7

### Testing
See recording - navigated to the version page and observed the user was linkified. Clicked the link and it went to the patch page.

### Evergreen PR
n/a