### PR TITLE
DEVPROD-360: Allow spec filtering for user submitted patches

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -525,4 +525,4 @@ buildvariants:
 parameters:
   - key: cypress_spec
     value: cypress/integration/*
-    description: Specify the Cypress spec files to run for user submitted patches running e2e_test.
+    description: Specify the Cypress spec files to run for user submitted patches running the e2e_test task.


### PR DESCRIPTION
DEVPROD-360

The `cypress_spec` parameter maps to the Cypress [spec](https://docs.cypress.io/guides/guides/command-line#cypress-run-spec-lt-spec-gt) flag but only for user submitted patches
