### PR TITLE
DEVPROD-357 Make spawn volume tests atomic

### DIFF
--- a/cypress/integration/spawn/volume.ts
+++ b/cypress/integration/spawn/volume.ts
@@ -44,7 +44,7 @@ describe("Spawn volume page", () => {
     cy.dataCy("spawn-volume-card-vol-0ea662ac92f611ed4").should("be.visible");
   });
 
-  it.skip("Click the trash can should remove the volume from the table and update free/mounted volumes badges.", () => {
+  it("Click the trash can should remove the volume from the table and update free/mounted volumes badges.", () => {
     cy.dataRowKey("vol-0c66e16459646704d").should("exist");
     cy.dataCy("trash-vol-0c66e16459646704d").click();
     cy.dataCy("delete-volume-popconfirm").should("be.visible");
@@ -60,7 +60,7 @@ describe("Spawn volume page", () => {
     cy.dataCy("free-badge").contains("3 Free");
   });
 
-  it.skip("Click the trash can for a mounted volume should show an additional confirmation checkbox which enables the submit button when checked.", () => {
+  it("Click the trash can for a mounted volume should show an additional confirmation checkbox which enables the submit button when checked.", () => {
     cy.dataRowKey(
       "1de2728dd9de82efc02dc21f6ca046eaa559462414d28e0b6bba6436436ac873"
     ).should("exist");
@@ -93,7 +93,7 @@ describe("Spawn volume page", () => {
     cy.dataCy("free-badge").contains("4 Free");
   });
 
-  it.skip("Clicking on unmount should result in a success toast appearing.", () => {
+  it("Clicking on unmount should result in a success toast appearing.", () => {
     cy.dataCy(
       "detach-btn-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b857"
     ).click();
@@ -111,7 +111,9 @@ describe("Spawn volume page", () => {
     cy.dataCy("spawn-volume-modal").should("be.visible");
   });
 
-  it.skip("Reopening the Spawn Volume modal clears previous input changes.", () => {
+  it("Reopening the Spawn Volume modal clears previous input changes.", () => {
+    cy.dataCy("spawn-volume-btn").click();
+    cy.dataCy("spawn-volume-modal").should("be.visible");
     cy.selectLGOption("Type", "sc1");
     cy.dataCy("spawn-volume-modal").within(() => {
       cy.contains("button", "Cancel").should(
@@ -206,8 +208,7 @@ describe("Spawn volume page", () => {
       );
     });
 
-    // TODO: Fix this test
-    it.skip("Clicking on save button should close the modal and show a success toast", () => {
+    it("Clicking on save button should close the modal and show a success toast", () => {
       cy.dataCy(
         "edit-btn-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b858"
       ).click();

--- a/cypress/integration/spawn/volume.ts
+++ b/cypress/integration/spawn/volume.ts
@@ -1,6 +1,8 @@
-describe("Navigating to Spawn Volume page", { testIsolation: false }, () => {
-  it("Visiting the spawn volume page should display the number of free and mounted volumes.", () => {
+describe("Spawn volume page", () => {
+  beforeEach(() => {
     cy.visit("/spawn/volume");
+  });
+  it("Visiting the spawn volume page should display the number of free and mounted volumes.", () => {
     cy.dataCy("mounted-badge").contains("9 Mounted");
     cy.dataCy("free-badge").contains("4 Free");
   });
@@ -32,6 +34,7 @@ describe("Navigating to Spawn Volume page", { testIsolation: false }, () => {
   });
 
   it("Clicking on the row should toggle the volume card open and closed", () => {
+    cy.visit("/spawn/volume?volume=vol-0ea662ac92f611ed4");
     cy.dataCy("spawn-volume-card-vol-0ea662ac92f611ed4").should("be.visible");
     cy.dataRowKey("vol-0ea662ac92f611ed4").click();
     cy.dataCy("spawn-volume-card-vol-0ea662ac92f611ed4").should(
@@ -41,8 +44,7 @@ describe("Navigating to Spawn Volume page", { testIsolation: false }, () => {
     cy.dataCy("spawn-volume-card-vol-0ea662ac92f611ed4").should("be.visible");
   });
 
-  it("Click the trash can should remove the volume from the table and update free/mounted volumes badges.", () => {
-    cy.visit("/spawn/volume");
+  it.skip("Click the trash can should remove the volume from the table and update free/mounted volumes badges.", () => {
     cy.dataRowKey("vol-0c66e16459646704d").should("exist");
     cy.dataCy("trash-vol-0c66e16459646704d").click();
     cy.dataCy("delete-volume-popconfirm").should("be.visible");
@@ -58,8 +60,7 @@ describe("Navigating to Spawn Volume page", { testIsolation: false }, () => {
     cy.dataCy("free-badge").contains("3 Free");
   });
 
-  it("Click the trash can for a mounted volume should show an additional confirmation checkbox which enables the submit button when checked.", () => {
-    cy.visit("/spawn/volume");
+  it.skip("Click the trash can for a mounted volume should show an additional confirmation checkbox which enables the submit button when checked.", () => {
     cy.dataRowKey(
       "1de2728dd9de82efc02dc21f6ca046eaa559462414d28e0b6bba6436436ac873"
     ).should("exist");
@@ -92,8 +93,7 @@ describe("Navigating to Spawn Volume page", { testIsolation: false }, () => {
     cy.dataCy("free-badge").contains("4 Free");
   });
 
-  it("Clicking on unmount should result in a success toast appearing.", () => {
-    cy.visit("/spawn/volume");
+  it.skip("Clicking on unmount should result in a success toast appearing.", () => {
     cy.dataCy(
       "detach-btn-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b857"
     ).click();
@@ -102,7 +102,6 @@ describe("Navigating to Spawn Volume page", { testIsolation: false }, () => {
   });
 
   it("Clicking on 'Spawn Volume' should open the Spawn Volume Modal", () => {
-    cy.visit("/spawn/volume");
     cy.dataCy("spawn-volume-btn").should(
       "not.have.attr",
       "aria-disabled",
@@ -112,7 +111,7 @@ describe("Navigating to Spawn Volume page", { testIsolation: false }, () => {
     cy.dataCy("spawn-volume-modal").should("be.visible");
   });
 
-  it("Reopening the Spawn Volume modal clears previous input changes.", () => {
+  it.skip("Reopening the Spawn Volume modal clears previous input changes.", () => {
     cy.selectLGOption("Type", "sc1");
     cy.dataCy("spawn-volume-modal").within(() => {
       cy.contains("button", "Cancel").should(
@@ -129,8 +128,10 @@ describe("Navigating to Spawn Volume page", { testIsolation: false }, () => {
   });
 
   describe("Edit volume modal", () => {
-    it("Clicking on 'Edit' should open the Edit Volume Modal", () => {
+    beforeEach(() => {
       cy.visit("/spawn/volume");
+    });
+    it("Clicking on 'Edit' should open the Edit Volume Modal", () => {
       cy.dataCy(
         "edit-btn-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b858"
       ).click();
@@ -138,6 +139,10 @@ describe("Navigating to Spawn Volume page", { testIsolation: false }, () => {
     });
 
     it("Volume name & expiration inputs should be populated with the volume display name & expiration on initial render", () => {
+      cy.dataCy(
+        "edit-btn-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b858"
+      ).click();
+      cy.dataCy("update-volume-modal").should("be.visible");
       cy.dataCy("volume-name-input").should(
         "have.value",
         "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b858"
@@ -147,6 +152,10 @@ describe("Navigating to Spawn Volume page", { testIsolation: false }, () => {
     });
 
     it("Reopening the edit volume modal should reset form input fields.", () => {
+      cy.dataCy(
+        "edit-btn-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b858"
+      ).click();
+      cy.dataCy("update-volume-modal").should("be.visible");
       cy.dataCy("volume-name-input").type("Hello, World");
       cy.dataCy("update-volume-modal").within(() => {
         cy.contains("button", "Cancel").click();
@@ -161,6 +170,10 @@ describe("Navigating to Spawn Volume page", { testIsolation: false }, () => {
     });
 
     it("Submit button should be enabled when the volume details input value differs from what already exists.", () => {
+      cy.dataCy(
+        "edit-btn-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b858"
+      ).click();
+      cy.dataCy("update-volume-modal").should("be.visible");
       cy.contains("button", "Save").should(
         "have.attr",
         "aria-disabled",
@@ -175,11 +188,10 @@ describe("Navigating to Spawn Volume page", { testIsolation: false }, () => {
       );
 
       // type original name
-      cy.dataCy("volume-name-input")
-        .clear()
-        .type(
-          "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b858"
-        );
+      cy.dataCy("volume-name-input").clear();
+      cy.dataCy("volume-name-input").type(
+        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b858"
+      );
       cy.contains("button", "Save").should(
         "have.attr",
         "aria-disabled",
@@ -194,7 +206,18 @@ describe("Navigating to Spawn Volume page", { testIsolation: false }, () => {
       );
     });
 
-    it("Clicking on save button should close the modal and show a success toast", () => {
+    // TODO: Fix this test
+    it.skip("Clicking on save button should close the modal and show a success toast", () => {
+      cy.dataCy(
+        "edit-btn-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b858"
+      ).click();
+      cy.dataCy("update-volume-modal").should("be.visible");
+      cy.dataCy("volume-name-input").type("Hello, World");
+      cy.contains("button", "Save").should(
+        "not.have.attr",
+        "aria-disabled",
+        "true"
+      );
       cy.contains("button", "Save").click();
       cy.validateToast("success", "Successfully updated volume");
       cy.dataCy("update-volume-modal").should("not.exist");
@@ -203,7 +226,6 @@ describe("Navigating to Spawn Volume page", { testIsolation: false }, () => {
 
   describe("Migrate Modal", () => {
     beforeEach(() => {
-      cy.setCookie("seen-migrate-guide-cue", "false");
       cy.visit("/spawn/volume");
     });
     it("migrate button is disabled for volumes with the migrating status", () => {
@@ -215,25 +237,6 @@ describe("Navigating to Spawn Volume page", { testIsolation: false }, () => {
         "aria-disabled",
         "true"
       );
-    });
-    it("will persistently not show the guide cue after the Migrate button has been clicked", () => {
-      cy.dataCy("migrate-cue").should("be.visible");
-      cy.dataCy(
-        "migrate-btn-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b858"
-      ).click();
-      cy.dataCy("migrate-cue").should("not.exist");
-      cy.reload();
-      cy.dataCy("migrate-cue").should("not.exist");
-    });
-    it("will persistently not show the guide cue after the guide cue 'Got it' button has been clicked", () => {
-      cy.dataCy("migrate-cue").should("be.visible");
-      cy.get("[role=dialog]")
-        .find("button")
-        .contains("Got it")
-        .click({ force: true });
-      cy.dataCy("migrate-cue").should("not.exist");
-      cy.reload();
-      cy.dataCy("migrate-cue").should("not.exist");
     });
     it("clicking cancel during confirmation renders the Migrate modal form", () => {
       cy.dataCy(

--- a/src/constants/cookies.ts
+++ b/src/constants/cookies.ts
@@ -16,6 +16,5 @@ export const INCLUDE_COMMIT_QUEUE_USER_PATCHES =
   "include-commit-queue-user-patches";
 export const INCLUDE_HIDDEN_PATCHES = "include-hidden-patches";
 export const SEEN_HONEYCOMB_GUIDE_CUE = "seen-honeycomb-guide-cue";
-export const SEEN_MIGRATE_GUIDE_CUE = "seen-migrate-guide-cue";
 export const SLACK_NOTIFICATION_BANNER = "has-closed-slack-banner";
 export const SUBSCRIPTION_METHOD = "subscription-method";

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -378,6 +378,7 @@ export type Distro = {
   iceCreamSettings: IceCreamSettings;
   isCluster: Scalars["Boolean"]["output"];
   isVirtualWorkStation: Scalars["Boolean"]["output"];
+  mountpoints: Array<Maybe<Scalars["String"]["output"]>>;
   name: Scalars["String"]["output"];
   note: Scalars["String"]["output"];
   plannerSettings: PlannerSettings;

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -149,6 +149,7 @@ export type BuildBaronSettings = {
   bfSuggestionServer?: Maybe<Scalars["String"]["output"]>;
   bfSuggestionTimeoutSecs?: Maybe<Scalars["Int"]["output"]>;
   bfSuggestionUsername?: Maybe<Scalars["String"]["output"]>;
+  ticketCreateIssueType: Scalars["String"]["output"];
   ticketCreateProject: Scalars["String"]["output"];
   ticketSearchProjects?: Maybe<Array<Scalars["String"]["output"]>>;
 };
@@ -159,6 +160,7 @@ export type BuildBaronSettingsInput = {
   bfSuggestionServer?: InputMaybe<Scalars["String"]["input"]>;
   bfSuggestionTimeoutSecs?: InputMaybe<Scalars["Int"]["input"]>;
   bfSuggestionUsername?: InputMaybe<Scalars["String"]["input"]>;
+  ticketCreateIssueType?: InputMaybe<Scalars["String"]["input"]>;
   ticketCreateProject: Scalars["String"]["input"];
   ticketSearchProjects?: InputMaybe<Array<Scalars["String"]["input"]>>;
 };

--- a/src/pages/spawn/spawnVolume/SpawnVolumeTable.tsx
+++ b/src/pages/spawn/spawnVolume/SpawnVolumeTable.tsx
@@ -1,11 +1,9 @@
 import { useMemo } from "react";
 import { ColumnProps } from "antd/es/table";
 import { formatDistanceToNow } from "date-fns";
-import Cookies from "js-cookie";
 import { useLocation } from "react-router-dom";
 import { DoesNotExpire, SpawnTable } from "components/Spawn";
 import { StyledRouterLink, WordBreak } from "components/styles";
-import { SEEN_MIGRATE_GUIDE_CUE } from "constants/cookies";
 import { getSpawnHostRoute } from "constants/routes";
 import { MyVolume, TableVolume } from "types/spawn";
 import { queryString, string } from "utils";
@@ -28,13 +26,8 @@ export const SpawnVolumeTable: React.FC<SpawnVolumeTableProps> = ({
   const dataSource: TableVolume[] = useMemo(() => {
     const volumesCopy = [...volumes];
     volumesCopy.sort(sortByHost);
-    const firstMigrateableVolumeId =
-      volumesCopy.find((v) => v.homeVolume)?.id ?? "";
     return volumes.map((v) => ({
       ...v,
-      showMigrateBtnCue:
-        v.id === firstMigrateableVolumeId &&
-        Cookies.get(SEEN_MIGRATE_GUIDE_CUE) !== "true",
     }));
   }, [volumes]);
   return (

--- a/src/pages/spawn/spawnVolume/spawnVolumeTableActions/MigrateButton.tsx
+++ b/src/pages/spawn/spawnVolume/spawnVolumeTableActions/MigrateButton.tsx
@@ -1,8 +1,5 @@
 import { useRef, useState } from "react";
 import Button, { Size } from "@leafygreen-ui/button";
-import { GuideCue } from "@leafygreen-ui/guide-cue";
-import Cookies from "js-cookie";
-import { SEEN_MIGRATE_GUIDE_CUE } from "constants/cookies";
 import { TableVolume } from "types/spawn";
 import { MigrateVolumeModal } from "./MigrateVolumeModal";
 
@@ -12,26 +9,9 @@ interface Props {
 
 export const MigrateButton: React.FC<Props> = ({ volume }) => {
   const [openModal, setOpenModal] = useState(false);
-  const [openGuideCue, setOpenGuideCue] = useState(volume.showMigrateBtnCue);
   const triggerRef = useRef(null);
-  const onHideCue = () => {
-    Cookies.set(SEEN_MIGRATE_GUIDE_CUE, "true");
-    setOpenGuideCue(false);
-  };
   return (
     <>
-      <GuideCue
-        data-cy="migrate-cue"
-        open={openGuideCue}
-        setOpen={setOpenGuideCue}
-        title="New feature!"
-        refEl={triggerRef}
-        numberOfSteps={1}
-        currentStep={1}
-        onPrimaryButtonClick={onHideCue}
-      >
-        You can now migrate your home volume to a new spawn host!
-      </GuideCue>
       <Button
         ref={triggerRef}
         size={Size.XSmall}
@@ -39,7 +19,6 @@ export const MigrateButton: React.FC<Props> = ({ volume }) => {
         disabled={volume.migrating}
         onClick={(e) => {
           e.stopPropagation();
-          onHideCue();
           setOpenModal(true);
         }}
       >

--- a/src/types/spawn.ts
+++ b/src/types/spawn.ts
@@ -1,7 +1,5 @@
 import { MyVolumesQuery, MyHostsQuery } from "gql/generated/types";
 
 export type MyVolume = MyVolumesQuery["myVolumes"][0];
-export interface TableVolume extends MyVolume {
-  showMigrateBtnCue: boolean;
-}
+export interface TableVolume extends MyVolume {}
 export type MyHost = MyHostsQuery["myHosts"][0];


### PR DESCRIPTION
DEVPROD-357

### Description
Make tests atomic and individually runnable.
Remove New Feature Guide cue for spawn host migration since it's been around for a while now.
