### PR TITLE
DEVPROD-358 Enable test isolation for remaining e2e tests 

### DIFF
--- a/cypress/integration/version/action_buttons.ts
+++ b/cypress/integration/version/action_buttons.ts
@@ -26,7 +26,7 @@ describe("Action Buttons", () => {
     });
   });
 
-  describe("Version dropdown options", { testIsolation: true }, () => {
+  describe("Version dropdown options", () => {
     beforeEach(() => {
       cy.visit(versionPath(patch));
       cy.dataCy("ellipsis-btn").click();

--- a/cypress/integration/version/restart_modal.ts
+++ b/cypress/integration/version/restart_modal.ts
@@ -31,14 +31,11 @@ describe("Restarting a patch", () => {
     cy.dataCy("task-status-badge").should("contain.text", "1 of 1 Selected");
   });
 
-  // TODO: Drop skip in https://jira.mongodb.org/browse/EVG-20762
-  it.skip("Selecting on the task status filter should toggle the tasks that have matching statuses to it", () => {
+  it("Selecting on the task status filter should toggle the tasks that have matching statuses to it", () => {
     cy.dataCy("task-status-filter").click();
     cy.getInputByLabel("All").check({ force: true });
     cy.dataCy("task-status-filter").click();
 
-    // ideally this would target the text field itself but leafygreen Body tags dont
-    // support cy-data elements currently
     cy.dataCy("version-restart-modal").should(
       "contain.text",
       "Are you sure you want to restart the 1 selected tasks?"
@@ -48,8 +45,7 @@ describe("Restarting a patch", () => {
     cy.dataCy("task-status-filter").click();
   });
 
-  // TODO: Drop skip in https://jira.mongodb.org/browse/EVG-20762
-  it.skip("Selecting on the base status filter should toggle the tasks that have matching statuses to it", () => {
+  it("Selecting on the base status filter should toggle the tasks that have matching statuses to it", () => {
     cy.dataCy("version-restart-modal").within(() => {
       cy.dataCy("base-task-status-filter").click();
       cy.getInputByLabel("Succeeded").check({ force: true });

--- a/cypress/integration/version/routes.ts
+++ b/cypress/integration/version/routes.ts
@@ -98,12 +98,11 @@ describe("Version route", () => {
           "sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC&statuses=success&variant=%5Eubuntu1604%24"
         );
 
-        // TODO: Drop skip in https://jira.mongodb.org/browse/EVG-20762
         // Check that filter values have updated.
-        // cy.toggleTableFilter(2);
-        // cy.getInputByLabel("success")
-        //   .should("have.attr", "aria-checked")
-        //   .and("equal", "true");
+        cy.toggleTableFilter(2);
+        cy.getInputByLabel("Succeeded")
+          .should("have.attr", "aria-checked")
+          .and("equal", "true");
 
         cy.toggleTableFilter(4);
         cy.dataCy("variant-input-wrapper")
@@ -117,11 +116,9 @@ describe("Version route", () => {
 
         // Apply name filter
         cy.toggleTableFilter(1);
-        cy.dataCy("taskname-input-wrapper")
-          .find("input")
-          .focus()
-          .type("a-task-name")
-          .type("{enter}");
+        cy.dataCy("taskname-input-wrapper").find("input").as("taskNameInput");
+        cy.get("@taskNameInput").focus();
+        cy.get("@taskNameInput").type("a-task-name{enter}");
 
         // name filter shouldn't be applied after clicking task status badge
         cy.dataCy("build-variants").within(() => {
@@ -168,11 +165,9 @@ describe("Version route", () => {
 
         // Apply name filter
         cy.toggleTableFilter(1);
-        cy.dataCy("taskname-input-wrapper")
-          .find("input")
-          .focus()
-          .type("a-task-name")
-          .type("{enter}");
+        cy.dataCy("taskname-input-wrapper").find("input").as("taskNameInput");
+        cy.get("@taskNameInput").focus();
+        cy.get("@taskNameInput").type("a-task-name{enter}");
 
         // name filter shouldn't be applied after clicking build variant name
         cy.dataCy("build-variant-display-name").first().click();

--- a/cypress/integration/version/task_duration.ts
+++ b/cypress/integration/version/task_duration.ts
@@ -1,6 +1,6 @@
 describe("Task Duration Tab", () => {
   beforeEach(() => {
-    cy.visit(`/version/5e4ff3abe3c3317e352062e4/task-duration`);
+    cy.visit("/version/5e4ff3abe3c3317e352062e4/task-duration");
   });
   describe("when interacting with the filters on the page", () => {
     it("updates URL appropriately when task name filter is applied", () => {
@@ -29,7 +29,7 @@ describe("Task Duration Tab", () => {
       cy.dataCy("task-duration-table-row").should("have.length", 3);
       cy.location("search").should(
         "include",
-        `duration=DESC&page=0&statuses=running-umbrella,started,dispatched`
+        "duration=DESC&page=0&statuses=running-umbrella,started,dispatched"
       );
       // Clear status filter.
       cy.dataCy("status-filter-popover").click();

--- a/cypress/integration/version/task_duration.ts
+++ b/cypress/integration/version/task_duration.ts
@@ -1,10 +1,9 @@
 describe("Task Duration Tab", () => {
-  const patch = "5e4ff3abe3c3317e352062e4";
-  const TASK_DURATION_ROUTE = `/version/${patch}/task-duration`;
-
+  beforeEach(() => {
+    cy.visit(`/version/5e4ff3abe3c3317e352062e4/task-duration`);
+  });
   describe("when interacting with the filters on the page", () => {
     it("updates URL appropriately when task name filter is applied", () => {
-      cy.visit(TASK_DURATION_ROUTE);
       const filterText = "test-annotation";
       // Apply text filter.
       cy.dataCy("task-name-filter-popover").click();
@@ -21,19 +20,16 @@ describe("Task Duration Tab", () => {
       cy.location("search").should("include", `page=0`);
     });
 
-    // TODO: Drop skip in https://jira.mongodb.org/browse/EVG-20762
-    it.skip("updates URL appropriately when status filter is applied", () => {
-      cy.visit(TASK_DURATION_ROUTE);
-
+    it("updates URL appropriately when status filter is applied", () => {
       // Apply status filter.
       cy.dataCy("status-filter-popover").click();
       cy.dataCy("tree-select-options").within(() =>
         cy.contains("Running").click({ force: true })
       );
-      cy.dataCy("task-duration-table-row").should("have.length", 2);
+      cy.dataCy("task-duration-table-row").should("have.length", 3);
       cy.location("search").should(
         "include",
-        `duration=DESC&page=0&statuses=started`
+        `duration=DESC&page=0&statuses=running-umbrella,started,dispatched`
       );
       // Clear status filter.
       cy.dataCy("status-filter-popover").click();
@@ -44,7 +40,6 @@ describe("Task Duration Tab", () => {
     });
 
     it("updates URL appropriately when build variant filter is applied", () => {
-      cy.visit(TASK_DURATION_ROUTE);
       const filterText = "Lint";
       // Apply text filter.
       cy.dataCy("build-variant-filter-popover").click();
@@ -62,7 +57,6 @@ describe("Task Duration Tab", () => {
     });
 
     it("updates URL appropriately when sort is changing", () => {
-      cy.visit(TASK_DURATION_ROUTE);
       // The default sort (DURATION DESC) should be applied
       cy.location("search").should("include", "duration=DESC");
       const longestTask = "test-thirdparty";
@@ -80,7 +74,6 @@ describe("Task Duration Tab", () => {
     });
 
     it("clearing all filters resets to the default sort", () => {
-      cy.visit(TASK_DURATION_ROUTE);
       cy.dataCy("duration-sort-icon").click();
       cy.location("search").should("include", "duration=ASC");
       cy.contains("Clear all filters").click();
@@ -88,7 +81,6 @@ describe("Task Duration Tab", () => {
     });
 
     it("shows message when no test results are found", () => {
-      cy.visit(TASK_DURATION_ROUTE);
       const filterText = "this_does_not_exist";
 
       cy.dataCy("task-name-filter-popover").click();

--- a/cypress/integration/version/unscheduled_patch/configure_patch.ts
+++ b/cypress/integration/version/unscheduled_patch/configure_patch.ts
@@ -175,7 +175,7 @@ describe("Configure Patch Page", () => {
         .find('[data-cy="task-count-badge"]')
         .should("contain.text", "1");
       cy.dataCy("selected-task-disclaimer").contains(
-        `1 task across 1 build variant`
+        "1 task across 1 build variant"
       );
 
       cy.dataCy("task-checkbox").uncheck({ force: true });
@@ -591,7 +591,8 @@ describe("Configure Patch Page", () => {
 
     it("Shows error toast if unsuccessful and keeps data", () => {
       const val = "hello world";
-      cy.dataCy(`patch-name-input`).clear().type(val);
+      cy.dataCy(`patch-name-input`).clear();
+      cy.dataCy(`patch-name-input`).type(val);
       cy.dataCy("task-checkbox").first().check({ force: true });
       mockErrorResponse({
         errorMessage: "An error occured",

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -149,6 +149,7 @@ export type BuildBaronSettings = {
   bfSuggestionServer?: Maybe<Scalars["String"]["output"]>;
   bfSuggestionTimeoutSecs?: Maybe<Scalars["Int"]["output"]>;
   bfSuggestionUsername?: Maybe<Scalars["String"]["output"]>;
+  ticketCreateIssueType: Scalars["String"]["output"];
   ticketCreateProject: Scalars["String"]["output"];
   ticketSearchProjects?: Maybe<Array<Scalars["String"]["output"]>>;
 };
@@ -159,6 +160,7 @@ export type BuildBaronSettingsInput = {
   bfSuggestionServer?: InputMaybe<Scalars["String"]["input"]>;
   bfSuggestionTimeoutSecs?: InputMaybe<Scalars["Int"]["input"]>;
   bfSuggestionUsername?: InputMaybe<Scalars["String"]["input"]>;
+  ticketCreateIssueType?: InputMaybe<Scalars["String"]["input"]>;
   ticketCreateProject: Scalars["String"]["input"];
   ticketSearchProjects?: InputMaybe<Array<Scalars["String"]["input"]>>;
 };


### PR DESCRIPTION
DEVPROD-358

### Description
Reenables commented-out tests and enables test isolation for configure patch tests
