### PR TITLE
DEVPROD-5132: Make tags unique

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,2 @@
+version-tag-prefix spruce/v
+version-git-message "spruce/v%s"

--- a/scripts/deploy/utils/git/tag/constants.ts
+++ b/scripts/deploy/utils/git/tag/constants.ts
@@ -1,1 +1,0 @@
-export const githubRemote = "https://github.com/evergreen-ci/spruce";

--- a/scripts/deploy/utils/git/tag/tag-utils.ts
+++ b/scripts/deploy/utils/git/tag/tag-utils.ts
@@ -1,5 +1,4 @@
 import { execSync } from "child_process";
-import { githubRemote } from "./constants";
 import { green, underline } from "../../../../utils/colors";
 
 /**
@@ -49,7 +48,7 @@ const getLatestTag = () => {
  */
 const deleteTag = (tag: string) => {
   console.log(`Deleting tag (${tag}) from remote...`);
-  const deleteCommand = `git push --delete ${githubRemote} ${tag}`;
+  const deleteCommand = `git push --delete upstream ${tag}`;
   try {
     execSync(deleteCommand, { stdio: "inherit", encoding: "utf-8" });
   } catch (err) {
@@ -63,7 +62,7 @@ const deleteTag = (tag: string) => {
 const pushTags = () => {
   console.log("Pushing tags...");
   try {
-    execSync(`git push --tags ${githubRemote}`, {
+    execSync(`git push --tags upstream`, {
       stdio: "inherit",
       encoding: "utf-8",
     });

--- a/scripts/push-version.sh
+++ b/scripts/push-version.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 WAIT_TIME=9
-GITHUB_REMOTE=https://github.com/evergreen-ci/spruce
+GIT_DESTINATION=$(git rev-parse --abbrev-ref main@{upstream})
 
-if git push $GITHUB_REMOTE
+if git push upstream
 then
-  echo "Successfully pushed to ${GITHUB_REMOTE}"
+  echo "Successfully pushed to ${GIT_DESTINATION}"
 else
-  echo "Failed to push to ${GITHUB_REMOTE}"
+  echo "Failed to push to ${GIT_DESTINATION}"
   exit 1
 fi
 
@@ -17,11 +17,11 @@ while [ $i -gt 0 ]
 done
 echo ""
 
-if git push --tags $GITHUB_REMOTE
+if git push --tags upstream
 then
-  echo "Successfully pushed tags to ${GITHUB_REMOTE}"
+  echo "Successfully pushed tags to ${GIT_DESTINATION}"
 else 
-  echo "Failed to push tags to ${GITHUB_REMOTE}"
+  echo "Failed to push tags to ${GIT_DESTINATION}"
   exit 1
 fi
 

--- a/scripts/push-version.sh
+++ b/scripts/push-version.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 WAIT_TIME=9
-GIT_DESTINATION=$(git rev-parse --abbrev-ref main@{upstream})
+GIT_DESTINATION=$(git rev-parse --abbrev-ref @{upstream})
 
 if git push upstream
 then

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -2910,6 +2910,7 @@ export type User = {
   __typename?: "User";
   displayName: Scalars["String"]["output"];
   emailAddress: Scalars["String"]["output"];
+  parsleyFilters: Array<ParsleyFilter>;
   patches: Patches;
   permissions: Permissions;
   subscriptions?: Maybe<Array<GeneralSubscription>>;


### PR DESCRIPTION
DEVPROD-5132

### Description
<!-- add description, context, thought process, etc -->
- Ahead of the monorepo merge, make Spruce's tags unique by using `spruce/vX.Y.Z`. The commit message has also been changed from "vX.Y.Z" to "spruce/vX.Y.Z"
- Remove references to remote URL. We can assume users have their upstream properly configured (and if they don't commands will fail, which is fine)
- Added a new git tag regex to Spruce's project settings. When this is merged I will delete the old one:
  <img width="429" alt="image" src="https://github.com/evergreen-ci/spruce/assets/9298431/4d70bead-491c-4413-9371-91a150e1f757">

### Testing
<!-- add a description of how you tested it -->
- Tested with my wifi off 🤣 the correct tag names were generated and git attempted to push to the correct place as part of the postversion script!