### PR TITLE
DEVPROD-789: Fix spacing bug in ArrayFieldTemplate

### DIFF
--- a/src/components/SpruceForm/FieldTemplates/ArrayFieldTemplates/index.tsx
+++ b/src/components/SpruceForm/FieldTemplates/ArrayFieldTemplates/index.tsx
@@ -199,23 +199,22 @@ export const ArrayFieldTemplate: React.FC<ArrayFieldTemplateProps> = ({
         hasChildren={!!items?.length}
         data-cy={arrayDataCy}
       >
-        {items.length === 0 ? (
+        {items.length === 0 && placeholder && (
           <Placeholder>{placeholder}</Placeholder>
-        ) : (
-          items.map((p, i) => (
-            <ArrayItem
-              {...p}
-              key={p.key}
-              border={border}
-              title={
-                formData?.[i]?.displayTitle ??
-                uiSchema?.items?.["ui:displayTitle"]
-              }
-              topAlignDelete={topAlignDelete}
-              useExpandableCard={useExpandableCard}
-            />
-          ))
         )}
+        {items.map((p, i) => (
+          <ArrayItem
+            {...p}
+            key={p.key}
+            border={border}
+            title={
+              formData?.[i]?.displayTitle ??
+              uiSchema?.items?.["ui:displayTitle"]
+            }
+            topAlignDelete={topAlignDelete}
+            useExpandableCard={useExpandableCard}
+          />
+        ))}
         {buttonAtEnd && (
           <AddButtonContainer>
             {addButton}

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -1692,6 +1692,7 @@ export type Project = {
   repotrackerError?: Maybe<RepotrackerError>;
   restricted?: Maybe<Scalars["Boolean"]["output"]>;
   spawnHostScriptPath: Scalars["String"]["output"];
+  stepbackBisect?: Maybe<Scalars["Boolean"]["output"]>;
   stepbackDisabled?: Maybe<Scalars["Boolean"]["output"]>;
   taskAnnotationSettings: TaskAnnotationSettings;
   taskSync: TaskSyncOptions;
@@ -1824,6 +1825,7 @@ export type ProjectInput = {
   repotrackerDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   restricted?: InputMaybe<Scalars["Boolean"]["input"]>;
   spawnHostScriptPath?: InputMaybe<Scalars["String"]["input"]>;
+  stepbackBisect?: InputMaybe<Scalars["Boolean"]["input"]>;
   stepbackDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   taskAnnotationSettings?: InputMaybe<TaskAnnotationSettingsInput>;
   taskSync?: InputMaybe<TaskSyncOptionsInput>;
@@ -2144,6 +2146,7 @@ export type RepoRef = {
   repotrackerDisabled: Scalars["Boolean"]["output"];
   restricted: Scalars["Boolean"]["output"];
   spawnHostScriptPath: Scalars["String"]["output"];
+  stepbackBisect?: Maybe<Scalars["Boolean"]["output"]>;
   stepbackDisabled: Scalars["Boolean"]["output"];
   taskAnnotationSettings: TaskAnnotationSettings;
   taskSync: RepoTaskSyncOptions;
@@ -2186,6 +2189,7 @@ export type RepoRefInput = {
   repotrackerDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   restricted?: InputMaybe<Scalars["Boolean"]["input"]>;
   spawnHostScriptPath?: InputMaybe<Scalars["String"]["input"]>;
+  stepbackBisect?: InputMaybe<Scalars["Boolean"]["input"]>;
   stepbackDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   taskAnnotationSettings?: InputMaybe<TaskAnnotationSettingsInput>;
   taskSync?: InputMaybe<TaskSyncOptionsInput>;


### PR DESCRIPTION
DEVPROD-789

### Description
There was an odd spacing around array buttons because we always rendered the `<Placeholder>` component for an empty array, even if `placeholder` was not defined.

### Screenshots
(These are just a few examples, you would be able to see it on any array form element.)

Before       |  After
:-------------------------:|:-------------------------:
<img width="724" alt="Screenshot 2023-11-28 at 12 12 20 PM" src="https://github.com/evergreen-ci/spruce/assets/47064971/400fe9cd-17f8-4a53-9c88-c1d4b627d394">  | <img width="743" alt="Screenshot 2023-11-28 at 12 16 19 PM" src="https://github.com/evergreen-ci/spruce/assets/47064971/ee22813e-994b-4e42-ad8d-2c64eb446477">


Before     |  After
:-------------------------:|:-------------------------:
<img width="410" alt="Screenshot 2023-11-28 at 12 14 00 PM" src="https://github.com/evergreen-ci/spruce/assets/47064971/8481fd31-3001-49eb-a927-4cd3120f21c0"> |  <img width="419" alt="Screenshot 2023-11-28 at 12 16 11 PM" src="https://github.com/evergreen-ci/spruce/assets/47064971/12599af3-d832-409e-b491-6e0cf714797e">


