### PR TITLE
DEVPROD-3935 Use correct query for project health view setting

### DIFF
--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -7111,13 +7111,10 @@ export type ProjectHealthViewQueryVariables = Exact<{
 
 export type ProjectHealthViewQuery = {
   __typename?: "Query";
-  projectSettings: {
-    __typename?: "ProjectSettings";
-    projectRef?: {
-      __typename?: "Project";
-      id: string;
-      projectHealthView: ProjectHealthView;
-    } | null;
+  project: {
+    __typename?: "Project";
+    id: string;
+    projectHealthView: ProjectHealthView;
   };
 };
 

--- a/src/gql/queries/project-health-view.graphql
+++ b/src/gql/queries/project-health-view.graphql
@@ -1,8 +1,6 @@
 query ProjectHealthView($identifier: String!) {
-  projectSettings(identifier: $identifier) {
-    projectRef {
-      id
-      projectHealthView
-    }
+  project(projectIdentifier: $identifier) {
+    id
+    projectHealthView
   }
 }

--- a/src/pages/commits/ViewToggle.tsx
+++ b/src/pages/commits/ViewToggle.tsx
@@ -42,7 +42,7 @@ export const ViewToggle: React.FC<Props> = ({ identifier }) => {
 
   useEffect(() => {
     if (!view) {
-      setView(data?.project.projectHealthView);
+      setView(data?.project?.projectHealthView);
     }
   }, [data, setView, view]);
 

--- a/src/pages/commits/ViewToggle.tsx
+++ b/src/pages/commits/ViewToggle.tsx
@@ -42,7 +42,7 @@ export const ViewToggle: React.FC<Props> = ({ identifier }) => {
 
   useEffect(() => {
     if (!view) {
-      setView(data?.projectSettings?.projectRef?.projectHealthView);
+      setView(data?.project.projectHealthView);
     }
   }, [data, setView, view]);
 


### PR DESCRIPTION
DEVPROD-3935

### Description
We have logged nearly 7k events to sentry due to a failing permission check caused by the `projectHealthView` query consistently failing. It was trying to use the `ProjectSettings` query to fetch the `projectHealthView` state
Since most users don't have project settings access this query always fails and will consistently report an error.
This pr updates it so that we use a query that does not require the same permissions.

### Testing
Since I am an admin it is difficult to test but since the query does not have a permissions check directive this should work.