### PR TITLE
DEVPROD-5788: Allow upgrading to minor or major version

### DIFF
--- a/scripts/deploy/deploy-production.ts
+++ b/scripts/deploy/deploy-production.ts
@@ -38,14 +38,20 @@ const evergreenDeploy = async () => {
     // Print all commits between the last tag and the current commit
     console.log(`Commit messages:\n${commitMessages}`);
 
-    const { value: shouldCreateTagAndPush } = await prompts({
-      type: "confirm",
+    const { value: version } = await prompts({
+      type: "select",
       name: "value",
       message: "Are you sure you want to deploy to production?",
+      choices: [
+        { title: "Patch", value: "patch" },
+        { title: "Minor", value: "minor" },
+        { title: "Major", value: "major" },
+      ],
+      initial: 0,
     });
 
-    if (shouldCreateTagAndPush) {
-      createTagAndPush();
+    if (version) {
+      createTagAndPush(version);
     }
   } catch (err) {
     console.error(err);

--- a/scripts/deploy/deploy-production.ts
+++ b/scripts/deploy/deploy-production.ts
@@ -41,7 +41,7 @@ const evergreenDeploy = async () => {
     const { value: version } = await prompts({
       type: "select",
       name: "value",
-      message: "Are you sure you want to deploy to production?",
+      message: "How should this deploy be versioned?",
       choices: [
         { title: "Patch", value: "patch" },
         { title: "Minor", value: "minor" },

--- a/scripts/deploy/utils/git/tag/mock-tag-utils.ts
+++ b/scripts/deploy/utils/git/tag/mock-tag-utils.ts
@@ -2,9 +2,12 @@ import { yellow } from "../../../../utils/colors";
 
 /**
  * `createTagAndPush` is a helper function that creates a new tag and pushes to remote.
+ * @param version - version indicates the type of upgrade of the new tag.
  */
-const createTagAndPush = () => {
-  console.log(yellow("Dry run mode enabled. Created new tag and pushed."));
+const createTagAndPush = (version: "patch" | "minor" | "major") => {
+  console.log(
+    yellow(`Dry run mode enabled. Created new ${version} tag and pushed.`),
+  );
 };
 
 /**

--- a/scripts/deploy/utils/git/tag/tag-utils.ts
+++ b/scripts/deploy/utils/git/tag/tag-utils.ts
@@ -4,11 +4,12 @@ import { green, underline } from "../../../../utils/colors";
 /**
  * `createTagAndPush` is a helper function that creates a new tag.
  * Pushing occurs in the postversion hook triggered by "yarn version"
+ * @param version - version indicates the type of upgrade of the new tag.
  */
-const createTagAndPush = () => {
+const createTagAndPush = (version: "patch" | "minor" | "major") => {
   console.log("Creating new tag...");
   try {
-    execSync("yarn version --new-version patch", {
+    execSync(`yarn version --new-version ${version}`, {
       encoding: "utf-8",
       stdio: "inherit",
     });
@@ -19,9 +20,9 @@ const createTagAndPush = () => {
   console.log(
     green(
       `Track deploy progress at ${underline(
-        "https://spruce.mongodb.com/commits/spruce?requester=git_tag_request"
-      )}`
-    )
+        "https://spruce.mongodb.com/commits/spruce?requester=git_tag_request",
+      )}`,
+    ),
   );
 };
 


### PR DESCRIPTION
DEVPROD-5788

### Description
<!-- add description, context, thought process, etc -->
Noticed that our deploy script no longer allows upgrading anything besides patch version. I'm going to upgrade the major version when we switch to a monorepo so we need this functionality. Will add to Parsley after!

### Screenshots
<!-- add screenshots of visible changes -->
<img width="543" alt="image" src="https://github.com/evergreen-ci/spruce/assets/9298431/2cef6b1a-2633-49b0-8004-ccb49931c12d">

### Testing
<!-- add a description of how you tested it -->
Ran `createTagAndPush` command locally/wifi off to verify prompt works as designed