### PR TITLE
DEVPROD-5766 Update HybridTree icon height

### DIFF
--- a/src/components/Header/Navbar.tsx
+++ b/src/components/Header/Navbar.tsx
@@ -185,7 +185,6 @@ const SecondaryLink = styled.a`
 `;
 
 const HybridTreeIcon = styled.img`
-  height: 70px;
-  width: 70px;
+  height: 72px;
   position: relative;
 `;


### PR DESCRIPTION
DEVPROD-5766

### Description
Updates the height of the HybridTreeIcon to preserve the aspect ratio of the original svg
### Screenshots
<img width="657" alt="image" src="https://github.com/evergreen-ci/spruce/assets/4605522/f511a2b2-d5cb-4307-9519-534b940308b3">

