### PR TITLE
DEVPROD-5097: Prevent deploy_to_prod task from failing silently

### DIFF
--- a/scripts/deploy/deploy.sh
+++ b/scripts/deploy/deploy.sh
@@ -1,8 +1,12 @@
-#!/bin/sh
+#!/bin/bash
 
-# This script runs the aws cli command to deploy the app to s3
+# This script runs the AWS CLI command to deploy the app to S3.
 
-# Try this step and throw an error if it fails
 echo "Deploying to S3"
-aws s3 sync build/ s3://"${BUCKET}"/ --acl public-read --follow-symlinks --delete --exclude .env-cmdrc.json 
-echo "Deployed to S3"
+
+if ! aws s3 sync build/ s3://"${BUCKET}"/ --acl public-read --follow-symlinks --delete --exclude .env-cmdrc.json; then
+  echo "Deployment to S3 failed"
+  exit 1
+else
+  echo "Successfully deployed to S3"
+fi


### PR DESCRIPTION
DEVPROD-5097

### Description
The `deploy_to_prod` task succeeds even if this command fails. We should error and exit on failure.

### Testing
- [Patch](https://spruce.mongodb.com/task/spruce_ubuntu2204_deploy_to_prod_patch_cde0efda6d1825120ab2d2ed4f91fc0331553359_65d8f3501e2d17c1f5afe208_24_02_23_19_34_47/logs?execution=0) where I made it fail