### PR TITLE
DEVPROD-788: Hide Slack banner more reliably

### DIFF
--- a/src/components/Banners/SlackNotificationBanner.tsx
+++ b/src/components/Banners/SlackNotificationBanner.tsx
@@ -82,7 +82,8 @@ export const SlackNotificationBanner = () => {
     !notifications &&
     (isNotificationSet(patchFirstFailure) || isNotificationSet(patchFinish));
 
-  const showSlackBanner = !hasClosedBanner && !hasSetNotifications;
+  const showSlackBanner =
+    !slackUsername && !hasClosedBanner && !hasSetNotifications;
 
   return showSlackBanner ? (
     <Banner

--- a/src/components/Banners/SlackNotificationBanner.tsx
+++ b/src/components/Banners/SlackNotificationBanner.tsx
@@ -82,10 +82,10 @@ export const SlackNotificationBanner = () => {
     !notifications &&
     (isNotificationSet(patchFirstFailure) || isNotificationSet(patchFinish));
 
-  const showSlackBanner =
+  const shouldShowSlackBanner =
     !defaultSlackUsername && !hasClosedBanner && !hasSetNotifications;
 
-  return showSlackBanner ? (
+  return shouldShowSlackBanner ? (
     <Banner
       variant="info"
       data-cy="slack-notification-banner"

--- a/src/components/Banners/SlackNotificationBanner.tsx
+++ b/src/components/Banners/SlackNotificationBanner.tsx
@@ -83,7 +83,7 @@ export const SlackNotificationBanner = () => {
     (isNotificationSet(patchFirstFailure) || isNotificationSet(patchFinish));
 
   const showSlackBanner =
-    !slackUsername && !hasClosedBanner && !hasSetNotifications;
+    !defaultSlackUsername && !hasClosedBanner && !hasSetNotifications;
 
   return showSlackBanner ? (
     <Banner

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -2515,6 +2515,7 @@ export type Task = {
   generateTask?: Maybe<Scalars["Boolean"]["output"]>;
   generatedBy?: Maybe<Scalars["String"]["output"]>;
   generatedByName?: Maybe<Scalars["String"]["output"]>;
+  hasCedarResults: Scalars["Boolean"]["output"];
   hostId?: Maybe<Scalars["String"]["output"]>;
   id: Scalars["String"]["output"];
   ingestTime?: Maybe<Scalars["Time"]["output"]>;


### PR DESCRIPTION
DEVPROD-788

### Description
<!-- add description, context, thought process, etc -->
- Don't show Slack banner if user has already added their Slack username. I think if they've done so it's safe to assume they have used notifications and don't need prompting.