### PR TITLE
DEVPROD-3088: Fix checkbox behavior for regex search on Configure Patch page

### DIFF
--- a/cypress/integration/version/unscheduled_patch/configure_patch.ts
+++ b/cypress/integration/version/unscheduled_patch/configure_patch.ts
@@ -195,7 +195,7 @@ describe("Configure Patch Page", () => {
         cy.dataCy("selected-task-disclaimer").contains(
           `0 tasks across 0 build variants`,
         );
-        cy.dataCy("task-filter-input").type("dist");
+        cy.dataCy("task-filter-input").type("^dist");
         cy.dataCy("task-checkbox").should("have.length", 2);
         cy.contains("Select all tasks in view").click();
         cy.dataCy("selected-task-disclaimer").contains(

--- a/src/pages/configurePatch/configurePatchCore/ConfigureTasks/ConfigureTasks.test.tsx
+++ b/src/pages/configurePatch/configurePatchCore/ConfigureTasks/ConfigureTasks.test.tsx
@@ -221,10 +221,11 @@ describe("configureTasks", () => {
       expect(checkbox).toBeInTheDocument();
       expect(checkbox).not.toBeChecked();
       expect(setSelectedBuildVariantTasks).not.toHaveBeenCalled();
-      await user.click(screen.getByText("Select all tasks in these variants"));
+      await user.type(screen.getByDataCy("task-filter-input"), "^c");
+      await user.click(screen.getByText("Select all tasks in view"));
       expect(setSelectedBuildVariantTasks).toHaveBeenCalledWith({
-        ubuntu2004: { compile: true, test: true },
-        ubuntu1804: { compile: true, lint: true },
+        ubuntu2004: { compile: true, test: false },
+        ubuntu1804: { compile: true, lint: false },
       });
     });
     it("applying a search should filter the tasks", async () => {
@@ -247,7 +248,6 @@ describe("configureTasks", () => {
           setSelectedAliases={() => {}}
         />,
       );
-
       await user.type(screen.getByDataCy("task-filter-input"), "compile");
       expect(screen.queryAllByDataCy("task-checkbox")).toHaveLength(1);
       const checkbox = screen.getByLabelText("compile");

--- a/src/pages/configurePatch/configurePatchCore/ConfigureTasks/index.tsx
+++ b/src/pages/configurePatch/configurePatchCore/ConfigureTasks/index.tsx
@@ -149,10 +149,11 @@ const ConfigureTasks: React.FC<Props> = ({
   const onClickSelectAll = (e: React.ChangeEvent<HTMLInputElement>) => {
     const selectedBuildVariantsCopy = { ...selectedBuildVariantTasks };
     const selectedAliasesCopy = { ...selectedAliases };
+    const searchAsRegex = new RegExp(search);
     selectedBuildVariants.forEach((v) => {
       if (selectedBuildVariantsCopy?.[v] !== undefined) {
         Object.keys(selectedBuildVariantsCopy[v]).forEach((task) => {
-          if (search !== "" && !task.includes(search)) return;
+          if (searchAsRegex && !searchAsRegex.test(task)) return;
           selectedBuildVariantsCopy[v][task] = e.target.checked;
         });
       } else if (selectedAliasesCopy?.[v] !== undefined) {


### PR DESCRIPTION
DEVPROD-3088

### Description
Fixes bug where the "Select all" checkbox was only checking the plain text string and not the regex expression.

### Testing
- Modified existing tests
