### PR TITLE
DEVPROD-5336 Allow projects to be deleted for projects not attached to a repo

### DIFF
--- a/src/pages/projectSettings/tabs/GeneralTab/getFormSchema.tsx
+++ b/src/pages/projectSettings/tabs/GeneralTab/getFormSchema.tsx
@@ -238,7 +238,7 @@ export const getFormSchema = (
           },
         },
       },
-      ...(projectType === ProjectType.AttachedProject && {
+      ...(projectType !== ProjectType.Repo && {
         delete: {
           type: "object" as "object",
           title: "Delete Project",


### PR DESCRIPTION
[DEVPROD-5336](https://jira.mongodb.org/browse/DEVPROD-5336)

### Description
This changes the conditional to include projects & projects attached to repos. The only type of projectref non-deletable (which is just hiding) is the repo project.

### Screenshots
With the UI change, the button showed up correctly. The true test was testing it against the PR (linked below) that changes the route to allow for this behavior.

The following is using this change always (I tested without but it just doesn't show the button). The 'change' referenced below is the app PR/route change.

Before change:
<img width="752" alt="DeleteProject1" src="https://github.com/evergreen-ci/spruce/assets/64446617/24a9d4e8-64d7-41cf-b593-5a3d32530d3e">


After change:
<img width="916" alt="DeleteProject2" src="https://github.com/evergreen-ci/spruce/assets/64446617/e34c5b9c-fc42-4192-913b-e1c8c8fe519d">


### Testing
There's [this](https://github.com/evergreen-ci/evergreen/pull/7591) PR in the app repository that I deployed and tested against. Separately I tested the app PR directly against the endpoint rather than spruce.

Here's the project I deleted: https://spruce-staging.corp.mongodb.com/project/deletemepls/settings/general

### Evergreen PR
https://github.com/evergreen-ci/evergreen/pull/7591
