### PR TITLE
DEVPROD-2707: Avoid modifying parent patch when restarting downstream tasks

### DIFF
--- a/src/components/VersionRestartModal/VersionRestartModal.tsx
+++ b/src/components/VersionRestartModal/VersionRestartModal.tsx
@@ -191,10 +191,12 @@ const selectTasksTotal = (selectedTasks: versionSelectedTasks) =>
   );
 
 const getTaskIds = (selectedTasks: versionSelectedTasks) =>
-  Object.entries(selectedTasks).map(([versionId, tasks]) => ({
-    versionId,
-    taskIds: selectedArray(tasks),
-  }));
+  Object.entries(selectedTasks)
+    .map(([versionId, tasks]) => ({
+      versionId,
+      taskIds: selectedArray(tasks),
+    }))
+    .filter(({ taskIds }) => taskIds.length > 0);
 
 const ConfirmationMessage = styled(Body)<BodyProps>`
   padding: ${size.s} 0;


### PR DESCRIPTION
DEVPROD-2707

### Description
This PR fixes a bug where restarting a downstream task via the VersionRestartModal would also restart all of the tasks in the parent patch.

The issue seems to stems from a change in restart logic made in Evergreen four months ago. When restarting a downstream task from the UI, the payload looks like the following:
```
{
   // In the parent patch, restart nothing.
   { 
        versionId: "123", 
        taskIds: []
    },
   // In the child patch, restart "downstream-task".
   { 
        versionId: "123", 
        taskIds: ["downstream-task"]
    }
}
```
However, according to the function that restarts versions, an empty `taskIds` array means that ALL completed tasks belonging to the version will be restarted. See screenshot below:

<img width="676" alt="Screenshot 2024-02-05 at 4 30 28 PM" src="https://github.com/evergreen-ci/spruce/assets/47064971/a4d17a2a-2917-451f-82c3-7f197a8663ab">
<br /><br />

The given payload means that `"downstream-task"` will be correctly restarted in the child patch, but so will every other completed task in the parent patch. 

To correct this we can just remove any items from the payload that have an empty `taskIds` array.

### Testing
- Restarted my patch on staging with these changes and confirmed that only my downstream task restarted
