### PR TITLE
DEVPROD-5282: Remove padding for nested table rows

### DIFF
--- a/src/components/Table/BaseTable.tsx
+++ b/src/components/Table/BaseTable.tsx
@@ -217,7 +217,7 @@ const RenderableRow = <T extends LGRowData>({
           virtualRow={virtualRow}
         >
           {subRow.getVisibleCells().map((cell) => (
-            <Cell key={cell.id} style={cellPaddingStyle}>
+            <Cell key={cell.id}>
               {flexRender(cell.column.columnDef.cell, cell.getContext())}
             </Cell>
           ))}

--- a/src/components/Table/__snapshots__/BaseTable.stories.storyshot
+++ b/src/components/Table/__snapshots__/BaseTable.stories.storyshot
@@ -7740,7 +7740,6 @@ exports[`Snapshot Tests BaseTable.stories LongContent 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -7759,7 +7758,6 @@ exports[`Snapshot Tests BaseTable.stories LongContent 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -7778,7 +7776,6 @@ exports[`Snapshot Tests BaseTable.stories LongContent 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -7904,7 +7901,6 @@ exports[`Snapshot Tests BaseTable.stories LongContent 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -7923,7 +7919,6 @@ exports[`Snapshot Tests BaseTable.stories LongContent 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -7942,7 +7937,6 @@ exports[`Snapshot Tests BaseTable.stories LongContent 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -8068,7 +8062,6 @@ exports[`Snapshot Tests BaseTable.stories LongContent 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -8087,7 +8080,6 @@ exports[`Snapshot Tests BaseTable.stories LongContent 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -8106,7 +8098,6 @@ exports[`Snapshot Tests BaseTable.stories LongContent 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -8465,7 +8456,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -8484,7 +8474,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -8503,7 +8492,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -8629,7 +8617,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -8648,7 +8635,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -8667,7 +8653,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -8793,7 +8778,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -8812,7 +8796,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -8831,7 +8814,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -8957,7 +8939,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -8976,7 +8957,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -8995,7 +8975,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -9121,7 +9100,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -9140,7 +9118,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -9159,7 +9136,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -9285,7 +9261,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -9304,7 +9279,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -9323,7 +9297,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -9449,7 +9422,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -9468,7 +9440,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -9487,7 +9458,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -9613,7 +9583,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -9632,7 +9601,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -9651,7 +9619,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -9777,7 +9744,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -9796,7 +9762,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -9815,7 +9780,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -9941,7 +9905,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -9960,7 +9923,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -9979,7 +9941,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -10105,7 +10066,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -10124,7 +10084,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -10143,7 +10102,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -10269,7 +10227,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -10288,7 +10245,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -10307,7 +10263,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -10433,7 +10388,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -10452,7 +10406,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -10471,7 +10424,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -10597,7 +10549,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -10616,7 +10567,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -10635,7 +10585,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -10761,7 +10710,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -10780,7 +10728,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -10799,7 +10746,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -10925,7 +10871,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -10944,7 +10889,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -10963,7 +10907,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -11089,7 +11032,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -11108,7 +11050,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -11127,7 +11068,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -11253,7 +11193,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -11272,7 +11211,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -11291,7 +11229,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -11417,7 +11354,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -11436,7 +11372,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -11455,7 +11390,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -11581,7 +11515,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -11600,7 +11533,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -11619,7 +11551,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -11745,7 +11676,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -11764,7 +11694,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -11783,7 +11712,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -11909,7 +11837,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -11928,7 +11855,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -11947,7 +11873,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -12073,7 +11998,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -12092,7 +12016,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -12111,7 +12034,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -12237,7 +12159,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -12256,7 +12177,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -12275,7 +12195,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -12401,7 +12320,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -12420,7 +12338,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -12439,7 +12356,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -12565,7 +12481,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -12584,7 +12499,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -12603,7 +12517,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -12729,7 +12642,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -12748,7 +12660,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -12767,7 +12678,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -12893,7 +12803,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -12912,7 +12821,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -12931,7 +12839,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -13057,7 +12964,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -13076,7 +12982,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -13095,7 +13000,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -13221,7 +13125,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -13240,7 +13143,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -13259,7 +13161,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -13385,7 +13286,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -13404,7 +13304,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -13423,7 +13322,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -13549,7 +13447,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -13568,7 +13465,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -13587,7 +13483,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -13713,7 +13608,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -13732,7 +13626,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -13751,7 +13644,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -13877,7 +13769,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -13896,7 +13787,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -13915,7 +13805,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -14041,7 +13930,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -14060,7 +13948,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -14079,7 +13966,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -14205,7 +14091,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -14224,7 +14109,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -14243,7 +14127,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -14369,7 +14252,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -14388,7 +14270,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -14407,7 +14288,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -14533,7 +14413,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -14552,7 +14431,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -14571,7 +14449,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -14697,7 +14574,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -14716,7 +14592,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -14735,7 +14610,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -14861,7 +14735,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -14880,7 +14753,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -14899,7 +14771,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -15025,7 +14896,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -15044,7 +14914,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -15063,7 +14932,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -15189,7 +15057,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -15208,7 +15075,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -15227,7 +15093,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -15353,7 +15218,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -15372,7 +15236,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -15391,7 +15254,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -15517,7 +15379,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -15536,7 +15397,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -15555,7 +15415,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -15681,7 +15540,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -15700,7 +15558,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -15719,7 +15576,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -15845,7 +15701,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -15864,7 +15719,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -15883,7 +15737,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -16009,7 +15862,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -16028,7 +15880,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -16047,7 +15898,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -16173,7 +16023,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -16192,7 +16041,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -16211,7 +16059,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -16337,7 +16184,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -16356,7 +16202,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -16375,7 +16220,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -16501,7 +16345,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -16520,7 +16363,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -16539,7 +16381,6 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"

--- a/src/pages/version/taskDuration/__snapshots__/TaskDurationTable.stories.storyshot
+++ b/src/pages/version/taskDuration/__snapshots__/TaskDurationTable.stories.storyshot
@@ -313,7 +313,6 @@ exports[`Snapshot Tests TaskDurationTable.stories Default 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -337,7 +336,6 @@ exports[`Snapshot Tests TaskDurationTable.stories Default 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -353,7 +351,6 @@ exports[`Snapshot Tests TaskDurationTable.stories Default 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -364,7 +361,6 @@ exports[`Snapshot Tests TaskDurationTable.stories Default 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -395,7 +391,6 @@ exports[`Snapshot Tests TaskDurationTable.stories Default 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -419,7 +414,6 @@ exports[`Snapshot Tests TaskDurationTable.stories Default 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -435,7 +429,6 @@ exports[`Snapshot Tests TaskDurationTable.stories Default 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -446,7 +439,6 @@ exports[`Snapshot Tests TaskDurationTable.stories Default 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -1607,7 +1599,6 @@ exports[`Snapshot Tests TaskDurationTable.stories LongContent 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -1631,7 +1622,6 @@ exports[`Snapshot Tests TaskDurationTable.stories LongContent 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -1647,7 +1637,6 @@ exports[`Snapshot Tests TaskDurationTable.stories LongContent 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -1658,7 +1647,6 @@ exports[`Snapshot Tests TaskDurationTable.stories LongContent 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -1689,7 +1677,6 @@ exports[`Snapshot Tests TaskDurationTable.stories LongContent 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -1713,7 +1700,6 @@ exports[`Snapshot Tests TaskDurationTable.stories LongContent 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -1729,7 +1715,6 @@ exports[`Snapshot Tests TaskDurationTable.stories LongContent 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -1740,7 +1725,6 @@ exports[`Snapshot Tests TaskDurationTable.stories LongContent 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -1771,7 +1755,6 @@ exports[`Snapshot Tests TaskDurationTable.stories LongContent 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -1795,7 +1778,6 @@ exports[`Snapshot Tests TaskDurationTable.stories LongContent 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -1811,7 +1793,6 @@ exports[`Snapshot Tests TaskDurationTable.stories LongContent 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -1822,7 +1803,6 @@ exports[`Snapshot Tests TaskDurationTable.stories LongContent 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -1853,7 +1833,6 @@ exports[`Snapshot Tests TaskDurationTable.stories LongContent 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -1877,7 +1856,6 @@ exports[`Snapshot Tests TaskDurationTable.stories LongContent 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -1893,7 +1871,6 @@ exports[`Snapshot Tests TaskDurationTable.stories LongContent 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -1904,7 +1881,6 @@ exports[`Snapshot Tests TaskDurationTable.stories LongContent 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -1935,7 +1911,6 @@ exports[`Snapshot Tests TaskDurationTable.stories LongContent 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -1959,7 +1934,6 @@ exports[`Snapshot Tests TaskDurationTable.stories LongContent 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -1975,7 +1949,6 @@ exports[`Snapshot Tests TaskDurationTable.stories LongContent 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -1986,7 +1959,6 @@ exports[`Snapshot Tests TaskDurationTable.stories LongContent 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -2017,7 +1989,6 @@ exports[`Snapshot Tests TaskDurationTable.stories LongContent 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -2041,7 +2012,6 @@ exports[`Snapshot Tests TaskDurationTable.stories LongContent 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -2057,7 +2027,6 @@ exports[`Snapshot Tests TaskDurationTable.stories LongContent 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -2068,7 +2037,6 @@ exports[`Snapshot Tests TaskDurationTable.stories LongContent 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -2099,7 +2067,6 @@ exports[`Snapshot Tests TaskDurationTable.stories LongContent 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -2123,7 +2090,6 @@ exports[`Snapshot Tests TaskDurationTable.stories LongContent 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -2139,7 +2105,6 @@ exports[`Snapshot Tests TaskDurationTable.stories LongContent 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -2150,7 +2115,6 @@ exports[`Snapshot Tests TaskDurationTable.stories LongContent 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -2181,7 +2145,6 @@ exports[`Snapshot Tests TaskDurationTable.stories LongContent 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -2205,7 +2168,6 @@ exports[`Snapshot Tests TaskDurationTable.stories LongContent 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -2221,7 +2183,6 @@ exports[`Snapshot Tests TaskDurationTable.stories LongContent 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -2232,7 +2193,6 @@ exports[`Snapshot Tests TaskDurationTable.stories LongContent 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -2263,7 +2223,6 @@ exports[`Snapshot Tests TaskDurationTable.stories LongContent 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -2287,7 +2246,6 @@ exports[`Snapshot Tests TaskDurationTable.stories LongContent 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -2303,7 +2261,6 @@ exports[`Snapshot Tests TaskDurationTable.stories LongContent 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -2314,7 +2271,6 @@ exports[`Snapshot Tests TaskDurationTable.stories LongContent 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -2345,7 +2301,6 @@ exports[`Snapshot Tests TaskDurationTable.stories LongContent 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -2369,7 +2324,6 @@ exports[`Snapshot Tests TaskDurationTable.stories LongContent 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -2385,7 +2339,6 @@ exports[`Snapshot Tests TaskDurationTable.stories LongContent 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -2396,7 +2349,6 @@ exports[`Snapshot Tests TaskDurationTable.stories LongContent 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -2427,7 +2379,6 @@ exports[`Snapshot Tests TaskDurationTable.stories LongContent 1`] = `
         >
           <td
             class="leafygreen-ui-dm20k9"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -2451,7 +2402,6 @@ exports[`Snapshot Tests TaskDurationTable.stories LongContent 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -2467,7 +2417,6 @@ exports[`Snapshot Tests TaskDurationTable.stories LongContent 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"
@@ -2478,7 +2427,6 @@ exports[`Snapshot Tests TaskDurationTable.stories LongContent 1`] = `
           </td>
           <td
             class="leafygreen-ui-1by885u"
-            style="padding-bottom: 4px; padding-top: 4px;"
           >
             <div
               class="leafygreen-ui-21vumk"


### PR DESCRIPTION
DEVPROD-5282

### Description
Wanted to fix this before [DEVPROD-1976](https://jira.mongodb.org/browse/DEVPROD-1976).

LeafyGreen just said to not use padding. I think padding might still be valuable for non-nested rows though, the test and files tables look kind of bad without it 😅
