### PR TITLE
DEVPROD-808: Use regular & privileged users to test non-admin views

### DIFF
--- a/cypress/constants/index.ts
+++ b/cypress/constants/index.ts
@@ -1,2 +1,14 @@
 export const EVG_BASE_URL = "http://localhost:9090";
 export const GQL_URL = `${EVG_BASE_URL}/graphql/query`;
+
+/**
+ * Defines user credentials that can be used to log in to the application.
+ * - admin: A user who has admin permissions and is a superuser.
+ * - privileged: A user who has admin permissions, but is not a superuser.
+ * - regular: A user who has no admin permissions.
+ */
+export const users = {
+  admin: { username: "admin", password: "password" },
+  privileged: { username: "privileged", password: "password" },
+  regular: { username: "regular", password: "password" },
+};

--- a/cypress/integration/distroSettings/permissions.ts
+++ b/cypress/integration/distroSettings/permissions.ts
@@ -1,15 +1,22 @@
 describe("distro permissions", () => {
   beforeEach(() => {
     cy.logout();
-    cy.login({ isAdmin: false });
   });
 
   it("hides the new distro button when a user cannot create distros", () => {
+    cy.login({ username: "privileged" });
     cy.visit("/distro/rhel71-power8-large/settings/general");
     cy.dataCy("new-distro-button").should("not.exist");
+    cy.dataCy("delete-distro-button").should(
+      "not.have.attr",
+      "aria-disabled",
+      "true",
+    );
+    cy.get("textarea").should("not.be.disabled");
   });
 
   it("disables the delete button when user lacks admin permissions", () => {
+    cy.login({ username: "regular" });
     cy.visit("/distro/rhel71-power8-large/settings/general");
     cy.dataCy("delete-distro-button").should(
       "have.attr",
@@ -19,6 +26,7 @@ describe("distro permissions", () => {
   });
 
   it("disables fields when user lacks edit permissions", () => {
+    cy.login({ username: "regular" });
     cy.visit("/distro/rhel71-power8-large/settings/general");
     cy.dataCy("distro-settings-page").within(() => {
       cy.get('input[type="checkbox"]').should(
@@ -31,6 +39,7 @@ describe("distro permissions", () => {
   });
 
   it("enables fields if user has edit permissions for a particular distro", () => {
+    cy.login({ username: "regular" });
     cy.visit("/distro/localhost/settings/general");
     cy.dataCy("distro-settings-page").within(() => {
       cy.get('input[type="checkbox"]').should(

--- a/cypress/integration/distroSettings/permissions.ts
+++ b/cypress/integration/distroSettings/permissions.ts
@@ -1,83 +1,44 @@
-describe("with various permission levels", () => {
+describe("distro permissions", () => {
+  beforeEach(() => {
+    cy.logout();
+    cy.login({ isAdmin: false });
+  });
+
   it("hides the new distro button when a user cannot create distros", () => {
-    const userData = {
-      data: {
-        user: {
-          userId: "admin",
-          permissions: {
-            canCreateDistro: false,
-            distroPermissions: {
-              admin: true,
-              edit: true,
-            },
-          },
-        },
-      },
-    };
-    cy.overwriteGQL("UserDistroSettingsPermissions", userData);
     cy.visit("/distro/rhel71-power8-large/settings/general");
     cy.dataCy("new-distro-button").should("not.exist");
-    cy.dataCy("delete-distro-button").should(
-      "not.have.attr",
-      "aria-disabled",
-      "true",
-    );
-    cy.get("textarea").should("not.be.disabled");
   });
 
   it("disables the delete button when user lacks admin permissions", () => {
-    const userData = {
-      data: {
-        user: {
-          userId: "admin",
-          permissions: {
-            canCreateDistro: false,
-            distroPermissions: {
-              admin: false,
-              edit: true,
-            },
-          },
-        },
-      },
-    };
-    cy.overwriteGQL("UserDistroSettingsPermissions", userData);
     cy.visit("/distro/rhel71-power8-large/settings/general");
-    cy.dataCy("new-distro-button").should("not.exist");
     cy.dataCy("delete-distro-button").should(
       "have.attr",
       "aria-disabled",
       "true",
     );
-    cy.get("textarea").should("not.be.disabled");
   });
 
   it("disables fields when user lacks edit permissions", () => {
-    const userData = {
-      data: {
-        user: {
-          userId: "admin",
-          permissions: {
-            canCreateDistro: false,
-            distroPermissions: {
-              admin: false,
-              edit: false,
-            },
-          },
-        },
-      },
-    };
-    cy.overwriteGQL("UserDistroSettingsPermissions", userData);
     cy.visit("/distro/rhel71-power8-large/settings/general");
-    cy.dataCy("new-distro-button").should("not.exist");
-    cy.dataCy("delete-distro-button").should(
-      "have.attr",
-      "aria-disabled",
-      "true",
-    );
     cy.dataCy("distro-settings-page").within(() => {
-      cy.get("input").should("be.disabled");
+      cy.get('input[type="checkbox"]').should(
+        "have.attr",
+        "aria-disabled",
+        "true",
+      );
       cy.get("textarea").should("be.disabled");
-      cy.get("button").should("have.attr", "aria-disabled", "true");
+    });
+  });
+
+  it("enables fields if user has edit permissions for a particular distro", () => {
+    cy.visit("/distro/localhost/settings/general");
+    cy.dataCy("distro-settings-page").within(() => {
+      cy.get('input[type="checkbox"]').should(
+        "have.attr",
+        "aria-disabled",
+        "false",
+      );
+      cy.get("textarea").should("not.be.disabled");
     });
   });
 });

--- a/cypress/integration/distroSettings/permissions.ts
+++ b/cypress/integration/distroSettings/permissions.ts
@@ -1,10 +1,12 @@
+import { users } from "../../constants";
+
 describe("distro permissions", () => {
   beforeEach(() => {
     cy.logout();
   });
 
   it("hides the new distro button when a user cannot create distros", () => {
-    cy.login({ username: "privileged" });
+    cy.login(users.privileged);
     cy.visit("/distro/rhel71-power8-large/settings/general");
     cy.dataCy("new-distro-button").should("not.exist");
     cy.dataCy("delete-distro-button").should(
@@ -16,7 +18,7 @@ describe("distro permissions", () => {
   });
 
   it("disables the delete button when user lacks admin permissions", () => {
-    cy.login({ username: "regular" });
+    cy.login(users.regular);
     cy.visit("/distro/rhel71-power8-large/settings/general");
     cy.dataCy("delete-distro-button").should(
       "have.attr",
@@ -26,7 +28,7 @@ describe("distro permissions", () => {
   });
 
   it("disables fields when user lacks edit permissions", () => {
-    cy.login({ username: "regular" });
+    cy.login(users.regular);
     cy.visit("/distro/rhel71-power8-large/settings/general");
     cy.dataCy("distro-settings-page").within(() => {
       cy.get('input[type="checkbox"]').should(
@@ -39,7 +41,7 @@ describe("distro permissions", () => {
   });
 
   it("enables fields if user has edit permissions for a particular distro", () => {
-    cy.login({ username: "regular" });
+    cy.login(users.regular);
     cy.visit("/distro/localhost/settings/general");
     cy.dataCy("distro-settings-page").within(() => {
       cy.get('input[type="checkbox"]').should(

--- a/cypress/integration/nav_bar.ts
+++ b/cypress/integration/nav_bar.ts
@@ -108,20 +108,20 @@ describe("Nav Bar", () => {
   });
 
   describe("Admin settings", () => {
-    it("Should not show Admin button to non-admins", () => {
-      cy.logout();
-      cy.login({ isAdmin: false });
-      cy.visit(SPRUCE_URLS.version);
-      cy.dataCy("user-dropdown-link").click();
-      cy.dataCy("admin-link").should("not.exist");
-    });
-
     it("Should show Admin button to admins", () => {
       cy.visit(SPRUCE_URLS.version);
       cy.dataCy("user-dropdown-link").click();
       cy.dataCy("admin-link")
         .should("be.visible")
         .should("have.attr", "href", LEGACY_URLS.admin);
+    });
+
+    it("Should not show Admin button to non-admins", () => {
+      cy.logout();
+      cy.login({ username: "regular" });
+      cy.visit(SPRUCE_URLS.version);
+      cy.dataCy("user-dropdown-link").click();
+      cy.dataCy("admin-link").should("not.exist");
     });
   });
 });

--- a/cypress/integration/nav_bar.ts
+++ b/cypress/integration/nav_bar.ts
@@ -1,4 +1,4 @@
-import { EVG_BASE_URL } from "../constants";
+import { EVG_BASE_URL, users } from "../constants";
 
 const PATCH_ID = "5e4ff3abe3c3317e352062e4";
 const USER_ID = "admin";
@@ -118,7 +118,7 @@ describe("Nav Bar", () => {
 
     it("Should not show Admin button to non-admins", () => {
       cy.logout();
-      cy.login({ username: "regular" });
+      cy.login(users.regular);
       cy.visit(SPRUCE_URLS.version);
       cy.dataCy("user-dropdown-link").click();
       cy.dataCy("admin-link").should("not.exist");

--- a/cypress/integration/nav_bar.ts
+++ b/cypress/integration/nav_bar.ts
@@ -109,19 +109,8 @@ describe("Nav Bar", () => {
 
   describe("Admin settings", () => {
     it("Should not show Admin button to non-admins", () => {
-      const userData = {
-        data: {
-          user: {
-            userId: "admin",
-            displayName: "Evergreen Admin",
-            emailAddress: "admin@evergreen.com",
-            permissions: {
-              canEditAdminSettings: false,
-            },
-          },
-        },
-      };
-      cy.overwriteGQL("User", userData);
+      cy.logout();
+      cy.login({ isAdmin: false });
       cy.visit(SPRUCE_URLS.version);
       cy.dataCy("user-dropdown-link").click();
       cy.dataCy("admin-link").should("not.exist");

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,4 +1,4 @@
-import { EVG_BASE_URL, GQL_URL } from "../constants";
+import { EVG_BASE_URL, GQL_URL, users } from "../constants";
 import { hasOperationName } from "../utils/graphql-test-utils";
 
 type cyGetOptions = Parameters<typeof cy.get>[1];
@@ -33,8 +33,8 @@ Cypress.Commands.add(
  * `enterLoginCredentials` is a custom command to enter login credentials
  */
 Cypress.Commands.add("enterLoginCredentials", () => {
-  cy.get("input[name=username]").type("admin");
-  cy.get("input[name=password]").type("password");
+  cy.get("input[name=username]").type(users.admin.username);
+  cy.get("input[name=password]").type(users.admin.password);
   cy.get("button[id=login-submit]").click();
 });
 
@@ -52,13 +52,10 @@ Cypress.Commands.add("getInputByLabel", (label: string | RegExp) => {
 });
 
 /* login */
-Cypress.Commands.add("login", ({ username = "admin" }) => {
+Cypress.Commands.add("login", (user = users.admin) => {
   cy.getCookie("mci-token").then((c) => {
     if (!c) {
-      cy.request("POST", `${EVG_BASE_URL}/login`, {
-        username,
-        password: "password",
-      });
+      cy.request("POST", `${EVG_BASE_URL}/login`, user);
     }
   });
 });

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -52,11 +52,11 @@ Cypress.Commands.add("getInputByLabel", (label: string | RegExp) => {
 });
 
 /* login */
-Cypress.Commands.add("login", ({ isAdmin = true }) => {
+Cypress.Commands.add("login", ({ username = "admin" }) => {
   cy.getCookie("mci-token").then((c) => {
     if (!c) {
       cy.request("POST", `${EVG_BASE_URL}/login`, {
-        username: isAdmin ? "admin" : "basic",
+        username,
         password: "password",
       });
     }

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,11 +1,6 @@
 import { EVG_BASE_URL, GQL_URL } from "../constants";
 import { hasOperationName } from "../utils/graphql-test-utils";
 
-const user = {
-  username: "admin",
-  password: "password",
-};
-
 type cyGetOptions = Parameters<typeof cy.get>[1];
 
 /* closeBanner */
@@ -38,8 +33,8 @@ Cypress.Commands.add(
  * `enterLoginCredentials` is a custom command to enter login credentials
  */
 Cypress.Commands.add("enterLoginCredentials", () => {
-  cy.get("input[name=username]").type(user.username);
-  cy.get("input[name=password]").type(user.password);
+  cy.get("input[name=username]").type("admin");
+  cy.get("input[name=password]").type("password");
   cy.get("button[id=login-submit]").click();
 });
 
@@ -57,10 +52,13 @@ Cypress.Commands.add("getInputByLabel", (label: string | RegExp) => {
 });
 
 /* login */
-Cypress.Commands.add("login", () => {
+Cypress.Commands.add("login", ({ isAdmin = true }) => {
   cy.getCookie("mci-token").then((c) => {
     if (!c) {
-      cy.request("POST", `${EVG_BASE_URL}/login`, { ...user });
+      cy.request("POST", `${EVG_BASE_URL}/login`, {
+        username: isAdmin ? "admin" : "basic",
+        password: "password",
+      });
     }
   });
 });

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -87,9 +87,10 @@ declare global {
       selectLGOption(label: string, option: string | RegExp): void;
       /**
        * Custom command to navigate to login page and login.
+       * @param username The username of the account to log in to.
        * @example cy.login()
        */
-      login({ isAdmin }: { isAdmin: boolean }): void;
+      login({ username }: { username: string }): void;
       /**
        * Custom command to log out of the application.
        * @example cy.logout()
@@ -147,7 +148,7 @@ before(() => {
 (() => {
   let mutationDispatched: boolean;
   beforeEach(() => {
-    cy.login({ isAdmin: true });
+    cy.login({ username: "admin" });
     cy.setCookie(bannerCookie, "true");
     cy.setCookie(CY_DISABLE_COMMITS_WELCOME_MODAL, "true");
     cy.setCookie(CY_DISABLE_NEW_USER_WELCOME_MODAL, "true");

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -86,11 +86,17 @@ declare global {
        */
       selectLGOption(label: string, option: string | RegExp): void;
       /**
-       * Custom command to navigate to login page and login.
-       * @param username The username of the account to log in to.
-       * @example cy.login()
+       * Custom command to navigate to login page and log in.
+       * @example cy.login({ username: "me", password: "abc" })
+       * @example cy.login() // defaults to admin login
        */
-      login({ username }: { username: string }): void;
+      login({
+        password,
+        username,
+      }?: {
+        username: string;
+        password: string;
+      }): void;
       /**
        * Custom command to log out of the application.
        * @example cy.logout()
@@ -148,7 +154,7 @@ before(() => {
 (() => {
   let mutationDispatched: boolean;
   beforeEach(() => {
-    cy.login({ username: "admin" });
+    cy.login();
     cy.setCookie(bannerCookie, "true");
     cy.setCookie(CY_DISABLE_COMMITS_WELCOME_MODAL, "true");
     cy.setCookie(CY_DISABLE_NEW_USER_WELCOME_MODAL, "true");

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -89,7 +89,7 @@ declare global {
        * Custom command to navigate to login page and login.
        * @example cy.login()
        */
-      login(): void;
+      login({ isAdmin }: { isAdmin: boolean }): void;
       /**
        * Custom command to log out of the application.
        * @example cy.logout()
@@ -147,7 +147,7 @@ before(() => {
 (() => {
   let mutationDispatched: boolean;
   beforeEach(() => {
-    cy.login();
+    cy.login({ isAdmin: true });
     cy.setCookie(bannerCookie, "true");
     cy.setCookie(CY_DISABLE_COMMITS_WELCOME_MODAL, "true");
     cy.setCookie(CY_DISABLE_NEW_USER_WELCOME_MODAL, "true");


### PR DESCRIPTION
DEVPROD-808

### Description
Edits the Cypress test to use the regular & privileged users for non-admin views. Some granularity was lost in the distro settings permission test but I'm kind of assuming that's okay.

### Evergreen PR
* evergreen-ci/evergreen/pull/7531 (must be merged first)
