### PR TITLE
DEVPROD-3495: Fix flaky git tag test

### DIFF
--- a/cypress/integration/projectSettings/not_defaulting_to_repo.ts
+++ b/cypress/integration/projectSettings/not_defaulting_to_repo.ts
@@ -119,6 +119,7 @@ describe("Project Settings when not defaulting to repo", () => {
       cy.dataCy("var-name-input").should("not.exist");
       // Verify persistence
       cy.reload();
+      saveButtonEnabled(false);
       cy.dataCy("var-name-input").should("not.exist");
     });
   });

--- a/src/gql/generated/types.ts
+++ b/src/gql/generated/types.ts
@@ -2910,6 +2910,7 @@ export type User = {
   __typename?: "User";
   displayName: Scalars["String"]["output"];
   emailAddress: Scalars["String"]["output"];
+  parsleyFilters: Array<ParsleyFilter>;
   patches: Patches;
   permissions: Permissions;
   subscriptions?: Maybe<Array<GeneralSubscription>>;


### PR DESCRIPTION
DEVPROD-3495

### Description
<!-- add description, context, thought process, etc -->
This test fails with the unexpected error "user 'admin' does not have permission to view project 'spruce'." My hypothesis is that the reload in the prior test is introducing some race condition with the seeding data, since the test for `cy.dataCy("var-name-input").should("not.exist");` does not really verify that the page has finished loading. Adding a check for an element on the page may remove this race.

### Testing
<!-- add a description of how you tested it -->
I've run a [passing patch](https://spruce.mongodb.com/task/spruce_ubuntu2204_e2e_test_patch_d5c630347001be8daa6166ce7c71ea9c67b88049_65e0f3232fbabecf79e6aa79_24_02_29_21_12_11/logs?sortBy=STATUS&sortDir=ASC) several times.

Since this addition is still correct and doesn't break anything, I think it makes sense to let it bake in production and see if further failures are observed rather than run 100 tests myself.