### PR TITLE
DEVPROD-2227: Remove family triggers from trigger definitions

### DIFF
--- a/cypress/integration/projectSettings/notifications.ts
+++ b/cypress/integration/projectSettings/notifications.ts
@@ -16,7 +16,7 @@ describe("Notifications", () => {
     cy.dataCy("add-button").contains("Add Subscription").should("be.visible");
     cy.dataCy("add-button").click();
     cy.dataCy("expandable-card").should("contain.text", "New Subscription");
-    cy.selectLGOption("Event", "Any Version Finishes");
+    cy.selectLGOption("Event", "Any version finishes");
     cy.selectLGOption("Notification Method", "Email");
     cy.getInputByLabel("Email").type("mohamed.khelif@mongodb.com");
     cy.dataCy("save-settings-button").scrollIntoView();
@@ -43,7 +43,7 @@ describe("Notifications", () => {
     cy.dataCy("expandable-card")
       .should("be.visible")
       .should("contain.text", "New Subscription");
-    cy.selectLGOption("Event", "Any Task Finishes");
+    cy.selectLGOption("Event", "Any task finishes");
     cy.selectLGOption("Notification Method", "Comment on a JIRA issue");
     cy.getInputByLabel("JIRA Issue").type("JIRA-123");
     cy.contains("Subscription type not allowed for tasks in a project.").should(
@@ -58,7 +58,7 @@ describe("Notifications", () => {
     cy.dataCy("expandable-card")
       .should("be.visible")
       .should("contain.text", "New Subscription");
-    cy.selectLGOption("Event", "Any Version Finishes");
+    cy.selectLGOption("Event", "Any version finishes");
     cy.selectLGOption("Notification Method", "Email");
     cy.getInputByLabel("Email").type("Not a real email");
     cy.contains("Value should be a valid email.").should("be.visible");

--- a/cypress/integration/subscription_modal.ts
+++ b/cypress/integration/subscription_modal.ts
@@ -146,7 +146,7 @@ describe("Waterfall subscription modal", () => {
     cy.dataCy("add-notification").click();
     cy.dataCy(dataCyModal).should("be.visible");
 
-    cy.selectLGOption("Event", "Any Version Finishes");
+    cy.selectLGOption("Event", "Any version finishes");
     cy.selectLGOption("Notification Method", "JIRA issue");
 
     cy.dataCy("jira-comment-input").type("EVG-2000");
@@ -160,7 +160,7 @@ describe("Waterfall subscription modal", () => {
     cy.dataCy("add-notification").click();
     cy.dataCy(dataCyModal).should("be.visible");
 
-    cy.selectLGOption("Event", "Any Build Finishes");
+    cy.selectLGOption("Event", "Any build finishes");
     cy.dataCy("add-button").click();
     saveButtonEnabled(false);
 
@@ -179,7 +179,7 @@ describe("Waterfall subscription modal", () => {
     cy.dataCy("add-notification").click();
     cy.dataCy(dataCyModal).should("be.visible");
 
-    cy.selectLGOption("Event", "Any Version Finishes");
+    cy.selectLGOption("Event", "Any version finishes");
     cy.dataCy("jira-comment-input").type("EVG-2000");
     mockErrorResponse({
       path: "SaveSubscription",
@@ -207,7 +207,7 @@ describe("Waterfall subscription modal", () => {
     cy.dataCy("waterfall-menu").click();
     cy.dataCy("add-notification").click();
     cy.dataCy(dataCyModal).should("be.visible");
-    cy.contains("Any Build Fails").should("be.visible");
+    cy.contains("Any build fails").should("be.visible");
     cy.contains("Slack").should("be.visible");
 
     cy.clearCookie(subscriptionCookie);

--- a/src/components/Notifications/utils.test.ts
+++ b/src/components/Notifications/utils.test.ts
@@ -106,7 +106,7 @@ describe("getGqlPayload", () => {
         type: "email",
         target: "fake.user@mongodb.com",
       },
-      trigger: "family-outcome",
+      trigger: "outcome",
       trigger_data: {},
     });
   });

--- a/src/constants/triggers.ts
+++ b/src/constants/triggers.ts
@@ -309,7 +309,7 @@ export const projectTriggers: Trigger = {
   [ProjectTriggers.SUCCESSFUL_TASK_EXCEEDS_DURATION]: {
     trigger: TriggerType.SUCCESSFUL_EXCEEDS_DURATION,
     resourceType: ResourceType.Task,
-    label: "The runtime For a successful task exceeds some duration",
+    label: "The runtime for a successful task exceeds some duration",
     regexSelectors: taskRegexSelectors,
     extraFields: [
       {

--- a/src/constants/triggers.ts
+++ b/src/constants/triggers.ts
@@ -135,19 +135,19 @@ export const taskTriggers: Trigger = {
 // VERSION TRIGGERS
 export const versionTriggers: Trigger = {
   [VersionTriggers.VERSION_FINISHES]: {
-    trigger: TriggerType.FAMILY_OUTCOME,
+    trigger: TriggerType.OUTCOME,
     label: "This version finishes",
     resourceType: ResourceType.Version,
     payloadResourceIdKey: "id",
   },
   [VersionTriggers.VERSION_FAILS]: {
-    trigger: TriggerType.FAMILY_FAILURE,
+    trigger: TriggerType.FAILURE,
     label: "This version fails",
     resourceType: ResourceType.Version,
     payloadResourceIdKey: "id",
   },
   [VersionTriggers.VERSION_SUCCEEDS]: {
-    trigger: TriggerType.FAMILY_SUCCESS,
+    trigger: TriggerType.SUCCESS,
     label: "This version succeeds",
     resourceType: ResourceType.Version,
     payloadResourceIdKey: "id",
@@ -207,70 +207,70 @@ export const versionTriggers: Trigger = {
 
 export const projectTriggers: Trigger = {
   [ProjectTriggers.ANY_VERSION_FINISHES]: {
-    trigger: TriggerType.FAMILY_OUTCOME,
+    trigger: TriggerType.OUTCOME,
     resourceType: ResourceType.Version,
-    label: "Any Version Finishes",
+    label: "Any version finishes",
     extraFields: [requesterSubscriberConfig],
   },
   [ProjectTriggers.ANY_VERSION_FAILS]: {
-    trigger: TriggerType.FAMILY_FAILURE,
+    trigger: TriggerType.FAILURE,
     resourceType: ResourceType.Version,
-    label: "Any Version Fails",
+    label: "Any version fails",
     extraFields: [requesterSubscriberConfig],
   },
   [ProjectTriggers.ANY_BUILD_FINISHES]: {
     trigger: TriggerType.OUTCOME,
     resourceType: ResourceType.Build,
-    label: "Any Build Finishes",
+    label: "Any build finishes",
     regexSelectors: buildRegexSelectors,
     extraFields: [requesterSubscriberConfig],
   },
   [ProjectTriggers.ANY_BUILD_FAILS]: {
     trigger: TriggerType.FAILURE,
     resourceType: ResourceType.Build,
-    label: "Any Build Fails",
+    label: "Any build fails",
     regexSelectors: buildRegexSelectors,
     extraFields: [requesterSubscriberConfig],
   },
   [ProjectTriggers.ANY_TASK_FINISHES]: {
     trigger: TriggerType.OUTCOME,
     resourceType: ResourceType.Task,
-    label: "Any Task Finishes",
+    label: "Any task finishes",
     regexSelectors: taskRegexSelectors,
     extraFields: [requesterSubscriberConfig],
   },
   [ProjectTriggers.ANY_TASK_FAILS]: {
     trigger: TriggerType.FAILURE,
     resourceType: ResourceType.Task,
-    label: "Any Task Fails",
+    label: "Any task fails",
     regexSelectors: taskRegexSelectors,
     extraFields: [failureTypeSubscriberConfig, requesterSubscriberConfig],
   },
   [ProjectTriggers.FIRST_FAILURE_VERSION]: {
     trigger: TriggerType.FIRST_FAILURE_VERSION,
     resourceType: ResourceType.Task,
-    label: "The First Failure In a Version Occurs",
+    label: "The first failure in a version occurs",
     regexSelectors: taskRegexSelectors,
     extraFields: [requesterSubscriberConfig],
   },
   [ProjectTriggers.FIRST_FAILURE_BUILD]: {
     trigger: TriggerType.FIRST_FAILURE_BUILD,
     resourceType: ResourceType.Task,
-    label: "The First Failure In Each Build Occurs",
+    label: "The first failure in each build occurs",
     regexSelectors: taskRegexSelectors,
     extraFields: [requesterSubscriberConfig],
   },
   [ProjectTriggers.FIRST_FAILURE_TASK]: {
     trigger: TriggerType.FIRST_FAILURE_VERSION_NAME,
     resourceType: ResourceType.Task,
-    label: "The First Failure In Each Version For Each Task Name Occurs",
+    label: "The first failure in each version for each task name occurs",
     regexSelectors: taskRegexSelectors,
     extraFields: [requesterSubscriberConfig],
   },
   [ProjectTriggers.PREVIOUS_PASSING_TASK_FAILS]: {
     trigger: TriggerType.REGRESSION,
     resourceType: ResourceType.Task,
-    label: "A Previously Passing Task Fails",
+    label: "A previously passing task fails",
     regexSelectors: taskRegexSelectors,
     extraFields: [
       {
@@ -286,7 +286,7 @@ export const projectTriggers: Trigger = {
   [ProjectTriggers.PREVIOUS_PASSING_TEST_FAILS]: {
     trigger: TriggerType.TEST_REGRESSION,
     resourceType: ResourceType.Task,
-    label: "A Previously Passing Test In a Task Fails",
+    label: "A previously passing test in a task fails",
     regexSelectors: taskRegexSelectors,
     extraFields: [
       {
@@ -309,7 +309,7 @@ export const projectTriggers: Trigger = {
   [ProjectTriggers.SUCCESSFUL_TASK_EXCEEDS_DURATION]: {
     trigger: TriggerType.SUCCESSFUL_EXCEEDS_DURATION,
     resourceType: ResourceType.Task,
-    label: "The Runtime For a Successful Task Exceeds Some Duration",
+    label: "The runtime For a successful task exceeds some duration",
     regexSelectors: taskRegexSelectors,
     extraFields: [
       {
@@ -324,7 +324,7 @@ export const projectTriggers: Trigger = {
   [ProjectTriggers.TASK_EXCEEDS_DURATION]: {
     trigger: TriggerType.EXCEEDS_DURATION,
     resourceType: ResourceType.Task,
-    label: "The Runtime For Any Task Exceeds Some Duration",
+    label: "The runtime for any task exceeds some duration",
     regexSelectors: taskRegexSelectors,
     extraFields: [
       {
@@ -339,7 +339,7 @@ export const projectTriggers: Trigger = {
   [ProjectTriggers.SUCCESSFUL_TASK_RUNTIME_CHANGES]: {
     trigger: TriggerType.RUNTIME_CHANGE,
     resourceType: ResourceType.Task,
-    label: "The Runtime For a Successful Task Changes By Some Percentage",
+    label: "The runtime for a successful task changes by some percentage",
     regexSelectors: taskRegexSelectors,
     extraFields: [
       {
@@ -355,41 +355,41 @@ export const projectTriggers: Trigger = {
 
 export const waterfallTriggers: Trigger = {
   [ProjectTriggers.ANY_VERSION_FINISHES]: {
-    trigger: TriggerType.FAMILY_OUTCOME,
+    trigger: TriggerType.OUTCOME,
     resourceType: ResourceType.Version,
-    label: "Any Version Finishes",
+    label: "Any version finishes",
     extraFields: [requesterSubscriberConfig],
   },
   [ProjectTriggers.ANY_VERSION_FAILS]: {
-    trigger: TriggerType.FAMILY_FAILURE,
+    trigger: TriggerType.FAILURE,
     resourceType: ResourceType.Version,
-    label: "Any Version Fails",
+    label: "Any version fails",
     extraFields: [requesterSubscriberConfig],
   },
   [ProjectTriggers.ANY_VERSION_SUCCEEDS]: {
-    trigger: TriggerType.FAMILY_SUCCESS,
+    trigger: TriggerType.SUCCESS,
     resourceType: ResourceType.Version,
-    label: "Any Version Succeeds",
+    label: "Any version succeeds",
     extraFields: [requesterSubscriberConfig],
   },
   [ProjectTriggers.ANY_BUILD_FINISHES]: {
     trigger: TriggerType.OUTCOME,
     resourceType: ResourceType.Build,
-    label: "Any Build Finishes",
+    label: "Any build finishes",
     regexSelectors: buildRegexSelectors,
     extraFields: [requesterSubscriberConfig],
   },
   [ProjectTriggers.ANY_BUILD_FAILS]: {
     trigger: TriggerType.FAILURE,
     resourceType: ResourceType.Build,
-    label: "Any Build Fails",
+    label: "Any build fails",
     regexSelectors: buildRegexSelectors,
     extraFields: [requesterSubscriberConfig],
   },
   [ProjectTriggers.ANY_BUILD_SUCCEEDS]: {
     trigger: TriggerType.SUCCESS,
     resourceType: ResourceType.Build,
-    label: "Any Build Succeeds",
+    label: "Any build succeeds",
     regexSelectors: buildRegexSelectors,
     extraFields: [requesterSubscriberConfig],
   },
@@ -418,9 +418,6 @@ export const triggerToCopy = {
   [TriggerType.OUTCOME]: "Outcome",
   [TriggerType.FAILURE]: "Failure",
   [TriggerType.SUCCESS]: "Success",
-  [TriggerType.FAMILY_OUTCOME]: "Outcome",
-  [TriggerType.FAMILY_FAILURE]: "Failure",
-  [TriggerType.FAMILY_SUCCESS]: "Success",
   [TriggerType.RUNTIME_CHANGE]: "Runtime changes by %",
   [TriggerType.EXCEEDS_DURATION]: "Runtime exceeds duration",
   [TriggerType.SUCCESSFUL_EXCEEDS_DURATION]: "Runtime exceeds duration",
@@ -428,14 +425,16 @@ export const triggerToCopy = {
   [TriggerType.TASK_FAILED_OR_BLOCKED]: "Task failed or blocked",
   [TriggerType.REGRESSION]: "Regression",
   [TriggerType.TEST_REGRESSION]: "Test regression",
-  [TriggerType.FIRST_FAILURE_BUILD]: "First failure",
   [TriggerType.FIRST_FAILURE_BUILD]: "First failure in build",
   [TriggerType.FIRST_FAILURE_VERSION]: "First failure in version",
   [TriggerType.FIRST_FAILURE_VERSION_NAME]:
     "First failure in version with name",
+  [TriggerType.FAMILY_OUTCOME]: "Outcome",
+  [TriggerType.FAMILY_FAILURE]: "Failure",
+  [TriggerType.FAMILY_SUCCESS]: "Success",
 };
 
-export const convertFamilyTrigger = (trigger: string) => {
+export const fromFamilyTrigger = (trigger: string) => {
   switch (trigger) {
     case TriggerType.FAMILY_OUTCOME:
       return TriggerType.OUTCOME;

--- a/src/constants/triggers.ts
+++ b/src/constants/triggers.ts
@@ -434,7 +434,12 @@ export const triggerToCopy = {
   [TriggerType.FAMILY_SUCCESS]: "Success",
 };
 
-export const fromFamilyTrigger = (trigger: string) => {
+/**
+ * Converts a family trigger into a non-family trigger.
+ * @param trigger - string representing a trigger. It may or may not be a family trigger.
+ * @returns string representing a non-family trigger
+ */
+export const convertFromFamilyTrigger = (trigger: string) => {
   switch (trigger) {
     case TriggerType.FAMILY_OUTCOME:
       return TriggerType.OUTCOME;

--- a/src/pages/preferences/preferencesTabs/notificationTab/useSubscriptionData.tsx
+++ b/src/pages/preferences/preferencesTabs/notificationTab/useSubscriptionData.tsx
@@ -3,7 +3,7 @@ import { useQuery } from "@apollo/client";
 import styled from "@emotion/styled";
 import { LeafyGreenTableRow } from "@leafygreen-ui/table";
 import { size } from "constants/tokens";
-import { fromFamilyTrigger } from "constants/triggers";
+import { convertFromFamilyTrigger } from "constants/triggers";
 import {
   UserSubscriptionsQuery,
   UserSubscriptionsQueryVariables,
@@ -61,7 +61,7 @@ const processSubscriptionData = (
       // For this table's purposes, FAMILY_TRIGGER = TRIGGER. Convert all family triggers to their base type.
       .map(({ trigger, ...subscription }) => ({
         ...subscription,
-        trigger: fromFamilyTrigger(trigger),
+        trigger: convertFromFamilyTrigger(trigger),
       }))
       // For subscriptions that contain regex selectors or additional trigger data, append an expandable section
       .map((subscription) => {

--- a/src/pages/preferences/preferencesTabs/notificationTab/useSubscriptionData.tsx
+++ b/src/pages/preferences/preferencesTabs/notificationTab/useSubscriptionData.tsx
@@ -3,7 +3,7 @@ import { useQuery } from "@apollo/client";
 import styled from "@emotion/styled";
 import { LeafyGreenTableRow } from "@leafygreen-ui/table";
 import { size } from "constants/tokens";
-import { convertFamilyTrigger } from "constants/triggers";
+import { fromFamilyTrigger } from "constants/triggers";
 import {
   UserSubscriptionsQuery,
   UserSubscriptionsQueryVariables,
@@ -61,7 +61,7 @@ const processSubscriptionData = (
       // For this table's purposes, FAMILY_TRIGGER = TRIGGER. Convert all family triggers to their base type.
       .map(({ trigger, ...subscription }) => ({
         ...subscription,
-        trigger: convertFamilyTrigger(trigger),
+        trigger: fromFamilyTrigger(trigger),
       }))
       // For subscriptions that contain regex selectors or additional trigger data, append an expandable section
       .map((subscription) => {

--- a/src/pages/projectSettings/tabs/NotificationsTab/getGqlPayload.test.ts
+++ b/src/pages/projectSettings/tabs/NotificationsTab/getGqlPayload.test.ts
@@ -38,7 +38,7 @@ describe("getGqlPayload", () => {
           webhookSubscriber: undefined,
           jiraIssueSubscriber: undefined,
         },
-        trigger: "family-outcome",
+        trigger: "outcome",
         trigger_data: { requester: "gitter_request" },
       },
     ]);
@@ -150,7 +150,7 @@ describe("getGqlPayload", () => {
         webhookSubscriber: undefined,
         jiraIssueSubscriber: undefined,
       },
-      trigger: "family-failure",
+      trigger: "failure",
       trigger_data: { requester: "ad_hoc" },
     });
   });

--- a/src/pages/projectSettings/tabs/NotificationsTab/transformers.test.ts
+++ b/src/pages/projectSettings/tabs/NotificationsTab/transformers.test.ts
@@ -80,7 +80,7 @@ describe("project data", () => {
             jiraIssueSubscriber: undefined,
             webhookSubscriber: undefined,
           },
-          trigger: "family-outcome",
+          trigger: "outcome",
           trigger_data: {
             requester: "gitter_request",
           },
@@ -143,7 +143,7 @@ describe("project data", () => {
             },
             webhookSubscriber: undefined,
           },
-          trigger: "family-outcome",
+          trigger: "outcome",
           trigger_data: {
             requester: "gitter_request",
           },
@@ -222,7 +222,7 @@ describe("project data", () => {
               ],
             },
           },
-          trigger: "family-outcome",
+          trigger: "outcome",
           trigger_data: {
             requester: "gitter_request",
           },

--- a/src/pages/projectSettings/tabs/NotificationsTab/transformers.ts
+++ b/src/pages/projectSettings/tabs/NotificationsTab/transformers.ts
@@ -1,6 +1,6 @@
 import { ProjectSettingsTabRoutes } from "constants/routes";
 import { getSubscriberText } from "constants/subscription";
-import { fromFamilyTrigger, projectTriggers } from "constants/triggers";
+import { convertFromFamilyTrigger, projectTriggers } from "constants/triggers";
 import {
   BannerTheme,
   ProjectInput,
@@ -16,19 +16,17 @@ type Tab = ProjectSettingsTabRoutes.Notifications;
 const { toSentenceCase } = string;
 
 const getTriggerText = (trigger: string, resourceType: string) => {
-  const convertedTrigger = fromFamilyTrigger(trigger);
   const triggerText =
     resourceType && trigger
-      ? `${toSentenceCase(resourceType)} ${convertedTrigger} `
+      ? `${toSentenceCase(resourceType)} ${convertFromFamilyTrigger(trigger)} `
       : "";
   return triggerText;
 };
 
 const getTriggerEnum = (trigger: string, resourceType: string) => {
-  const convertedTrigger = fromFamilyTrigger(trigger);
   const triggerEnum = Object.keys(projectTriggers).find(
     (t) =>
-      projectTriggers[t].trigger === convertedTrigger &&
+      projectTriggers[t].trigger === convertFromFamilyTrigger(trigger) &&
       projectTriggers[t].resourceType === resourceType
   );
   return triggerEnum;

--- a/src/pages/projectSettings/tabs/NotificationsTab/transformers.ts
+++ b/src/pages/projectSettings/tabs/NotificationsTab/transformers.ts
@@ -1,6 +1,6 @@
 import { ProjectSettingsTabRoutes } from "constants/routes";
 import { getSubscriberText } from "constants/subscription";
-import { convertFamilyTrigger, projectTriggers } from "constants/triggers";
+import { fromFamilyTrigger, projectTriggers } from "constants/triggers";
 import {
   BannerTheme,
   ProjectInput,
@@ -16,7 +16,7 @@ type Tab = ProjectSettingsTabRoutes.Notifications;
 const { toSentenceCase } = string;
 
 const getTriggerText = (trigger: string, resourceType: string) => {
-  const convertedTrigger = convertFamilyTrigger(trigger);
+  const convertedTrigger = fromFamilyTrigger(trigger);
   const triggerText =
     resourceType && trigger
       ? `${toSentenceCase(resourceType)} ${convertedTrigger} `
@@ -25,9 +25,10 @@ const getTriggerText = (trigger: string, resourceType: string) => {
 };
 
 const getTriggerEnum = (trigger: string, resourceType: string) => {
+  const convertedTrigger = fromFamilyTrigger(trigger);
   const triggerEnum = Object.keys(projectTriggers).find(
     (t) =>
-      projectTriggers[t].trigger === trigger &&
+      projectTriggers[t].trigger === convertedTrigger &&
       projectTriggers[t].resourceType === resourceType
   );
   return triggerEnum;

--- a/src/types/triggers.ts
+++ b/src/types/triggers.ts
@@ -28,7 +28,7 @@ export enum TriggerType {
   FIRST_FAILURE_VERSION = "first-failure-in-version",
   FIRST_FAILURE_VERSION_NAME = "first-failure-in-version-with-name",
 
-  // Family triggers are for patches with child patches.
+  // Family triggers are for patches only.
   FAMILY_OUTCOME = "family-outcome",
   FAMILY_FAILURE = "family-failure",
   FAMILY_SUCCESS = "family-success",

--- a/src/types/triggers.ts
+++ b/src/types/triggers.ts
@@ -17,9 +17,6 @@ export enum TriggerType {
   OUTCOME = "outcome",
   FAILURE = "failure",
   SUCCESS = "success",
-  FAMILY_OUTCOME = "family-outcome",
-  FAMILY_FAILURE = "family-failure",
-  FAMILY_SUCCESS = "family-success",
   RUNTIME_CHANGE = "runtime-change",
   EXCEEDS_DURATION = "exceeds-duration",
   SUCCESSFUL_EXCEEDS_DURATION = "successful-exceeds-duration",
@@ -30,6 +27,11 @@ export enum TriggerType {
   FIRST_FAILURE_BUILD = "first-failure-in-build",
   FIRST_FAILURE_VERSION = "first-failure-in-version",
   FIRST_FAILURE_VERSION_NAME = "first-failure-in-version-with-name",
+
+  // Family triggers are for patches with child patches.
+  FAMILY_OUTCOME = "family-outcome",
+  FAMILY_FAILURE = "family-failure",
+  FAMILY_SUCCESS = "family-success",
 }
 
 export enum TaskTriggers {


### PR DESCRIPTION
DEVPROD-2227

### Description
This PR removes the usage of family triggers from the trigger definitions. 

It's too complicated to process which trigger we need to assign in the frontend. The notifications are already quite tricky and they would become even harder to understand if we added another layer of complexity. Instead, we will make up for it by doing some extra processing in the backend.

### Evergreen PR
* evergreen-ci/evergreen/pull/7333
