### PR TITLE
DEVPROD-3326: Reset edit host modal state

### DIFF
--- a/src/pages/spawn/spawnHost/EditSpawnHostButton.tsx
+++ b/src/pages/spawn/spawnHost/EditSpawnHostButton.tsx
@@ -52,6 +52,7 @@ export const EditSpawnHostButton: React.FC<EditSpawnHostButtonProps> = ({
         </Tooltip>
       </span>
       <EditSpawnHostModal
+        key={host.id}
         onCancel={() => setOpenModal(false)}
         visible={openModal}
         host={host}


### PR DESCRIPTION
DEVPROD-3326

### Description
<!-- add description, context, thought process, etc -->
- Use a `key` prop associated with the host ID to reset the modal's state when working with different hosts.

### Testing
<!-- add a description of how you tested it -->
- Unable to reproduce as described in ticket with these changes applied