### PR TITLE
Dependabot: Add team as reviewer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,5 @@ updates:
     commit-message:
       # Prefix all commit messages with "npm"
       prefix: "CHORE(NPM) - "
+    reviewers:
+      - "evergreen-ci/evg-ui"


### PR DESCRIPTION
### Description
<!-- add description, context, thought process, etc -->
- I sometimes forget to review dependabot PRs on rotation because they don't show up in my inbox without a request from `evg-ui`. I figured adding the team would be helpful to flag these PRs, and then the rotator can change the reviewer to their own user.
- [Config file docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#reviewers)