### PR TITLE
DEVPROD-4251: Resolve flake in select_execution.ts

### DIFF
--- a/cypress/integration/task/select_execution.ts
+++ b/cypress/integration/task/select_execution.ts
@@ -8,12 +8,15 @@ describe("Selecting Task Execution", () => {
   });
 
   it("Should take user to the latest execution if no execution is specified", () => {
+    cy.location("search").should("include", "execution=1");
     cy.dataCy("execution-select").contains("Execution 2 (latest)");
     cy.dataCy("task-status-badge").contains("Will Run");
-    cy.location("search").should("include", "execution=1");
   });
 
   it("Toggling a different execution should change the displayed execution", () => {
+    cy.location("search").should("include", "execution=1");
+    cy.dataCy("execution-select").contains("Execution 2 (latest)");
+    cy.dataCy("execution-select").should("have.attr", "aria-disabled", "false");
     cy.dataCy("execution-select").click();
     cy.dataCy("execution-0").click();
     cy.dataCy("task-status-badge").contains("Succeeded");

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -2402,6 +2402,7 @@ export type SpruceConfig = {
   jira?: Maybe<JiraConfig>;
   keys: Array<SshKey>;
   providers?: Maybe<CloudProviderConfig>;
+  secretFields: Array<Scalars["String"]["output"]>;
   slack?: Maybe<SlackConfig>;
   spawnHost: SpawnHostConfig;
   ui?: Maybe<UiConfig>;

--- a/src/pages/task/executionDropdown/ExecutionSelector.tsx
+++ b/src/pages/task/executionDropdown/ExecutionSelector.tsx
@@ -37,16 +37,17 @@ export const ExecutionSelect: React.FC<ExecutionSelectProps> = ({
   const getDateCopy = useDateFormat();
   return (
     <StyledSelect
-      placeholder="Choose an execution"
+      aria-disabled={executionsLoading}
+      data-cy="execution-select"
       disabled={executionsLoading}
       key={currentExecution}
-      data-cy="execution-select"
-      value={`Execution ${formatZeroIndexForDisplay(currentExecution)}${
-        currentExecution === latestExecution ? " (latest)" : ""
-      }`}
       onChange={(selected: number | null) => {
         updateExecution(selected);
       }}
+      placeholder="Choose an execution"
+      value={`Execution ${formatZeroIndexForDisplay(currentExecution)}${
+        currentExecution === latestExecution ? " (latest)" : ""
+      }`}
     >
       {allExecutions?.map((singleExecution) => {
         const optionText = `Execution ${formatZeroIndexForDisplay(
@@ -58,9 +59,9 @@ export const ExecutionSelect: React.FC<ExecutionSelectProps> = ({
 
         return (
           <Option
+            data-cy={`execution-${singleExecution.execution}`}
             key={singleExecution.execution}
             value={singleExecution.execution}
-            data-cy={`execution-${singleExecution.execution}`}
           >
             <ExecutionInfo>
               <StyledTaskStatusIcon status={singleExecution.status} />


### PR DESCRIPTION
DEVPROD-4251

### Description
Fixes flaky test in `select_execution.ts`.

### Testing
- The current test is flaky locally as well and fails about 50% of the time for me. I ran the test with these changes 10+ times and did not observe any failures
- Sorry that you can't see the files right now... that will be fixed by my other PR
