### PR TITLE
DEVPROD-787: Retry Node installation on CI

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -109,7 +109,12 @@ functions:
           [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
           cd -
 
-          nvm install --no-progress --default ${node_version}
+          # Retry the download for Node in case it flakes.
+          for i in {1..5}; do
+            nvm install --no-progress --default ${node_version}
+            [[ $? -eq 0 ]] && break
+            sleep 10
+          done
           npm install -g yarn
 
   run-make-background:

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -113,6 +113,7 @@ functions:
           for i in {1..5}; do
             nvm install --no-progress --default ${node_version}
             [[ $? -eq 0 ]] && break
+            echo "Attempt $i of 5 to install Node failed"
             sleep 10
           done
           npm install -g yarn


### PR DESCRIPTION
DEVPROD-787

### Description
The Node installation can sometimes fail due to network errors. This PR retries the installation 5 times, with a 10 second waiting period between each try. I can raise the waiting time if you guys think it should be higher!

Will open Parsley PR after I get approval.

### Testing
- Tested with a [patch](https://spruce.mongodb.com/version/65e0aaec3066150264d38aca/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) in which the loop instead prints a message and waits for 60 seconds in between attempts. You can see five messages for `"Running in the loop."` printed. The timestamps of these messages are kinda weird but I assume that's a symptom of how the agent processes output because the task takes as long as I would expect.