### PR TITLE
DEVPROD-2662 Show exact time on hover of project health timestamp

### DIFF
--- a/src/components/CommitChartLabel/index.tsx
+++ b/src/components/CommitChartLabel/index.tsx
@@ -65,7 +65,7 @@ const CommitChartLabel: React.FC<Props> = ({
         >
           {shortenGithash(githash)}
         </InlineCode>{" "}
-        <b>
+        <b title={getDateCopy(createDate)}>
           {getDateCopy(createDate, { omitSeconds: true, omitTimezone: true })}
         </b>{" "}
       </LabelText>


### PR DESCRIPTION
DEVPROD-2662

### Description
Thought it would be nice to see the exact time when you hover over the date on the project health page. We use this pattern in a few other spots as well.

### Screenshots
<img width="471" alt="image" src="https://github.com/evergreen-ci/spruce/assets/4605522/e60e05b3-3914-4daf-8c9f-d82a18a54419">
