### PR TITLE
DEVPROD-1134: Add project link to configure patch page

### DIFF
--- a/src/gql/mocks/taskData.ts
+++ b/src/gql/mocks/taskData.ts
@@ -17,6 +17,7 @@ export const taskQuery: TaskQuery = {
     details: {
       description:
         "Long description that requirese use of the inline definition component. This would include details about where the task failed.",
+      diskDevices: [],
       oomTracker: {
         detected: false,
       },

--- a/src/pages/configurePatch/configurePatchCore/index.tsx
+++ b/src/pages/configurePatch/configurePatchCore/index.tsx
@@ -12,9 +12,14 @@ import {
   MetadataItem,
   MetadataTitle,
 } from "components/MetadataCard";
-import { PageContent, PageLayout, PageSider } from "components/styles";
+import {
+  StyledRouterLink,
+  PageContent,
+  PageLayout,
+  PageSider,
+} from "components/styles";
 import { StyledTabs } from "components/styles/StyledTabs";
-import { getVersionRoute } from "constants/routes";
+import { getProjectPatchesRoute, getVersionRoute } from "constants/routes";
 import { fontSize, size } from "constants/tokens";
 import { useToastContext } from "context/toast";
 import {
@@ -53,6 +58,7 @@ const ConfigurePatchCore: React.FC<ConfigurePatchCoreProps> = ({ patch }) => {
     id,
     patchTriggerAliases,
     project,
+    projectIdentifier,
     time,
     variantsTasks,
   } = patch;
@@ -183,6 +189,12 @@ const ConfigurePatchCore: React.FC<ConfigurePatchCoreProps> = ({ patch }) => {
             <MetadataTitle>Patch Metadata</MetadataTitle>
             <MetadataItem>Submitted by: {author}</MetadataItem>
             <MetadataItem>Submitted at: {time.submittedAt}</MetadataItem>
+            <MetadataItem>
+              Project:{" "}
+              <StyledRouterLink to={getProjectPatchesRoute(projectIdentifier)}>
+                {projectIdentifier}
+              </StyledRouterLink>
+            </MetadataItem>
           </MetadataCard>
           <ConfigureBuildVariants
             variants={getVariantEntries(variants, selectedBuildVariantTasks)}


### PR DESCRIPTION
DEVPROD-1134

### Description
<!-- add description, context, thought process, etc -->
Indicate project associated with patch on the configure tasks page

### Screenshots
<!-- add screenshots of visible changes -->
<img width="1366" alt="image" src="https://github.com/evergreen-ci/spruce/assets/9298431/d7ec0053-ccb0-4e18-873f-2d24897fbaaa">