### PR TITLE
DEVPROD-5132: Don't include tag prefix in test

### DIFF
--- a/scripts/deploy/utils/git/tag/tag-utils.test.ts
+++ b/scripts/deploy/utils/git/tag/tag-utils.test.ts
@@ -1,6 +1,6 @@
 import { getLatestTag } from "./tag-utils";
 
-const currentlyDeployedTagRegex = /^v\d+\.\d+\.\d+$/;
+const currentlyDeployedTagRegex = /.*\d+\.\d+\.\d+$/;
 
 describe("getLatestTag", () => {
   it("should return the latest tag", () => {


### PR DESCRIPTION
Fixes bug in DEVPROD-5132 (#2282)

### Description
<!-- add description, context, thought process, etc -->
- This test started failing after we introduced the first tag with the `spruce/v` prefix.
- Fix test by only having it check that the tag ends in X.Y.Z; when we start tagging Spruce and Parsley in the same codebase we won't have a consistent prefix so this is more future-proof.