### PR TITLE
DEVPROD-1661 add disk metrics to honeycomb metrics link

### DIFF
--- a/src/constants/externalResources.test.ts
+++ b/src/constants/externalResources.test.ts
@@ -65,7 +65,7 @@ describe("getTaskTraceUrl", () => {
   });
 });
 
-describe("getTaskSystemMetricsUrl", () => {
+describe("getHoneycombSystemMetricsUrl", () => {
   it("generates the correct url", () => {
     expect(
       getHoneycombSystemMetricsUrl(
@@ -77,11 +77,7 @@ describe("getTaskSystemMetricsUrl", () => {
     ).toBe(
       `/datasets/evergreen?query={"calculations":[{"op":"AVG","column":"system.memory.usage.used"},{"op":"AVG","column":"system.cpu.utilization"},{"op":"RATE_AVG","column":"system.network.io.transmit"},{"op":"RATE_AVG","column":"system.network.io.receive"}],"filters":[{"op":"=","column":"evergreen.task.id","value":"task_12345"}],"start_time":1688756921,"end_time":1688760000}&omitMissingValues`
     );
-  });
-});
 
-describe("getTaskSystemMetricsUrlWithDisks", () => {
-  it("generates the correct url", () => {
     expect(
       getHoneycombSystemMetricsUrl(
         "task_12345",

--- a/src/constants/externalResources.test.ts
+++ b/src/constants/externalResources.test.ts
@@ -70,11 +70,27 @@ describe("getTaskSystemMetricsUrl", () => {
     expect(
       getHoneycombSystemMetricsUrl(
         "task_12345",
+        null,
         new Date("2023-07-07T19:08:41"),
         new Date("2023-07-07T20:00:00")
       )
     ).toBe(
       `/datasets/evergreen?query={"calculations":[{"op":"AVG","column":"system.memory.usage.used"},{"op":"AVG","column":"system.cpu.utilization"},{"op":"RATE_AVG","column":"system.network.io.transmit"},{"op":"RATE_AVG","column":"system.network.io.receive"}],"filters":[{"op":"=","column":"evergreen.task.id","value":"task_12345"}],"start_time":1688756921,"end_time":1688760000}&omitMissingValues`
+    );
+  });
+});
+
+describe("getTaskSystemMetricsUrlWithDisks", () => {
+  it("generates the correct url", () => {
+    expect(
+      getHoneycombSystemMetricsUrl(
+        "task_12345",
+        ["disk1", "disk2"],
+        new Date("2023-07-07T19:08:41"),
+        new Date("2023-07-07T20:00:00")
+      )
+    ).toBe(
+      `/datasets/evergreen?query={"calculations":[{"op":"AVG","column":"system.memory.usage.used"},{"op":"AVG","column":"system.cpu.utilization"},{"op":"RATE_AVG","column":"system.network.io.transmit"},{"op":"RATE_AVG","column":"system.network.io.receive"},{"op":"RATE_AVG","column":"system.disk.io.disk1.write"},{"op":"RATE_AVG","column":"system.disk.operations.disk1.read"},{"op":"RATE_AVG","column":"system.disk.operations.disk1.write"},{"op":"RATE_AVG","column":"system.disk.io_time.disk1"},{"op":"RATE_AVG","column":"system.disk.io.disk2.read"},{"op":"RATE_AVG","column":"system.disk.io.disk2.write"},{"op":"RATE_AVG","column":"system.disk.operations.disk2.read"},{"op":"RATE_AVG","column":"system.disk.operations.disk2.write"},{"op":"RATE_AVG","column":"system.disk.io_time.disk2"}],"filters":[{"op":"=","column":"evergreen.task.id","value":"task_12345"}],"start_time":1688756921,"end_time":1688760000}&omitMissingValues`
     );
   });
 });

--- a/src/constants/externalResources.test.ts
+++ b/src/constants/externalResources.test.ts
@@ -70,7 +70,7 @@ describe("getTaskSystemMetricsUrl", () => {
     expect(
       getHoneycombSystemMetricsUrl(
         "task_12345",
-        null,
+        [],
         new Date("2023-07-07T19:08:41"),
         new Date("2023-07-07T20:00:00")
       )
@@ -90,7 +90,7 @@ describe("getTaskSystemMetricsUrlWithDisks", () => {
         new Date("2023-07-07T20:00:00")
       )
     ).toBe(
-      `/datasets/evergreen?query={"calculations":[{"op":"AVG","column":"system.memory.usage.used"},{"op":"AVG","column":"system.cpu.utilization"},{"op":"RATE_AVG","column":"system.network.io.transmit"},{"op":"RATE_AVG","column":"system.network.io.receive"},{"op":"RATE_AVG","column":"system.disk.io.disk1.write"},{"op":"RATE_AVG","column":"system.disk.operations.disk1.read"},{"op":"RATE_AVG","column":"system.disk.operations.disk1.write"},{"op":"RATE_AVG","column":"system.disk.io_time.disk1"},{"op":"RATE_AVG","column":"system.disk.io.disk2.read"},{"op":"RATE_AVG","column":"system.disk.io.disk2.write"},{"op":"RATE_AVG","column":"system.disk.operations.disk2.read"},{"op":"RATE_AVG","column":"system.disk.operations.disk2.write"},{"op":"RATE_AVG","column":"system.disk.io_time.disk2"}],"filters":[{"op":"=","column":"evergreen.task.id","value":"task_12345"}],"start_time":1688756921,"end_time":1688760000}&omitMissingValues`
+      `/datasets/evergreen?query={"calculations":[{"op":"AVG","column":"system.memory.usage.used"},{"op":"AVG","column":"system.cpu.utilization"},{"op":"RATE_AVG","column":"system.network.io.transmit"},{"op":"RATE_AVG","column":"system.network.io.receive"},{"op":"RATE_AVG","column":"system.disk.io.disk1.read"},{"op":"RATE_AVG","column":"system.disk.io.disk1.write"},{"op":"RATE_AVG","column":"system.disk.operations.disk1.read"},{"op":"RATE_AVG","column":"system.disk.operations.disk1.write"},{"op":"RATE_AVG","column":"system.disk.io_time.disk1"},{"op":"RATE_AVG","column":"system.disk.io.disk2.read"},{"op":"RATE_AVG","column":"system.disk.io.disk2.write"},{"op":"RATE_AVG","column":"system.disk.operations.disk2.read"},{"op":"RATE_AVG","column":"system.disk.operations.disk2.write"},{"op":"RATE_AVG","column":"system.disk.io_time.disk2"}],"filters":[{"op":"=","column":"evergreen.task.id","value":"task_12345"}],"start_time":1688756921,"end_time":1688760000}&omitMissingValues`
     );
   });
 });

--- a/src/constants/externalResources.ts
+++ b/src/constants/externalResources.ts
@@ -114,6 +114,7 @@ export const getHoneycombTraceUrl = (
 
 export const getHoneycombSystemMetricsUrl = (
   taskId: string,
+  diskDevices: string[],
   startTs: Date,
   endTs: Date
 ): string => {
@@ -123,7 +124,20 @@ export const getHoneycombSystemMetricsUrl = (
       { op: "AVG", column: "system.cpu.utilization" },
       { op: "RATE_AVG", column: "system.network.io.transmit" },
       { op: "RATE_AVG", column: "system.network.io.receive" },
-    ],
+    ].concat(
+      diskDevices
+        .map((device) => [
+          { op: "RATE_AVG", column: `system.disk.io.${device}.read` },
+          { op: "RATE_AVG", column: `system.disk.io.${device}.write` },
+          { op: "RATE_AVG", column: `system.disk.operations.${device}.read` },
+          {
+            op: "RATE_AVG",
+            column: `system.disk.operations.${device}.write`,
+          },
+          { op: "RATE_AVG", column: `system.disk.io_time.${device}` },
+        ])
+        .flat()
+    ),
     filters: [{ op: "=", column: "evergreen.task.id", value: taskId }],
     start_time: getUnixTime(new Date(startTs)),
     end_time: getUnixTime(new Date(endTs)),

--- a/src/constants/externalResources.ts
+++ b/src/constants/externalResources.ts
@@ -125,18 +125,16 @@ export const getHoneycombSystemMetricsUrl = (
       { op: "RATE_AVG", column: "system.network.io.transmit" },
       { op: "RATE_AVG", column: "system.network.io.receive" },
     ].concat(
-      diskDevices
-        .map((device) => [
-          { op: "RATE_AVG", column: `system.disk.io.${device}.read` },
-          { op: "RATE_AVG", column: `system.disk.io.${device}.write` },
-          { op: "RATE_AVG", column: `system.disk.operations.${device}.read` },
-          {
-            op: "RATE_AVG",
-            column: `system.disk.operations.${device}.write`,
-          },
-          { op: "RATE_AVG", column: `system.disk.io_time.${device}` },
-        ])
-        .flat()
+      diskDevices.flatMap((device) => [
+        { op: "RATE_AVG", column: `system.disk.io.${device}.read` },
+        { op: "RATE_AVG", column: `system.disk.io.${device}.write` },
+        { op: "RATE_AVG", column: `system.disk.operations.${device}.read` },
+        {
+          op: "RATE_AVG",
+          column: `system.disk.operations.${device}.write`,
+        },
+        { op: "RATE_AVG", column: `system.disk.io_time.${device}` },
+      ])
     ),
     filters: [{ op: "=", column: "evergreen.task.id", value: taskId }],
     start_time: getUnixTime(new Date(startTs)),

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -2567,6 +2567,7 @@ export type TaskContainerCreationOpts = {
 export type TaskEndDetail = {
   __typename?: "TaskEndDetail";
   description?: Maybe<Scalars["String"]["output"]>;
+  diskDevices?: Maybe<Array<Maybe<Scalars["String"]["output"]>>>;
   oomTracker: OomTrackerInfo;
   status: Scalars["String"]["output"];
   timedOut?: Maybe<Scalars["Boolean"]["output"]>;
@@ -8510,6 +8511,7 @@ export type TaskQuery = {
     details?: {
       __typename?: "TaskEndDetail";
       description?: string | null;
+      diskDevices?: Array<string | null> | null;
       status: string;
       timedOut?: boolean | null;
       timeoutType?: string | null;

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -2567,7 +2567,7 @@ export type TaskContainerCreationOpts = {
 export type TaskEndDetail = {
   __typename?: "TaskEndDetail";
   description?: Maybe<Scalars["String"]["output"]>;
-  diskDevices?: Maybe<Array<Maybe<Scalars["String"]["output"]>>>;
+  diskDevices: Array<Scalars["String"]["output"]>;
   oomTracker: OomTrackerInfo;
   status: Scalars["String"]["output"];
   timedOut?: Maybe<Scalars["Boolean"]["output"]>;
@@ -8511,7 +8511,7 @@ export type TaskQuery = {
     details?: {
       __typename?: "TaskEndDetail";
       description?: string | null;
-      diskDevices?: Array<string | null> | null;
+      diskDevices: Array<string>;
       status: string;
       timedOut?: boolean | null;
       timeoutType?: string | null;

--- a/src/gql/queries/task.graphql
+++ b/src/gql/queries/task.graphql
@@ -46,6 +46,7 @@ query Task($taskId: String!, $execution: Int) {
     }
     details {
       description
+      diskDevices
       oomTracker {
         detected
         pids

--- a/src/pages/task/metadata/Metadata.test.tsx
+++ b/src/pages/task/metadata/Metadata.test.tsx
@@ -118,6 +118,7 @@ const taskSucceeded = {
       oomTracker: {
         detected: false,
       },
+      diskDevices: [],
     },
   },
 };

--- a/src/pages/task/metadata/index.tsx
+++ b/src/pages/task/metadata/index.tsx
@@ -93,6 +93,7 @@ export const Metadata: React.FC<Props> = ({ error, loading, task, taskId }) => {
   const { author, id: versionID } = versionMetadata ?? {};
   const oomTracker = details?.oomTracker;
   const taskTrace = details?.traceID;
+  const diskDevices = details?.diskDevices;
   const { id: podId } = pod ?? {};
   const isContainerTask = !!podId;
   const { metadataLinks } = annotation ?? {};
@@ -382,7 +383,12 @@ export const Metadata: React.FC<Props> = ({ error, loading, task, taskId }) => {
           </StyledLink>
           <StyledLink
             data-cy="task-metrics-link"
-            href={getHoneycombSystemMetricsUrl(taskId, startTime, finishTime)}
+            href={getHoneycombSystemMetricsUrl(
+              taskId,
+              diskDevices,
+              startTime,
+              finishTime
+            )}
             onClick={() => {
               onHideCue();
               taskAnalytics.sendEvent({ name: "Click Trace Metrics Link" });


### PR DESCRIPTION
[DEVPROD-1661](https://jira.mongodb.org/browse/DEVPROD-1661)

### Description
This ought to be the last of the PRs for this feature. This modifies the Honeycomb system metrics link to include disk stats for the disk names that were recorded when a task finished running.

### Screenshots
N/A

### Testing
[This query](https://ui.honeycomb.io/mongodb-4b/environments/staging/datasets/evergreen/result/kNsjoK2xqau?omitMissingValues) got generated for a task with a distro that had two disk devices configured.

### Evergreen PR
https://github.com/evergreen-ci/evergreen/pull/7308
