### PR TITLE
DEVPROD-356: Add Sentry grouping

### DIFF
--- a/src/components/ErrorHandling/Sentry.tsx
+++ b/src/components/ErrorHandling/Sentry.tsx
@@ -40,7 +40,7 @@ const initializeSentry = () => {
 
 const isInitialized = () => !!getCurrentHub().getClient();
 
-type ErrorMetadata = {
+export type ErrorMetadata = {
   gqlErr?: ErrorResponse["graphQLErrors"][0];
   operationName?: ErrorResponse["operation"]["operationName"];
   variables?: ErrorResponse["operation"]["variables"];

--- a/src/components/ErrorHandling/Sentry.tsx
+++ b/src/components/ErrorHandling/Sentry.tsx
@@ -1,3 +1,4 @@
+import { ErrorResponse } from "@apollo/client/link/error";
 import {
   captureException,
   ErrorBoundary as SentryErrorBoundary,
@@ -39,10 +40,16 @@ const initializeSentry = () => {
 
 const isInitialized = () => !!getCurrentHub().getClient();
 
+type ErrorMetadata = {
+  gqlErr?: ErrorResponse["graphQLErrors"][0];
+  operationName?: ErrorResponse["operation"]["operationName"];
+  variables?: ErrorResponse["operation"]["variables"];
+};
+
 const sendError = (
   err: Error,
   severity: SeverityLevel,
-  metadata?: { [key: string]: any },
+  metadata?: ErrorMetadata,
 ) => {
   withScope((scope) => {
     setScope(scope, { level: severity, context: metadata });
@@ -59,7 +66,7 @@ const sendError = (
       scope.setFingerprint(fingerprint);
 
       // Apply tag, which is a searchable/filterable property
-      setTag("operationName", metadata.operationName);
+      setTag("operationName", operationName);
     }
 
     captureException(err);

--- a/src/gql/GQLWrapper.tsx
+++ b/src/gql/GQLWrapper.tsx
@@ -144,10 +144,17 @@ const authLink = (logout: () => void): ApolloLink =>
 const logErrorsLink = onError(({ graphQLErrors, operation }) => {
   if (Array.isArray(graphQLErrors)) {
     graphQLErrors.forEach((gqlErr) => {
+      const fingerprint = [operation.operationName];
+      if (gqlErr?.path?.length) {
+        fingerprint.push(...gqlErr.path);
+      }
       reportError(new Error(gqlErr.message), {
-        gqlErr,
-        operationName: operation.operationName,
-        variables: operation.variables,
+        fingerprint,
+        tags: { operationName: operation.operationName },
+        context: {
+          gqlErr,
+          variables: operation.variables,
+        },
       }).warning();
     });
   }

--- a/src/utils/errorReporting.test.ts
+++ b/src/utils/errorReporting.test.ts
@@ -34,7 +34,7 @@ describe("error reporting", () => {
     expect(Sentry.captureException).not.toHaveBeenCalled();
   });
 
-  it("should report errors to Sentry when in production", () => {
+  it("reports errors to Sentry when in production", () => {
     mockEnv("NODE_ENV", "production");
     jest.spyOn(Sentry, "captureException").mockImplementation(jest.fn());
 
@@ -46,7 +46,7 @@ describe("error reporting", () => {
     expect(Sentry.captureException).toHaveBeenCalledWith(err);
   });
 
-  it("supports metadata field", () => {
+  it("supports context field", () => {
     mockEnv("NODE_ENV", "production");
     jest.spyOn(Sentry, "captureException").mockImplementation(jest.fn());
     const err = {
@@ -54,12 +54,31 @@ describe("error reporting", () => {
       name: "Error Name",
     };
 
-    const metadata = { operationName: "foo" };
-    const result = reportError(err, metadata);
+    const context = { anything: "foo" };
+    const result = reportError(err, { context });
     result.severe();
     expect(Sentry.captureException).toHaveBeenCalledWith(err);
     result.warning();
     expect(Sentry.captureException).toHaveBeenCalledWith(err);
+  });
+
+  it("supports tags", () => {
+    mockEnv("NODE_ENV", "production");
+    jest.spyOn(Sentry, "captureException").mockImplementation(jest.fn());
+    jest.spyOn(Sentry, "setTags").mockImplementation(jest.fn());
+    const err = {
+      message: "GraphQL Error",
+      name: "Error Name",
+    };
+
+    const tags = { spruce: "true" };
+    const result = reportError(err, { tags });
+    result.severe();
+    expect(Sentry.captureException).toHaveBeenCalledWith(err);
+    expect(Sentry.setTags).toHaveBeenCalledWith(tags);
+    result.warning();
+    expect(Sentry.captureException).toHaveBeenCalledWith(err);
+    expect(Sentry.setTags).toHaveBeenCalledWith(tags);
   });
 });
 

--- a/src/utils/errorReporting.test.ts
+++ b/src/utils/errorReporting.test.ts
@@ -54,7 +54,7 @@ describe("error reporting", () => {
       name: "Error Name",
     };
 
-    const metadata = { customField: "foo" };
+    const metadata = { operationName: "foo" };
     const result = reportError(err, metadata);
     result.severe();
     expect(Sentry.captureException).toHaveBeenCalledWith(err);

--- a/src/utils/errorReporting.ts
+++ b/src/utils/errorReporting.ts
@@ -1,6 +1,6 @@
 import { addBreadcrumb, Breadcrumb } from "@sentry/react";
 import {
-  ErrorMetadata,
+  ErrorInput,
   sendError as sentrySendError,
 } from "components/ErrorHandling/Sentry";
 import { isProductionBuild } from "./environmentVariables";
@@ -10,27 +10,45 @@ interface reportErrorResult {
   warning: () => void;
 }
 
+type ErrorMetadata = {
+  fingerprint?: ErrorInput["fingerprint"];
+  tags?: ErrorInput["tags"];
+  context?: ErrorInput["context"];
+};
+
 const reportError = (
   err: Error,
-  metadata?: ErrorMetadata,
+  { context, fingerprint, tags }: ErrorMetadata = {},
 ): reportErrorResult => {
   if (!isProductionBuild()) {
     return {
       severe: () => {
-        console.error({ err, severity: "severe", metadata });
+        console.error({ err, severity: "severe", context, fingerprint, tags });
       },
       warning: () => {
-        console.error({ err, severity: "warning", metadata });
+        console.error({ err, severity: "warning", context, fingerprint, tags });
       },
     };
   }
 
   return {
     severe: () => {
-      sentrySendError(err, "error", metadata);
+      sentrySendError({
+        context,
+        err,
+        fingerprint,
+        severity: "error",
+        tags,
+      });
     },
     warning: () => {
-      sentrySendError(err, "warning", metadata);
+      sentrySendError({
+        context,
+        err,
+        fingerprint,
+        severity: "warning",
+        tags,
+      });
     },
   };
 };

--- a/src/utils/errorReporting.ts
+++ b/src/utils/errorReporting.ts
@@ -1,5 +1,8 @@
 import { addBreadcrumb, Breadcrumb } from "@sentry/react";
-import { sendError as sentrySendError } from "components/ErrorHandling/Sentry";
+import {
+  ErrorMetadata,
+  sendError as sentrySendError,
+} from "components/ErrorHandling/Sentry";
 import { isProductionBuild } from "./environmentVariables";
 
 interface reportErrorResult {
@@ -9,7 +12,7 @@ interface reportErrorResult {
 
 const reportError = (
   err: Error,
-  metadata?: { [key: string]: any },
+  metadata?: ErrorMetadata,
 ): reportErrorResult => {
   if (!isProductionBuild()) {
     return {


### PR DESCRIPTION
DEVPROD-356

### Description
<!-- add description, context, thought process, etc -->
Added two new fields to GraphQL errors that should help with grouping in the app:
- Adding a [fingerprint](https://docs.sentry.io/platforms/javascript/usage/sdk-fingerprinting/) based on the operation name should force these errors to be grouped together. I've also appended the path to the fingerprint, which means that errors will only be grouped if the same field was the cause of the error. This is a little bit more aggressive than just grouping on operation name, but I think it will be helpful
- Adding operation name as a [tag](https://docs.sentry.io/platforms/javascript/guides/react/enriching-events/tags/) allows it to be searchable.

### Testing
<!-- add a description of how you tested it -->
- The [event grouping information](https://mongodb-org.sentry.io/issues/4981024769/?environment=staging&project=4505211042856960&referrer=issue-stream&statsPeriod=7d&stream_index=2#grouping-info) for this event shows the custom fingerprint in use.
- Clicking "All Events" at the top of that page allows you to see all errors that were thrown by `UserProjectSettingsPermissions` being thrown with an error in the project identifier.
- `operationName` is now a tag appearing at the top of the page:
  <img width="343" alt="image" src="https://github.com/evergreen-ci/spruce/assets/9298431/ddaccacb-9966-468e-a555-27e2dc56e3f1">


I think this is a pretty logical way of grouping things. You can also take a look on staging and see how incoming errors are grouped. Sentry's "recommended error" view is still confusing to me, and the error titles are still somewhat useless, but I think the grouping is improved.