### PR TITLE
DEVPROD-820 Support displaying sub 1s durations on the tests table

### DIFF
--- a/src/utils/string/index.ts
+++ b/src/utils/string/index.ts
@@ -28,6 +28,7 @@ export const msToDuration = (ms: number): string => {
   if (seconds > 0) {
     return `${seconds}s`;
   }
+  return `${ms}ms`;
 };
 
 /**

--- a/src/utils/string/string.test.ts
+++ b/src/utils/string/string.test.ts
@@ -44,6 +44,10 @@ describe("msToDuration", () => {
     const ms = 25000;
     expect(msToDuration(ms)).toBe("25s");
   });
+  it("does not convert milli < 1s", () => {
+    const ms = 500;
+    expect(msToDuration(ms)).toBe("500ms");
+  });
 });
 
 describe("sortFunctionDate", () => {


### PR DESCRIPTION
DEVPROD-820

### Description
`msToDuration` did not return any thing when the duration was below 1s so this corrects that and will return the ms unit.

### Screenshots
<img width="1190" alt="image" src="https://github.com/evergreen-ci/spruce/assets/4605522/65a3ee5e-fc61-4513-8735-05432db9a0c1">

### Testing
Unit tests and tested on the task provided in the ticket

