### PR TITLE
DEVPROD-5595: Downgrade LG text input

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@leafygreen-ui/table": "12.5.0",
     "@leafygreen-ui/tabs": "11.0.4",
     "@leafygreen-ui/text-area": "8.0.21",
-    "@leafygreen-ui/text-input": "12.1.24",
+    "@leafygreen-ui/text-input": "12.1.12",
     "@leafygreen-ui/toast": "6.1.4",
     "@leafygreen-ui/toggle": "10.0.17",
     "@leafygreen-ui/tokens": "2.3.0",

--- a/src/components/EditableTagField/__snapshots__/EditableTagField.stories.storyshot
+++ b/src/components/EditableTagField/__snapshots__/EditableTagField.stories.storyshot
@@ -19,47 +19,35 @@ exports[`Snapshot Tests EditableTagField.stories Default 1`] = `
             class="css-jmhbun-FlexColumnContainer-Section e161fbrp1"
           >
             <div
-              class="leafygreen-ui-1br9h7w"
+              class="leafygreen-ui-90q1a7"
             >
               <div
                 class="leafygreen-ui-e3fvh5"
               >
                 <label
-                  class="leafygreen-ui-1qjbbjd"
+                  class="leafygreen-ui-t01kw4"
                   for="tag_key_1"
-                  id="lg-form-field-label-3"
                 >
                   Key
                 </label>
               </div>
               <div
-                aria-disabled="false"
-                class="leafygreen-ui-mrtshz"
+                class="leafygreen-ui-lzja97"
               >
+                <input
+                  aria-invalid="false"
+                  autocomplete="on"
+                  class="leafygreen-ui-1kmfbzh"
+                  data-cy="user-tag-key-field"
+                  id="tag_key_1"
+                  required=""
+                  type="text"
+                  value="keyA"
+                />
                 <div
-                  class="leafygreen-ui-1ago99h"
-                >
-                  <input
-                    aria-describedby=""
-                    aria-invalid="false"
-                    aria-label=""
-                    aria-labelledby="lg-form-field-label-3"
-                    autocomplete="on"
-                    class="lg-ui-form-field-input-0000 leafygreen-ui-vrj1me"
-                    data-cy="user-tag-key-field"
-                    id="tag_key_1"
-                    required=""
-                    type="text"
-                    value="keyA"
-                  />
-                </div>
-                <div
-                  class="leafygreen-ui-iwiovi"
+                  class="lg-ui-icon-selector-0000 leafygreen-ui-11c7q5r"
                 />
               </div>
-              <div
-                class="leafygreen-ui-jsxxy6"
-              />
             </div>
           </div>
         </div>
@@ -70,47 +58,35 @@ exports[`Snapshot Tests EditableTagField.stories Default 1`] = `
             class="css-jmhbun-FlexColumnContainer-Section e161fbrp1"
           >
             <div
-              class="leafygreen-ui-1br9h7w"
+              class="leafygreen-ui-90q1a7"
             >
               <div
                 class="leafygreen-ui-e3fvh5"
               >
                 <label
-                  class="leafygreen-ui-1qjbbjd"
+                  class="leafygreen-ui-t01kw4"
                   for="tag_value_1"
-                  id="lg-form-field-label-7"
                 >
                   Value
                 </label>
               </div>
               <div
-                aria-disabled="false"
-                class="leafygreen-ui-mrtshz"
+                class="leafygreen-ui-lzja97"
               >
+                <input
+                  aria-invalid="false"
+                  autocomplete="on"
+                  class="leafygreen-ui-1kmfbzh"
+                  data-cy="user-tag-value-field"
+                  id="tag_value_1"
+                  required=""
+                  type="text"
+                  value="valueA"
+                />
                 <div
-                  class="leafygreen-ui-1ago99h"
-                >
-                  <input
-                    aria-describedby=""
-                    aria-invalid="false"
-                    aria-label=""
-                    aria-labelledby="lg-form-field-label-7"
-                    autocomplete="on"
-                    class="lg-ui-form-field-input-0000 leafygreen-ui-vrj1me"
-                    data-cy="user-tag-value-field"
-                    id="tag_value_1"
-                    required=""
-                    type="text"
-                    value="valueA"
-                  />
-                </div>
-                <div
-                  class="leafygreen-ui-iwiovi"
+                  class="lg-ui-icon-selector-0000 leafygreen-ui-11c7q5r"
                 />
               </div>
-              <div
-                class="leafygreen-ui-jsxxy6"
-              />
             </div>
           </div>
         </div>
@@ -163,47 +139,35 @@ exports[`Snapshot Tests EditableTagField.stories Default 1`] = `
             class="css-jmhbun-FlexColumnContainer-Section e161fbrp1"
           >
             <div
-              class="leafygreen-ui-1br9h7w"
+              class="leafygreen-ui-90q1a7"
             >
               <div
                 class="leafygreen-ui-e3fvh5"
               >
                 <label
-                  class="leafygreen-ui-1qjbbjd"
+                  class="leafygreen-ui-t01kw4"
                   for="tag_key_2"
-                  id="lg-form-field-label-11"
                 >
                   Key
                 </label>
               </div>
               <div
-                aria-disabled="false"
-                class="leafygreen-ui-mrtshz"
+                class="leafygreen-ui-lzja97"
               >
+                <input
+                  aria-invalid="false"
+                  autocomplete="on"
+                  class="leafygreen-ui-1kmfbzh"
+                  data-cy="user-tag-key-field"
+                  id="tag_key_2"
+                  required=""
+                  type="text"
+                  value="keyB"
+                />
                 <div
-                  class="leafygreen-ui-1ago99h"
-                >
-                  <input
-                    aria-describedby=""
-                    aria-invalid="false"
-                    aria-label=""
-                    aria-labelledby="lg-form-field-label-11"
-                    autocomplete="on"
-                    class="lg-ui-form-field-input-0000 leafygreen-ui-vrj1me"
-                    data-cy="user-tag-key-field"
-                    id="tag_key_2"
-                    required=""
-                    type="text"
-                    value="keyB"
-                  />
-                </div>
-                <div
-                  class="leafygreen-ui-iwiovi"
+                  class="lg-ui-icon-selector-0000 leafygreen-ui-11c7q5r"
                 />
               </div>
-              <div
-                class="leafygreen-ui-jsxxy6"
-              />
             </div>
           </div>
         </div>
@@ -214,47 +178,35 @@ exports[`Snapshot Tests EditableTagField.stories Default 1`] = `
             class="css-jmhbun-FlexColumnContainer-Section e161fbrp1"
           >
             <div
-              class="leafygreen-ui-1br9h7w"
+              class="leafygreen-ui-90q1a7"
             >
               <div
                 class="leafygreen-ui-e3fvh5"
               >
                 <label
-                  class="leafygreen-ui-1qjbbjd"
+                  class="leafygreen-ui-t01kw4"
                   for="tag_value_2"
-                  id="lg-form-field-label-15"
                 >
                   Value
                 </label>
               </div>
               <div
-                aria-disabled="false"
-                class="leafygreen-ui-mrtshz"
+                class="leafygreen-ui-lzja97"
               >
+                <input
+                  aria-invalid="false"
+                  autocomplete="on"
+                  class="leafygreen-ui-1kmfbzh"
+                  data-cy="user-tag-value-field"
+                  id="tag_value_2"
+                  required=""
+                  type="text"
+                  value="valueB"
+                />
                 <div
-                  class="leafygreen-ui-1ago99h"
-                >
-                  <input
-                    aria-describedby=""
-                    aria-invalid="false"
-                    aria-label=""
-                    aria-labelledby="lg-form-field-label-15"
-                    autocomplete="on"
-                    class="lg-ui-form-field-input-0000 leafygreen-ui-vrj1me"
-                    data-cy="user-tag-value-field"
-                    id="tag_value_2"
-                    required=""
-                    type="text"
-                    value="valueB"
-                  />
-                </div>
-                <div
-                  class="leafygreen-ui-iwiovi"
+                  class="lg-ui-icon-selector-0000 leafygreen-ui-11c7q5r"
                 />
               </div>
-              <div
-                class="leafygreen-ui-jsxxy6"
-              />
             </div>
           </div>
         </div>
@@ -307,47 +259,35 @@ exports[`Snapshot Tests EditableTagField.stories Default 1`] = `
             class="css-jmhbun-FlexColumnContainer-Section e161fbrp1"
           >
             <div
-              class="leafygreen-ui-1br9h7w"
+              class="leafygreen-ui-90q1a7"
             >
               <div
                 class="leafygreen-ui-e3fvh5"
               >
                 <label
-                  class="leafygreen-ui-1qjbbjd"
+                  class="leafygreen-ui-t01kw4"
                   for="tag_key_3"
-                  id="lg-form-field-label-19"
                 >
                   Key
                 </label>
               </div>
               <div
-                aria-disabled="false"
-                class="leafygreen-ui-mrtshz"
+                class="leafygreen-ui-lzja97"
               >
+                <input
+                  aria-invalid="false"
+                  autocomplete="on"
+                  class="leafygreen-ui-1kmfbzh"
+                  data-cy="user-tag-key-field"
+                  id="tag_key_3"
+                  required=""
+                  type="text"
+                  value="keyC"
+                />
                 <div
-                  class="leafygreen-ui-1ago99h"
-                >
-                  <input
-                    aria-describedby=""
-                    aria-invalid="false"
-                    aria-label=""
-                    aria-labelledby="lg-form-field-label-19"
-                    autocomplete="on"
-                    class="lg-ui-form-field-input-0000 leafygreen-ui-vrj1me"
-                    data-cy="user-tag-key-field"
-                    id="tag_key_3"
-                    required=""
-                    type="text"
-                    value="keyC"
-                  />
-                </div>
-                <div
-                  class="leafygreen-ui-iwiovi"
+                  class="lg-ui-icon-selector-0000 leafygreen-ui-11c7q5r"
                 />
               </div>
-              <div
-                class="leafygreen-ui-jsxxy6"
-              />
             </div>
           </div>
         </div>
@@ -358,47 +298,35 @@ exports[`Snapshot Tests EditableTagField.stories Default 1`] = `
             class="css-jmhbun-FlexColumnContainer-Section e161fbrp1"
           >
             <div
-              class="leafygreen-ui-1br9h7w"
+              class="leafygreen-ui-90q1a7"
             >
               <div
                 class="leafygreen-ui-e3fvh5"
               >
                 <label
-                  class="leafygreen-ui-1qjbbjd"
+                  class="leafygreen-ui-t01kw4"
                   for="tag_value_3"
-                  id="lg-form-field-label-23"
                 >
                   Value
                 </label>
               </div>
               <div
-                aria-disabled="false"
-                class="leafygreen-ui-mrtshz"
+                class="leafygreen-ui-lzja97"
               >
+                <input
+                  aria-invalid="false"
+                  autocomplete="on"
+                  class="leafygreen-ui-1kmfbzh"
+                  data-cy="user-tag-value-field"
+                  id="tag_value_3"
+                  required=""
+                  type="text"
+                  value="valueC"
+                />
                 <div
-                  class="leafygreen-ui-1ago99h"
-                >
-                  <input
-                    aria-describedby=""
-                    aria-invalid="false"
-                    aria-label=""
-                    aria-labelledby="lg-form-field-label-23"
-                    autocomplete="on"
-                    class="lg-ui-form-field-input-0000 leafygreen-ui-vrj1me"
-                    data-cy="user-tag-value-field"
-                    id="tag_value_3"
-                    required=""
-                    type="text"
-                    value="valueC"
-                  />
-                </div>
-                <div
-                  class="leafygreen-ui-iwiovi"
+                  class="lg-ui-icon-selector-0000 leafygreen-ui-11c7q5r"
                 />
               </div>
-              <div
-                class="leafygreen-ui-jsxxy6"
-              />
             </div>
           </div>
         </div>

--- a/src/components/FilterBadges/__snapshots__/FilterBadges.stories.storyshot
+++ b/src/components/FilterBadges/__snapshots__/FilterBadges.stories.storyshot
@@ -54,90 +54,66 @@ exports[`Snapshot Tests FilterBadges.stories Default 1`] = `
     </div>
     <div>
       <div
-        class="leafygreen-ui-1br9h7w"
+        class="leafygreen-ui-90q1a7"
       >
         <div
           class="leafygreen-ui-e3fvh5"
         >
           <label
-            class="leafygreen-ui-1qjbbjd"
-            for="lg-form-field-input-31"
-            id="lg-form-field-label-28"
+            class="leafygreen-ui-t01kw4"
+            for="textinput-1"
           >
             key
           </label>
         </div>
         <div
-          aria-disabled="false"
-          class="leafygreen-ui-mrtshz"
+          class="leafygreen-ui-lzja97"
         >
+          <input
+            aria-invalid="false"
+            autocomplete="on"
+            class="leafygreen-ui-1kmfbzh"
+            id="textinput-1"
+            placeholder="key"
+            required=""
+            type="text"
+            value=""
+          />
           <div
-            class="leafygreen-ui-1ago99h"
-          >
-            <input
-              aria-describedby=""
-              aria-invalid="false"
-              aria-label=""
-              aria-labelledby="lg-form-field-label-28"
-              autocomplete="on"
-              class="lg-ui-form-field-input-0000 leafygreen-ui-vrj1me"
-              id="lg-form-field-input-31"
-              placeholder="key"
-              required=""
-              type="text"
-              value=""
-            />
-          </div>
-          <div
-            class="leafygreen-ui-iwiovi"
+            class="lg-ui-icon-selector-0000 leafygreen-ui-11c7q5r"
           />
         </div>
-        <div
-          class="leafygreen-ui-jsxxy6"
-        />
       </div>
       <div
-        class="leafygreen-ui-1br9h7w"
+        class="leafygreen-ui-90q1a7"
       >
         <div
           class="leafygreen-ui-e3fvh5"
         >
           <label
-            class="leafygreen-ui-1qjbbjd"
-            for="lg-form-field-input-35"
-            id="lg-form-field-label-32"
+            class="leafygreen-ui-t01kw4"
+            for="textinput-2"
           >
             value
           </label>
         </div>
         <div
-          aria-disabled="false"
-          class="leafygreen-ui-mrtshz"
+          class="leafygreen-ui-lzja97"
         >
+          <input
+            aria-invalid="false"
+            autocomplete="on"
+            class="leafygreen-ui-1kmfbzh"
+            id="textinput-2"
+            placeholder="value"
+            required=""
+            type="text"
+            value=""
+          />
           <div
-            class="leafygreen-ui-1ago99h"
-          >
-            <input
-              aria-describedby=""
-              aria-invalid="false"
-              aria-label=""
-              aria-labelledby="lg-form-field-label-32"
-              autocomplete="on"
-              class="lg-ui-form-field-input-0000 leafygreen-ui-vrj1me"
-              id="lg-form-field-input-35"
-              placeholder="value"
-              required=""
-              type="text"
-              value=""
-            />
-          </div>
-          <div
-            class="leafygreen-ui-iwiovi"
+            class="lg-ui-icon-selector-0000 leafygreen-ui-11c7q5r"
           />
         </div>
-        <div
-          class="leafygreen-ui-jsxxy6"
-        />
       </div>
       <button
         aria-disabled="false"

--- a/src/components/HistoryTable/HistoryTableTestSearch/__snapshots__/HistoryTableTestSearch.stories.storyshot
+++ b/src/components/HistoryTable/HistoryTableTestSearch/__snapshots__/HistoryTableTestSearch.stories.storyshot
@@ -12,47 +12,36 @@ exports[`Snapshot Tests Components/HistoryTable/HistoryTableTestSearch Default 1
         class="css-mk4qpy-TextInputWrapper e13gwrw81"
       >
         <div
-          class="leafygreen-ui-1br9h7w"
+          class="leafygreen-ui-90q1a7"
         >
           <div
             class="leafygreen-ui-e3fvh5"
           >
             <label
-              class="leafygreen-ui-1qjbbjd"
-              for="lg-form-field-input-65"
-              id="lg-form-field-label-62"
+              class="leafygreen-ui-t01kw4"
+              for="textinput-3"
             >
               Filter by Failed Tests
             </label>
           </div>
           <div
-            aria-disabled="false"
-            class="leafygreen-ui-mrtshz"
+            class="leafygreen-ui-lzja97"
           >
+            <input
+              aria-invalid="false"
+              aria-label="history-table-test-search-input"
+              autocomplete="on"
+              class="leafygreen-ui-1kmfbzh"
+              id="textinput-3"
+              placeholder="Search test name regex"
+              required=""
+              type="search"
+              value=""
+            />
             <div
-              class="leafygreen-ui-1ago99h"
-            >
-              <input
-                aria-describedby=""
-                aria-invalid="false"
-                aria-label=""
-                aria-labelledby="lg-form-field-label-62"
-                autocomplete="on"
-                class="lg-ui-form-field-input-0000 leafygreen-ui-vrj1me"
-                id="lg-form-field-input-65"
-                placeholder="Search test name regex"
-                required=""
-                type="search"
-                value=""
-              />
-            </div>
-            <div
-              class="leafygreen-ui-iwiovi"
+              class="lg-ui-icon-selector-0000 leafygreen-ui-11c7q5r"
             />
           </div>
-          <div
-            class="leafygreen-ui-jsxxy6"
-          />
         </div>
         <div
           class="css-4bamt4-IconWrapper e13gwrw80"

--- a/src/components/PageSizeSelector/__snapshots__/PageSizeSelector.stories.storyshot
+++ b/src/components/PageSizeSelector/__snapshots__/PageSizeSelector.stories.storyshot
@@ -6,15 +6,15 @@ exports[`Snapshot Tests PageSizeSelector.stories Default 1`] = `
     class="leafygreen-ui-1iyoj2o css-5krlfz-StyledSelect ekttol50"
   >
     <button
-      aria-controls="select-220-menu"
-      aria-describedby="select-220-description"
+      aria-controls="select-184-menu"
+      aria-describedby="select-184-description"
       aria-disabled="false"
       aria-expanded="false"
       aria-invalid="false"
       aria-labelledby="page-size-select"
       class="lg-ui-button-0000 leafygreen-ui-1rmc7qb"
       data-testid="leafygreen-ui-select-menubutton"
-      id="select-221"
+      id="select-185"
       type="button"
       value="10"
     >

--- a/src/components/SpruceForm/__snapshots__/SpruceForm.stories.storyshot
+++ b/src/components/SpruceForm/__snapshots__/SpruceForm.stories.storyshot
@@ -38,22 +38,22 @@ exports[`Snapshot Tests SpruceForm.stories Example1 1`] = `
                   >
                     <label
                       class="leafygreen-ui-nf64md"
-                      for="select-227"
-                      id="select-226-label"
+                      for="select-191"
+                      id="select-190-label"
                     >
                       Project Cloning Method
                     </label>
                   </div>
                   <button
-                    aria-controls="select-226-menu"
-                    aria-describedby="select-226-description"
+                    aria-controls="select-190-menu"
+                    aria-describedby="select-190-description"
                     aria-disabled="false"
                     aria-expanded="false"
                     aria-invalid="false"
-                    aria-labelledby="select-226-label"
+                    aria-labelledby="select-190-label"
                     class="lg-ui-button-0000 leafygreen-ui-1bkgt4w"
                     data-testid="leafygreen-ui-select-menubutton"
-                    id="select-227"
+                    id="select-191"
                     type="button"
                     value="legacy-ssh"
                   >
@@ -160,46 +160,35 @@ exports[`Snapshot Tests SpruceForm.stories Example1 1`] = `
                           class="css-cjejq9-ElementWrapper ee4bs9n0"
                         >
                           <div
-                            class="leafygreen-ui-1br9h7w css-1kbcljo-StyledTextInput eevpusu6"
+                            class="css-1kbcljo-StyledTextInput eevpusu6 leafygreen-ui-90q1a7"
                           >
                             <div
                               class="leafygreen-ui-e3fvh5"
                             >
                               <label
-                                class="leafygreen-ui-1qjbbjd"
-                                for="lg-form-field-input-231"
-                                id="lg-form-field-label-228"
+                                class="leafygreen-ui-t01kw4"
+                                for="textinput-4"
                               >
                                 key
                               </label>
                             </div>
                             <div
-                              aria-disabled="false"
-                              class="leafygreen-ui-mrtshz"
+                              class="leafygreen-ui-lzja97"
                             >
+                              <input
+                                aria-invalid="false"
+                                aria-label="key"
+                                autocomplete="on"
+                                class="leafygreen-ui-1kmfbzh"
+                                id="textinput-4"
+                                required=""
+                                type="text"
+                                value="Sample Input"
+                              />
                               <div
-                                class="leafygreen-ui-1ago99h"
-                              >
-                                <input
-                                  aria-describedby=""
-                                  aria-invalid="false"
-                                  aria-label=""
-                                  aria-labelledby="lg-form-field-label-228"
-                                  autocomplete="on"
-                                  class="lg-ui-form-field-input-0000 leafygreen-ui-vrj1me"
-                                  id="lg-form-field-input-231"
-                                  required=""
-                                  type="text"
-                                  value="Sample Input"
-                                />
-                              </div>
-                              <div
-                                class="leafygreen-ui-iwiovi"
+                                class="lg-ui-icon-selector-0000 leafygreen-ui-11c7q5r"
                               />
                             </div>
-                            <div
-                              class="leafygreen-ui-jsxxy6"
-                            />
                           </div>
                         </div>
                       </div>
@@ -211,46 +200,35 @@ exports[`Snapshot Tests SpruceForm.stories Example1 1`] = `
                           class="css-cjejq9-ElementWrapper ee4bs9n0"
                         >
                           <div
-                            class="leafygreen-ui-1br9h7w css-1kbcljo-StyledTextInput eevpusu6"
+                            class="css-1kbcljo-StyledTextInput eevpusu6 leafygreen-ui-90q1a7"
                           >
                             <div
                               class="leafygreen-ui-e3fvh5"
                             >
                               <label
-                                class="leafygreen-ui-1qjbbjd"
-                                for="lg-form-field-input-235"
-                                id="lg-form-field-label-232"
+                                class="leafygreen-ui-t01kw4"
+                                for="textinput-5"
                               >
                                 value
                               </label>
                             </div>
                             <div
-                              aria-disabled="false"
-                              class="leafygreen-ui-mrtshz"
+                              class="leafygreen-ui-lzja97"
                             >
+                              <input
+                                aria-invalid="false"
+                                aria-label="value"
+                                autocomplete="on"
+                                class="leafygreen-ui-1kmfbzh"
+                                id="textinput-5"
+                                required=""
+                                type="text"
+                                value="Sample Input"
+                              />
                               <div
-                                class="leafygreen-ui-1ago99h"
-                              >
-                                <input
-                                  aria-describedby=""
-                                  aria-invalid="false"
-                                  aria-label=""
-                                  aria-labelledby="lg-form-field-label-232"
-                                  autocomplete="on"
-                                  class="lg-ui-form-field-input-0000 leafygreen-ui-vrj1me"
-                                  id="lg-form-field-input-235"
-                                  required=""
-                                  type="text"
-                                  value="Sample Input"
-                                />
-                              </div>
-                              <div
-                                class="leafygreen-ui-iwiovi"
+                                class="lg-ui-icon-selector-0000 leafygreen-ui-11c7q5r"
                               />
                             </div>
-                            <div
-                              class="leafygreen-ui-jsxxy6"
-                            />
                           </div>
                         </div>
                       </div>
@@ -306,13 +284,13 @@ exports[`Snapshot Tests SpruceForm.stories Example1 1`] = `
                 >
                   <label
                     class="leafygreen-ui-1fi5x3a"
-                    for="textarea-236"
+                    for="textarea-192"
                   >
                     Valid Projects
                   </label>
                   <textarea
                     class="leafygreen-ui-18em0fn"
-                    id="textarea-236"
+                    id="textarea-192"
                     rows="5"
                     title="Valid Projects"
                   />
@@ -601,7 +579,7 @@ exports[`Snapshot Tests SpruceForm.stories Example2 1`] = `
                     >
                       <input
                         aria-checked="false"
-                        aria-describedby="lg-237"
+                        aria-describedby="lg-193"
                         aria-disabled="false"
                         class="lg-ui-radio-group-0002 leafygreen-ui-1iwed1m"
                         id="radio-group--0"
@@ -628,7 +606,7 @@ exports[`Snapshot Tests SpruceForm.stories Example2 1`] = `
                     >
                       <input
                         aria-checked="false"
-                        aria-describedby="lg-238"
+                        aria-describedby="lg-194"
                         aria-disabled="false"
                         class="lg-ui-radio-group-0002 leafygreen-ui-1iwed1m"
                         id="radio-group--1"

--- a/src/components/Table/TableControl/__snapshots__/TableControl.stories.storyshot
+++ b/src/components/Table/TableControl/__snapshots__/TableControl.stories.storyshot
@@ -128,8 +128,8 @@ exports[`Snapshot Tests TableControl.stories Default 1`] = `
         class="leafygreen-ui-1iyoj2o css-5krlfz-StyledSelect ekttol50"
       >
         <button
-          aria-controls="select-239-menu"
-          aria-describedby="select-239-description"
+          aria-controls="select-195-menu"
+          aria-describedby="select-195-description"
           aria-disabled="false"
           aria-expanded="false"
           aria-invalid="false"
@@ -137,7 +137,7 @@ exports[`Snapshot Tests TableControl.stories Default 1`] = `
           class="lg-ui-button-0000 leafygreen-ui-1rmc7qb"
           data-cy="tasks-table-page-size-selector"
           data-testid="leafygreen-ui-select-menubutton"
-          id="select-240"
+          id="select-196"
           type="button"
           value="10"
         >

--- a/src/components/TextInputWithGlyph/__snapshots__/TextInputWithGlyph.stories.storyshot
+++ b/src/components/TextInputWithGlyph/__snapshots__/TextInputWithGlyph.stories.storyshot
@@ -6,47 +6,35 @@ exports[`Snapshot Tests Components/TextInput/TextInputWithGlyph Default 1`] = `
     class="css-mk4qpy-TextInputWrapper e13gwrw81"
   >
     <div
-      class="leafygreen-ui-1br9h7w"
+      class="leafygreen-ui-90q1a7"
     >
       <div
         class="leafygreen-ui-e3fvh5"
       >
         <label
-          class="leafygreen-ui-1qjbbjd"
-          for="lg-form-field-input-244"
-          id="lg-form-field-label-241"
+          class="leafygreen-ui-t01kw4"
+          for="textinput-6"
         >
           Some search field
         </label>
       </div>
       <div
-        aria-disabled="false"
-        class="leafygreen-ui-mrtshz"
+        class="leafygreen-ui-lzja97"
       >
+        <input
+          aria-invalid="false"
+          autocomplete="on"
+          class="leafygreen-ui-1kmfbzh"
+          id="textinput-6"
+          placeholder="Search"
+          required=""
+          type="text"
+          value=""
+        />
         <div
-          class="leafygreen-ui-1ago99h"
-        >
-          <input
-            aria-describedby=""
-            aria-invalid="false"
-            aria-label=""
-            aria-labelledby="lg-form-field-label-241"
-            autocomplete="on"
-            class="lg-ui-form-field-input-0000 leafygreen-ui-vrj1me"
-            id="lg-form-field-input-244"
-            placeholder="Search"
-            required=""
-            type="text"
-            value=""
-          />
-        </div>
-        <div
-          class="leafygreen-ui-iwiovi"
+          class="lg-ui-icon-selector-0000 leafygreen-ui-11c7q5r"
         />
       </div>
-      <div
-        class="leafygreen-ui-jsxxy6"
-      />
     </div>
     <div
       class="css-4bamt4-IconWrapper e13gwrw80"

--- a/src/components/TextInputWithValidation/__snapshots__/TextInputWithValidation.stories.storyshot
+++ b/src/components/TextInputWithValidation/__snapshots__/TextInputWithValidation.stories.storyshot
@@ -6,46 +6,34 @@ exports[`Snapshot Tests Components/TextInput/TextInputWithValidation Default 1`]
     class="css-mk4qpy-TextInputWrapper e13gwrw81"
   >
     <div
-      class="leafygreen-ui-1br9h7w"
+      class="leafygreen-ui-90q1a7"
     >
       <div
         class="leafygreen-ui-e3fvh5"
       >
         <label
-          class="leafygreen-ui-1qjbbjd"
-          for="lg-form-field-input-248"
-          id="lg-form-field-label-245"
+          class="leafygreen-ui-t01kw4"
+          for="textinput-7"
         >
           Some search field
         </label>
       </div>
       <div
-        aria-disabled="false"
-        class="leafygreen-ui-mrtshz"
+        class="leafygreen-ui-lzja97"
       >
+        <input
+          aria-invalid="false"
+          autocomplete="on"
+          class="leafygreen-ui-1kmfbzh"
+          id="textinput-7"
+          required=""
+          type="text"
+          value=""
+        />
         <div
-          class="leafygreen-ui-1ago99h"
-        >
-          <input
-            aria-describedby=""
-            aria-invalid="false"
-            aria-label=""
-            aria-labelledby="lg-form-field-label-245"
-            autocomplete="on"
-            class="lg-ui-form-field-input-0000 leafygreen-ui-vrj1me"
-            id="lg-form-field-input-248"
-            required=""
-            type="text"
-            value=""
-          />
-        </div>
-        <div
-          class="leafygreen-ui-iwiovi"
+          class="lg-ui-icon-selector-0000 leafygreen-ui-11c7q5r"
         />
       </div>
-      <div
-        class="leafygreen-ui-jsxxy6"
-      />
     </div>
     <div
       class="css-4bamt4-IconWrapper e13gwrw80"

--- a/src/components/TupleSelect/__snapshots__/TupleSelect.stories.storyshot
+++ b/src/components/TupleSelect/__snapshots__/TupleSelect.stories.storyshot
@@ -20,8 +20,8 @@ exports[`Snapshot Tests TupleSelect.stories Default 1`] = `
         class="leafygreen-ui-1iyoj2o css-1scwv0u-GroupedSelect e5gn9hl1"
       >
         <button
-          aria-controls="select-249-menu"
-          aria-describedby="select-249-description"
+          aria-controls="select-197-menu"
+          aria-describedby="select-197-description"
           aria-disabled="false"
           aria-expanded="false"
           aria-invalid="false"
@@ -29,7 +29,7 @@ exports[`Snapshot Tests TupleSelect.stories Default 1`] = `
           class="lg-ui-button-0000 leafygreen-ui-1bkgt4w"
           data-cy="tuple-select-dropdown"
           data-testid="leafygreen-ui-select-menubutton"
-          id="select-250"
+          id="select-198"
           type="button"
           value="build_variant"
         >
@@ -69,38 +69,27 @@ exports[`Snapshot Tests TupleSelect.stories Default 1`] = `
         class="e5gn9hl0 css-47706i-TextInputWrapper-GroupedTextInput e13gwrw81"
       >
         <div
-          class="leafygreen-ui-1br9h7w"
+          class="leafygreen-ui-90q1a7"
         >
           <div
-            class="leafygreen-ui-e3fvh5"
-          />
-          <div
-            aria-disabled="false"
-            class="leafygreen-ui-mrtshz"
+            class="leafygreen-ui-lzja97"
           >
+            <input
+              aria-invalid="false"
+              aria-label="Build Variant"
+              autocomplete="on"
+              class="leafygreen-ui-1kmfbzh"
+              data-cy="tuple-select-input"
+              id="filter-input"
+              placeholder="Search Build Variant names"
+              required=""
+              type="search"
+              value=""
+            />
             <div
-              class="leafygreen-ui-1ago99h"
-            >
-              <input
-                aria-describedby=""
-                aria-invalid="false"
-                autocomplete="on"
-                class="lg-ui-form-field-input-0000 leafygreen-ui-vrj1me"
-                data-cy="tuple-select-input"
-                id="filter-input"
-                placeholder="Search Build Variant names"
-                required=""
-                type="search"
-                value=""
-              />
-            </div>
-            <div
-              class="leafygreen-ui-iwiovi"
+              class="lg-ui-icon-selector-0000 leafygreen-ui-11c7q5r"
             />
           </div>
-          <div
-            class="leafygreen-ui-jsxxy6"
-          />
         </div>
         <div
           class="css-4bamt4-IconWrapper e13gwrw80"

--- a/src/components/TupleSelectWithRegexConditional/__snapshots__/TupleSelectWithRegexConditional.stories.storyshot
+++ b/src/components/TupleSelectWithRegexConditional/__snapshots__/TupleSelectWithRegexConditional.stories.storyshot
@@ -17,8 +17,8 @@ exports[`Snapshot Tests Components/TupleSelect WithConditional 1`] = `
           class="leafygreen-ui-ozfao7 css-1qa4isu-PaddedSegmentedControl egmqwjk0"
         >
           <div
-            aria-label="segmented-control-255"
-            aria-owns="segmented-control-255-0 segmented-control-255-1"
+            aria-label="segmented-control-199"
+            aria-owns="segmented-control-199-0 segmented-control-199-1"
             class="leafygreen-ui-18en4yf"
             role="tablist"
           >
@@ -35,7 +35,7 @@ exports[`Snapshot Tests Components/TupleSelect WithConditional 1`] = `
                   aria-controls="tuple-select-with-regex"
                   aria-selected="true"
                   class="leafygreen-ui-ypz97o"
-                  id="segmented-control-255-0"
+                  id="segmented-control-199-0"
                   role="tab"
                   tabindex="0"
                   type="button"
@@ -65,7 +65,7 @@ exports[`Snapshot Tests Components/TupleSelect WithConditional 1`] = `
                   aria-controls="tuple-select-with-regex"
                   aria-selected="false"
                   class="leafygreen-ui-ypz97o"
-                  id="segmented-control-255-1"
+                  id="segmented-control-199-1"
                   role="tab"
                   tabindex="-1"
                   type="button"
@@ -99,8 +99,8 @@ exports[`Snapshot Tests Components/TupleSelect WithConditional 1`] = `
         class="leafygreen-ui-1iyoj2o css-1scwv0u-GroupedSelect e5gn9hl1"
       >
         <button
-          aria-controls="select-256-menu"
-          aria-describedby="select-256-description"
+          aria-controls="select-200-menu"
+          aria-describedby="select-200-description"
           aria-disabled="false"
           aria-expanded="false"
           aria-invalid="false"
@@ -108,7 +108,7 @@ exports[`Snapshot Tests Components/TupleSelect WithConditional 1`] = `
           class="lg-ui-button-0000 leafygreen-ui-1bkgt4w"
           data-cy="tuple-select-dropdown"
           data-testid="leafygreen-ui-select-menubutton"
-          id="select-257"
+          id="select-201"
           type="button"
           value="build_variant"
         >
@@ -148,38 +148,27 @@ exports[`Snapshot Tests Components/TupleSelect WithConditional 1`] = `
         class="e5gn9hl0 css-47706i-TextInputWrapper-GroupedTextInput e13gwrw81"
       >
         <div
-          class="leafygreen-ui-1br9h7w"
+          class="leafygreen-ui-90q1a7"
         >
           <div
-            class="leafygreen-ui-e3fvh5"
-          />
-          <div
-            aria-disabled="false"
-            class="leafygreen-ui-mrtshz"
+            class="leafygreen-ui-lzja97"
           >
+            <input
+              aria-invalid="false"
+              aria-label="Build Variant"
+              autocomplete="on"
+              class="leafygreen-ui-1kmfbzh"
+              data-cy="tuple-select-input"
+              id="filter-input"
+              placeholder="Search Build Variant names"
+              required=""
+              type="search"
+              value=""
+            />
             <div
-              class="leafygreen-ui-1ago99h"
-            >
-              <input
-                aria-describedby=""
-                aria-invalid="false"
-                autocomplete="on"
-                class="lg-ui-form-field-input-0000 leafygreen-ui-vrj1me"
-                data-cy="tuple-select-input"
-                id="filter-input"
-                placeholder="Search Build Variant names"
-                required=""
-                type="search"
-                value=""
-              />
-            </div>
-            <div
-              class="leafygreen-ui-iwiovi"
+              class="lg-ui-icon-selector-0000 leafygreen-ui-11c7q5r"
             />
           </div>
-          <div
-            class="leafygreen-ui-jsxxy6"
-          />
         </div>
         <div
           class="css-4bamt4-IconWrapper e13gwrw80"

--- a/src/pages/commits/__snapshots__/ProjectHealth.stories.storyshot
+++ b/src/pages/commits/__snapshots__/ProjectHealth.stories.storyshot
@@ -256,7 +256,7 @@ exports[`Snapshot Tests Pages/Commits/Project Health Page Default 1`] = `
                             >
                               <input
                                 aria-checked="true"
-                                aria-describedby="lg-278"
+                                aria-describedby="lg-218"
                                 aria-disabled="false"
                                 checked=""
                                 class="lg-ui-radio-group-0002 leafygreen-ui-1iwed1m"
@@ -284,7 +284,7 @@ exports[`Snapshot Tests Pages/Commits/Project Health Page Default 1`] = `
                               for="chart-radio-percent"
                             >
                               <input
-                                aria-describedby="lg-279"
+                                aria-describedby="lg-219"
                                 aria-disabled="false"
                                 class="lg-ui-radio-group-0002 leafygreen-ui-1iwed1m"
                                 data-cy="cy-chart-percent-radio"

--- a/src/pages/configurePatch/configurePatchCore/__snapshots__/ConfigurePatchCore.stories.storyshot
+++ b/src/pages/configurePatch/configurePatchCore/__snapshots__/ConfigurePatchCore.stories.storyshot
@@ -6,47 +6,35 @@ exports[`Snapshot Tests pages/configurePatch/configurePatchCore ConfigureTasksDe
     class="css-d31jx9-FlexRow ek3m3u40"
   >
     <div
-      class="leafygreen-ui-1br9h7w css-pjeyga-StyledInput ek3m3u42"
+      class="css-pjeyga-StyledInput ek3m3u42 leafygreen-ui-90q1a7"
     >
       <div
         class="leafygreen-ui-e3fvh5"
       >
         <label
-          class="leafygreen-ui-1qjbbjd"
-          for="lg-form-field-input-306"
-          id="lg-form-field-label-303"
+          class="leafygreen-ui-t01kw4"
+          for="textinput-8"
         >
           Patch Name
         </label>
       </div>
       <div
-        aria-disabled="false"
-        class="leafygreen-ui-mrtshz"
+        class="leafygreen-ui-lzja97"
       >
+        <input
+          aria-invalid="false"
+          autocomplete="on"
+          class="leafygreen-ui-1kmfbzh"
+          data-cy="patch-name-input"
+          id="textinput-8"
+          required=""
+          type="text"
+          value="test"
+        />
         <div
-          class="leafygreen-ui-1ago99h"
-        >
-          <input
-            aria-describedby=""
-            aria-invalid="false"
-            aria-label=""
-            aria-labelledby="lg-form-field-label-303"
-            autocomplete="on"
-            class="lg-ui-form-field-input-0000 leafygreen-ui-vrj1me"
-            data-cy="patch-name-input"
-            id="lg-form-field-input-306"
-            required=""
-            type="text"
-            value="test"
-          />
-        </div>
-        <div
-          class="leafygreen-ui-iwiovi"
+          class="lg-ui-icon-selector-0000 leafygreen-ui-11c7q5r"
         />
       </div>
-      <div
-        class="leafygreen-ui-jsxxy6"
-      />
     </div>
     <div
       class="css-8i32g1-ButtonWrapper ek3m3u41"
@@ -317,38 +305,27 @@ exports[`Snapshot Tests pages/configurePatch/configurePatchCore ConfigureTasksDe
                     class="eoqkpw13 css-1pn85ix-TextInputWrapper-StyledTextInput e13gwrw81"
                   >
                     <div
-                      class="leafygreen-ui-1br9h7w"
+                      class="leafygreen-ui-90q1a7"
                     >
                       <div
-                        class="leafygreen-ui-e3fvh5"
-                      />
-                      <div
-                        aria-disabled="false"
-                        class="leafygreen-ui-mrtshz"
+                        class="leafygreen-ui-lzja97"
                       >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="search-tasks"
+                          autocomplete="on"
+                          class="leafygreen-ui-1kmfbzh"
+                          data-cy="task-filter-input"
+                          id="textinput-10"
+                          placeholder="Search tasks regex"
+                          required=""
+                          type="text"
+                          value=""
+                        />
                         <div
-                          class="leafygreen-ui-1ago99h"
-                        >
-                          <input
-                            aria-describedby=""
-                            aria-invalid="false"
-                            autocomplete="on"
-                            class="lg-ui-form-field-input-0000 leafygreen-ui-vrj1me"
-                            data-cy="task-filter-input"
-                            id="lg-form-field-input-314"
-                            placeholder="Search tasks regex"
-                            required=""
-                            type="text"
-                            value=""
-                          />
-                        </div>
-                        <div
-                          class="leafygreen-ui-iwiovi"
+                          class="lg-ui-icon-selector-0000 leafygreen-ui-11c7q5r"
                         />
                       </div>
-                      <div
-                        class="leafygreen-ui-jsxxy6"
-                      />
                     </div>
                     <div
                       class="css-4bamt4-IconWrapper e13gwrw80"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3488,19 +3488,6 @@
     "@leafygreen-ui/typography" "^18.2.2"
     react-transition-group "^4.4.5"
 
-"@leafygreen-ui/form-field@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@leafygreen-ui/form-field/-/form-field-0.2.0.tgz#b1b87a9bd91e1014b6e2aa84787480f9d68171a1"
-  integrity sha512-sGpm+U+m3ErK76YciPapP9oC2GxvICKc1sMRGaAI1vMyYUbIlXEGxtLkL7Xd6HrJcC7aDRcN75MUlC2SJYQsTQ==
-  dependencies:
-    "@leafygreen-ui/emotion" "^4.0.7"
-    "@leafygreen-ui/hooks" "^8.0.0"
-    "@leafygreen-ui/icon" "^11.24.0"
-    "@leafygreen-ui/lib" "^13.0.0"
-    "@leafygreen-ui/palette" "^4.0.7"
-    "@leafygreen-ui/tokens" "^2.2.0"
-    "@leafygreen-ui/typography" "^18.0.0"
-
 "@leafygreen-ui/form-field@^0.3.0":
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/@leafygreen-ui/form-field/-/form-field-0.3.2.tgz#dc6b6fc15e003386b53e1dbd5e7ebcab58475b8f"
@@ -3570,7 +3557,7 @@
     "@leafygreen-ui/emotion" "^4.0.7"
     lodash "^4.17.21"
 
-"@leafygreen-ui/icon@^11.12.5", "@leafygreen-ui/icon@^11.15.0", "@leafygreen-ui/icon@^11.17.0", "@leafygreen-ui/icon@^11.22.1", "@leafygreen-ui/icon@^11.22.2", "@leafygreen-ui/icon@^11.23.0", "@leafygreen-ui/icon@^11.24.0", "@leafygreen-ui/icon@^11.25.0", "@leafygreen-ui/icon@^11.25.1", "@leafygreen-ui/icon@^11.27.0", "@leafygreen-ui/icon@^11.27.1", "@leafygreen-ui/icon@^11.28.0", "@leafygreen-ui/icon@^11.29.1":
+"@leafygreen-ui/icon@^11.12.5", "@leafygreen-ui/icon@^11.15.0", "@leafygreen-ui/icon@^11.17.0", "@leafygreen-ui/icon@^11.22.1", "@leafygreen-ui/icon@^11.22.2", "@leafygreen-ui/icon@^11.23.0", "@leafygreen-ui/icon@^11.25.0", "@leafygreen-ui/icon@^11.25.1", "@leafygreen-ui/icon@^11.27.0", "@leafygreen-ui/icon@^11.27.1", "@leafygreen-ui/icon@^11.28.0", "@leafygreen-ui/icon@^11.29.1":
   version "11.29.1"
   resolved "https://registry.yarnpkg.com/@leafygreen-ui/icon/-/icon-11.29.1.tgz#f61115a5b0b36310a5ffb008bf51dd9ae8982917"
   integrity sha512-bCfeJ3mndU5wHayMWfkVWo0NXhPpBpHIG53aox/eRterqLvWg6jWyiuF930MHbyWDNEXC9Qw1WD637kZ93mmog==
@@ -4027,19 +4014,18 @@
     "@leafygreen-ui/tokens" "^2.2.0"
     "@leafygreen-ui/typography" "^18.0.0"
 
-"@leafygreen-ui/text-input@12.1.24":
-  version "12.1.24"
-  resolved "https://registry.yarnpkg.com/@leafygreen-ui/text-input/-/text-input-12.1.24.tgz#abb93148cc57aa151d918c37277ce92929bbe95f"
-  integrity sha512-IE7Ukw3brzBkPqaSAQNsjaYrj5AHsZO4T1VMPME/06ESWk0YUukPlc3vRH9F72LkPkrOetf8TzmfRglGs3wShQ==
+"@leafygreen-ui/text-input@12.1.12":
+  version "12.1.12"
+  resolved "https://registry.yarnpkg.com/@leafygreen-ui/text-input/-/text-input-12.1.12.tgz#552beaae38625adb85ee45ed657a563969e7292b"
+  integrity sha512-CXbAKTVjeYtathdF+mI19PeQWp3KRhS8CqlS5tRZkz2RBMtkqgCn3YFmmnmMJrfEOnKfxt7ln15oRj2sM6c/nQ==
   dependencies:
-    "@leafygreen-ui/emotion" "^4.0.7"
-    "@leafygreen-ui/form-field" "^0.2.0"
-    "@leafygreen-ui/hooks" "^8.0.0"
-    "@leafygreen-ui/icon" "^11.23.0"
-    "@leafygreen-ui/lib" "^13.0.0"
-    "@leafygreen-ui/palette" "^4.0.7"
-    "@leafygreen-ui/tokens" "^2.2.0"
-    "@leafygreen-ui/typography" "^18.0.0"
+    "@leafygreen-ui/emotion" "^4.0.4"
+    "@leafygreen-ui/hooks" "^7.7.3"
+    "@leafygreen-ui/icon" "^11.15.0"
+    "@leafygreen-ui/lib" "^10.3.3"
+    "@leafygreen-ui/palette" "^4.0.4"
+    "@leafygreen-ui/tokens" "^2.1.0"
+    "@leafygreen-ui/typography" "^16.4.0"
 
 "@leafygreen-ui/text-input@^12.1.23":
   version "12.1.25"


### PR DESCRIPTION
DEVPROD-5595

### Description
<!-- add description, context, thought process, etc -->
- Downgrade package to the same version on Parsley. This version does not use the `@leafygreen-ui/form-field` package which introduced the styling bugs.

### Screenshots
<!-- add screenshots of visible changes -->
The input on this page is styled correctly again:
<img width="1361" alt="image" src="https://github.com/evergreen-ci/spruce/assets/9298431/69e073cf-67f7-4776-bcb9-35fded6dba1d">