### PR TITLE
DEVPROD-2597 Delete test that fails due to no GitHub Token

### DIFF
--- a/cypress/integration/version/unscheduled_patch/configure_patch.ts
+++ b/cypress/integration/version/unscheduled_patch/configure_patch.ts
@@ -1,6 +1,5 @@
 import { GQL_URL } from "../../../constants";
 import { hasOperationName } from "../../../utils/graphql-test-utils";
-import { mockErrorResponse } from "../../../utils/mockErrorResponse";
 
 describe("Configure Patch Page", () => {
   const unactivatedPatchId = "5e6bb9e23066155a993e0f1a";
@@ -377,7 +376,7 @@ describe("Configure Patch Page", () => {
           .click();
         cy.getInputByLabel("test-agent").should("be.checked");
 
-        // Deselect the buttons and reset                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                ;
+        // Deselect the buttons and reset;
         cy.getInputByLabel("test-agent").uncheck({
           force: true,
         });
@@ -557,7 +556,6 @@ describe("Configure Patch Page", () => {
     });
   });
 
-  // Using mocked responses because we are unable to schedule a patch because of a missing github token
   describe("Scheduling a patch", () => {
     beforeEach(() => {
       cy.visit(`/patch/${unactivatedPatchId}`);
@@ -578,23 +576,6 @@ describe("Configure Patch Page", () => {
         "eq",
         `/version/${activatedPatchId}/tasks`
       );
-    });
-
-    it("Shows error toast if unsuccessful and keeps data", () => {
-      const val = "hello world";
-      cy.dataCy(`patch-name-input`).clear().type(val);
-      cy.dataCy("task-checkbox").first().check({ force: true });
-      mockErrorResponse({
-        errorMessage: "An error occured",
-        operationName: "SchedulePatch",
-        path: "schedulePatch",
-      });
-      cy.dataCy("schedule-patch").click();
-      cy.location("pathname").should(
-        "eq",
-        `/patch/${unactivatedPatchId}/configure/tasks`
-      );
-      cy.validateToast("error");
     });
   });
 });

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -149,6 +149,7 @@ export type BuildBaronSettings = {
   bfSuggestionServer?: Maybe<Scalars["String"]["output"]>;
   bfSuggestionTimeoutSecs?: Maybe<Scalars["Int"]["output"]>;
   bfSuggestionUsername?: Maybe<Scalars["String"]["output"]>;
+  ticketCreateIssueType: Scalars["String"]["output"];
   ticketCreateProject: Scalars["String"]["output"];
   ticketSearchProjects?: Maybe<Array<Scalars["String"]["output"]>>;
 };
@@ -159,6 +160,7 @@ export type BuildBaronSettingsInput = {
   bfSuggestionServer?: InputMaybe<Scalars["String"]["input"]>;
   bfSuggestionTimeoutSecs?: InputMaybe<Scalars["Int"]["input"]>;
   bfSuggestionUsername?: InputMaybe<Scalars["String"]["input"]>;
+  ticketCreateIssueType?: InputMaybe<Scalars["String"]["input"]>;
   ticketCreateProject: Scalars["String"]["input"];
   ticketSearchProjects?: InputMaybe<Array<Scalars["String"]["input"]>>;
 };
@@ -378,7 +380,7 @@ export type Distro = {
   iceCreamSettings: IceCreamSettings;
   isCluster: Scalars["Boolean"]["output"];
   isVirtualWorkStation: Scalars["Boolean"]["output"];
-  mountpoints: Array<Maybe<Scalars["String"]["output"]>>;
+  mountpoints?: Maybe<Array<Maybe<Scalars["String"]["output"]>>>;
   name: Scalars["String"]["output"];
   note: Scalars["String"]["output"];
   plannerSettings: PlannerSettings;
@@ -443,6 +445,7 @@ export type DistroInput = {
   iceCreamSettings: IceCreamSettingsInput;
   isCluster: Scalars["Boolean"]["input"];
   isVirtualWorkStation: Scalars["Boolean"]["input"];
+  mountpoints?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
   name: Scalars["String"]["input"];
   note: Scalars["String"]["input"];
   plannerSettings: PlannerSettingsInput;


### PR DESCRIPTION
DEVPROD-2597

### Description
Testing for patches not being able to be scheduled because of an empty github token is redundant now that we are not relying on that behavior now

### Evergreen PR
https://github.com/evergreen-ci/evergreen/pull/7245