### PR TITLE
Revert "DEVPROD-941: linkify user name on version metadata panel (#21…

### DIFF
--- a/src/pages/version/Metadata.tsx
+++ b/src/pages/version/Metadata.tsx
@@ -12,7 +12,6 @@ import {
   getCommitQueueRoute,
   getProjectPatchesRoute,
   getTriggerRoute,
-  getUserPatchesRoute,
   getVersionRoute,
 } from "constants/routes";
 import { VersionQuery } from "gql/generated/types";
@@ -118,15 +117,7 @@ export const Metadata: React.FC<Props> = ({ loading, version }) => {
           </span>
         </MetadataItem>
       )}
-      <MetadataItem>
-        Submitted by:{" "}
-        <StyledRouterLink
-          to={getUserPatchesRoute(author)}
-          data-cy="user-patches-link"
-        >
-          {author}
-        </StyledRouterLink>
-      </MetadataItem>
+      <MetadataItem>{`Submitted by: ${author}`}</MetadataItem>
       {isPatch ? (
         <MetadataItem>
           Base commit:{" "}


### PR DESCRIPTION
This reverts commit 14bfbf6340666d6b166195baf301727a387c4afd (DEVPROD-941)

There's a bug where some folks have their username as the author name, and others have a display name.
