### PR TITLE
DEVPROD-823 Remove terminated status from hosts table filters

### DIFF
--- a/src/constants/hosts.ts
+++ b/src/constants/hosts.ts
@@ -13,11 +13,6 @@ export const hostStatuses: Status[] = [
     key: HostStatus.Running,
   },
   {
-    title: "Terminated",
-    value: HostStatus.Terminated,
-    key: HostStatus.Terminated,
-  },
-  {
     title: "Uninitialized",
     value: HostStatus.Uninitialized,
     key: HostStatus.Uninitialized,


### PR DESCRIPTION
DEVPROD-823

### Description
Removes the terminated status so it's no longer a filterable option on the hosts table since it is omitted by the underlying query

### Screenshots
<img width="209" alt="image" src="https://github.com/evergreen-ci/spruce/assets/4605522/364959ec-29ff-40f2-be41-57c97963a6d7">


