### PR TITLE
DEVPROD-1122 Add stepback information to task metadata

### DIFF
--- a/src/analytics/task/useTaskAnalytics.ts
+++ b/src/analytics/task/useTaskAnalytics.ts
@@ -70,6 +70,10 @@ type Action =
     }
   | { name: "Click Trace Link" }
   | { name: "Click Trace Metrics Link" }
+  | { name: "Click Last Passing Stepback Task Link" }
+  | { name: "Click Last Failing Stepback Task Link" }
+  | { name: "Click Previous Stepback Task Link" }
+  | { name: "Click Next Stepback Task Link" }
   | { name: "Submit Previous Commit Selector"; type: CommitType };
 
 export const useTaskAnalytics = () => {

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -2418,6 +2418,14 @@ export type StatusCount = {
   status: Scalars["String"]["output"];
 };
 
+export type StepbackInfo = {
+  __typename?: "StepbackInfo";
+  lastFailingStepbackTaskId?: Maybe<Scalars["String"]["output"]>;
+  lastPassingStepbackTaskId?: Maybe<Scalars["String"]["output"]>;
+  nextStepbackTaskId?: Maybe<Scalars["String"]["output"]>;
+  previousStepbackTaskId?: Maybe<Scalars["String"]["output"]>;
+};
+
 export type Subscriber = {
   __typename?: "Subscriber";
   emailSubscriber?: Maybe<Scalars["String"]["output"]>;
@@ -2526,6 +2534,7 @@ export type Task = {
   spawnHostLink?: Maybe<Scalars["String"]["output"]>;
   startTime?: Maybe<Scalars["Time"]["output"]>;
   status: Scalars["String"]["output"];
+  stepbackInfo?: Maybe<StepbackInfo>;
   /** @deprecated Use files instead */
   taskFiles: TaskFiles;
   taskGroup?: Maybe<Scalars["String"]["output"]>;
@@ -8562,6 +8571,13 @@ export type TaskQuery = {
     };
     pod?: { __typename?: "Pod"; id: string } | null;
     project?: { __typename?: "Project"; id: string; identifier: string } | null;
+    stepbackInfo?: {
+      __typename?: "StepbackInfo";
+      lastFailingStepbackTaskId?: string | null;
+      lastPassingStepbackTaskId?: string | null;
+      nextStepbackTaskId?: string | null;
+      previousStepbackTaskId?: string | null;
+    } | null;
     versionMetadata: {
       __typename?: "Version";
       author: string;

--- a/src/gql/queries/task.graphql
+++ b/src/gql/queries/task.graphql
@@ -107,6 +107,12 @@ query Task($taskId: String!, $execution: Int) {
     resetWhenFinished
     spawnHostLink
     startTime
+    stepbackInfo {
+      lastFailingStepbackTaskId
+      lastPassingStepbackTaskId
+      nextStepbackTaskId
+      previousStepbackTaskId
+    }
     timeTaken
     totalTestCount
     versionMetadata {

--- a/src/pages/task/metadata/index.tsx
+++ b/src/pages/task/metadata/index.tsx
@@ -79,6 +79,7 @@ export const Metadata: React.FC<Props> = ({ error, loading, task, taskId }) => {
     spawnHostLink,
     startTime,
     status,
+    stepbackInfo,
     timeTaken,
     versionMetadata,
   } = task || {};
@@ -401,6 +402,70 @@ export const Metadata: React.FC<Props> = ({ error, loading, task, taskId }) => {
           >
             Honeycomb System Metrics
           </StyledLink>
+        </MetadataItem>
+      )}
+      {stepbackInfo?.lastPassingStepbackTaskId && (
+        <>
+          <MetadataItem>
+            Last Passing Stepback Task:{" "}
+            <StyledRouterLink
+              data-cy="last-passing-stepback-task-link"
+              to={getTaskRoute(stepbackInfo.lastPassingStepbackTaskId)}
+              onClick={() =>
+                taskAnalytics.sendEvent({
+                  name: "Click Last Passing Stepback Task Link",
+                })
+              }
+            >
+              {stepbackInfo.lastPassingStepbackTaskId}
+            </StyledRouterLink>
+          </MetadataItem>
+          <MetadataItem>
+            Last Failing Stepback Task:{" "}
+            <StyledRouterLink
+              data-cy="last-failing-stepback-task-link"
+              to={getTaskRoute(stepbackInfo.lastFailingStepbackTaskId)}
+              onClick={() =>
+                taskAnalytics.sendEvent({
+                  name: "Click Last Failing Stepback Task Link",
+                })
+              }
+            >
+              {stepbackInfo.lastFailingStepbackTaskId}
+            </StyledRouterLink>
+          </MetadataItem>
+        </>
+      )}
+      {stepbackInfo?.previousStepbackTaskId && (
+        <MetadataItem>
+          Previous Stepback Task:{" "}
+          <StyledRouterLink
+            data-cy="previous-stepback-task-link"
+            to={getTaskRoute(stepbackInfo.previousStepbackTaskId)}
+            onClick={() =>
+              taskAnalytics.sendEvent({
+                name: "Click Previous Stepback Task Link",
+              })
+            }
+          >
+            {stepbackInfo.previousStepbackTaskId}
+          </StyledRouterLink>
+        </MetadataItem>
+      )}
+      {stepbackInfo?.nextStepbackTaskId && (
+        <MetadataItem>
+          Next Stepback Task:{" "}
+          <StyledRouterLink
+            data-cy="next-stepback-task-link"
+            to={getTaskRoute(stepbackInfo.nextStepbackTaskId)}
+            onClick={() =>
+              taskAnalytics.sendEvent({
+                name: "Click Next Stepback Task Link",
+              })
+            }
+          >
+            {stepbackInfo.nextStepbackTaskId}
+          </StyledRouterLink>
         </MetadataItem>
       )}
     </MetadataCard>

--- a/src/pages/task/metadata/index.tsx
+++ b/src/pages/task/metadata/index.tsx
@@ -409,7 +409,6 @@ export const Metadata: React.FC<Props> = ({ error, loading, task, taskId }) => {
           <MetadataItem>
             Last Passing Stepback Task:{" "}
             <StyledRouterLink
-              data-cy="last-passing-stepback-task-link"
               to={getTaskRoute(stepbackInfo.lastPassingStepbackTaskId)}
               onClick={() =>
                 taskAnalytics.sendEvent({
@@ -423,7 +422,6 @@ export const Metadata: React.FC<Props> = ({ error, loading, task, taskId }) => {
           <MetadataItem>
             Last Failing Stepback Task:{" "}
             <StyledRouterLink
-              data-cy="last-failing-stepback-task-link"
               to={getTaskRoute(stepbackInfo.lastFailingStepbackTaskId)}
               onClick={() =>
                 taskAnalytics.sendEvent({
@@ -440,7 +438,6 @@ export const Metadata: React.FC<Props> = ({ error, loading, task, taskId }) => {
         <MetadataItem>
           Previous Stepback Task:{" "}
           <StyledRouterLink
-            data-cy="previous-stepback-task-link"
             to={getTaskRoute(stepbackInfo.previousStepbackTaskId)}
             onClick={() =>
               taskAnalytics.sendEvent({
@@ -456,7 +453,6 @@ export const Metadata: React.FC<Props> = ({ error, loading, task, taskId }) => {
         <MetadataItem>
           Next Stepback Task:{" "}
           <StyledRouterLink
-            data-cy="next-stepback-task-link"
             to={getTaskRoute(stepbackInfo.nextStepbackTaskId)}
             onClick={() =>
               taskAnalytics.sendEvent({


### PR DESCRIPTION
DEVPROD-1122

### Description
This adds and propogates the "stepbackInfo" field in the Task struct to the task page's metadata card on the left hand side.

### Screenshots
I explain in the video:

https://github.com/evergreen-ci/spruce/assets/64446617/52ce85dd-a9c9-4439-8ac5-9a34b89f1eee



### Testing
Tested via staging. I considered some tests for it but I'm not sure if it is worth testing, since it is only links from the task data. I thought it might be more baggage to test it via cypress than the returns- but if the UI team feels otherwise, I won't hesitate to add them! I don't hold this opinion strongly, it's more so I don't want to add roi tests

### Evergreen PR
[Evergreen PR](https://github.com/evergreen-ci/evergreen/pull/7341)