### PR TITLE
DEVPROD-2253: Mark Evergreen commit queue as deprecated

### DIFF
--- a/src/pages/projectSettings/tabs/GithubCommitQueueTab/getFormSchema.tsx
+++ b/src/pages/projectSettings/tabs/GithubCommitQueueTab/getFormSchema.tsx
@@ -226,15 +226,15 @@ export const getFormSchema = (
                           oneOf: [
                             {
                               type: "string" as "string",
-                              title: "Evergreen",
-                              enum: [MergeQueue.Evergreen],
-                              description: "Evergreen's commit queue.",
-                            },
-                            {
-                              type: "string" as "string",
                               title: "GitHub",
                               enum: [MergeQueue.Github],
                               description: "GitHub's merge queue.",
+                            },
+                            {
+                              type: "string" as "string",
+                              title: "Evergreen (deprecated)",
+                              enum: [MergeQueue.Evergreen],
+                              description: "Evergreen's commit queue.",
                             },
                           ],
                         },


### PR DESCRIPTION
DEVPROD-2253

### Description
<!-- add description, context, thought process, etc -->
- Mark Evergreen commit queue as deprecated

### Screenshots
<!-- add screenshots of visible changes -->
<img width="643" alt="image" src="https://github.com/evergreen-ci/spruce/assets/9298431/4d08454d-ac43-4107-86d6-5e44fa6c5737">