### PR TITLE
DEVPROD-3533: Add admin-only distro setting

### DIFF
--- a/cypress/integration/distroSettings/general_section.ts
+++ b/cypress/integration/distroSettings/general_section.ts
@@ -19,6 +19,7 @@ describe("general section", () => {
     cy.getInputByLabel("Disable shallow clone for this distro").check({
       force: true,
     });
+    cy.getInputByLabel("Admin only").check({ force: true });
     save();
     cy.validateToast("success");
 
@@ -29,6 +30,7 @@ describe("general section", () => {
     cy.getInputByLabel("Disable shallow clone for this distro").should(
       "be.checked",
     );
+    cy.getInputByLabel("Admin only").should("be.checked");
 
     // Undo changes.
     cy.dataCy("delete-item-button").click();
@@ -36,6 +38,7 @@ describe("general section", () => {
     cy.getInputByLabel("Disable shallow clone for this distro").uncheck({
       force: true,
     });
+    cy.getInputByLabel("Admin only").uncheck({ force: true });
     save();
     cy.validateToast("success");
   });

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -2515,6 +2515,7 @@ export type Task = {
   generateTask?: Maybe<Scalars["Boolean"]["output"]>;
   generatedBy?: Maybe<Scalars["String"]["output"]>;
   generatedByName?: Maybe<Scalars["String"]["output"]>;
+  hasCedarResults: Scalars["Boolean"]["output"];
   hostId?: Maybe<Scalars["String"]["output"]>;
   id: Scalars["String"]["output"];
   ingestTime?: Maybe<Scalars["Time"]["output"]>;

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -5730,6 +5730,7 @@ export type DistroQuery = {
   __typename?: "Query";
   distro?: {
     __typename?: "Distro";
+    adminOnly: boolean;
     aliases: Array<string>;
     arch: Arch;
     authorizedKeysFile: string;

--- a/src/gql/queries/distro.graphql
+++ b/src/gql/queries/distro.graphql
@@ -1,5 +1,6 @@
 query Distro($distroId: String!) {
   distro(distroId: $distroId) {
+    adminOnly
     aliases
     arch
     authorizedKeysFile

--- a/src/pages/distroSettings/tabs/GeneralTab/getFormSchema.ts
+++ b/src/pages/distroSettings/tabs/GeneralTab/getFormSchema.ts
@@ -39,6 +39,11 @@ export const getFormSchema = (
         type: "object" as "object",
         title: "Distro Options",
         properties: {
+          adminOnly: {
+            type: "boolean" as "boolean",
+            title: "Admin only",
+            default: false,
+          },
           isCluster: {
             type: "boolean" as "boolean",
             title: "Mark distro as cluster",
@@ -88,6 +93,10 @@ export const getFormSchema = (
     },
     distroOptions: {
       "ui:ObjectFieldTemplate": CardFieldTemplate,
+      adminOnly: {
+        "ui:description":
+          "Admin-only distros are not selectable by general users (e.g. when spawning a host). They do not have their access controlled beyond being hidden.",
+      },
       isCluster: {
         "ui:description":
           "Jobs will not be run on this host. Used for special purposes.",

--- a/src/pages/distroSettings/tabs/GeneralTab/transformers.test.ts
+++ b/src/pages/distroSettings/tabs/GeneralTab/transformers.test.ts
@@ -21,7 +21,7 @@ const generalForm: GeneralFormState = {
     aliases: ["rhel71-power8", "rhel71-power8-build"],
   },
   distroOptions: {
-    adminOnly: true,
+    adminOnly: false,
     isCluster: false,
     disableShallowClone: true,
     disabled: false,
@@ -32,7 +32,7 @@ const generalForm: GeneralFormState = {
 const generalGql: DistroInput = {
   ...distroData,
   name: "rhel71-power8-large",
-  adminOnly: true,
+  adminOnly: false,
   aliases: ["rhel71-power8", "rhel71-power8-build"],
   isCluster: false,
   disableShallowClone: true,

--- a/src/pages/distroSettings/tabs/GeneralTab/transformers.test.ts
+++ b/src/pages/distroSettings/tabs/GeneralTab/transformers.test.ts
@@ -21,6 +21,7 @@ const generalForm: GeneralFormState = {
     aliases: ["rhel71-power8", "rhel71-power8-build"],
   },
   distroOptions: {
+    adminOnly: true,
     isCluster: false,
     disableShallowClone: true,
     disabled: false,
@@ -31,6 +32,7 @@ const generalForm: GeneralFormState = {
 const generalGql: DistroInput = {
   ...distroData,
   name: "rhel71-power8-large",
+  adminOnly: true,
   aliases: ["rhel71-power8", "rhel71-power8-build"],
   isCluster: false,
   disableShallowClone: true,

--- a/src/pages/distroSettings/tabs/GeneralTab/transformers.ts
+++ b/src/pages/distroSettings/tabs/GeneralTab/transformers.ts
@@ -6,8 +6,15 @@ type Tab = DistroSettingsTabRoutes.General;
 export const gqlToForm = ((data) => {
   if (!data) return null;
 
-  const { aliases, disableShallowClone, disabled, isCluster, name, note } =
-    data;
+  const {
+    adminOnly,
+    aliases,
+    disableShallowClone,
+    disabled,
+    isCluster,
+    name,
+    note,
+  } = data;
 
   return {
     distroName: {
@@ -17,6 +24,7 @@ export const gqlToForm = ((data) => {
       aliases,
     },
     distroOptions: {
+      adminOnly,
       isCluster,
       disableShallowClone,
       disabled,
@@ -31,6 +39,7 @@ export const formToGql = ((
 ) => ({
   ...distro,
   name: distroName.identifier,
+  adminOnly: distroOptions.adminOnly,
   aliases: distroAliases.aliases,
   note: distroOptions.note,
   isCluster: distroOptions.isCluster,

--- a/src/pages/distroSettings/tabs/GeneralTab/types.ts
+++ b/src/pages/distroSettings/tabs/GeneralTab/types.ts
@@ -6,6 +6,7 @@ export interface GeneralFormState {
     aliases: string[];
   };
   distroOptions: {
+    adminOnly: boolean;
     isCluster: boolean;
     disableShallowClone: boolean;
     disabled: boolean;

--- a/src/pages/distroSettings/tabs/testData.ts
+++ b/src/pages/distroSettings/tabs/testData.ts
@@ -16,6 +16,7 @@ import {
 
 const distroData: DistroQuery["distro"] = {
   __typename: "Distro",
+  adminOnly: false,
   aliases: ["rhel71-power8", "rhel71-power8-build"],
   arch: Arch.Linux_64Bit,
   authorizedKeysFile: "",


### PR DESCRIPTION
DEVPROD-3533

### Description
<!-- add description, context, thought process, etc -->
- Add field on general distro settings tab to mark distro as admin-only. This has no effect at present, but DEVPROD-3532 will hide these distros from user-facing menus, like distro selection when spawning hosts.

### Screenshots
<!-- add screenshots of visible changes -->
<img width="682" alt="image" src="https://github.com/evergreen-ci/spruce/assets/9298431/4bcdb265-a31b-4ba4-8716-f5c3bc567b30">

### Testing
<!-- add a description of how you tested it -->
- Update unit and Cypress tests

### Evergreen PR
<!-- link to a corresponding Evergreen PR if applicable -->
https://github.com/evergreen-ci/evergreen/pull/7376