### PR TITLE
DEVPROD-1134 fix: Remove duplicate key

### DIFF
--- a/src/gql/mocks/taskData.ts
+++ b/src/gql/mocks/taskData.ts
@@ -23,7 +23,6 @@ export const taskQuery: TaskQuery = {
       },
       status: TaskStatus.Failed,
       type: "type",
-      diskDevices: [],
     },
     timeTaken: null,
     annotation: null,


### PR DESCRIPTION
My PR #2194 introduced a field that had already been added to the mock. This should fix the waterfall.
